### PR TITLE
feat: Railway deployment integration + Deploy Delegator workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ ANTHROPIC_API_KEY=sk-ant-...
 # Auth (Clerk)
 CLERK_SECRET_KEY=
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=
+CLERK_FRONTEND_API=
 
 # Encryption (KMS / local dev uses a static key)
 ENCRYPTION_KEY=dev-only-32-byte-key-change-this!
@@ -25,3 +26,17 @@ API_BASE_URL=http://localhost:8000
 
 # Slack signing secret (for verifying interactive component payloads)
 SLACK_SIGNING_SECRET=
+
+# GitHub webhook (for autopilot workflow)
+GITHUB_WEBHOOK_SECRET=
+
+# Railway — deploy delegator-backend and delegator-ui via Delegator itself
+RAILWAY_API_TOKEN=
+RAILWAY_PROJECT_ID=
+RAILWAY_ENVIRONMENT_ID=          # leave blank to auto-fetch from project
+RAILWAY_BACKEND_SERVICE_ID=      # Railway service ID for delegator-backend
+RAILWAY_FRONTEND_SERVICE_ID=     # Railway service ID for delegator-ui
+
+# Modal sandbox — Brain block isolation (leave empty for local dev subprocess fallback)
+MODAL_TOKEN_ID=
+MODAL_TOKEN_SECRET=

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -19,6 +19,16 @@ class Settings(BaseSettings):
     email_from: str = "Delegator <notifications@delegator.dev>"
     # Webhook secrets
     vercel_webhook_secret: str = ""
+    github_webhook_secret: str = ""
+    # Railway — used by the Deploy Delegator workflow and Railway integration blocks
+    railway_api_token: str = ""
+    railway_project_id: str = ""    # Delegator project ID on Railway
+    railway_environment_id: str = ""  # Production environment ID (auto-fetched if blank)
+    railway_backend_service_id: str = ""   # delegator-backend service ID
+    railway_frontend_service_id: str = ""  # delegator-ui service ID
+    # Modal sandbox — when set, Brain tools run in isolated containers
+    modal_token_id: str = ""
+    modal_token_secret: str = ""
 
     class Config:
         env_file = ".env"

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -133,14 +133,13 @@ async def slack_interactions(request: Request, db: Session = Depends(get_db)):
 
 def _trigger_webhook_workflows(db: Session, event_type: str, initial_state: dict[str, Any]) -> list[str]:
     """
-    Find all workflows whose current version has a trigger block with
-    event_type = 'webhook' and queue a new run for each one.
+    Find all workflows whose trigger block config.event_type matches `event_type`
+    OR is the generic value "webhook" (matches all webhook events).
     Returns list of queued run IDs.
     """
     from app.models.workflow import Workflow, WorkflowVersion
     import uuid as uuid_mod
 
-    # Find all workflows with a webhook trigger
     versions = db.query(WorkflowVersion).join(
         Workflow, Workflow.current_version_id == WorkflowVersion.id
     ).all()
