### PR TITLE
feat: trust & safety — issues #1 #2 #3 #4

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,7 @@ API_BASE_URL=http://localhost:8000
 
 # Slack signing secret (for verifying interactive component payloads)
 SLACK_SIGNING_SECRET=
+
+# Modal sandbox — Brain block isolation (leave empty for local dev subprocess fallback)
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,216 @@
+# Delegator — Product Roadmap
+
+> *Delegator is the AI layer on top of your existing engineering workflow — it picks up tickets, writes code, runs tests, and opens PRs, with a human approving before anything ships.*
+
+---
+
+## The Problem
+
+Engineering teams are slow not because developers are slow — but because the gap between "ticket created" and "code in production" is filled with context switching, manual steps, and waiting.
+
+- A ticket sits for days before someone picks it up
+- A developer spends hours reading context before writing a line
+- PRs wait for review while the author moves to the next task
+- Deploys are manual, nerve-wracking, and undocumented
+
+Delegator closes that gap. Not by replacing developers — by eliminating the mechanical work between intent and outcome.
+
+---
+
+## What Delegator Does
+
+A developer labels a GitHub issue `autopilot ready`.
+
+Delegator:
+1. Reads the issue
+2. Clones the repo, understands the codebase
+3. Writes the fix
+4. Runs the tests — fixes failures automatically (up to 3 attempts)
+5. Opens a pull request with a clear description
+6. Notifies the developer on Slack
+7. Waits for human approval before anything merges
+
+The developer reviews the PR. One click. Done.
+
+**Same day. Zero context switching. Human still in control.**
+
+---
+
+## Who It's For
+
+Engineering teams of 5–50 who:
+- Use GitHub + Slack (or Linear) already
+- Ship features on a weekly cadence
+- Want to move faster without hiring more engineers
+- Need auditability — they can't have a black box touching production
+
+---
+
+## What We Are Not
+
+- Not a no-code tool for non-engineers
+- Not an AI chatbot
+- Not an agent platform (infrastructure)
+- Not a replacement for developers
+- Not competing with LangChain, Temporal, or Google Agentspace on runtime infrastructure
+
+We sit **on top** of your existing tools. We don't replace them.
+
+---
+
+## Roadmap
+
+### Phase 1 — Core SDLC Loop ✅ Done
+
+The end-to-end path from ticket to PR, running locally.
+
+- Visual canvas: drag-and-drop workflow builder
+- DAG executor with background worker
+- GitHub integration: fetch issue, clone, branch, push, open PR
+- Slack integration: post message, DM, approval buttons
+- Brain block: agentic Claude loop with file/shell/search tools
+- Logic block: branch on test pass/fail
+- Approval block: pause, notify, resume on human decision
+- Run trace: live SSE stream, full event log
+- Dry Run: simulate without touching real systems
+- Credential vault: encrypted per workspace
+- Autopilot workflow seeded: label issue → Brain implements → tests → PR → Slack notify
+
+---
+
+### Phase 2 — Reliability & Trust ← Now
+
+The thing that makes teams actually let it touch production.
+
+**Parameterized runs**
+- Define input schema per workflow (repo, branch, issue number, etc.)
+- Pre-run form in UI — fill params before triggering
+- Webhook payloads auto-map to params
+- Block configs reference `{{params.repo}}` — same canvas, different inputs
+
+**Better test handling**
+- Detect test runner automatically (pytest, jest, npm test, go test)
+- Parse test output — show which tests failed and why in the trace
+- Fix loop improvements: Brain sees structured failure, not raw output
+
+**Smarter Brain prompts**
+- Auto-inject repo context: language, framework, folder structure
+- Brain reads existing tests before writing code — matches style
+- Brain writes a test for every change it makes
+
+**Trace improvements**
+- Show token count + estimated cost per run
+- Show which files were changed in the Brain block output
+- Link directly to the opened PR from the trace
+
+---
+
+### Phase 3 — Pre-built Workflow Library
+
+Teams shouldn't have to build from scratch. Ship ready-to-use workflows for the most common SDLC tasks.
+
+| Workflow | Trigger | What it does |
+|----------|---------|-------------|
+| **Autopilot** | Issue labeled `autopilot ready` | Implement fix, run tests, open PR |
+| **Test generator** | Issue labeled `add tests` | Read code, write missing tests, open PR |
+| **Dependency upgrade** | Weekly schedule | Bump deps, run tests, open PR if green |
+| **Incident responder** | PagerDuty / Slack alert | Read logs, identify root cause, post summary, open fix PR |
+| **PR reviewer** | PR opened | Read diff, post review comments on GitHub |
+| **Release notes** | Tag pushed | Read merged PRs since last tag, write release notes, post to Slack |
+
+Each workflow:
+- One-click install into your workspace
+- Works with GitHub + Slack out of the box
+- Fully editable on the canvas after install
+
+---
+
+### Phase 4 — Connects to Where Teams Live
+
+Expand the integration surface so Delegator fits into any engineering team's existing stack without asking them to change tools.
+
+**Ticket sources (triggers)**
+- Linear — label `autopilot ready`
+- Jira — transition to `In Progress (AI)`
+- GitHub Issues — already done ✓
+
+**Notification targets**
+- Slack — already done ✓
+- Email — already done ✓
+- Microsoft Teams
+- GitHub PR comments (Brain posts its own progress updates)
+
+**CI/CD awareness**
+- Read GitHub Actions results — Brain sees test output from CI, not just local
+- Trigger on CI failure — workflow fires when a build breaks
+- Post deploy status back to the originating Slack thread
+
+---
+
+### Phase 5 — Governance & Auditability
+
+What enterprises need before they allow agents near production.
+
+**Per-workflow policies**
+- Tool allowlist — define exactly which integrations an agent may use
+- Max lines changed per run — reject PRs over a threshold
+- Forbidden file paths — agent cannot touch `.env`, `secrets/`, migrations
+- Budget caps — max LLM spend and max wall time per run
+
+**Audit log**
+- Every external API call logged with timestamp, params, response hash
+- Immutable — cannot be edited or deleted
+- Exportable to CSV / shipped to your SIEM
+
+**Agent Registry**
+- Catalog of all workflows in the workspace
+- Version history with diff view
+- Clone a workflow as a template
+
+---
+
+### Phase 6 — Scale & Self-Hosted
+
+For larger teams and enterprises who need to run Delegator in their own infrastructure.
+
+- Docker Compose production bundle (single command deploy)
+- Helm chart for Kubernetes
+- Bring-your-own LLM — OpenAI, Mistral, local Ollama (not just Claude)
+- SSO via SAML / OIDC
+- Per-team workspaces with RBAC
+
+---
+
+## The Metric That Matters
+
+**Time from ticket to merged PR.**
+
+Everything on this roadmap either reduces that number or makes teams trust the process enough to let it run. If a feature doesn't do one of those two things, it's not on the roadmap.
+
+---
+
+## Current Status
+
+| Capability | Status |
+|-----------|--------|
+| Autopilot: issue → Brain → tests → PR | ✅ Live |
+| Canvas workflow builder | ✅ Live |
+| GitHub, Slack, Linear, Vercel, Railway, DO, Email | ✅ Live |
+| Approval gates | ✅ Live |
+| Dry Run mode | ✅ Live |
+| Webhook triggers (GitHub, Vercel, Railway) | ✅ Live |
+| Run trace (live + history) | ✅ Live |
+| Parameterized runs | 🔲 Phase 2 |
+| Pre-built workflow library | 🔲 Phase 3 |
+| Jira / Teams / CI integration | 🔲 Phase 4 |
+| Governance & audit log | 🔲 Phase 5 |
+| Self-hosted / RBAC | 🔲 Phase 6 |
+
+---
+
+## Deployment (Pending)
+
+- **Backend + worker**: Railway — `sseshachala/delegator`, root `apps/api`
+- **Database**: Railway Postgres plugin
+- **Frontend**: Vercel — `sseshachala/delegator`, root `apps/web`
+- **GitHub webhook**: `POST https://<railway-url>/webhooks/github` → Issues events

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -83,7 +83,8 @@ def get_workspace_id(
     - If set and valid JWT: extracts workspace from 'org_id' or 'sub' claim
     - If set and invalid JWT: raises 401
     """
-    if not settings.clerk_secret_key:
+    # Require both keys to be set — partial Clerk config falls back to dev workspace
+    if not settings.clerk_secret_key or not settings.clerk_frontend_api:
         return DEV_WORKSPACE_ID
 
     if not credentials:

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -19,6 +19,10 @@ class Settings(BaseSettings):
     email_from: str = "Delegator <notifications@delegator.dev>"
     # Webhook secrets
     vercel_webhook_secret: str = ""
+    github_webhook_secret: str = ""
+    # Modal sandbox — when set, Brain tools run in isolated containers
+    modal_token_id: str = ""
+    modal_token_secret: str = ""
 
     class Config:
         env_file = ".env"

--- a/apps/api/app/routers/credentials.py
+++ b/apps/api/app/routers/credentials.py
@@ -4,19 +4,16 @@ POST   /credentials          — upsert a credential by handle
 GET    /credentials          — list all (no secret values)
 DELETE /credentials/:handle  — remove
 """
-from uuid import UUID
-
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.core.auth import get_workspace_id
 from app.core.crypto import decrypt, encrypt
 from app.core.database import get_db
 from app.models.integration import Integration
 
 router = APIRouter(prefix="/credentials", tags=["credentials"])
-
-DEV_WORKSPACE = UUID("00000000-0000-0000-0000-000000000001")
 
 KNOWN_SERVICES = {
     "github":       {"fields": ["token"],        "label": "GitHub",       "hint": "Personal access token or OAuth token"},
@@ -44,9 +41,9 @@ class CredentialOut(BaseModel):
 
 
 @router.get("", response_model=list[CredentialOut])
-def list_credentials(db: Session = Depends(get_db)):
+def list_credentials(db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
     rows = db.query(Integration).filter(
-        Integration.workspace_id == DEV_WORKSPACE
+        Integration.workspace_id == workspace_id
     ).order_by(Integration.created_at).all()
 
     return [
@@ -61,16 +58,15 @@ def list_credentials(db: Session = Depends(get_db)):
 
 
 @router.post("", status_code=201)
-def upsert_credential(body: CredentialUpsert, db: Session = Depends(get_db)):
+def upsert_credential(body: CredentialUpsert, db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
     if not body.credentials:
         raise HTTPException(status_code=422, detail="credentials dict must not be empty")
 
     existing = db.query(Integration).filter(
-        Integration.workspace_id == DEV_WORKSPACE,
+        Integration.workspace_id == workspace_id,
         Integration.handle == body.handle,
     ).first()
 
-    service_meta = KNOWN_SERVICES.get(body.service, {})
     auth_method = "api_key" if "api_key" in body.credentials else "oauth"
 
     if existing:
@@ -79,7 +75,7 @@ def upsert_credential(body: CredentialUpsert, db: Session = Depends(get_db)):
         existing.encrypted_credentials = encrypt(body.credentials)
     else:
         row = Integration(
-            workspace_id=DEV_WORKSPACE,
+            workspace_id=workspace_id,
             service=body.service,
             handle=body.handle,
             auth_method=auth_method,
@@ -92,9 +88,9 @@ def upsert_credential(body: CredentialUpsert, db: Session = Depends(get_db)):
 
 
 @router.delete("/{handle}", status_code=204)
-def delete_credential(handle: str, db: Session = Depends(get_db)):
+def delete_credential(handle: str, db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
     row = db.query(Integration).filter(
-        Integration.workspace_id == DEV_WORKSPACE,
+        Integration.workspace_id == workspace_id,
         Integration.handle == handle,
     ).first()
     if not row:

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -1,4 +1,5 @@
 import json
+from typing import Annotated
 from uuid import UUID
 
 import redis
@@ -7,6 +8,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.core.auth import get_workspace_id
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.run import Run, RunEvent
@@ -22,11 +24,24 @@ def _redis():
     return redis.from_url(settings.redis_url, decode_responses=True)
 
 
-@router.get("", response_model=list[RunOut])
-def list_runs(workflow_id: UUID, db: Session = Depends(get_db)):
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+def _get_workflow(workflow_id: UUID, workspace_id: str, db: Session) -> Workflow:
+    """Fetch workflow and verify it belongs to the caller's workspace."""
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
+    return workflow
+
+
+@router.get("", response_model=list[RunOut])
+def list_runs(
+    workflow_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    workflow = _get_workflow(workflow_id, workspace_id, db)
     return (
         db.query(Run)
         .filter(Run.workflow_version_id == workflow.current_version_id)
@@ -36,10 +51,13 @@ def list_runs(workflow_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.post("", response_model=RunOut, status_code=201)
-def create_run(workflow_id: UUID, body: RunCreate, db: Session = Depends(get_db)):
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
-    if not workflow:
-        raise HTTPException(status_code=404, detail="Workflow not found")
+def create_run(
+    workflow_id: UUID,
+    body: RunCreate,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    workflow = _get_workflow(workflow_id, workspace_id, db)
     if not workflow.current_version_id:
         raise HTTPException(status_code=400, detail="Workflow has no published version")
 
@@ -60,7 +78,14 @@ def create_run(workflow_id: UUID, body: RunCreate, db: Session = Depends(get_db)
 
 
 @router.get("/{run_id}", response_model=RunDetailOut)
-def get_run(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
+def get_run(
+    workflow_id: UUID,
+    run_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    # Verify the workflow belongs to this workspace before exposing run data.
+    _get_workflow(workflow_id, workspace_id, db)
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -68,8 +93,14 @@ def get_run(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.get("/{run_id}/stream")
-def stream_run_events(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
+def stream_run_events(
+    workflow_id: UUID,
+    run_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
     """SSE stream of run_events as they are written by the executor."""
+    _get_workflow(workflow_id, workspace_id, db)
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -131,6 +162,7 @@ def approve_run(
     run_id: UUID,
     body: ApprovalDecision,
     db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
 ):
     """
     Called by the human approver (or Slack webhook) to resume a paused run.
@@ -138,6 +170,8 @@ def approve_run(
     """
     if body.decision not in ("approved", "rejected"):
         raise HTTPException(status_code=422, detail="decision must be 'approved' or 'rejected'")
+
+    _get_workflow(workflow_id, workspace_id, db)
 
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
@@ -149,7 +183,6 @@ def approve_run(
     if not block_id:
         raise HTTPException(status_code=400, detail="No approval block recorded on paused run")
 
-    # Record decision into state so executor can resume past the approval block
     state = dict(run.state or {})
     state[f"__approval_{block_id}"] = body.decision
     if body.approver:
@@ -159,7 +192,6 @@ def approve_run(
     run.paused_at = None
     db.commit()
 
-    # Emit event
     event = RunEvent(
         run_id=run_id,
         block_id=block_id,
@@ -169,7 +201,6 @@ def approve_run(
     db.add(event)
     db.commit()
 
-    # Re-queue for the worker
     _redis().rpush(QUEUE_KEY, str(run_id))
 
     return {"run_id": str(run_id), "decision": body.decision, "status": "queued"}

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -4,6 +4,7 @@ Webhook endpoints for external services.
 POST /webhooks/slack/interactions  — Slack approval button clicks
 POST /webhooks/vercel              — Vercel deployment events (deployment.succeeded etc.)
 POST /webhooks/railway             — Railway deployment events
+POST /webhooks/github              — GitHub issue/PR events (issues.labeled, etc.)
 """
 import hashlib
 import hmac
@@ -258,3 +259,105 @@ async def railway_webhook(request: Request, db: Session = Depends(get_db)):
 
     queued = _trigger_webhook_workflows(db, event_type, initial_state)
     return {"ok": True, "queued": len(queued), "run_ids": queued}
+
+
+# ── GitHub webhook ────────────────────────────────────────────────────────────
+
+def _verify_github_signature(body: bytes, signature: str) -> bool:
+    secret = settings.github_webhook_secret
+    if not secret:
+        return True  # Skip in dev if not configured
+    expected = "sha256=" + hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()  # type: ignore[attr-defined]
+    return hmac.compare_digest(expected, signature)
+
+
+def _trigger_github_workflows(db: Session, event_type: str, label_filter: str, initial_state: dict[str, Any]) -> list[str]:
+    """
+    Find workflow versions with a trigger block matching:
+      - event_type == "github_issue"
+      - config.label == label_filter (or label_filter is empty = match all)
+    """
+    import uuid as uuid_mod
+
+    versions = db.query(WorkflowVersion).join(
+        Workflow, Workflow.current_version_id == WorkflowVersion.id
+    ).all()
+
+    queued: list[str] = []
+    for version in versions:
+        nodes = version.graph.get("nodes", [])
+        match = any(
+            n.get("data", {}).get("type") == "trigger" and
+            n.get("data", {}).get("config", {}).get("event_type") == event_type and
+            (
+                not n.get("data", {}).get("config", {}).get("label") or
+                n.get("data", {}).get("config", {}).get("label") == label_filter
+            )
+            for n in nodes
+        )
+        if not match:
+            continue
+
+        run = Run(
+            workflow_version_id=version.id,
+            triggered_by=f"github:{event_type}:{label_filter}",
+            status="pending",
+            state={**initial_state, "__triggered_by": f"github:{event_type}"},
+        )
+        db.add(run)
+        db.flush()
+        db.commit()
+        _redis().rpush(QUEUE_KEY, str(run.id))
+        queued.append(str(run.id))
+        log.info("GitHub %s (label=%s) triggered run %s for version %s", event_type, label_filter, run.id, version.id)
+
+    return queued
+
+
+@router.post("/github")
+async def github_webhook(request: Request, db: Session = Depends(get_db)):
+    """
+    Receive GitHub webhook events.
+    Configure in GitHub → repo → Settings → Webhooks.
+    Listens for: issues (labeled), push, pull_request (opened, merged).
+    """
+    body = await request.body()
+
+    sig = request.headers.get("X-Hub-Signature-256", "")
+    if not _verify_github_signature(body, sig):
+        raise HTTPException(status_code=401, detail="Invalid GitHub signature")
+
+    event = request.headers.get("X-GitHub-Event", "unknown")
+
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    # Only handle issue labeled events for now
+    if event != "issues" or payload.get("action") != "labeled":
+        return {"ok": True, "queued": 0, "reason": f"event {event}/{payload.get('action')} not handled"}
+
+    issue = payload.get("issue", {})
+    label = payload.get("label", {}).get("name", "")
+    repo = payload.get("repository", {})
+
+    initial_state = {
+        "github_issue": {
+            "issue_number": issue.get("number"),
+            "title": issue.get("title"),
+            "body": issue.get("body") or "",
+            "url": issue.get("html_url"),
+            "author": issue.get("user", {}).get("login"),
+            "labels": [l["name"] for l in issue.get("labels", [])],
+            "label_added": label,
+            "repo_full_name": repo.get("full_name"),
+            "repo_name": repo.get("name"),
+            "repo_owner": repo.get("owner", {}).get("login"),
+            "default_branch": repo.get("default_branch", "main"),
+            "clone_url": repo.get("clone_url"),
+        }
+    }
+
+    queued = _trigger_github_workflows(db, "github_issue", label, initial_state)
+    return {"ok": True, "queued": len(queued), "run_ids": queued, "label": label}

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -271,17 +271,24 @@ def _verify_github_signature(body: bytes, signature: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-def _trigger_github_workflows(db: Session, event_type: str, label_filter: str, initial_state: dict[str, Any]) -> list[str]:
+def _trigger_github_workflows(
+    db: Session, event_type: str, label_filter: str, initial_state: dict[str, Any],
+    workspace_id: str | None = None,
+) -> list[str]:
     """
     Find workflow versions with a trigger block matching:
       - event_type == "github_issue"
       - config.label == label_filter (or label_filter is empty = match all)
+    If workspace_id is provided, only triggers workflows in that workspace.
     """
     import uuid as uuid_mod
 
-    versions = db.query(WorkflowVersion).join(
+    query = db.query(WorkflowVersion).join(
         Workflow, Workflow.current_version_id == WorkflowVersion.id
-    ).all()
+    )
+    if workspace_id:
+        query = query.filter(Workflow.workspace_id == workspace_id)
+    versions = query.all()
 
     queued: list[str] = []
     for version in versions:
@@ -315,11 +322,18 @@ def _trigger_github_workflows(db: Session, event_type: str, label_filter: str, i
 
 
 @router.post("/github")
-async def github_webhook(request: Request, db: Session = Depends(get_db)):
+async def github_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    workspace_id: str | None = None,
+):
     """
     Receive GitHub webhook events.
     Configure in GitHub → repo → Settings → Webhooks.
     Listens for: issues (labeled), push, pull_request (opened, merged).
+
+    Pass ?workspace_id=<uuid> in the webhook URL to scope triggers to a single
+    workspace (required in multi-tenant deployments).
     """
     body = await request.body()
 
@@ -359,5 +373,5 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
         }
     }
 
-    queued = _trigger_github_workflows(db, "github_issue", label, initial_state)
+    queued = _trigger_github_workflows(db, "github_issue", label, initial_state, workspace_id)
     return {"ok": True, "queued": len(queued), "run_ids": queued, "label": label}

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, HTTPException, BackgroundTasks
 from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
+from app.core.auth import get_workspace_id
 from app.core.database import get_db
 from app.models.workflow import Workflow, WorkflowVersion
 from app.schemas.workflow import WorkflowCreate, WorkflowUpdate, WorkflowOut, WorkflowDetailOut
@@ -10,8 +11,6 @@ from app.compiler.compiler import compile_workflow
 from app.compiler.stream import stream_compile_block
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
-
-DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
 
 
 def _run_compiler(version_id, graph: dict):
@@ -32,15 +31,15 @@ def _run_compiler(version_id, graph: dict):
 
 
 @router.get("", response_model=list[WorkflowOut])
-def list_workflows(db: Session = Depends(get_db)):
+def list_workflows(db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
     return db.query(Workflow).filter(
-        Workflow.workspace_id == DEV_WORKSPACE_ID
+        Workflow.workspace_id == workspace_id
     ).order_by(Workflow.updated_at.desc()).all()
 
 
 @router.post("", response_model=WorkflowDetailOut, status_code=201)
-def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db)):
-    workflow = Workflow(workspace_id=DEV_WORKSPACE_ID, name=body.name)
+def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
+    workflow = Workflow(workspace_id=workspace_id, name=body.name)
     db.add(workflow)
     db.flush()
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -260,20 +260,6 @@ def _dispatch_tool(tool_name: str, tool_input: dict) -> str:
     return dispatch_brain_tool(tool_name, tool_input)
 
 
-def _dispatch_tool_legacy(tool_name: str, tool_input: dict) -> str:
-    if tool_name == "read_file":
-        return _tool_read_file(tool_input["path"])
-    if tool_name == "write_file":
-        return _tool_write_file(tool_input["path"], tool_input["content"])
-    if tool_name == "run_shell":
-        return _tool_run_shell(tool_input["command"], tool_input.get("working_dir"))
-    if tool_name == "search_code":
-        return _tool_search_code(
-            tool_input["pattern"],
-            tool_input.get("path", "."),
-            tool_input.get("file_glob", "*"),
-        )
-    return f"Unknown tool: {tool_name}"
 
 
 # ── block executors ───────────────────────────────────────────────────────────
@@ -358,6 +344,7 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
             final_text = " ".join(b.text for b in text_blocks)
 
             if response.stop_reason == "end_turn" or not tool_calls:
+                # Sonnet 4.6 pricing: $3/1M input, $15/1M output — update if model changes
                 cost_usd = round((total_input_tokens * 3 + total_output_tokens * 15) / 1_000_000, 6)
                 files_changed, diff_stat = _extract_git_evidence(working_dir)
                 return {

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -256,6 +256,11 @@ def _tool_search_code(pattern: str, path: str = ".", file_glob: str = "*") -> st
 
 
 def _dispatch_tool(tool_name: str, tool_input: dict) -> str:
+    from app.runtime.sandbox import dispatch_brain_tool
+    return dispatch_brain_tool(tool_name, tool_input)
+
+
+def _dispatch_tool_legacy(tool_name: str, tool_input: dict) -> str:
     if tool_name == "read_file":
         return _tool_read_file(tool_input["path"])
     if tool_name == "write_file":
@@ -272,6 +277,40 @@ def _dispatch_tool(tool_name: str, tool_input: dict) -> str:
 
 
 # ── block executors ───────────────────────────────────────────────────────────
+
+def _extract_git_evidence(working_dir: str | None) -> tuple[list[dict], str]:
+    """Run git diff --stat in working_dir. Returns (files_changed, diff_stat_text)."""
+    if not working_dir:
+        return [], ""
+    try:
+        result = subprocess.run(
+            ["git", "diff", "--stat", "HEAD"],
+            capture_output=True, text=True, timeout=10, cwd=working_dir,
+        )
+        stat = result.stdout.strip()
+        if not stat:
+            # Nothing committed yet — diff against index
+            result = subprocess.run(
+                ["git", "diff", "--stat"],
+                capture_output=True, text=True, timeout=10, cwd=working_dir,
+            )
+            stat = result.stdout.strip()
+
+        files: list[dict] = []
+        for line in stat.splitlines():
+            line = line.strip()
+            if "|" in line:
+                path = line.split("|")[0].strip()
+                action = "modified"
+                if "new file" in line.lower():
+                    action = "created"
+                elif "deleted" in line.lower():
+                    action = "deleted"
+                files.append({"path": path, "action": action})
+        return files, stat
+    except Exception:
+        return [], ""
+
 
 def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
     if state.get("__dry_run"):
@@ -296,6 +335,9 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
         messages: list[dict] = [{"role": "user", "content": user_message}]
         turns = 0
         max_turns = 20
+        total_input_tokens = 0
+        total_output_tokens = 0
+        working_dir: str | None = None  # track if Brain cloned a repo
 
         while turns < max_turns:
             response = client.messages.create(
@@ -306,6 +348,9 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
                 messages=messages,
             )
             turns += 1
+            if hasattr(response, "usage") and response.usage:
+                total_input_tokens += getattr(response.usage, "input_tokens", 0)
+                total_output_tokens += getattr(response.usage, "output_tokens", 0)
 
             # Collect tool calls from response
             tool_calls = [b for b in response.content if b.type == "tool_use"]
@@ -313,7 +358,17 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
             final_text = " ".join(b.text for b in text_blocks)
 
             if response.stop_reason == "end_turn" or not tool_calls:
-                return {"output": final_text, "turns": turns}
+                cost_usd = round((total_input_tokens * 3 + total_output_tokens * 15) / 1_000_000, 6)
+                files_changed, diff_stat = _extract_git_evidence(working_dir)
+                return {
+                    "output": final_text,
+                    "turns": turns,
+                    "input_tokens": total_input_tokens,
+                    "output_tokens": total_output_tokens,
+                    "cost_usd": cost_usd,
+                    "files_changed": files_changed,
+                    "diff_stat": diff_stat,
+                }
 
             # Append assistant message
             messages.append({"role": "assistant", "content": response.content})
@@ -321,6 +376,9 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
             # Execute tool calls and build tool_result message
             tool_results = []
             for tc in tool_calls:
+                # Track working dir if Brain runs shell commands
+                if tc.name == "run_shell" and tc.input.get("working_dir"):
+                    working_dir = tc.input["working_dir"]
                 result_content = _dispatch_tool(tc.name, tc.input)
                 tool_results.append({
                     "type": "tool_result",
@@ -329,7 +387,17 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
                 })
             messages.append({"role": "user", "content": tool_results})
 
-        return {"output": "Turn budget exhausted", "turns": max_turns}
+        cost_usd = round((total_input_tokens * 3 + total_output_tokens * 15) / 1_000_000, 6)
+        files_changed, diff_stat = _extract_git_evidence(working_dir)
+        return {
+            "output": "Turn budget exhausted",
+            "turns": max_turns,
+            "input_tokens": total_input_tokens,
+            "output_tokens": total_output_tokens,
+            "cost_usd": cost_usd,
+            "files_changed": files_changed,
+            "diff_stat": diff_stat,
+        }
 
     else:
         # Single call (no tools)
@@ -340,7 +408,15 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
             messages=[{"role": "user", "content": user_message}],
         )
         text = next((b.text for b in response.content if hasattr(b, "text")), "")
-        return {"output": text}
+        input_tokens = getattr(getattr(response, "usage", None), "input_tokens", 0)
+        output_tokens = getattr(getattr(response, "usage", None), "output_tokens", 0)
+        cost_usd = round((input_tokens * 3 + output_tokens * 15) / 1_000_000, 6)
+        return {
+            "output": text,
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "cost_usd": cost_usd,
+        }
 
 
 def _dry_run_mock(integration: str, action: str, params: dict) -> dict:

--- a/apps/api/app/runtime/integrations/github.py
+++ b/apps/api/app/runtime/integrations/github.py
@@ -15,6 +15,36 @@ def _headers(token: str) -> dict:
     }
 
 
+def fetch_issue(token: str, owner: str, repo: str, issue_number: int) -> dict:
+    r = httpx.get(f"{BASE}/repos/{owner}/{repo}/issues/{issue_number}", headers=_headers(token), timeout=15)
+    r.raise_for_status()
+    d = r.json()
+    return {
+        "issue_number": d["number"],
+        "title": d["title"],
+        "body": d.get("body") or "",
+        "state": d["state"],
+        "url": d["html_url"],
+        "labels": [l["name"] for l in d.get("labels", [])],
+        "author": d["user"]["login"],
+    }
+
+
+def list_issues(token: str, owner: str, repo: str, label: str = "", state: str = "open") -> dict:
+    params: dict = {"state": state, "per_page": 20}
+    if label:
+        params["labels"] = label
+    r = httpx.get(f"{BASE}/repos/{owner}/{repo}/issues", headers=_headers(token), params=params, timeout=15)
+    r.raise_for_status()
+    issues = [
+        {"number": i["number"], "title": i["title"], "url": i["html_url"],
+         "labels": [l["name"] for l in i.get("labels", [])]}
+        for i in r.json()
+        if "pull_request" not in i
+    ]
+    return {"issues": issues, "count": len(issues)}
+
+
 def get_repo(token: str, owner: str, repo: str) -> dict:
     r = httpx.get(f"{BASE}/repos/{owner}/{repo}", headers=_headers(token), timeout=15)
     r.raise_for_status()
@@ -128,6 +158,8 @@ def add_repo_secret(token: str, owner: str, repo: str, secret_name: str, secret_
 
 
 TOOL_MAP = {
+    "fetch_issue": fetch_issue,
+    "list_issues": list_issues,
     "get_repo": get_repo,
     "create_branch": create_branch,
     "open_pull_request": open_pull_request,

--- a/apps/api/app/runtime/sandbox.py
+++ b/apps/api/app/runtime/sandbox.py
@@ -1,0 +1,186 @@
+"""
+Isolated execution sandbox for Brain block tool calls.
+
+When MODAL_TOKEN_ID + MODAL_TOKEN_SECRET are set, each Brain block run
+dispatches file/shell tools into an ephemeral Modal container — fully isolated,
+destroyed after the block completes.
+
+When those env vars are NOT set (local dev), falls back to direct subprocess
+execution on the host (existing behaviour).
+"""
+import logging
+import os
+import re
+import subprocess
+
+log = logging.getLogger(__name__)
+
+_FORBIDDEN_SHELL_PATTERNS = [
+    r"rm\s+-rf\s+/",
+    r"rm\s+-fr\s+/",
+    r"mkfs",
+    r"dd\s+if=",
+    r":\(\)\{.*\}",
+    r">\s*/dev/sd",
+    r"chmod\s+777\s+/",
+    r"chown.*root",
+]
+
+_modal_available = bool(os.environ.get("MODAL_TOKEN_ID") and os.environ.get("MODAL_TOKEN_SECRET"))
+
+
+# ── Local fallback (dev mode) ─────────────────────────────────────────────────
+
+def _local_read_file(path: str) -> str:
+    try:
+        with open(path) as f:
+            content = f.read()
+        return content[:20_000] + "\n[... truncated]" if len(content) > 20_000 else content
+    except Exception as e:
+        return f"Error reading file: {e}"
+
+
+def _local_write_file(path: str, content: str) -> str:
+    try:
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return f"Written {len(content)} bytes to {path}"
+    except Exception as e:
+        return f"Error writing file: {e}"
+
+
+def _local_run_shell(command: str, working_dir: str | None = None) -> str:
+    for pattern in _FORBIDDEN_SHELL_PATTERNS:
+        if re.search(pattern, command):
+            return f"Refused: command matches forbidden pattern '{pattern}'"
+    try:
+        result = subprocess.run(
+            command, shell=True, capture_output=True, text=True, timeout=120, cwd=working_dir,
+        )
+        output = result.stdout + result.stderr
+        return (output[:10_000] + "\n[... truncated]") if len(output) > 10_000 else output or "(no output)"
+    except subprocess.TimeoutExpired:
+        return "Error: command timed out after 120s"
+    except Exception as e:
+        return f"Error running shell: {e}"
+
+
+def _local_search_code(pattern: str, path: str = ".", file_glob: str = "*") -> str:
+    try:
+        result = subprocess.run(
+            ["grep", "-r", "--include", file_glob, "-n", pattern, path],
+            capture_output=True, text=True, timeout=15,
+        )
+        output = result.stdout
+        return (output[:8_000] + "\n[... truncated]") if len(output) > 8_000 else output or "(no matches)"
+    except Exception as e:
+        return f"Error searching: {e}"
+
+
+# ── Modal sandbox (production) ────────────────────────────────────────────────
+
+def _modal_dispatch(tool_name: str, tool_input: dict) -> str:
+    """Dispatch a single tool call into a Modal sandbox container."""
+    try:
+        import modal  # type: ignore[import]
+
+        app = modal.App.lookup("delegator-brain-sandbox", create_if_missing=True)
+
+        @app.function(
+            timeout=120,
+            cpu=1,
+            memory=512,
+            retries=0,
+        )
+        def _run_tool_in_sandbox(name: str, inputs: dict) -> str:
+            import os, re, subprocess  # noqa: F401
+
+            forbidden = [
+                r"rm\s+-rf\s+/", r"rm\s+-fr\s+/", r"mkfs", r"dd\s+if=",
+                r":\(\)\{.*\}", r">\s*/dev/sd", r"chmod\s+777\s+/", r"chown.*root",
+            ]
+
+            if name == "read_file":
+                try:
+                    with open(inputs["path"]) as f:
+                        c = f.read()
+                    return c[:20_000] + "\n[... truncated]" if len(c) > 20_000 else c
+                except Exception as e:
+                    return f"Error: {e}"
+
+            if name == "write_file":
+                try:
+                    os.makedirs(os.path.dirname(os.path.abspath(inputs["path"])), exist_ok=True)
+                    with open(inputs["path"], "w") as f:
+                        f.write(inputs["content"])
+                    return f"Written {len(inputs['content'])} bytes to {inputs['path']}"
+                except Exception as e:
+                    return f"Error: {e}"
+
+            if name == "run_shell":
+                cmd = inputs["command"]
+                for p in forbidden:
+                    if re.search(p, cmd):
+                        return f"Refused: matches forbidden pattern '{p}'"
+                try:
+                    r = subprocess.run(
+                        cmd, shell=True, capture_output=True, text=True,
+                        timeout=110, cwd=inputs.get("working_dir"),
+                    )
+                    out = r.stdout + r.stderr
+                    return (out[:10_000] + "\n[... truncated]") if len(out) > 10_000 else out or "(no output)"
+                except subprocess.TimeoutExpired:
+                    return "Error: timed out"
+                except Exception as e:
+                    return f"Error: {e}"
+
+            if name == "search_code":
+                try:
+                    r = subprocess.run(
+                        ["grep", "-r", "--include", inputs.get("file_glob", "*"), "-n",
+                         inputs["pattern"], inputs.get("path", ".")],
+                        capture_output=True, text=True, timeout=15,
+                    )
+                    out = r.stdout
+                    return (out[:8_000] + "\n[... truncated]") if len(out) > 8_000 else out or "(no matches)"
+                except Exception as e:
+                    return f"Error: {e}"
+
+            return f"Unknown tool: {name}"
+
+        with modal.enable_output():
+            return _run_tool_in_sandbox.remote(tool_name, tool_input)
+
+    except Exception as e:
+        log.warning("Modal dispatch failed, falling back to local: %s", e)
+        return _dispatch_local(tool_name, tool_input)
+
+
+# ── Public interface ──────────────────────────────────────────────────────────
+
+def _dispatch_local(tool_name: str, tool_input: dict) -> str:
+    if tool_name == "read_file":
+        return _local_read_file(tool_input["path"])
+    if tool_name == "write_file":
+        return _local_write_file(tool_input["path"], tool_input["content"])
+    if tool_name == "run_shell":
+        return _local_run_shell(tool_input["command"], tool_input.get("working_dir"))
+    if tool_name == "search_code":
+        return _local_search_code(
+            tool_input["pattern"],
+            tool_input.get("path", "."),
+            tool_input.get("file_glob", "*"),
+        )
+    return f"Unknown tool: {tool_name}"
+
+
+def dispatch_brain_tool(tool_name: str, tool_input: dict) -> str:
+    """
+    Main entry point for Brain block tool execution.
+    Routes to Modal sandbox in production, local subprocess in dev.
+    """
+    if _modal_available:
+        log.debug("Dispatching %s to Modal sandbox", tool_name)
+        return _modal_dispatch(tool_name, tool_input)
+    return _dispatch_local(tool_name, tool_input)

--- a/apps/api/app/runtime/sandbox.py
+++ b/apps/api/app/runtime/sandbox.py
@@ -15,6 +15,7 @@ import subprocess
 
 log = logging.getLogger(__name__)
 
+# Shared across local and Modal execution paths — single source of truth.
 _FORBIDDEN_SHELL_PATTERNS = [
     r"rm\s+-rf\s+/",
     r"rm\s+-fr\s+/",
@@ -26,7 +27,11 @@ _FORBIDDEN_SHELL_PATTERNS = [
     r"chown.*root",
 ]
 
-_modal_available = bool(os.environ.get("MODAL_TOKEN_ID") and os.environ.get("MODAL_TOKEN_SECRET"))
+
+def _modal_available() -> bool:
+    """Check at call time so .env loading order doesn't matter."""
+    from app.core.config import settings
+    return bool(settings.modal_token_id and settings.modal_token_secret)
 
 
 # ── Local fallback (dev mode) ─────────────────────────────────────────────────
@@ -80,78 +85,82 @@ def _local_search_code(pattern: str, path: str = ".", file_glob: str = "*") -> s
 
 # ── Modal sandbox (production) ────────────────────────────────────────────────
 
+# Lazy-initialised Modal function stub — defined once, reused across calls.
+_modal_run_tool = None
+
+
+def _get_modal_run_tool():
+    global _modal_run_tool
+    if _modal_run_tool is not None:
+        return _modal_run_tool
+
+    import modal  # type: ignore[import]
+
+    _app = modal.App("delegator-brain-sandbox")
+    forbidden_patterns = _FORBIDDEN_SHELL_PATTERNS  # captured at definition time
+
+    @_app.function(timeout=120, cpu=1, memory=512, retries=0)
+    def run_tool(name: str, inputs: dict) -> str:
+        import os as _os
+        import re as _re
+        import subprocess as _sp
+
+        if name == "read_file":
+            try:
+                with open(inputs["path"]) as f:
+                    c = f.read()
+                return c[:20_000] + "\n[... truncated]" if len(c) > 20_000 else c
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "write_file":
+            try:
+                _os.makedirs(_os.path.dirname(_os.path.abspath(inputs["path"])), exist_ok=True)
+                with open(inputs["path"], "w") as f:
+                    f.write(inputs["content"])
+                return f"Written {len(inputs['content'])} bytes to {inputs['path']}"
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "run_shell":
+            cmd = inputs["command"]
+            for p in forbidden_patterns:
+                if _re.search(p, cmd):
+                    return f"Refused: matches forbidden pattern '{p}'"
+            try:
+                r = _sp.run(
+                    cmd, shell=True, capture_output=True, text=True,
+                    timeout=110, cwd=inputs.get("working_dir"),
+                )
+                out = r.stdout + r.stderr
+                return (out[:10_000] + "\n[... truncated]") if len(out) > 10_000 else out or "(no output)"
+            except _sp.TimeoutExpired:
+                return "Error: timed out"
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "search_code":
+            try:
+                r = _sp.run(
+                    ["grep", "-r", "--include", inputs.get("file_glob", "*"), "-n",
+                     inputs["pattern"], inputs.get("path", ".")],
+                    capture_output=True, text=True, timeout=15,
+                )
+                out = r.stdout
+                return (out[:8_000] + "\n[... truncated]") if len(out) > 8_000 else out or "(no matches)"
+            except Exception as e:
+                return f"Error: {e}"
+
+        return f"Unknown tool: {name}"
+
+    _modal_run_tool = run_tool
+    return _modal_run_tool
+
+
 def _modal_dispatch(tool_name: str, tool_input: dict) -> str:
-    """Dispatch a single tool call into a Modal sandbox container."""
     try:
-        import modal  # type: ignore[import]
-
-        app = modal.App.lookup("delegator-brain-sandbox", create_if_missing=True)
-
-        @app.function(
-            timeout=120,
-            cpu=1,
-            memory=512,
-            retries=0,
-        )
-        def _run_tool_in_sandbox(name: str, inputs: dict) -> str:
-            import os, re, subprocess  # noqa: F401
-
-            forbidden = [
-                r"rm\s+-rf\s+/", r"rm\s+-fr\s+/", r"mkfs", r"dd\s+if=",
-                r":\(\)\{.*\}", r">\s*/dev/sd", r"chmod\s+777\s+/", r"chown.*root",
-            ]
-
-            if name == "read_file":
-                try:
-                    with open(inputs["path"]) as f:
-                        c = f.read()
-                    return c[:20_000] + "\n[... truncated]" if len(c) > 20_000 else c
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "write_file":
-                try:
-                    os.makedirs(os.path.dirname(os.path.abspath(inputs["path"])), exist_ok=True)
-                    with open(inputs["path"], "w") as f:
-                        f.write(inputs["content"])
-                    return f"Written {len(inputs['content'])} bytes to {inputs['path']}"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "run_shell":
-                cmd = inputs["command"]
-                for p in forbidden:
-                    if re.search(p, cmd):
-                        return f"Refused: matches forbidden pattern '{p}'"
-                try:
-                    r = subprocess.run(
-                        cmd, shell=True, capture_output=True, text=True,
-                        timeout=110, cwd=inputs.get("working_dir"),
-                    )
-                    out = r.stdout + r.stderr
-                    return (out[:10_000] + "\n[... truncated]") if len(out) > 10_000 else out or "(no output)"
-                except subprocess.TimeoutExpired:
-                    return "Error: timed out"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "search_code":
-                try:
-                    r = subprocess.run(
-                        ["grep", "-r", "--include", inputs.get("file_glob", "*"), "-n",
-                         inputs["pattern"], inputs.get("path", ".")],
-                        capture_output=True, text=True, timeout=15,
-                    )
-                    out = r.stdout
-                    return (out[:8_000] + "\n[... truncated]") if len(out) > 8_000 else out or "(no matches)"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            return f"Unknown tool: {name}"
-
-        with modal.enable_output():
-            return _run_tool_in_sandbox.remote(tool_name, tool_input)
-
+        fn = _get_modal_run_tool()
+        return fn.remote(tool_name, tool_input)
     except Exception as e:
         log.warning("Modal dispatch failed, falling back to local: %s", e)
         return _dispatch_local(tool_name, tool_input)
@@ -180,7 +189,7 @@ def dispatch_brain_tool(tool_name: str, tool_input: dict) -> str:
     Main entry point for Brain block tool execution.
     Routes to Modal sandbox in production, local subprocess in dev.
     """
-    if _modal_available:
+    if _modal_available():
         log.debug("Dispatching %s to Modal sandbox", tool_name)
         return _modal_dispatch(tool_name, tool_input)
     return _dispatch_local(tool_name, tool_input)

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -12,3 +12,4 @@ python-dotenv==1.0.1
 httpx==0.27.2
 cryptography==43.0.3
 PyJWT==2.9.0
+modal>=0.64.0

--- a/apps/api/seed_autopilot.py
+++ b/apps/api/seed_autopilot.py
@@ -1,8 +1,18 @@
 """
 Seed the Autopilot workflow — watches for GitHub issues labeled 'autopilot ready',
-implements the fix, runs tests, and opens a PR.
+implements the fix, runs tests (with inline retry), and opens a PR.
 
 Run with: docker compose exec api python seed_autopilot.py
+
+Graph: a1 → a2 → a3 → a4 → a5 → a6 → a7
+  a1: Trigger (github issue labeled)
+  a2: Fetch issue (tool block)
+  a3: Implement fix (Brain)
+  a4: Run tests + fix failures (Brain — handles retry internally, no DAG cycle)
+  a5: Logic — did tests pass?
+  a6: Push & open PR (Brain) — pass path
+  a7: Notify PR ready (output/slack)
+  a8: Notify failure (output/slack) — fail path from a5
 """
 import json
 from sqlalchemy import create_engine, text
@@ -10,6 +20,7 @@ from app.core.config import settings
 
 engine = create_engine(settings.database_url)
 
+# dev workspace only — do not run against production
 WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
 WORKFLOW_ID   = "00000000-0000-0000-0000-000000000003"
 
@@ -77,18 +88,24 @@ nodes = [
         "id": "a4", "type": "block", "position": pos(3, 0),
         "data": {
             "type": "brain",
-            "label": "Run tests",
+            "label": "Run tests & fix",
             "isAgentic": True,
             "description": (
-                "Run the test suite for the repo at /tmp/autopilot_repo.\n"
-                "1. Detect the test runner (pytest, npm test, etc.) by reading package.json or requirements.txt\n"
+                "Run the test suite for the repo at /tmp/autopilot_repo. "
+                "If tests fail, fix the failures and re-run. Repeat up to 3 times.\n\n"
+                "1. Detect the test runner (pytest, npm test, etc.) by reading "
+                "package.json or requirements.txt\n"
                 "2. Run the tests\n"
-                "3. Output: {passed: true/false, output: <test output summary>}"
+                "3. If tests fail: read the failure output, patch the code, re-run\n"
+                "4. After up to 3 fix attempts, stop regardless of outcome\n\n"
+                "Output as JSON on the final line:\n"
+                '{"passed": true/false, "attempts": <number>, '
+                '"output": "<brief summary of test results>"}'
             ),
         },
     },
     {
-        "id": "a5", "type": "block", "position": pos(2, 1),
+        "id": "a5", "type": "block", "position": pos(3, 1),
         "data": {
             "type": "logic",
             "label": "Tests pass?",
@@ -96,21 +113,7 @@ nodes = [
         },
     },
     {
-        "id": "a6", "type": "block", "position": pos(1, 2),
-        "data": {
-            "type": "brain",
-            "label": "Fix failures",
-            "isAgentic": True,
-            "description": (
-                "Tests failed. Output from test run:\n{{a4.output}}\n\n"
-                "Read the failing test output, identify the root cause, patch the code, "
-                "re-run tests. Max 3 attempts. "
-                "If still failing after 3 attempts, output {passed: false, gave_up: true}."
-            ),
-        },
-    },
-    {
-        "id": "a7", "type": "block", "position": pos(3, 1),
+        "id": "a6", "type": "block", "position": pos(4, 0),
         "data": {
             "type": "brain",
             "label": "Push & open PR",
@@ -121,25 +124,44 @@ nodes = [
                 "Branch: autopilot/issue-{{a2.issue_number}}\n"
                 "Base: {{a1.github_issue.default_branch}}\n\n"
                 "1. cd /tmp/autopilot_repo\n"
-                "2. git push origin autopilot/issue-{{a2.issue_number}}\n"
-                "   (Use the GitHub token from credentials — set it via: "
-                "git remote set-url origin https://<token>@github.com/{{a1.github_issue.repo_full_name}}.git)\n"
-                "3. Use the GitHub API to open a pull request:\n"
+                "2. Set the remote with credentials:\n"
+                "   git remote set-url origin "
+                "https://<github_token>@github.com/{{a1.github_issue.repo_full_name}}.git\n"
+                "   (retrieve the GitHub token from the Delegator credentials vault)\n"
+                "3. git push origin autopilot/issue-{{a2.issue_number}}\n"
+                "4. Open a PR via the GitHub API:\n"
                 "   POST https://api.github.com/repos/{{a1.github_issue.repo_full_name}}/pulls\n"
-                "   {title: 'fix: {{a2.title}} (closes #{{a2.issue_number}})', "
-                "head: 'autopilot/issue-{{a2.issue_number}}', "
-                "base: '{{a1.github_issue.default_branch}}', "
-                "body: 'Automated fix by Delegator.\n\nCloses #{{a2.issue_number}}'}\n"
-                "4. Output the PR URL"
+                '   {"title": "fix: {{a2.title}} (closes #{{a2.issue_number}})", '
+                '"head": "autopilot/issue-{{a2.issue_number}}", '
+                '"base": "{{a1.github_issue.default_branch}}", '
+                '"body": "Automated fix by Delegator.\\n\\nCloses #{{a2.issue_number}}"}\n\n'
+                "Output ONLY the following JSON on the last line of your response:\n"
+                '{"pr_url": "<full PR URL>"}'
             ),
         },
     },
     {
-        "id": "a8", "type": "block", "position": pos(3, 2),
+        "id": "a7", "type": "block", "position": pos(4, 1),
         "data": {
             "type": "output",
             "label": "Notify PR ready",
-            "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a7.pr_url}}",
+            "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a6.pr_url}}",
+            "integration": "slack",
+            "config": {
+                "integration": "slack",
+                "channel": "#engineering",
+            },
+        },
+    },
+    {
+        "id": "a8", "type": "block", "position": pos(2, 2),
+        "data": {
+            "type": "output",
+            "label": "Notify failure",
+            "description": (
+                "Tests failed after {{a4.attempts}} attempt(s) for issue "
+                "#{{a2.issue_number}}: {{a2.title}}. Manual review needed."
+            ),
             "integration": "slack",
             "config": {
                 "integration": "slack",
@@ -154,10 +176,9 @@ edges = [
     {"id": "e2-3", "source": "a2", "target": "a3"},
     {"id": "e3-4", "source": "a3", "target": "a4"},
     {"id": "e4-5", "source": "a4", "target": "a5"},
-    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "fail"},
-    {"id": "e6-4", "source": "a6", "target": "a4"},
-    {"id": "e5-7", "source": "a5", "target": "a7", "sourceHandle": "pass"},
-    {"id": "e7-8", "source": "a7", "target": "a8"},
+    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "pass"},
+    {"id": "e6-7", "source": "a6", "target": "a7"},
+    {"id": "e5-8", "source": "a5", "target": "a8", "sourceHandle": "fail"},
 ]
 
 graph = {"nodes": nodes, "edges": edges}

--- a/apps/api/seed_autopilot.py
+++ b/apps/api/seed_autopilot.py
@@ -1,0 +1,187 @@
+"""
+Seed the Autopilot workflow — watches for GitHub issues labeled 'autopilot ready',
+implements the fix, runs tests, and opens a PR.
+
+Run with: docker compose exec api python seed_autopilot.py
+"""
+import json
+from sqlalchemy import create_engine, text
+from app.core.config import settings
+
+engine = create_engine(settings.database_url)
+
+WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+WORKFLOW_ID   = "00000000-0000-0000-0000-000000000003"
+
+
+def pos(col, row):
+    return {"x": 80 + col * 260, "y": 80 + row * 180}
+
+
+nodes = [
+    {
+        "id": "a1", "type": "block", "position": pos(0, 0),
+        "data": {
+            "type": "trigger",
+            "label": "Issue labeled",
+            "description": "GitHub issue labeled 'autopilot ready'",
+            "integration": "github",
+            "config": {
+                "event_type": "github_issue",
+                "label": "autopilot ready",
+            },
+        },
+    },
+    {
+        "id": "a2", "type": "block", "position": pos(1, 0),
+        "data": {
+            "type": "tool",
+            "label": "Fetch issue",
+            "description": "Get full issue title, body, and metadata",
+            "integration": "github",
+            "config": {
+                "action": "fetch_issue",
+                "params": {
+                    "owner": "{{a1.github_issue.repo_owner}}",
+                    "repo": "{{a1.github_issue.repo_name}}",
+                    "issue_number": "{{a1.github_issue.issue_number}}",
+                },
+            },
+        },
+    },
+    {
+        "id": "a3", "type": "block", "position": pos(2, 0),
+        "data": {
+            "type": "brain",
+            "label": "Implement fix",
+            "isAgentic": True,
+            "description": (
+                "You are an expert software engineer. "
+                "A GitHub issue has been labeled 'autopilot ready'.\n\n"
+                "Issue title: {{a2.title}}\n"
+                "Issue body: {{a2.body}}\n"
+                "Repo: {{a1.github_issue.repo_full_name}}\n"
+                "Clone URL: {{a1.github_issue.clone_url}}\n\n"
+                "Steps:\n"
+                "1. Clone the repo: git clone <clone_url> /tmp/autopilot_repo\n"
+                "2. Create a branch: git checkout -b autopilot/issue-{{a2.issue_number}}\n"
+                "3. Read relevant files to understand the codebase\n"
+                "4. Implement the fix described in the issue\n"
+                "5. Stage changes: git add -A\n"
+                "6. Commit: git commit -m 'fix: <short description> (closes #{{a2.issue_number}})'\n"
+                "7. Output the branch name and a brief summary of what you changed"
+            ),
+        },
+    },
+    {
+        "id": "a4", "type": "block", "position": pos(3, 0),
+        "data": {
+            "type": "brain",
+            "label": "Run tests",
+            "isAgentic": True,
+            "description": (
+                "Run the test suite for the repo at /tmp/autopilot_repo.\n"
+                "1. Detect the test runner (pytest, npm test, etc.) by reading package.json or requirements.txt\n"
+                "2. Run the tests\n"
+                "3. Output: {passed: true/false, output: <test output summary>}"
+            ),
+        },
+    },
+    {
+        "id": "a5", "type": "block", "position": pos(2, 1),
+        "data": {
+            "type": "logic",
+            "label": "Tests pass?",
+            "description": "Branch on whether tests passed. Check a4.passed == true",
+        },
+    },
+    {
+        "id": "a6", "type": "block", "position": pos(1, 2),
+        "data": {
+            "type": "brain",
+            "label": "Fix failures",
+            "isAgentic": True,
+            "description": (
+                "Tests failed. Output from test run:\n{{a4.output}}\n\n"
+                "Read the failing test output, identify the root cause, patch the code, "
+                "re-run tests. Max 3 attempts. "
+                "If still failing after 3 attempts, output {passed: false, gave_up: true}."
+            ),
+        },
+    },
+    {
+        "id": "a7", "type": "block", "position": pos(3, 1),
+        "data": {
+            "type": "brain",
+            "label": "Push & open PR",
+            "isAgentic": True,
+            "description": (
+                "Push the branch and open a pull request.\n"
+                "Repo: {{a1.github_issue.repo_full_name}}\n"
+                "Branch: autopilot/issue-{{a2.issue_number}}\n"
+                "Base: {{a1.github_issue.default_branch}}\n\n"
+                "1. cd /tmp/autopilot_repo\n"
+                "2. git push origin autopilot/issue-{{a2.issue_number}}\n"
+                "   (Use the GitHub token from credentials — set it via: "
+                "git remote set-url origin https://<token>@github.com/{{a1.github_issue.repo_full_name}}.git)\n"
+                "3. Use the GitHub API to open a pull request:\n"
+                "   POST https://api.github.com/repos/{{a1.github_issue.repo_full_name}}/pulls\n"
+                "   {title: 'fix: {{a2.title}} (closes #{{a2.issue_number}})', "
+                "head: 'autopilot/issue-{{a2.issue_number}}', "
+                "base: '{{a1.github_issue.default_branch}}', "
+                "body: 'Automated fix by Delegator.\n\nCloses #{{a2.issue_number}}'}\n"
+                "4. Output the PR URL"
+            ),
+        },
+    },
+    {
+        "id": "a8", "type": "block", "position": pos(3, 2),
+        "data": {
+            "type": "output",
+            "label": "Notify PR ready",
+            "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a7.pr_url}}",
+            "integration": "slack",
+            "config": {
+                "integration": "slack",
+                "channel": "#engineering",
+            },
+        },
+    },
+]
+
+edges = [
+    {"id": "e1-2", "source": "a1", "target": "a2"},
+    {"id": "e2-3", "source": "a2", "target": "a3"},
+    {"id": "e3-4", "source": "a3", "target": "a4"},
+    {"id": "e4-5", "source": "a4", "target": "a5"},
+    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "fail"},
+    {"id": "e6-4", "source": "a6", "target": "a4"},
+    {"id": "e5-7", "source": "a5", "target": "a7", "sourceHandle": "pass"},
+    {"id": "e7-8", "source": "a7", "target": "a8"},
+]
+
+graph = {"nodes": nodes, "edges": edges}
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT id FROM workflows WHERE name = 'Autopilot — GitHub Issues' LIMIT 1"))
+    if result.fetchone():
+        print("Already seeded — skipping.")
+    else:
+        conn.execute(text("""
+            INSERT INTO workflows (id, workspace_id, name, default_mode)
+            VALUES (:wf_id, :ws_id, 'Autopilot — GitHub Issues', 'dag')
+        """), {"wf_id": WORKFLOW_ID, "ws_id": WORKSPACE_ID})
+
+        version_id = conn.execute(text("""
+            INSERT INTO workflow_versions (workflow_id, graph)
+            VALUES (:wf_id, cast(:graph as jsonb))
+            RETURNING id
+        """), {"wf_id": WORKFLOW_ID, "graph": json.dumps(graph)}).fetchone()[0]
+
+        conn.execute(text("""
+            UPDATE workflows SET current_version_id = :vid WHERE id = :wf_id
+        """), {"vid": str(version_id), "wf_id": WORKFLOW_ID})
+
+        conn.commit()
+        print(f"Seeded 'Autopilot — GitHub Issues' — {len(nodes)} blocks, {len(edges)} edges.")
+        print(f"Workflow ID: {WORKFLOW_ID}")

--- a/apps/web/DESIGN_SYSTEM.md
+++ b/apps/web/DESIGN_SYSTEM.md
@@ -1,0 +1,264 @@
+# Delegator Design System
+
+A minimal, developer-focused design language. Stone neutrals as the base, indigo as the accent, semantic color per block type. Every decision optimises for clarity and trust — engineers need to read this UI like they read code: precise, scannable, no ambiguity.
+
+---
+
+## Foundations
+
+### Color Palette
+
+#### Base (all pages)
+| Token | Tailwind | Hex | Usage |
+|-------|----------|-----|-------|
+| Background | `bg-stone-50` | `#FAFAF9` | Page background |
+| Surface | `bg-white` | `#FFFFFF` | Cards, panels, canvas |
+| Border | `border-stone-200` | `#E7E5E4` | Cards, dividers |
+| Border strong | `border-stone-300` | `#D6D3D1` | Hover states |
+| Text primary | `text-stone-900` | `#1C1917` | Headings, labels |
+| Text secondary | `text-stone-500` | `#78716C` | Descriptions, meta |
+| Text muted | `text-stone-400` | `#A8A29E` | Timestamps, counts |
+
+#### Accent (interactions, selection)
+| Token | Tailwind | Hex | Usage |
+|-------|----------|-----|-------|
+| Accent | `text-indigo-700` | `#4338CA` | Link hover, selected node ring |
+| Accent ring | `ring-indigo-400` | `#818CF8` | Selected canvas node |
+| Accent edge | stroke `#6366F1` | `#6366F1` | Selected React Flow edge |
+
+#### Primary CTA
+| State | Tailwind | Notes |
+|-------|----------|-------|
+| Default | `bg-stone-900 text-white` | Near-black, not pure black |
+| Hover | `hover:bg-stone-700` | Lightens on hover |
+| Disabled | `opacity-50 cursor-not-allowed` | |
+
+#### Status colors (semantic only — never decorative)
+| Status | Color | Tailwind |
+|--------|-------|----------|
+| Success | Emerald | `text-emerald-600 bg-emerald-50` |
+| Warning | Amber | `text-amber-600 bg-amber-50` |
+| Error | Red | `text-red-600 bg-red-50` |
+| Info | Blue | `text-blue-600 bg-blue-50` |
+
+---
+
+### Block Type Colors
+
+Each block type has a fixed semantic color. Never reuse these colors for non-block UI.
+
+| Block | Background | Border | Label text |
+|-------|-----------|--------|-----------|
+| TRIGGER | `bg-blue-50` | `border-blue-200` | `text-blue-700` |
+| BRAIN | `bg-purple-50` | `border-purple-300` | `text-purple-700` |
+| TOOL | `bg-green-50` | `border-green-200` | `text-green-700` |
+| LOGIC | `bg-gray-50` | `border-gray-200` | `text-gray-600` |
+| MEMORY | `bg-amber-50` | `border-amber-200` | `text-amber-700` |
+| APPROVAL | `bg-orange-50` | `border-orange-200` | `text-orange-700` |
+| OUTPUT | `bg-rose-50` | `border-rose-200` | `text-rose-700` |
+| CLEANUP | `bg-yellow-50` | `border-yellow-200` | `text-yellow-700` |
+
+Source of truth: `apps/web/src/lib/block-types.ts` → `BLOCK_STYLES`
+
+---
+
+### Typography
+
+| Role | Font | Size | Weight | Color |
+|------|------|------|--------|-------|
+| Page heading | Inter | `text-xl` (20px) | `font-semibold` | `text-stone-900` |
+| Section heading | Inter | `text-base` (16px) | `font-medium` | `text-stone-900` |
+| Body | Inter | `text-sm` (14px) | `font-normal` | `text-stone-700` |
+| Label / meta | Inter | `text-xs` (12px) | `font-normal` | `text-stone-400/500` |
+| Block type badge | Inter | `text-[8px]` | `font-bold` | block type color |
+| Monospace (code, commands) | JetBrains Mono | `text-xs` | `font-normal` | `text-stone-600` |
+| Eyebrow | Inter | `text-[10px]` | `font-bold uppercase tracking-widest` | `text-stone-400` |
+
+---
+
+### Spacing & Layout
+
+| Pattern | Value |
+|---------|-------|
+| Page max width | `max-w-3xl` (48rem) for content pages |
+| Page padding | `px-6 py-10` |
+| Card padding | `px-5 py-4` |
+| Gap between cards | `gap-2` (list) / `gap-4` (grid) |
+| Header height | `py-4` + border-b |
+| Section gap | `mb-6` |
+
+---
+
+### Border Radius
+
+| Element | Value |
+|---------|-------|
+| Cards, panels | `rounded-xl` (12px) |
+| Buttons | `rounded-lg` (8px) |
+| Badges / chips | `rounded` (4px) |
+| Canvas nodes | `rounded-xl` (12px) |
+| Input fields | `rounded-lg` (8px) |
+| Canvas handles | circular (`rounded-full` implied) |
+
+---
+
+## Components
+
+### Header (global)
+```
+bg-white border-b border-stone-200 px-6 py-4
+Left:  font-semibold text-stone-900  →  "Delegator"
+Right: nav links (text-sm text-stone-500) + CTA button + AuthButton
+```
+
+### CTA Button (primary)
+```
+bg-stone-900 text-white rounded-lg px-4 py-2 text-sm font-medium
+hover: bg-stone-700
+```
+
+### Ghost / Secondary Button
+```
+border border-stone-200 text-stone-700 rounded-lg px-4 py-2 text-sm font-medium
+hover: bg-stone-50
+```
+
+### List Card (workflow / run list items)
+```
+rounded-xl border border-stone-200 bg-white px-5 py-4
+hover: border-stone-300 shadow-sm
+group-hover on title: text-indigo-700
+Right side: muted meta text + "→" arrow
+```
+
+### Empty State
+```
+rounded-xl border border-dashed border-stone-300 p-16 text-center
+Message: text-stone-500 text-sm
+CTA: primary button below message
+```
+
+### Canvas Node (BlockNode)
+```
+width: 200px fixed
+rounded-xl border-2 px-3 py-2.5
+Default:  block type bg + border (see BLOCK_STYLES)
+Selected: ring-2 ring-indigo-400 ring-offset-2 shadow-md
+Hover:    hover:shadow-md hover:ring-1 hover:ring-stone-300
+
+Block type badge: text-[8px] font-bold uppercase tracking-widest px-1.5 py-0.5 rounded
+Block label:      text-xs font-semibold text-stone-800 leading-tight truncate
+Integration badge: colored pill (see INTEGRATION_COLORS in BlockNode.tsx)
+Action label:     text-[9px] text-stone-400 truncate
+```
+
+### Canvas Handles
+```
+!w-2.5 !h-2.5 !border-2 !border-white !shadow-sm
+hover: !scale-125
+Pass handle: !bg-green-400
+Fail handle: !bg-red-400
+Default:     !bg-stone-400
+```
+
+### Status Badge (run status)
+```
+pending:   bg-stone-100   text-stone-600
+running:   bg-blue-50     text-blue-700    (+ animate-pulse)
+paused:    bg-orange-50   text-orange-700
+succeeded: bg-emerald-50  text-emerald-700
+failed:    bg-red-50      text-red-700
+```
+
+### Form Fields (block editor)
+```
+Input:    w-full rounded-lg border border-stone-200 px-3 py-2 text-sm
+          focus: outline-none ring-2 ring-indigo-200 border-indigo-300
+Textarea: same + resize-none
+Select:   same styling as input
+Label:    text-xs font-medium text-stone-600 mb-1
+```
+
+### Integration Color Badges (on canvas nodes)
+```
+github:       bg-stone-800 text-white
+slack:        bg-purple-600 text-white
+linear:       bg-indigo-600 text-white
+vercel:       bg-stone-700 text-white
+railway:      bg-violet-600 text-white
+digitalocean: bg-blue-500 text-white
+email:        bg-emerald-600 text-white
+```
+
+---
+
+## Page Patterns
+
+### Canvas Page layout
+```
+Header (fixed top): workflow name + Draft badge + Dry Run + Run buttons
+Left sidebar (w-56): block library drag tiles
+Main area: React Flow canvas (bg-stone-50 dotted grid)
+Bottom panel (h-64): block editor for selected node
+```
+
+### Settings Page layout
+```
+Header + page title "Connect your tools"
+Integration cards grid (2 col): colored badge + name + description + Connected dot
+Inline expand on click — no modals
+Footer CTA: "Create your first agent →" (disabled until 1 credential)
+```
+
+### Run Trace layout
+```
+Header: workflow name + run status badge + back link
+Timeline: left-aligned event list, newest at bottom
+Each event: block type indicator + block name + duration + output summary
+Approval event: inline Approve / Reject buttons
+```
+
+---
+
+## React Flow Canvas Specifics
+
+```css
+/* edges */
+.react-flow__edge-path {
+  stroke: #D1D5DB;      /* stone-300 */
+  stroke-width: 1.5;
+}
+.react-flow__edge.selected .react-flow__edge-path {
+  stroke: #6366F1;      /* indigo-500 */
+}
+
+/* background grid */
+.react-flow__background {
+  background-color: #FAFAF9;   /* stone-50 */
+}
+```
+
+---
+
+## What NOT to do
+
+- Do not use `bg-gray-*` for page backgrounds — use `bg-stone-*`
+- Do not use pure black (`#000`) — use `stone-900`
+- Do not use block type colors outside of block nodes / sidebar tiles
+- Do not add new accent colors — indigo is the only accent
+- Do not use modals for inline actions that can expand in place (settings credentials)
+- Do not truncate labels on canvas nodes with ellipsis beyond the node width — the 200px width is fixed for a reason
+- Do not use `font-bold` for body text — `font-medium` or `font-semibold` max outside badges
+
+---
+
+## File Locations
+
+| Asset | Path |
+|-------|------|
+| Block colors + types | `apps/web/src/lib/block-types.ts` |
+| Tailwind config + color tokens | `apps/web/tailwind.config.ts` |
+| Global CSS + React Flow overrides | `apps/web/src/app/globals.css` |
+| Canvas node component | `apps/web/src/components/canvas/BlockNode.tsx` |
+| Block editor panel | `apps/web/src/components/canvas/BlockEditor.tsx` |
+| Integration color badges | `apps/web/src/components/canvas/BlockNode.tsx` → `INTEGRATION_COLORS` |

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -133,6 +133,11 @@ const TYPE_BADGE: Record<string, string> = {
 
 // ── Block row component ───────────────────────────────────────────────────────
 
+interface FileChanged {
+  path: string
+  action: "created" | "modified" | "deleted"
+}
+
 interface BlockRow {
   blockId: string
   label: string
@@ -142,13 +147,26 @@ interface BlockRow {
   completedAt?: string
   output?: Record<string, unknown>
   error?: string
+  costUsd?: number
+  inputTokens?: number
+  outputTokens?: number
+  filesChanged?: FileChanged[]
+  diffStat?: string
+}
+
+const FILE_ACTION_COLOR: Record<string, string> = {
+  created:  "text-emerald-600",
+  modified: "text-blue-600",
+  deleted:  "text-red-500",
 }
 
 function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
   const [expanded, setExpanded] = useState(row.status === "failed")
+  const [diffExpanded, setDiffExpanded] = useState(false)
   const dur = duration(row.startedAt, row.completedAt)
   const summary = row.output ? summariseOutput(row.output, row.type) : null
   const isSkipped = row.output?.skipped === true
+  const prUrl = row.output?.pr_url as string | undefined
 
   const dot =
     row.status === "completed" && !isSkipped ? "bg-green-400" :
@@ -165,20 +183,19 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
       <div className={`pb-3 ${row.status === "failed" ? "rounded-lg bg-red-50 border border-red-100 px-3 py-2.5 -ml-1 mb-1" : ""}`}>
         {/* Header row */}
         <div className="flex items-center gap-2 flex-wrap">
-          {/* Block label */}
           <span className={`text-sm font-semibold ${row.status === "failed" ? "text-red-800" : isSkipped ? "text-stone-400" : "text-stone-800"}`}>
             {row.label}
           </span>
-
-          {/* Block type badge */}
           <span className={`text-[9px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded ${TYPE_BADGE[row.type] ?? "bg-stone-100 text-stone-500"}`}>
             {row.type}
           </span>
-
-          {/* Duration */}
-          {dur && (
-            <span className="text-xs text-stone-400 ml-auto">{dur}</span>
+          {/* Cost badge for Brain blocks */}
+          {row.type === "brain" && row.costUsd !== undefined && row.costUsd > 0 && (
+            <span className="text-[9px] text-stone-400 font-mono bg-stone-50 border border-stone-200 px-1.5 py-0.5 rounded ml-1">
+              {row.inputTokens?.toLocaleString()} tok · ${row.costUsd.toFixed(4)}
+            </span>
           )}
+          {dur && <span className="text-xs text-stone-400 ml-auto">{dur}</span>}
           {row.status === "running" && (
             <span className="text-xs text-blue-500 animate-pulse ml-auto">running…</span>
           )}
@@ -196,12 +213,44 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
           </p>
         )}
 
+        {/* PR link — prominent */}
+        {prUrl && (
+          <a href={prUrl} target="_blank" rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 mt-1.5 text-xs font-medium text-indigo-600 hover:text-indigo-800 hover:underline">
+            View PR →
+          </a>
+        )}
+
+        {/* Files changed (Brain block) */}
+        {row.filesChanged && row.filesChanged.length > 0 && (
+          <div className="mt-2 space-y-0.5">
+            <p className="text-[9px] font-bold uppercase tracking-widest text-stone-400 mb-1">Files changed</p>
+            {row.filesChanged.map((f, i) => (
+              <div key={i} className="flex items-center gap-1.5">
+                <span className={`text-[9px] font-bold uppercase w-12 shrink-0 ${FILE_ACTION_COLOR[f.action]}`}>{f.action}</span>
+                <span className="text-[10px] font-mono text-stone-600 truncate">{f.path}</span>
+              </div>
+            ))}
+            {row.diffStat && (
+              <>
+                <button onClick={() => setDiffExpanded(d => !d)}
+                  className="mt-1 text-[10px] text-stone-400 hover:text-stone-600">
+                  {diffExpanded ? "▾ hide diff stat" : "▸ diff stat"}
+                </button>
+                {diffExpanded && (
+                  <pre className="mt-1 text-[10px] font-mono text-stone-500 bg-stone-50 border border-stone-200 rounded p-2 overflow-x-auto whitespace-pre">
+                    {row.diffStat}
+                  </pre>
+                )}
+              </>
+            )}
+          </div>
+        )}
+
         {/* Expand/collapse raw output */}
         {row.output && !isSkipped && row.status === "completed" && (
-          <button
-            onClick={() => setExpanded(e => !e)}
-            className="mt-1 text-[10px] text-stone-400 hover:text-stone-600"
-          >
+          <button onClick={() => setExpanded(e => !e)}
+            className="mt-1 text-[10px] text-stone-400 hover:text-stone-600">
             {expanded ? "▾ hide output" : "▸ raw output"}
           </button>
         )}
@@ -295,9 +344,17 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       blockMap[ev.block_id] = row
       blockRows.push(row)
     } else if (ev.kind === "block_completed" && blockMap[ev.block_id]) {
+      const out = ev.payload.output as Record<string, unknown> | undefined
       blockMap[ev.block_id].status = "completed"
       blockMap[ev.block_id].completedAt = ev.created_at
-      blockMap[ev.block_id].output = ev.payload.output as Record<string, unknown>
+      blockMap[ev.block_id].output = out
+      if (out) {
+        if (typeof out.cost_usd === "number") blockMap[ev.block_id].costUsd = out.cost_usd
+        if (typeof out.input_tokens === "number") blockMap[ev.block_id].inputTokens = out.input_tokens
+        if (typeof out.output_tokens === "number") blockMap[ev.block_id].outputTokens = out.output_tokens
+        if (Array.isArray(out.files_changed)) blockMap[ev.block_id].filesChanged = out.files_changed as FileChanged[]
+        if (typeof out.diff_stat === "string") blockMap[ev.block_id].diffStat = out.diff_stat
+      }
     } else if (ev.kind === "block_failed" && blockMap[ev.block_id]) {
       blockMap[ev.block_id].status = "failed"
       blockMap[ev.block_id].completedAt = ev.created_at

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -354,6 +354,17 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         if (typeof out.output_tokens === "number") blockMap[ev.block_id].outputTokens = out.output_tokens
         if (Array.isArray(out.files_changed)) blockMap[ev.block_id].filesChanged = out.files_changed as FileChanged[]
         if (typeof out.diff_stat === "string") blockMap[ev.block_id].diffStat = out.diff_stat
+        // Brain blocks output pr_url as JSON on the last line of their text output.
+        // Try to parse it from out.output so the "View PR →" link works.
+        if (typeof out.output === "string" && !out.pr_url) {
+          const lastLine = out.output.trim().split("\n").pop() ?? ""
+          try {
+            const parsed = JSON.parse(lastLine)
+            if (typeof parsed?.pr_url === "string") {
+              blockMap[ev.block_id].output = { ...out, pr_url: parsed.pr_url }
+            }
+          } catch { /* not JSON, ignore */ }
+        }
       }
     } else if (ev.kind === "block_failed" && blockMap[ev.block_id]) {
       blockMap[ev.block_id].status = "failed"


### PR DESCRIPTION
## What this PR does

Addresses all four Week 1-2 trust & safety issues.

## Issues closed

- Closes sseshachala/conduct-internal#40 — Brain block sandbox isolation
- Closes sseshachala/conductai#2 — Workspace scoping from Clerk JWT  
- Closes sseshachala/conductai#3 — Token count + cost tracking per Brain block
- Closes sseshachala/conductai#4 — Files changed + PR link in run trace

## Changes

### Issue sseshachala/conduct-internal#40 — Sandbox isolation
- New `apps/api/app/runtime/sandbox.py` — `dispatch_brain_tool()` routes Brain tools to Modal ephemeral container when `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` are set
- Falls back to local subprocess when env vars not set (no dev disruption)
- 120s hard timeout on sandbox containers
- `_dispatch_tool()` in `executor.py` now delegates to sandbox module

### Issue sseshachala/conductai#2 — Workspace scoping
- All routers (`workflows.py`, `credentials.py`) now use `Depends(get_workspace_id)` — no more hardcoded UUID
- `get_workspace_id()` in `auth.py` extracts `org_id` from Clerk JWT; falls back to dev workspace when Clerk is not fully configured (both `CLERK_SECRET_KEY` and `CLERK_FRONTEND_API` must be set)
- Dev mode works unchanged

### Issue sseshachala/conductai#3 — Cost tracking
- `_execute_brain()` accumulates `input_tokens` + `output_tokens` across all turns
- Returns `cost_usd` calculated at Sonnet 4.6 pricing ($3/$15 per 1M tokens)
- Included in `block_completed` RunEvent payload

### Issue sseshachala/conductai#4 — Evidence in trace
- `_extract_git_evidence()` runs `git diff --stat HEAD` after Brain loop to extract files changed
- `RunTrace.tsx`: Brain block rows show cost badge, files changed list (created/modified/deleted), collapsible diff stat, prominent "View PR →" link

## Other
- `DESIGN_SYSTEM.md` added to `apps/web/` — codifies current design tokens, components, and rules
- `ROADMAP.md` added at repo root — focused product roadmap
- Autopilot seed script and GitHub webhook endpoint included in commit

## Test plan
- [ ] Local dev: `docker compose restart api worker` — credentials endpoint returns 200 without auth header (Clerk fallback working)
- [ ] Brain block run: `block_completed` event payload contains `cost_usd`, `input_tokens`, `output_tokens`
- [ ] Run trace: Brain block row shows token/cost badge
- [ ] After a run that clones a repo: `files_changed` array populated in trace
- [ ] Production: set `MODAL_TOKEN_ID` + `MODAL_TOKEN_SECRET` in Railway env vars to enable sandbox