### PR TITLE
fix: address all PR #5 review issues

### DIFF
--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -1,4 +1,5 @@
 import json
+from typing import Annotated
 from uuid import UUID
 
 import redis
@@ -7,6 +8,7 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
+from app.core.auth import get_workspace_id
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.run import Run, RunEvent
@@ -22,11 +24,24 @@ def _redis():
     return redis.from_url(settings.redis_url, decode_responses=True)
 
 
-@router.get("", response_model=list[RunOut])
-def list_runs(workflow_id: UUID, db: Session = Depends(get_db)):
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+def _get_workflow(workflow_id: UUID, workspace_id: str, db: Session) -> Workflow:
+    """Fetch workflow and verify it belongs to the caller's workspace."""
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
+    return workflow
+
+
+@router.get("", response_model=list[RunOut])
+def list_runs(
+    workflow_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    workflow = _get_workflow(workflow_id, workspace_id, db)
     return (
         db.query(Run)
         .filter(Run.workflow_version_id == workflow.current_version_id)
@@ -36,10 +51,13 @@ def list_runs(workflow_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.post("", response_model=RunOut, status_code=201)
-def create_run(workflow_id: UUID, body: RunCreate, db: Session = Depends(get_db)):
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
-    if not workflow:
-        raise HTTPException(status_code=404, detail="Workflow not found")
+def create_run(
+    workflow_id: UUID,
+    body: RunCreate,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    workflow = _get_workflow(workflow_id, workspace_id, db)
     if not workflow.current_version_id:
         raise HTTPException(status_code=400, detail="Workflow has no published version")
 
@@ -60,7 +78,14 @@ def create_run(workflow_id: UUID, body: RunCreate, db: Session = Depends(get_db)
 
 
 @router.get("/{run_id}", response_model=RunDetailOut)
-def get_run(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
+def get_run(
+    workflow_id: UUID,
+    run_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    # Verify the workflow belongs to this workspace before exposing run data.
+    _get_workflow(workflow_id, workspace_id, db)
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -68,8 +93,14 @@ def get_run(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
 
 
 @router.get("/{run_id}/stream")
-def stream_run_events(workflow_id: UUID, run_id: UUID, db: Session = Depends(get_db)):
+def stream_run_events(
+    workflow_id: UUID,
+    run_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
     """SSE stream of run_events as they are written by the executor."""
+    _get_workflow(workflow_id, workspace_id, db)
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
         raise HTTPException(status_code=404, detail="Run not found")
@@ -131,6 +162,7 @@ def approve_run(
     run_id: UUID,
     body: ApprovalDecision,
     db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
 ):
     """
     Called by the human approver (or Slack webhook) to resume a paused run.
@@ -138,6 +170,8 @@ def approve_run(
     """
     if body.decision not in ("approved", "rejected"):
         raise HTTPException(status_code=422, detail="decision must be 'approved' or 'rejected'")
+
+    _get_workflow(workflow_id, workspace_id, db)
 
     run = db.query(Run).filter(Run.id == run_id).first()
     if not run:
@@ -149,7 +183,6 @@ def approve_run(
     if not block_id:
         raise HTTPException(status_code=400, detail="No approval block recorded on paused run")
 
-    # Record decision into state so executor can resume past the approval block
     state = dict(run.state or {})
     state[f"__approval_{block_id}"] = body.decision
     if body.approver:
@@ -159,7 +192,6 @@ def approve_run(
     run.paused_at = None
     db.commit()
 
-    # Emit event
     event = RunEvent(
         run_id=run_id,
         block_id=block_id,
@@ -169,7 +201,6 @@ def approve_run(
     db.add(event)
     db.commit()
 
-    # Re-queue for the worker
     _redis().rpush(QUEUE_KEY, str(run_id))
 
     return {"run_id": str(run_id), "decision": body.decision, "status": "queued"}

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -271,17 +271,24 @@ def _verify_github_signature(body: bytes, signature: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-def _trigger_github_workflows(db: Session, event_type: str, label_filter: str, initial_state: dict[str, Any]) -> list[str]:
+def _trigger_github_workflows(
+    db: Session, event_type: str, label_filter: str, initial_state: dict[str, Any],
+    workspace_id: str | None = None,
+) -> list[str]:
     """
     Find workflow versions with a trigger block matching:
       - event_type == "github_issue"
       - config.label == label_filter (or label_filter is empty = match all)
+    If workspace_id is provided, only triggers workflows in that workspace.
     """
     import uuid as uuid_mod
 
-    versions = db.query(WorkflowVersion).join(
+    query = db.query(WorkflowVersion).join(
         Workflow, Workflow.current_version_id == WorkflowVersion.id
-    ).all()
+    )
+    if workspace_id:
+        query = query.filter(Workflow.workspace_id == workspace_id)
+    versions = query.all()
 
     queued: list[str] = []
     for version in versions:
@@ -315,11 +322,18 @@ def _trigger_github_workflows(db: Session, event_type: str, label_filter: str, i
 
 
 @router.post("/github")
-async def github_webhook(request: Request, db: Session = Depends(get_db)):
+async def github_webhook(
+    request: Request,
+    db: Session = Depends(get_db),
+    workspace_id: str | None = None,
+):
     """
     Receive GitHub webhook events.
     Configure in GitHub → repo → Settings → Webhooks.
     Listens for: issues (labeled), push, pull_request (opened, merged).
+
+    Pass ?workspace_id=<uuid> in the webhook URL to scope triggers to a single
+    workspace (required in multi-tenant deployments).
     """
     body = await request.body()
 
@@ -359,5 +373,5 @@ async def github_webhook(request: Request, db: Session = Depends(get_db)):
         }
     }
 
-    queued = _trigger_github_workflows(db, "github_issue", label, initial_state)
+    queued = _trigger_github_workflows(db, "github_issue", label, initial_state, workspace_id)
     return {"ok": True, "queued": len(queued), "run_ids": queued, "label": label}

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -260,20 +260,6 @@ def _dispatch_tool(tool_name: str, tool_input: dict) -> str:
     return dispatch_brain_tool(tool_name, tool_input)
 
 
-def _dispatch_tool_legacy(tool_name: str, tool_input: dict) -> str:
-    if tool_name == "read_file":
-        return _tool_read_file(tool_input["path"])
-    if tool_name == "write_file":
-        return _tool_write_file(tool_input["path"], tool_input["content"])
-    if tool_name == "run_shell":
-        return _tool_run_shell(tool_input["command"], tool_input.get("working_dir"))
-    if tool_name == "search_code":
-        return _tool_search_code(
-            tool_input["pattern"],
-            tool_input.get("path", "."),
-            tool_input.get("file_glob", "*"),
-        )
-    return f"Unknown tool: {tool_name}"
 
 
 # ── block executors ───────────────────────────────────────────────────────────
@@ -358,6 +344,7 @@ def _execute_brain(block: dict, state: dict, compiled_artifacts: dict) -> dict:
             final_text = " ".join(b.text for b in text_blocks)
 
             if response.stop_reason == "end_turn" or not tool_calls:
+                # Sonnet 4.6 pricing: $3/1M input, $15/1M output — update if model changes
                 cost_usd = round((total_input_tokens * 3 + total_output_tokens * 15) / 1_000_000, 6)
                 files_changed, diff_stat = _extract_git_evidence(working_dir)
                 return {

--- a/apps/api/app/runtime/sandbox.py
+++ b/apps/api/app/runtime/sandbox.py
@@ -15,6 +15,7 @@ import subprocess
 
 log = logging.getLogger(__name__)
 
+# Shared across local and Modal execution paths — single source of truth.
 _FORBIDDEN_SHELL_PATTERNS = [
     r"rm\s+-rf\s+/",
     r"rm\s+-fr\s+/",
@@ -26,7 +27,11 @@ _FORBIDDEN_SHELL_PATTERNS = [
     r"chown.*root",
 ]
 
-_modal_available = bool(os.environ.get("MODAL_TOKEN_ID") and os.environ.get("MODAL_TOKEN_SECRET"))
+
+def _modal_available() -> bool:
+    """Check at call time so .env loading order doesn't matter."""
+    from app.core.config import settings
+    return bool(settings.modal_token_id and settings.modal_token_secret)
 
 
 # ── Local fallback (dev mode) ─────────────────────────────────────────────────
@@ -80,78 +85,82 @@ def _local_search_code(pattern: str, path: str = ".", file_glob: str = "*") -> s
 
 # ── Modal sandbox (production) ────────────────────────────────────────────────
 
+# Lazy-initialised Modal function stub — defined once, reused across calls.
+_modal_run_tool = None
+
+
+def _get_modal_run_tool():
+    global _modal_run_tool
+    if _modal_run_tool is not None:
+        return _modal_run_tool
+
+    import modal  # type: ignore[import]
+
+    _app = modal.App("delegator-brain-sandbox")
+    forbidden_patterns = _FORBIDDEN_SHELL_PATTERNS  # captured at definition time
+
+    @_app.function(timeout=120, cpu=1, memory=512, retries=0)
+    def run_tool(name: str, inputs: dict) -> str:
+        import os as _os
+        import re as _re
+        import subprocess as _sp
+
+        if name == "read_file":
+            try:
+                with open(inputs["path"]) as f:
+                    c = f.read()
+                return c[:20_000] + "\n[... truncated]" if len(c) > 20_000 else c
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "write_file":
+            try:
+                _os.makedirs(_os.path.dirname(_os.path.abspath(inputs["path"])), exist_ok=True)
+                with open(inputs["path"], "w") as f:
+                    f.write(inputs["content"])
+                return f"Written {len(inputs['content'])} bytes to {inputs['path']}"
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "run_shell":
+            cmd = inputs["command"]
+            for p in forbidden_patterns:
+                if _re.search(p, cmd):
+                    return f"Refused: matches forbidden pattern '{p}'"
+            try:
+                r = _sp.run(
+                    cmd, shell=True, capture_output=True, text=True,
+                    timeout=110, cwd=inputs.get("working_dir"),
+                )
+                out = r.stdout + r.stderr
+                return (out[:10_000] + "\n[... truncated]") if len(out) > 10_000 else out or "(no output)"
+            except _sp.TimeoutExpired:
+                return "Error: timed out"
+            except Exception as e:
+                return f"Error: {e}"
+
+        if name == "search_code":
+            try:
+                r = _sp.run(
+                    ["grep", "-r", "--include", inputs.get("file_glob", "*"), "-n",
+                     inputs["pattern"], inputs.get("path", ".")],
+                    capture_output=True, text=True, timeout=15,
+                )
+                out = r.stdout
+                return (out[:8_000] + "\n[... truncated]") if len(out) > 8_000 else out or "(no matches)"
+            except Exception as e:
+                return f"Error: {e}"
+
+        return f"Unknown tool: {name}"
+
+    _modal_run_tool = run_tool
+    return _modal_run_tool
+
+
 def _modal_dispatch(tool_name: str, tool_input: dict) -> str:
-    """Dispatch a single tool call into a Modal sandbox container."""
     try:
-        import modal  # type: ignore[import]
-
-        app = modal.App.lookup("delegator-brain-sandbox", create_if_missing=True)
-
-        @app.function(
-            timeout=120,
-            cpu=1,
-            memory=512,
-            retries=0,
-        )
-        def _run_tool_in_sandbox(name: str, inputs: dict) -> str:
-            import os, re, subprocess  # noqa: F401
-
-            forbidden = [
-                r"rm\s+-rf\s+/", r"rm\s+-fr\s+/", r"mkfs", r"dd\s+if=",
-                r":\(\)\{.*\}", r">\s*/dev/sd", r"chmod\s+777\s+/", r"chown.*root",
-            ]
-
-            if name == "read_file":
-                try:
-                    with open(inputs["path"]) as f:
-                        c = f.read()
-                    return c[:20_000] + "\n[... truncated]" if len(c) > 20_000 else c
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "write_file":
-                try:
-                    os.makedirs(os.path.dirname(os.path.abspath(inputs["path"])), exist_ok=True)
-                    with open(inputs["path"], "w") as f:
-                        f.write(inputs["content"])
-                    return f"Written {len(inputs['content'])} bytes to {inputs['path']}"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "run_shell":
-                cmd = inputs["command"]
-                for p in forbidden:
-                    if re.search(p, cmd):
-                        return f"Refused: matches forbidden pattern '{p}'"
-                try:
-                    r = subprocess.run(
-                        cmd, shell=True, capture_output=True, text=True,
-                        timeout=110, cwd=inputs.get("working_dir"),
-                    )
-                    out = r.stdout + r.stderr
-                    return (out[:10_000] + "\n[... truncated]") if len(out) > 10_000 else out or "(no output)"
-                except subprocess.TimeoutExpired:
-                    return "Error: timed out"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            if name == "search_code":
-                try:
-                    r = subprocess.run(
-                        ["grep", "-r", "--include", inputs.get("file_glob", "*"), "-n",
-                         inputs["pattern"], inputs.get("path", ".")],
-                        capture_output=True, text=True, timeout=15,
-                    )
-                    out = r.stdout
-                    return (out[:8_000] + "\n[... truncated]") if len(out) > 8_000 else out or "(no matches)"
-                except Exception as e:
-                    return f"Error: {e}"
-
-            return f"Unknown tool: {name}"
-
-        with modal.enable_output():
-            return _run_tool_in_sandbox.remote(tool_name, tool_input)
-
+        fn = _get_modal_run_tool()
+        return fn.remote(tool_name, tool_input)
     except Exception as e:
         log.warning("Modal dispatch failed, falling back to local: %s", e)
         return _dispatch_local(tool_name, tool_input)
@@ -180,7 +189,7 @@ def dispatch_brain_tool(tool_name: str, tool_input: dict) -> str:
     Main entry point for Brain block tool execution.
     Routes to Modal sandbox in production, local subprocess in dev.
     """
-    if _modal_available:
+    if _modal_available():
         log.debug("Dispatching %s to Modal sandbox", tool_name)
         return _modal_dispatch(tool_name, tool_input)
     return _dispatch_local(tool_name, tool_input)

--- a/apps/api/seed_autopilot.py
+++ b/apps/api/seed_autopilot.py
@@ -1,8 +1,18 @@
 """
 Seed the Autopilot workflow — watches for GitHub issues labeled 'autopilot ready',
-implements the fix, runs tests, and opens a PR.
+implements the fix, runs tests (with inline retry), and opens a PR.
 
 Run with: docker compose exec api python seed_autopilot.py
+
+Graph: a1 → a2 → a3 → a4 → a5 → a6 → a7
+  a1: Trigger (github issue labeled)
+  a2: Fetch issue (tool block)
+  a3: Implement fix (Brain)
+  a4: Run tests + fix failures (Brain — handles retry internally, no DAG cycle)
+  a5: Logic — did tests pass?
+  a6: Push & open PR (Brain) — pass path
+  a7: Notify PR ready (output/slack)
+  a8: Notify failure (output/slack) — fail path from a5
 """
 import json
 from sqlalchemy import create_engine, text
@@ -10,6 +20,7 @@ from app.core.config import settings
 
 engine = create_engine(settings.database_url)
 
+# dev workspace only — do not run against production
 WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
 WORKFLOW_ID   = "00000000-0000-0000-0000-000000000003"
 
@@ -77,18 +88,24 @@ nodes = [
         "id": "a4", "type": "block", "position": pos(3, 0),
         "data": {
             "type": "brain",
-            "label": "Run tests",
+            "label": "Run tests & fix",
             "isAgentic": True,
             "description": (
-                "Run the test suite for the repo at /tmp/autopilot_repo.\n"
-                "1. Detect the test runner (pytest, npm test, etc.) by reading package.json or requirements.txt\n"
+                "Run the test suite for the repo at /tmp/autopilot_repo. "
+                "If tests fail, fix the failures and re-run. Repeat up to 3 times.\n\n"
+                "1. Detect the test runner (pytest, npm test, etc.) by reading "
+                "package.json or requirements.txt\n"
                 "2. Run the tests\n"
-                "3. Output: {passed: true/false, output: <test output summary>}"
+                "3. If tests fail: read the failure output, patch the code, re-run\n"
+                "4. After up to 3 fix attempts, stop regardless of outcome\n\n"
+                "Output as JSON on the final line:\n"
+                '{"passed": true/false, "attempts": <number>, '
+                '"output": "<brief summary of test results>"}'
             ),
         },
     },
     {
-        "id": "a5", "type": "block", "position": pos(2, 1),
+        "id": "a5", "type": "block", "position": pos(3, 1),
         "data": {
             "type": "logic",
             "label": "Tests pass?",
@@ -96,21 +113,7 @@ nodes = [
         },
     },
     {
-        "id": "a6", "type": "block", "position": pos(1, 2),
-        "data": {
-            "type": "brain",
-            "label": "Fix failures",
-            "isAgentic": True,
-            "description": (
-                "Tests failed. Output from test run:\n{{a4.output}}\n\n"
-                "Read the failing test output, identify the root cause, patch the code, "
-                "re-run tests. Max 3 attempts. "
-                "If still failing after 3 attempts, output {passed: false, gave_up: true}."
-            ),
-        },
-    },
-    {
-        "id": "a7", "type": "block", "position": pos(3, 1),
+        "id": "a6", "type": "block", "position": pos(4, 0),
         "data": {
             "type": "brain",
             "label": "Push & open PR",
@@ -121,25 +124,44 @@ nodes = [
                 "Branch: autopilot/issue-{{a2.issue_number}}\n"
                 "Base: {{a1.github_issue.default_branch}}\n\n"
                 "1. cd /tmp/autopilot_repo\n"
-                "2. git push origin autopilot/issue-{{a2.issue_number}}\n"
-                "   (Use the GitHub token from credentials — set it via: "
-                "git remote set-url origin https://<token>@github.com/{{a1.github_issue.repo_full_name}}.git)\n"
-                "3. Use the GitHub API to open a pull request:\n"
+                "2. Set the remote with credentials:\n"
+                "   git remote set-url origin "
+                "https://<github_token>@github.com/{{a1.github_issue.repo_full_name}}.git\n"
+                "   (retrieve the GitHub token from the Delegator credentials vault)\n"
+                "3. git push origin autopilot/issue-{{a2.issue_number}}\n"
+                "4. Open a PR via the GitHub API:\n"
                 "   POST https://api.github.com/repos/{{a1.github_issue.repo_full_name}}/pulls\n"
-                "   {title: 'fix: {{a2.title}} (closes #{{a2.issue_number}})', "
-                "head: 'autopilot/issue-{{a2.issue_number}}', "
-                "base: '{{a1.github_issue.default_branch}}', "
-                "body: 'Automated fix by Delegator.\n\nCloses #{{a2.issue_number}}'}\n"
-                "4. Output the PR URL"
+                '   {"title": "fix: {{a2.title}} (closes #{{a2.issue_number}})", '
+                '"head": "autopilot/issue-{{a2.issue_number}}", '
+                '"base": "{{a1.github_issue.default_branch}}", '
+                '"body": "Automated fix by Delegator.\\n\\nCloses #{{a2.issue_number}}"}\n\n'
+                "Output ONLY the following JSON on the last line of your response:\n"
+                '{"pr_url": "<full PR URL>"}'
             ),
         },
     },
     {
-        "id": "a8", "type": "block", "position": pos(3, 2),
+        "id": "a7", "type": "block", "position": pos(4, 1),
         "data": {
             "type": "output",
             "label": "Notify PR ready",
-            "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a7.pr_url}}",
+            "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a6.pr_url}}",
+            "integration": "slack",
+            "config": {
+                "integration": "slack",
+                "channel": "#engineering",
+            },
+        },
+    },
+    {
+        "id": "a8", "type": "block", "position": pos(2, 2),
+        "data": {
+            "type": "output",
+            "label": "Notify failure",
+            "description": (
+                "Tests failed after {{a4.attempts}} attempt(s) for issue "
+                "#{{a2.issue_number}}: {{a2.title}}. Manual review needed."
+            ),
             "integration": "slack",
             "config": {
                 "integration": "slack",
@@ -154,10 +176,9 @@ edges = [
     {"id": "e2-3", "source": "a2", "target": "a3"},
     {"id": "e3-4", "source": "a3", "target": "a4"},
     {"id": "e4-5", "source": "a4", "target": "a5"},
-    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "fail"},
-    {"id": "e6-4", "source": "a6", "target": "a4"},
-    {"id": "e5-7", "source": "a5", "target": "a7", "sourceHandle": "pass"},
-    {"id": "e7-8", "source": "a7", "target": "a8"},
+    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "pass"},
+    {"id": "e6-7", "source": "a6", "target": "a7"},
+    {"id": "e5-8", "source": "a5", "target": "a8", "sourceHandle": "fail"},
 ]
 
 graph = {"nodes": nodes, "edges": edges}

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -354,6 +354,17 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         if (typeof out.output_tokens === "number") blockMap[ev.block_id].outputTokens = out.output_tokens
         if (Array.isArray(out.files_changed)) blockMap[ev.block_id].filesChanged = out.files_changed as FileChanged[]
         if (typeof out.diff_stat === "string") blockMap[ev.block_id].diffStat = out.diff_stat
+        // Brain blocks output pr_url as JSON on the last line of their text output.
+        // Try to parse it from out.output so the "View PR →" link works.
+        if (typeof out.output === "string" && !out.pr_url) {
+          const lastLine = out.output.trim().split("\n").pop() ?? ""
+          try {
+            const parsed = JSON.parse(lastLine)
+            if (typeof parsed?.pr_url === "string") {
+              blockMap[ev.block_id].output = { ...out, pr_url: parsed.pr_url }
+            }
+          } catch { /* not JSON, ignore */ }
+        }
       }
     } else if (ev.kind === "block_failed" && blockMap[ev.block_id]) {
       blockMap[ev.block_id].status = "failed"


### PR DESCRIPTION
## Summary

Fixes all issues raised in the PR #5 code review.

### sandbox.py
- `_modal_available` was a module-level bool evaluated at import time — moved to a function that reads `settings` so `.env` load order doesn't affect it
- Modal function was re-defined inside `_modal_dispatch` on every call — moved to lazy module-level init (`_get_modal_run_tool`)
- `modal.enable_output()` removed (would flood server logs in production)
- `_FORBIDDEN_SHELL_PATTERNS` was duplicated inside the Modal function body — now the single module-level list is the source of truth

### executor.py
- Removed dead `_dispatch_tool_legacy` function
- Added pricing model comment next to cost calculation (`# Sonnet 4.6 pricing...`)

### runs.py
- All 5 endpoints (`list_runs`, `create_run`, `get_run`, `stream_run_events`, `approve_run`) now require `workspace_id` via `Depends(get_workspace_id)`
- Added `_get_workflow()` helper that enforces `workspace_id` match on every workflow lookup — prevents cross-workspace run data access

### webhooks.py
- `github_webhook` now accepts optional `?workspace_id=<uuid>` query param
- `_trigger_github_workflows` filters by workspace when `workspace_id` is provided — prevents a GitHub event in org A triggering workflows in org B

### seed_autopilot.py
- Removed DAG cycle `a6 → a4` (Fix failures → Run tests) which would have caused the topological sort to fail silently
- Merged test + retry into a single Brain block (`a4: Run tests & fix`) that handles up to 3 attempts internally
- Added explicit failure notify path: `a5 (fail) → a8 (Notify failure)` Slack block
- "Push & open PR" Brain block now explicitly instructs Claude to output `{"pr_url": "..."}` as the last JSON line

### RunTrace.tsx
- `pr_url` is now parsed from the last line of Brain output text (where the Brain is instructed to emit it as JSON) — fixes the broken "View PR →" link

## Test plan
- [ ] Run without `MODAL_TOKEN_ID` set — confirm local sandbox still works
- [ ] Run with `MODAL_TOKEN_ID` set — confirm `_modal_available()` returns true
- [ ] Hit `GET /workflows/{id}/runs` without auth when `CLERK_SECRET_KEY` unset — still returns dev workspace runs
- [ ] Hit `GET /workflows/{id}/runs` with a workflow_id from a different workspace — confirm 404
- [ ] Trigger GitHub webhook with `?workspace_id=xxx` — confirm only that workspace's workflows fire
- [ ] Run autopilot workflow — confirm no "cycle detected" error in executor logs
- [ ] Brain block that outputs `{"pr_url": "https://..."}` — confirm "View PR →" link appears in RunTrace