### PR TITLE
fix: wrap startCommand in sh -c for PORT expansion

### DIFF
--- a/railway.toml
+++ b/railway.toml
@@ -5,7 +5,7 @@ buildTarget = "prod"
 
 [deploy]
 preDeployCommand = "alembic upgrade head"
-startCommand = "uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 2"
+startCommand = "sh -c 'uvicorn app.main:app --host 0.0.0.0 --port ${PORT:-8000} --workers 2'"
 healthcheckPath = "/health"
 healthcheckTimeout = 300
 restartPolicyType = "on_failure"


### PR DESCRIPTION
Railway passes startCommand directly to the process — no shell. `${PORT:-8000}` was never expanded, uvicorn received the literal string. Wrap in `sh -c` so the shell expands $PORT before passing to uvicorn.