### PR TITLE
fix: move alembic to preDeployCommand so uvicorn starts independently

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -4,7 +4,8 @@ dockerfilePath = "apps/api/Dockerfile"
 buildTarget = "prod"
 
 [deploy]
-startCommand = "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 2"
+preDeployCommand = "alembic upgrade head"
+startCommand = "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 2"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"


### PR DESCRIPTION
## Problem

`alembic upgrade head` was running inline in `startCommand`, blocking uvicorn from ever starting. Railway's healthcheck fires against the running service — but uvicorn never bound to `$PORT` because alembic was holding the process. Healthcheck timed out and deployment failed.

This fix was originally in PR #15 but was accidentally dropped during config consolidation in PR #17.

## Fix

```toml
preDeployCommand = "alembic upgrade head"
startCommand = "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 2"
```

`preDeployCommand` runs and completes before Railway starts the service and begins the healthcheck timer. Uvicorn starts clean on `$PORT`.

## Test plan
- [ ] Railway deployment reaches `ACTIVE`
- [ ] `GET /health` returns `{"status": "ok"}`