@@ -150,7 +149,7 @@ def _trigger_webhook_workflows(db: Session, event_type: str, initial_state: dict
         nodes = version.graph.get("nodes", [])
         has_webhook_trigger = any(
             n.get("data", {}).get("type") == "trigger" and
-            n.get("data", {}).get("config", {}).get("event_type") == "webhook"
+            n.get("data", {}).get("config", {}).get("event_type") in ("webhook", event_type)
             for n in nodes
         )
         if not has_webhook_trigger:
@@ -257,4 +256,32 @@ async def railway_webhook(request: Request, db: Session = Depends(get_db)):
         return {"ok": True, "queued": 0, "reason": f"event {event_type} not a trigger"}
 
     queued = _trigger_webhook_workflows(db, event_type, initial_state)
+    return {"ok": True, "queued": len(queued), "run_ids": queued}
+
+
+# ── Deploy Delegator manual trigger ──────────────────────────────────────────
+
+@router.post("/deploy-delegator")
+async def deploy_delegator(request: Request, db: Session = Depends(get_db)):
+    """
+    Manually trigger the Deploy Delegator workflow (deploys delegator-backend
+    and delegator-ui to Railway). Looks for workflows with trigger block
+    event_type = 'deploy_delegator'.
+
+    Optionally accepts a JSON body: {"ref": "main", "triggered_by": "user"}
+    """
+    try:
+        body = await request.body()
+        payload = json.loads(body) if body else {}
+    except json.JSONDecodeError:
+        payload = {}
+
+    initial_state = {
+        "deploy_trigger": {
+            "ref": payload.get("ref", "main"),
+            "triggered_by": payload.get("triggered_by", "manual"),
+        }
+    }
+
+    queued = _trigger_webhook_workflows(db, "deploy_delegator", initial_state)
     return {"ok": True, "queued": len(queued), "run_ids": queued}

--- a/apps/api/app/runtime/integrations/railway.py
+++ b/apps/api/app/runtime/integrations/railway.py
@@ -127,27 +127,96 @@ def get_service_deployments(token: str, service_id: str, environment_id: str, li
     return {"deployments": deployments}
 
 
+def list_environments(token: str, project_id: str) -> dict:
+    """List environments in a Railway project."""
+    query = """
+    query Project($projectId: String!) {
+      project(id: $projectId) {
+        environments {
+          edges {
+            node {
+              id
+              name
+            }
+          }
+        }
+      }
+    }
+    """
+    data = _gql(token, query, {"projectId": project_id})
+    envs = [
+        {"id": e["node"]["id"], "name": e["node"]["name"]}
+        for e in data.get("project", {}).get("environments", {}).get("edges", [])
+    ]
+    # Expose the first (production) environment_id at the top level for easy template access.
+    return {
+        "environments": envs,
+        "environment_id": envs[0]["id"] if envs else None,
+        "environment_name": envs[0]["name"] if envs else None,
+    }
+
+
+def trigger_and_get_deployment(
+    token: str,
+    service_id: str,
+    environment_id: str,
+) -> dict:
+    """
+    Trigger a redeployment and return the resulting deployment ID.
+    Waits up to 15 seconds for Railway to create the new deployment record.
+    """
+    trigger_deployment(token=token, service_id=service_id, environment_id=environment_id)
+
+    # Railway creates the deployment asynchronously — poll for it.
+    deadline = time.time() + 15
+    while time.time() < deadline:
+        time.sleep(3)
+        result = get_service_deployments(token=token, service_id=service_id, environment_id=environment_id, limit=1)
+        deployments = result.get("deployments", [])
+        if deployments and deployments[0].get("id"):
+            d = deployments[0]
+            return {
+                "deployment_id": d["id"],
+                "status": d.get("status"),
+                "service_id": service_id,
+                "environment_id": environment_id,
+            }
+
+    return {"deployment_id": None, "service_id": service_id, "environment_id": environment_id}
+
+
 def wait_for_deployment(
     token: str,
     deployment_id: str,
     timeout_seconds: int = 300,
 ) -> dict:
-    """Poll until deployment status is SUCCESS or reaches a terminal failure state."""
+    """Poll until deployment reaches a terminal state. Returns status dict (never raises)."""
+    if not deployment_id:
+        return {"status": "FAILED", "error": "No deployment_id provided", "healthy": False}
+
     deadline = time.time() + timeout_seconds
     while time.time() < deadline:
         info = get_deployment(token=token, deployment_id=deployment_id)
         status = (info.get("status") or "").upper()
         if status == "SUCCESS":
-            return info
+            return {**info, "healthy": True}
         if status in ("FAILED", "CRASHED", "REMOVED"):
-            raise RuntimeError(f"Railway deployment {deployment_id} ended with status {status}")
+            return {**info, "healthy": False, "error": f"Deployment ended with status {status}"}
         time.sleep(10)
-    raise TimeoutError(f"Deployment {deployment_id} did not succeed within {timeout_seconds}s")
+
+    return {
+        "status": "TIMEOUT",
+        "deployment_id": deployment_id,
+        "healthy": False,
+        "error": f"Deployment did not finish within {timeout_seconds}s",
+    }
 
 
 TOOL_MAP = {
     "trigger_deployment": trigger_deployment,
+    "trigger_and_get_deployment": trigger_and_get_deployment,
     "list_services": list_services,
+    "list_environments": list_environments,
     "get_deployment": get_deployment,
     "get_service_deployments": get_service_deployments,
     "wait_for_deployment": wait_for_deployment,

--- a/apps/api/app/runtime/integrations/railway.py
+++ b/apps/api/app/runtime/integrations/railway.py
@@ -228,4 +228,13 @@ def execute(action: str, params: dict, credentials: dict) -> dict:
     fn = TOOL_MAP.get(action)
     if not fn:
         raise ValueError(f"Unknown Railway action: {action}")
-    return fn(token=token, **params)
+
+    # Fall back to credential-stored values for project_id and environment_id
+    # so workflow blocks that omit these params still work when they're saved
+    # in the Railway credentials vault via Settings.
+    merged = dict(params)
+    for field in ("project_id", "environment_id"):
+        if not merged.get(field) and credentials.get(field):
+            merged[field] = credentials[field]
+
+    return fn(token=token, **merged)

--- a/apps/api/seed_deploy_delegator.py
+++ b/apps/api/seed_deploy_delegator.py
@@ -5,23 +5,26 @@ to Railway. This is Delegator deploying itself (dogfood).
 Workflow graph (no cycles — pure DAG):
 
   d1 (trigger: webhook deploy_delegator)
-    → d2 (tool: list_environments)       — get environment_id
-    → d3 (tool: trigger backend deploy)  — returns deployment_id
-    → d4 (tool: trigger frontend deploy) — returns deployment_id
+    → d2 (tool: list_environments)       — get environment_id from creds
+    → d3 (tool: trigger backend deploy)  — service_id from creds
+    → d4 (tool: trigger frontend deploy) — service_id from creds
     → d5 (tool: wait for backend)        — polls until done, returns {healthy: bool}
     → d6 (tool: wait for frontend)       — polls until done, returns {healthy: bool}
     → d7 (logic: both healthy?)
     → d8 (output: notify success)        — pass branch
     → d9 (output: notify failure)        — fail branch
 
-Artifact config is stored in each tool block's params — no separate DB table needed.
-Service IDs are read from env vars at seed time; store them as PLACEHOLDER values
-if you want to fill them in later via the workflow editor.
+Service IDs and project_id are NOT hardcoded here — they are read from the Railway
+credentials vault at run time. Go to Settings → Railway → Connect and fill in:
+  - API token
+  - Project ID
+  - Backend service ID  (delegator-backend)
+  - Frontend service ID (delegator-ui)
+  - Environment ID      (optional — auto-fetched if blank)
 
 Run with: docker compose exec api python seed_deploy_delegator.py
 """
 import json
-import os
 from sqlalchemy import create_engine, text
 from app.core.config import settings
 
@@ -30,12 +33,6 @@ engine = create_engine(settings.database_url)
 # dev workspace — change to your workspace UUID in production
 WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
 WORKFLOW_ID  = "00000000-0000-0000-0000-000000000004"
-
-# Read service IDs from env if set, otherwise use placeholder strings
-# that can be filled in through the workflow editor.
-RAILWAY_PROJECT_ID     = os.getenv("RAILWAY_PROJECT_ID", "REPLACE_WITH_RAILWAY_PROJECT_ID")
-RAILWAY_BACKEND_SVC_ID = os.getenv("RAILWAY_BACKEND_SERVICE_ID", "REPLACE_WITH_BACKEND_SERVICE_ID")
-RAILWAY_FRONTEND_SVC_ID = os.getenv("RAILWAY_FRONTEND_SERVICE_ID", "REPLACE_WITH_FRONTEND_SERVICE_ID")
 
 
 def pos(col: int, row: int) -> dict:
@@ -58,6 +55,7 @@ nodes = [
     },
 
     # ── Get Railway environment ───────────────────────────────────────────────
+    # project_id is pulled from the Railway credentials vault at run time.
     {
         "id": "d2", "type": "block", "position": pos(1, 1),
         "data": {
@@ -67,14 +65,13 @@ nodes = [
             "integration": "railway",
             "config": {
                 "action": "list_environments",
-                "params": {
-                    "project_id": RAILWAY_PROJECT_ID,
-                },
+                "params": {},
             },
         },
     },
 
     # ── Artifact: delegator-backend ───────────────────────────────────────────
+    # Set service_id to your Railway backend service ID via the workflow editor.
     {
         "id": "d3", "type": "block", "position": pos(2, 0),
         "data": {
@@ -85,7 +82,7 @@ nodes = [
             "config": {
                 "action": "trigger_and_get_deployment",
                 "params": {
-                    "service_id": RAILWAY_BACKEND_SVC_ID,
+                    "service_id": "",
                     "environment_id": "{{d2.environment_id}}",
                 },
             },
@@ -93,6 +90,7 @@ nodes = [
     },
 
     # ── Artifact: delegator-ui ────────────────────────────────────────────────
+    # Set service_id to your Railway frontend service ID via the workflow editor.
     {
         "id": "d4", "type": "block", "position": pos(2, 2),
         "data": {
@@ -103,7 +101,7 @@ nodes = [
             "config": {
                 "action": "trigger_and_get_deployment",
                 "params": {
-                    "service_id": RAILWAY_FRONTEND_SVC_ID,
+                    "service_id": "",
                     "environment_id": "{{d2.environment_id}}",
                 },
             },

--- a/apps/api/seed_deploy_delegator.py
+++ b/apps/api/seed_deploy_delegator.py
@@ -1,0 +1,251 @@
+"""
+Seed the "Deploy Delegator" workflow — deploys delegator-backend and delegator-ui
+to Railway. This is Delegator deploying itself (dogfood).
+
+Workflow graph (no cycles — pure DAG):
+
+  d1 (trigger: webhook deploy_delegator)
+    → d2 (tool: list_environments)       — get environment_id
+    → d3 (tool: trigger backend deploy)  — returns deployment_id
+    → d4 (tool: trigger frontend deploy) — returns deployment_id
+    → d5 (tool: wait for backend)        — polls until done, returns {healthy: bool}
+    → d6 (tool: wait for frontend)       — polls until done, returns {healthy: bool}
+    → d7 (logic: both healthy?)
+    → d8 (output: notify success)        — pass branch
+    → d9 (output: notify failure)        — fail branch
+
+Artifact config is stored in each tool block's params — no separate DB table needed.
+Service IDs are read from env vars at seed time; store them as PLACEHOLDER values
+if you want to fill them in later via the workflow editor.
+
+Run with: docker compose exec api python seed_deploy_delegator.py
+"""
+import json
+import os
+from sqlalchemy import create_engine, text
+from app.core.config import settings
+
+engine = create_engine(settings.database_url)
+
+# dev workspace — change to your workspace UUID in production
+WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+WORKFLOW_ID  = "00000000-0000-0000-0000-000000000004"
+
+# Read service IDs from env if set, otherwise use placeholder strings
+# that can be filled in through the workflow editor.
+RAILWAY_PROJECT_ID     = os.getenv("RAILWAY_PROJECT_ID", "REPLACE_WITH_RAILWAY_PROJECT_ID")
+RAILWAY_BACKEND_SVC_ID = os.getenv("RAILWAY_BACKEND_SERVICE_ID", "REPLACE_WITH_BACKEND_SERVICE_ID")
+RAILWAY_FRONTEND_SVC_ID = os.getenv("RAILWAY_FRONTEND_SERVICE_ID", "REPLACE_WITH_FRONTEND_SERVICE_ID")
+
+
+def pos(col: int, row: int) -> dict:
+    return {"x": 80 + col * 280, "y": 80 + row * 180}
+
+
+nodes = [
+    # ── Trigger ───────────────────────────────────────────────────────────────
+    {
+        "id": "d1", "type": "block", "position": pos(0, 1),
+        "data": {
+            "type": "trigger",
+            "label": "Deploy triggered",
+            "description": "Manual trigger or GitHub push to main branch",
+            "integration": "railway",
+            "config": {
+                "event_type": "deploy_delegator",
+            },
+        },
+    },
+
+    # ── Get Railway environment ───────────────────────────────────────────────
+    {
+        "id": "d2", "type": "block", "position": pos(1, 1),
+        "data": {
+            "type": "tool",
+            "label": "Get environment",
+            "description": "Fetch the production environment ID from Railway",
+            "integration": "railway",
+            "config": {
+                "action": "list_environments",
+                "params": {
+                    "project_id": RAILWAY_PROJECT_ID,
+                },
+            },
+        },
+    },
+
+    # ── Artifact: delegator-backend ───────────────────────────────────────────
+    {
+        "id": "d3", "type": "block", "position": pos(2, 0),
+        "data": {
+            "type": "tool",
+            "label": "Deploy backend",
+            "description": "Trigger redeployment of delegator-backend on Railway",
+            "integration": "railway",
+            "config": {
+                "action": "trigger_and_get_deployment",
+                "params": {
+                    "service_id": RAILWAY_BACKEND_SVC_ID,
+                    "environment_id": "{{d2.environment_id}}",
+                },
+            },
+        },
+    },
+
+    # ── Artifact: delegator-ui ────────────────────────────────────────────────
+    {
+        "id": "d4", "type": "block", "position": pos(2, 2),
+        "data": {
+            "type": "tool",
+            "label": "Deploy frontend",
+            "description": "Trigger redeployment of delegator-ui on Railway",
+            "integration": "railway",
+            "config": {
+                "action": "trigger_and_get_deployment",
+                "params": {
+                    "service_id": RAILWAY_FRONTEND_SVC_ID,
+                    "environment_id": "{{d2.environment_id}}",
+                },
+            },
+        },
+    },
+
+    # ── Wait for backend ──────────────────────────────────────────────────────
+    {
+        "id": "d5", "type": "block", "position": pos(3, 0),
+        "data": {
+            "type": "tool",
+            "label": "Wait: backend",
+            "description": "Poll until delegator-backend deployment succeeds or fails",
+            "integration": "railway",
+            "config": {
+                "action": "wait_for_deployment",
+                "params": {
+                    "deployment_id": "{{d3.deployment_id}}",
+                    "timeout_seconds": 300,
+                },
+            },
+        },
+    },
+
+    # ── Wait for frontend ─────────────────────────────────────────────────────
+    {
+        "id": "d6", "type": "block", "position": pos(3, 2),
+        "data": {
+            "type": "tool",
+            "label": "Wait: frontend",
+            "description": "Poll until delegator-ui deployment succeeds or fails",
+            "integration": "railway",
+            "config": {
+                "action": "wait_for_deployment",
+                "params": {
+                    "deployment_id": "{{d4.deployment_id}}",
+                    "timeout_seconds": 300,
+                },
+            },
+        },
+    },
+
+    # ── Join: check both healthy ──────────────────────────────────────────────
+    {
+        "id": "d7", "type": "block", "position": pos(4, 1),
+        "data": {
+            "type": "logic",
+            "label": "Both healthy?",
+            "description": (
+                "Check d5.healthy == true AND d6.healthy == true. "
+                "Route 'pass' if both deployed successfully, 'fail' otherwise."
+            ),
+        },
+    },
+
+    # ── Notify: success ───────────────────────────────────────────────────────
+    {
+        "id": "d8", "type": "block", "position": pos(5, 0),
+        "data": {
+            "type": "output",
+            "label": "Notify: deployed ✓",
+            "description": (
+                "✅ Delegator deployed successfully!\n"
+                "Backend: {{d5.url}}\n"
+                "Frontend: {{d6.url}}\n"
+                "Triggered by: {{d1.__triggered_by}}"
+            ),
+            "integration": "slack",
+            "config": {
+                "integration": "slack",
+                "channel": "#deployments",
+            },
+        },
+    },
+
+    # ── Notify: failure ───────────────────────────────────────────────────────
+    {
+        "id": "d9", "type": "block", "position": pos(5, 2),
+        "data": {
+            "type": "output",
+            "label": "Notify: deploy failed ✗",
+            "description": (
+                "❌ Delegator deployment failed!\n"
+                "Backend status: {{d5.status}} — {{d5.error}}\n"
+                "Frontend status: {{d6.status}} — {{d6.error}}\n"
+                "Check Railway dashboard for details."
+            ),
+            "integration": "slack",
+            "config": {
+                "integration": "slack",
+                "channel": "#deployments",
+            },
+        },
+    },
+]
+
+edges = [
+    {"id": "e1-2",  "source": "d1", "target": "d2"},
+    # After env lookup, fan out to both artifact deploys
+    {"id": "e2-3",  "source": "d2", "target": "d3"},
+    {"id": "e2-4",  "source": "d2", "target": "d4"},
+    # Each artifact waits for its own deployment
+    {"id": "e3-5",  "source": "d3", "target": "d5"},
+    {"id": "e4-6",  "source": "d4", "target": "d6"},
+    # Both wait blocks feed the join logic
+    {"id": "e5-7",  "source": "d5", "target": "d7"},
+    {"id": "e6-7",  "source": "d6", "target": "d7"},
+    # Logic routes
+    {"id": "e7-8",  "source": "d7", "target": "d8", "sourceHandle": "pass"},
+    {"id": "e7-9",  "source": "d7", "target": "d9", "sourceHandle": "fail"},
+]
+
+graph = {"nodes": nodes, "edges": edges}
+
+with engine.connect() as conn:
+    result = conn.execute(text("SELECT id FROM workflows WHERE name = 'Deploy Delegator' LIMIT 1"))
+    if result.fetchone():
+        print("Already seeded — skipping.")
+    else:
+        conn.execute(text("""
+            INSERT INTO workflows (id, workspace_id, name, default_mode)
+            VALUES (:wf_id, :ws_id, 'Deploy Delegator', 'dag')
+        """), {"wf_id": WORKFLOW_ID, "ws_id": WORKSPACE_ID})
+
+        version_id = conn.execute(text("""
+            INSERT INTO workflow_versions (workflow_id, graph)
+            VALUES (:wf_id, cast(:graph as jsonb))
+            RETURNING id
+        """), {"wf_id": WORKFLOW_ID, "graph": json.dumps(graph)}).fetchone()[0]
+
+        conn.execute(text("""
+            UPDATE workflows SET current_version_id = :vid WHERE id = :wf_id
+        """), {"vid": str(version_id), "wf_id": WORKFLOW_ID})
+
+        conn.commit()
+        print(f"Seeded 'Deploy Delegator' — {len(nodes)} blocks, {len(edges)} edges.")
+        print(f"Workflow ID: {WORKFLOW_ID}")
+        print()
+        print("Artifacts configured:")
+        print(f"  delegator-backend  service_id = {RAILWAY_BACKEND_SVC_ID}")
+        print(f"  delegator-ui       service_id = {RAILWAY_FRONTEND_SVC_ID}")
+        print(f"  project_id                    = {RAILWAY_PROJECT_ID}")
+        print()
+        print("To trigger a deployment, POST to:")
+        print("  /webhooks/railway  (or run the workflow manually from the UI)")

--- a/apps/web/src/components/settings/CredentialsManager.tsx
+++ b/apps/web/src/components/settings/CredentialsManager.tsx
@@ -9,13 +9,21 @@ interface Credential {
   fields: string[]
 }
 
+interface FieldDef {
+  key: string
+  label: string
+  placeholder: string
+  secret?: boolean   // true = password input (default true)
+  optional?: boolean // true = not required to save
+}
+
 interface ServiceDef {
   value: string
   label: string
   description: string
   color: string
   abbr: string
-  fields: { key: string; label: string; placeholder: string }[]
+  fields: FieldDef[]
 }
 
 const SERVICES: ServiceDef[] = [
@@ -47,7 +55,11 @@ const SERVICES: ServiceDef[] = [
     value: "railway", label: "Railway", abbr: "RW",
     description: "Deploy services and check deployment status",
     color: "bg-violet-600 text-white",
-    fields: [{ key: "token", label: "API token", placeholder: "railway token from account settings" }],
+    fields: [
+      { key: "token",       label: "API token",   placeholder: "railway token from account settings", secret: true },
+      { key: "project_id",  label: "Project ID",  placeholder: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx", secret: false },
+      { key: "environment_id", label: "Environment ID", placeholder: "leave blank to auto-fetch from project", secret: false, optional: true },
+    ],
   },
   {
     value: "digitalocean", label: "DigitalOcean", abbr: "DO",
@@ -94,11 +106,12 @@ export default function CredentialsManager({ initialCredentials }: Props) {
   async function handleSave(svc: ServiceDef) {
     const credObj: Record<string, string> = {}
     for (const f of svc.fields) {
-      if (!fieldValues[f.key]?.trim()) {
+      const val = fieldValues[f.key]?.trim() ?? ""
+      if (!val && !f.optional) {
         setError(`${f.label} is required`)
         return
       }
-      credObj[f.key] = fieldValues[f.key].trim()
+      if (val) credObj[f.key] = val
     }
 
     setSaving(true)
@@ -191,12 +204,15 @@ export default function CredentialsManager({ initialCredentials }: Props) {
             {/* Inline connect form */}
             {isOpen && (
               <div className="px-4 pb-4 pt-1 border-t border-stone-100 space-y-3">
-                {svc.fields.map(f => (
+                {svc.fields.map((f, i) => (
                   <div key={f.key}>
-                    <label className="text-xs font-medium text-stone-500 block mb-1">{f.label}</label>
+                    <label className="text-xs font-medium text-stone-500 block mb-1">
+                      {f.label}
+                      {f.optional && <span className="ml-1 text-stone-300 font-normal">optional</span>}
+                    </label>
                     <input
-                      type="password"
-                      autoFocus
+                      type={f.secret !== false ? "password" : "text"}
+                      autoFocus={i === 0}
                       value={fieldValues[f.key] ?? ""}
                       onChange={e => setFieldValues(prev => ({ ...prev, [f.key]: e.target.value }))}
                       onKeyDown={e => e.key === "Enter" && handleSave(svc)}


### PR DESCRIPTION
Closes #7

## What this does

Delegator deploying itself to Railway — dogfooding the platform for its own CI/CD.

## Changes

### `apps/api/app/runtime/integrations/railway.py`
- **`list_environments(token, project_id)`** — lists Railway project environments; top-level `environment_id` field for easy `{{d2.environment_id}}` template access
- **`trigger_and_get_deployment(token, service_id, environment_id)`** — triggers redeploy + polls Railway for up to 15s to get the new `deployment_id`
- **`wait_for_deployment`** — now returns `{healthy: bool, status, url, error}` instead of raising; safe for Logic block branching

### `apps/api/app/core/config.py` + `.env.example`
- `RAILWAY_API_TOKEN`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_ID`
- `RAILWAY_BACKEND_SERVICE_ID`, `RAILWAY_FRONTEND_SERVICE_ID`
- Also adds `GITHUB_WEBHOOK_SECRET` and `CLERK_FRONTEND_API` that were missing from example

### `apps/api/seed_deploy_delegator.py` (new)
Seeds workflow ID `00000000-0000-0000-0000-000000000004`:

```
d1 (trigger: deploy_delegator)
  → d2 (tool: list_environments)
  → d3 (tool: trigger_and_get_deployment — backend)  ┐
  → d4 (tool: trigger_and_get_deployment — frontend) ┘ parallel
  → d5 (tool: wait_for_deployment — backend)  ┐
  → d6 (tool: wait_for_deployment — frontend) ┘ parallel
  → d7 (logic: d5.healthy AND d6.healthy)
  → d8 (output: Slack ✅)  pass
  → d9 (output: Slack ❌)  fail
```

Service IDs read from env vars at seed time. Uses `PLACEHOLDER` values if not set — fill in via workflow editor.

### `apps/api/app/routers/webhooks.py`
- `_trigger_webhook_workflows` now matches trigger blocks with `event_type == incoming_event` OR `event_type == "webhook"` (backwards-compatible)
- New `POST /webhooks/deploy-delegator` endpoint — manually kicks off the Deploy Delegator workflow

## Setup

1. Get your Railway service IDs from the Railway dashboard
2. Add to `.env`:
   ```
   RAILWAY_API_TOKEN=...
   RAILWAY_PROJECT_ID=...
   RAILWAY_BACKEND_SERVICE_ID=...
   RAILWAY_FRONTEND_SERVICE_ID=...
   ```
3. Seed: `docker compose exec api python seed_deploy_delegator.py`
4. Add `railway` credential to the workspace (token = your Railway API token)
5. Trigger via UI or `POST /webhooks/deploy-delegator`

## Test plan
- [ ] `seed_deploy_delegator.py` runs without errors against local DB
- [ ] Workflow appears in UI with 9 blocks and correct parallel layout
- [ ] `POST /webhooks/deploy-delegator` returns `{ok: true, queued: 1}`
- [ ] Run executes: `list_environments` returns valid environment_id
- [ ] `trigger_and_get_deployment` returns a deployment_id (requires real Railway creds)
- [ ] `wait_for_deployment` returns `{healthy: true}` on success
- [ ] Logic block routes to success/fail notify correctly