### PR TITLE
feat: projects — multi-project with templates and project switcher

### DIFF
--- a/apps/api/alembic/versions/0002_projects.py
+++ b/apps/api/alembic/versions/0002_projects.py
@@ -1,0 +1,134 @@
+"""add owner_id to workspaces and project_templates table
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-05-08
+"""
+from typing import Sequence, Union
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+import json
+
+revision: str = "0002"
+down_revision: Union[str, None] = "0001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+# ---------------------------------------------------------------------------
+# Template graph data
+# ---------------------------------------------------------------------------
+
+def _pos(col, row):
+    return {"x": 80 + col * 260, "y": 80 + row * 180}
+
+
+_AUTOPILOT_NODES = [
+    {"id": "a1", "type": "block", "position": _pos(0, 0), "data": {"type": "trigger", "label": "Issue labeled", "description": "GitHub issue labeled 'autopilot ready'", "integration": "github", "config": {"event_type": "github_issue", "label": "autopilot ready"}}},
+    {"id": "a2", "type": "block", "position": _pos(1, 0), "data": {"type": "tool", "label": "Fetch issue", "description": "Get full issue title, body, and metadata", "integration": "github", "config": {"action": "fetch_issue", "params": {"owner": "{{a1.github_issue.repo_owner}}", "repo": "{{a1.github_issue.repo_name}}", "issue_number": "{{a1.github_issue.issue_number}}"}}}},
+    {"id": "a3", "type": "block", "position": _pos(2, 0), "data": {"type": "brain", "label": "Implement fix", "isAgentic": True, "description": "You are an expert software engineer. A GitHub issue has been labeled 'autopilot ready'.\n\nIssue title: {{a2.title}}\nIssue body: {{a2.body}}\nRepo: {{a1.github_issue.repo_full_name}}\nClone URL: {{a1.github_issue.clone_url}}\n\nSteps:\n1. Clone the repo: git clone <clone_url> /tmp/autopilot_repo\n2. Create a branch: git checkout -b autopilot/issue-{{a2.issue_number}}\n3. Read relevant files to understand the codebase\n4. Implement the fix described in the issue\n5. Stage changes: git add -A\n6. Commit: git commit -m 'fix: <short description> (closes #{{a2.issue_number}})'\n7. Output the branch name and a brief summary of what you changed"}},
+    {"id": "a4", "type": "block", "position": _pos(3, 0), "data": {"type": "brain", "label": "Run tests & fix", "isAgentic": True, "description": "Run the test suite for the repo at /tmp/autopilot_repo. If tests fail, fix the failures and re-run. Repeat up to 3 times.\n\n1. Detect the test runner (pytest, npm test, etc.) by reading package.json or requirements.txt\n2. Run the tests\n3. If tests fail: read the failure output, patch the code, re-run\n4. After up to 3 fix attempts, stop regardless of outcome\n\nOutput as JSON on the final line:\n{\"passed\": true/false, \"attempts\": <number>, \"output\": \"<brief summary of test results>\"}"}},
+    {"id": "a5", "type": "block", "position": _pos(3, 1), "data": {"type": "logic", "label": "Tests pass?", "description": "Branch on whether tests passed. Check a4.passed == true"}},
+    {"id": "a6", "type": "block", "position": _pos(4, 0), "data": {"type": "brain", "label": "Push & open PR", "isAgentic": True, "description": "Push the branch and open a pull request.\nRepo: {{a1.github_issue.repo_full_name}}\nBranch: autopilot/issue-{{a2.issue_number}}\nBase: {{a1.github_issue.default_branch}}\n\n1. cd /tmp/autopilot_repo\n2. Set the remote with credentials:\n   git remote set-url origin https://<github_token>@github.com/{{a1.github_issue.repo_full_name}}.git\n3. git push origin autopilot/issue-{{a2.issue_number}}\n4. Open a PR via the GitHub API\n\nOutput ONLY the following JSON on the last line of your response:\n{\"pr_url\": \"<full PR URL>\"}"}},
+    {"id": "a7", "type": "block", "position": _pos(4, 1), "data": {"type": "output", "label": "Notify PR ready", "description": "PR opened for issue #{{a2.issue_number}}: {{a2.title}}. Review at {{a6.pr_url}}", "integration": "slack", "config": {"integration": "slack", "channel": "#engineering"}}},
+    {"id": "a8", "type": "block", "position": _pos(2, 2), "data": {"type": "output", "label": "Notify failure", "description": "Tests failed after {{a4.attempts}} attempt(s) for issue #{{a2.issue_number}}: {{a2.title}}. Manual review needed.", "integration": "slack", "config": {"integration": "slack", "channel": "#engineering"}}},
+]
+_AUTOPILOT_EDGES = [
+    {"id": "e1-2", "source": "a1", "target": "a2"},
+    {"id": "e2-3", "source": "a2", "target": "a3"},
+    {"id": "e3-4", "source": "a3", "target": "a4"},
+    {"id": "e4-5", "source": "a4", "target": "a5"},
+    {"id": "e5-6", "source": "a5", "target": "a6", "sourceHandle": "pass"},
+    {"id": "e6-7", "source": "a6", "target": "a7"},
+    {"id": "e5-8", "source": "a5", "target": "a8", "sourceHandle": "fail"},
+]
+
+def _pos2(col, row):
+    return {"x": 60 + col * 200, "y": 60 + row * 160}
+
+_STORY_PR_NODES = [
+    {"id": "b1",  "type": "block", "position": _pos2(0, 0), "data": {"type": "trigger",  "label": "Story ready",       "description": "Linear webhook when label = ai-ready", "integration": "linear"}},
+    {"id": "b2",  "type": "block", "position": _pos2(1, 0), "data": {"type": "tool",     "label": "Fetch story",        "description": "Pull title, description, criteria",    "integration": "linear"}},
+    {"id": "b3",  "type": "block", "position": _pos2(2, 0), "data": {"type": "output",   "label": "Slack: starting",    "description": "Post 'working on STORY-X'",            "integration": "slack"}},
+    {"id": "b4",  "type": "block", "position": _pos2(3, 0), "data": {"type": "tool",     "label": "Provision sandbox",  "description": "Spin up Ubuntu droplet",               "integration": "digitalocean"}},
+    {"id": "b5",  "type": "block", "position": _pos2(0, 1), "data": {"type": "tool",     "label": "Checkout",           "description": "Clone repo, create feat/STORY-X branch","integration": "github"}},
+    {"id": "b6",  "type": "block", "position": _pos2(1, 1), "data": {"type": "brain",    "label": "Generate code",      "description": "Implement story with file/shell tools", "isAgentic": True}},
+    {"id": "b7",  "type": "block", "position": _pos2(2, 1), "data": {"type": "tool",     "label": "Run tests",          "description": "Execute unit + smoke suites"}},
+    {"id": "b8",  "type": "block", "position": _pos2(3, 1), "data": {"type": "logic",    "label": "Pass or fail?",      "description": "Branch on test exit code"}},
+    {"id": "b9",  "type": "block", "position": _pos2(0, 2), "data": {"type": "brain",    "label": "Fix loop",           "description": "Read failures, patch — max 3 tries",   "isAgentic": True}},
+    {"id": "b10", "type": "block", "position": _pos2(1, 2), "data": {"type": "tool",     "label": "Push + draft PR",    "description": "Push branch, open draft PR",           "integration": "github"}},
+    {"id": "b11", "type": "block", "position": _pos2(2, 2), "data": {"type": "tool",     "label": "Wait for preview",   "description": "Poll until Vercel deploy is READY",    "integration": "vercel"}},
+    {"id": "b12", "type": "block", "position": _pos2(3, 2), "data": {"type": "approval", "label": "Await reviewer",     "description": "DM with PR + preview link, pause until ✓", "integration": "slack"}},
+    {"id": "b13", "type": "block", "position": _pos2(1, 3), "data": {"type": "tool",     "label": "Merge to main",      "description": "Squash-merge on approval",             "integration": "github"}},
+    {"id": "b14", "type": "block", "position": _pos2(2, 3), "data": {"type": "tool",     "label": "Wait for prod",      "description": "Poll until production deploy is READY","integration": "vercel"}},
+    {"id": "b15", "type": "block", "position": _pos2(3, 3), "data": {"type": "output",   "label": "Notify shipped",     "description": "Post confirmation with prod URL",       "integration": "slack"}},
+    {"id": "b16", "type": "block", "position": _pos2(0, 3), "data": {"type": "cleanup",  "label": "Tear down",          "description": "Destroy droplet — always runs",        "integration": "digitalocean"}},
+]
+_STORY_PR_EDGES = [
+    {"id": "e1-2",   "source": "b1",  "target": "b2"},
+    {"id": "e2-3",   "source": "b2",  "target": "b3"},
+    {"id": "e3-4",   "source": "b3",  "target": "b4"},
+    {"id": "e4-5",   "source": "b4",  "target": "b5"},
+    {"id": "e5-6",   "source": "b5",  "target": "b6"},
+    {"id": "e6-7",   "source": "b6",  "target": "b7"},
+    {"id": "e7-8",   "source": "b7",  "target": "b8"},
+    {"id": "e8-9",   "source": "b8",  "target": "b9",  "label": "fail"},
+    {"id": "e9-7",   "source": "b9",  "target": "b7",  "label": "retry"},
+    {"id": "e8-10",  "source": "b8",  "target": "b10", "label": "pass"},
+    {"id": "e10-11", "source": "b10", "target": "b11"},
+    {"id": "e11-12", "source": "b11", "target": "b12"},
+    {"id": "e12-13", "source": "b12", "target": "b13"},
+    {"id": "e13-14", "source": "b13", "target": "b14"},
+    {"id": "e14-15", "source": "b14", "target": "b15"},
+    {"id": "e15-16", "source": "b15", "target": "b16"},
+]
+
+_TEMPLATES = [
+    {
+        "id": "00000000-0000-0000-0000-000000000010",
+        "slug": "autopilot",
+        "name": "Autopilot — GitHub Issues",
+        "description": "Watches for issues labeled 'autopilot ready', writes the fix, runs tests, and opens a PR.",
+        "default_mode": "dag",
+        "nodes": json.dumps(_AUTOPILOT_NODES),
+        "edges": json.dumps(_AUTOPILOT_EDGES),
+    },
+    {
+        "id": "00000000-0000-0000-0000-000000000011",
+        "slug": "story-pr",
+        "name": "Story → PR",
+        "description": "Linear ticket labeled ai-ready triggers code generation, test run, Vercel preview, and human approval before merge.",
+        "default_mode": "dag",
+        "nodes": json.dumps(_STORY_PR_NODES),
+        "edges": json.dumps(_STORY_PR_EDGES),
+    },
+]
+
+
+def upgrade() -> None:
+    # Add owner_id to workspaces (nullable — existing rows get NULL / 'dev')
+    op.add_column("workspaces", sa.Column("owner_id", sa.String(255), nullable=True))
+    op.execute("UPDATE workspaces SET owner_id = 'dev' WHERE id = '00000000-0000-0000-0000-000000000001'")
+
+    op.create_table(
+        "project_templates",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("slug", sa.String(100), nullable=False, unique=True),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=False),
+        sa.Column("default_mode", sa.String(50), nullable=False, server_default="dag"),
+        sa.Column("nodes", JSONB, nullable=False, server_default="[]"),
+        sa.Column("edges", JSONB, nullable=False, server_default="[]"),
+    )
+
+    for t in _TEMPLATES:
+        op.execute(sa.text(
+            "INSERT INTO project_templates (id, slug, name, description, default_mode, nodes, edges) "
+            "VALUES (:id, :slug, :name, :description, :default_mode, cast(:nodes as jsonb), cast(:edges as jsonb))"
+        ).bindparams(**t))
+
+
+def downgrade() -> None:
+    op.drop_table("project_templates")
+    op.drop_column("workspaces", "owner_id")

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -5,8 +5,9 @@ When CLERK_SECRET_KEY is set, validates Bearer tokens from Clerk.
 Falls back to the dev workspace when no key is configured (local dev only).
 
 Usage in routes:
-    from app.core.auth import get_workspace_id
+    from app.core.auth import get_workspace_id, get_user_id
     workspace_id: str = Depends(get_workspace_id)
+    user_id: str = Depends(get_user_id)
 """
 import logging
 from typing import Annotated
@@ -20,10 +21,10 @@ from app.core.config import settings
 log = logging.getLogger(__name__)
 
 DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+DEV_USER_ID = "dev"
 
 _bearer = HTTPBearer(auto_error=False)
 
-# Cache Clerk JWKS to avoid fetching on every request
 _jwks_cache: dict | None = None
 
 
@@ -45,7 +46,6 @@ def _get_jwks() -> dict:
 
 
 def _verify_clerk_token(token: str) -> dict | None:
-    """Verify a Clerk JWT. Returns claims dict or None if invalid."""
     try:
         import jwt as pyjwt
 
@@ -73,19 +73,16 @@ def _verify_clerk_token(token: str) -> dict | None:
         return None
 
 
-def get_workspace_id(
+def _clerk_enabled() -> bool:
+    return bool(settings.clerk_secret_key and settings.clerk_frontend_api)
+
+
+def get_user_id(
     credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
 ) -> str:
-    """
-    Dependency that returns the workspace ID for the current request.
-
-    - If CLERK_SECRET_KEY is not set: returns dev workspace ID (no auth)
-    - If set and valid JWT: extracts workspace from 'org_id' or 'sub' claim
-    - If set and invalid JWT: raises 401
-    """
-    # Require both keys to be set — partial Clerk config falls back to dev workspace
-    if not settings.clerk_secret_key or not settings.clerk_frontend_api:
-        return DEV_WORKSPACE_ID
+    """Returns the Clerk user_id (sub claim), or 'dev' in local dev mode."""
+    if not _clerk_enabled():
+        return DEV_USER_ID
 
     if not credentials:
         raise HTTPException(status_code=401, detail="Authorization header required")
@@ -94,7 +91,43 @@ def get_workspace_id(
     if not claims:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
 
-    # Clerk stores org_id in the session claims when the user has an active org
+    user_id = claims.get("sub")
+    if not user_id:
+        raise HTTPException(status_code=401, detail="No user ID in token")
+
+    return user_id
+
+
+def get_workspace_id(
+    credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
+    x_workspace_id: Annotated[str | None, Header()] = None,
+) -> str:
+    """
+    Returns the active workspace/project ID for the request.
+
+    Resolution order:
+    1. X-Workspace-ID header (explicit project selection from frontend)
+    2. Clerk JWT org_id or sub (single-workspace-per-user fallback)
+    3. Dev workspace (when Clerk is not configured)
+
+    When Clerk is enabled, the workspace must exist and be owned by the user
+    — validated at the router level for project-scoped endpoints.
+    """
+    if not _clerk_enabled():
+        # Dev mode: accept any X-Workspace-ID or fall back to dev workspace
+        return x_workspace_id or DEV_WORKSPACE_ID
+
+    if not credentials:
+        raise HTTPException(status_code=401, detail="Authorization header required")
+
+    claims = _verify_clerk_token(credentials.credentials)
+    if not claims:
+        raise HTTPException(status_code=401, detail="Invalid or expired token")
+
+    # If the frontend passed an explicit project, use it (ownership validated by caller)
+    if x_workspace_id:
+        return x_workspace_id
+
     workspace_id = claims.get("org_id") or claims.get("sub")
     if not workspace_id:
         raise HTTPException(status_code=401, detail="No workspace in token claims")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import credentials, runs, webhooks, workflows
+from app.routers import credentials, projects, runs, webhooks, workflows
 
 app = FastAPI(title="Marshal API", version="0.1.0")
 
@@ -12,6 +12,7 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+app.include_router(projects.router)
 app.include_router(workflows.router)
 app.include_router(runs.router)
 app.include_router(credentials.router)

--- a/apps/api/app/models/workspace.py
+++ b/apps/api/app/models/workspace.py
@@ -11,6 +11,7 @@ class Workspace(Base):
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     name = Column(String(255), nullable=False)
+    owner_id = Column(String(255), nullable=True)
     plan = Column(String(50), nullable=False, default="free")
     kms_key_id = Column(String(255), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/apps/api/app/routers/projects.py
+++ b/apps/api/app/routers/projects.py
@@ -1,0 +1,172 @@
+"""
+Projects (workspaces) CRUD + template listing.
+
+A "project" is a workspace owned by a single user. Workflows and credentials
+are scoped to a project.
+"""
+import json
+import uuid
+from datetime import datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_user_id
+from app.core.database import get_db
+from app.models.workspace import Workspace
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+# ---------------------------------------------------------------------------
+# Schemas
+# ---------------------------------------------------------------------------
+
+class TemplateOut(BaseModel):
+    id: str
+    slug: str
+    name: str
+    description: str
+    default_mode: str
+
+
+class ProjectOut(BaseModel):
+    id: str
+    name: str
+    owner_id: str
+    created_at: datetime
+    workflow_count: int = 0
+
+
+class ProjectCreate(BaseModel):
+    name: str
+    template_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/templates", response_model=list[TemplateOut])
+def list_templates(db: Session = Depends(get_db)):
+    rows = db.execute(text("SELECT id, slug, name, description, default_mode FROM project_templates ORDER BY name")).fetchall()
+    return [TemplateOut(id=str(r.id), slug=r.slug, name=r.name, description=r.description, default_mode=r.default_mode) for r in rows]
+
+
+@router.get("", response_model=list[ProjectOut])
+def list_projects(
+    user_id: Annotated[str, Depends(get_user_id)],
+    db: Session = Depends(get_db),
+):
+    rows = db.execute(text("""
+        SELECT w.id, w.name, w.owner_id, w.created_at,
+               COUNT(wf.id) AS workflow_count
+        FROM workspaces w
+        LEFT JOIN workflows wf ON wf.workspace_id = w.id
+        WHERE w.owner_id = :owner_id
+        GROUP BY w.id
+        ORDER BY w.created_at DESC
+    """), {"owner_id": user_id}).fetchall()
+
+    return [
+        ProjectOut(
+            id=str(r.id),
+            name=r.name,
+            owner_id=r.owner_id,
+            created_at=r.created_at,
+            workflow_count=r.workflow_count or 0,
+        )
+        for r in rows
+    ]
+
+
+@router.post("", response_model=ProjectOut, status_code=201)
+def create_project(
+    body: ProjectCreate,
+    user_id: Annotated[str, Depends(get_user_id)],
+    db: Session = Depends(get_db),
+):
+    if not body.name.strip():
+        raise HTTPException(status_code=422, detail="Project name cannot be empty")
+
+    project_id = uuid.uuid4()
+    now = datetime.utcnow()
+
+    db.execute(text("""
+        INSERT INTO workspaces (id, name, owner_id, plan, created_at, updated_at)
+        VALUES (:id, :name, :owner_id, 'free', :now, :now)
+    """), {"id": str(project_id), "name": body.name.strip(), "owner_id": user_id, "now": now})
+
+    # Seed workflows from template if requested
+    if body.template_id:
+        tmpl = db.execute(text(
+            "SELECT name, default_mode, nodes, edges FROM project_templates WHERE id = :id"
+        ), {"id": body.template_id}).fetchone()
+
+        if tmpl:
+            _seed_workflow_from_template(db, project_id, tmpl)
+
+    db.commit()
+
+    return ProjectOut(id=str(project_id), name=body.name.strip(), owner_id=user_id, created_at=now, workflow_count=1 if body.template_id else 0)
+
+
+@router.delete("/{project_id}", status_code=204)
+def delete_project(
+    project_id: str,
+    user_id: Annotated[str, Depends(get_user_id)],
+    db: Session = Depends(get_db),
+):
+    row = db.execute(text("SELECT owner_id FROM workspaces WHERE id = :id"), {"id": project_id}).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if row.owner_id != user_id:
+        raise HTTPException(status_code=403, detail="Not your project")
+
+    # Cascade: runs → run_events, workflow_versions, workflows, integrations
+    db.execute(text("""
+        DELETE FROM run_events WHERE run_id IN (
+            SELECT r.id FROM runs r
+            JOIN workflow_versions wv ON wv.id = r.workflow_version_id
+            JOIN workflows w ON w.id = wv.workflow_id
+            WHERE w.workspace_id = :pid
+        )
+    """), {"pid": project_id})
+    db.execute(text("""
+        DELETE FROM runs WHERE workflow_version_id IN (
+            SELECT wv.id FROM workflow_versions wv
+            JOIN workflows w ON w.id = wv.workflow_id
+            WHERE w.workspace_id = :pid
+        )
+    """), {"pid": project_id})
+    db.execute(text("DELETE FROM workflow_versions WHERE workflow_id IN (SELECT id FROM workflows WHERE workspace_id = :pid)"), {"pid": project_id})
+    db.execute(text("DELETE FROM workflows WHERE workspace_id = :pid"), {"pid": project_id})
+    db.execute(text("DELETE FROM integrations WHERE workspace_id = :pid"), {"pid": project_id})
+    db.execute(text("DELETE FROM workspaces WHERE id = :pid"), {"pid": project_id})
+    db.commit()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _seed_workflow_from_template(db, project_id: uuid.UUID, tmpl) -> None:
+    wf_id = uuid.uuid4()
+    graph = {"nodes": tmpl.nodes, "edges": tmpl.edges}
+
+    db.execute(text("""
+        INSERT INTO workflows (id, workspace_id, name, default_mode)
+        VALUES (:id, :ws, :name, :mode)
+    """), {"id": str(wf_id), "ws": str(project_id), "name": tmpl.name, "mode": tmpl.default_mode})
+
+    version_id = db.execute(text("""
+        INSERT INTO workflow_versions (workflow_id, graph)
+        VALUES (:wf, cast(:graph as jsonb))
+        RETURNING id
+    """), {"wf": str(wf_id), "graph": json.dumps(graph)}).fetchone()[0]
+
+    db.execute(text("UPDATE workflows SET current_version_id = :vid WHERE id = :id"),
+               {"vid": str(version_id), "id": str(wf_id)})

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -10,7 +10,7 @@ export default function Home() {
 
   // Without Clerk, go straight to app
   useEffect(() => {
-    if (!clerkEnabled) router.replace("/workflows")
+    if (!clerkEnabled) router.replace("/projects")
   }, [clerkEnabled, router])
 
   if (!clerkEnabled) return null
@@ -23,7 +23,7 @@ function LandingPage() {
   const { isSignedIn, isLoaded } = useAuth()
 
   useEffect(() => {
-    if (isLoaded && isSignedIn) router.replace("/workflows")
+    if (isLoaded && isSignedIn) router.replace("/projects")
   }, [isLoaded, isSignedIn, router])
 
   return (

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -1,0 +1,132 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@clerk/nextjs"
+import AuthButton from "@/components/AuthButton"
+import NewProjectModal from "@/components/NewProjectModal"
+
+interface Project {
+  id: string
+  name: string
+  workflow_count: number
+  created_at: string
+}
+
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime()
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return "today"
+  if (days === 1) return "yesterday"
+  if (days < 30) return `${days}d ago`
+  return new Date(ts).toLocaleDateString()
+}
+
+export default function ProjectsPage() {
+  const router = useRouter()
+  const { getToken, isLoaded, isSignedIn } = useAuth()
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+  const [projects, setProjects] = useState<Project[]>([])
+  const [loading, setLoading] = useState(true)
+  const [showModal, setShowModal] = useState(false)
+
+  async function fetchProjects() {
+    try {
+      const headers: Record<string, string> = {}
+      if (clerkEnabled) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects`, { headers })
+      if (res.ok) setProjects(await res.json())
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!clerkEnabled || (isLoaded && isSignedIn)) {
+      fetchProjects()
+    } else if (isLoaded && !isSignedIn) {
+      router.replace("/")
+    }
+  }, [isLoaded, isSignedIn, clerkEnabled])
+
+  function selectProject(id: string) {
+    document.cookie = `delegator_project_id=${id}; path=/; max-age=31536000`
+    router.push("/workflows")
+  }
+
+  return (
+    <div className="min-h-screen bg-stone-50">
+      <header className="border-b border-stone-200 bg-white px-6 py-3.5 flex items-center justify-between">
+        <span className="text-base font-bold text-stone-900 tracking-tight">Delegator</span>
+        <div className="flex items-center gap-3">
+          {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-3xl px-6 py-10">
+        <div className="flex items-center justify-between mb-6">
+          <div>
+            <h1 className="text-xl font-semibold text-stone-900">Your projects</h1>
+            <p className="text-sm text-stone-400 mt-0.5">Each project has its own agents, credentials, and settings</p>
+          </div>
+          <button
+            onClick={() => setShowModal(true)}
+            className="rounded-lg bg-stone-900 px-4 py-2 text-sm font-medium text-white hover:bg-stone-700 transition-colors"
+          >
+            + New project
+          </button>
+        </div>
+
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2].map(i => (
+              <div key={i} className="h-20 rounded-xl border border-stone-200 bg-white animate-pulse" />
+            ))}
+          </div>
+        ) : projects.length === 0 ? (
+          <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
+            <p className="text-stone-800 font-medium mb-1">No projects yet</p>
+            <p className="text-stone-400 text-sm mb-6">Create your first project to get started</p>
+            <button
+              onClick={() => setShowModal(true)}
+              className="inline-block rounded-lg bg-stone-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-stone-700 transition-colors"
+            >
+              Create your first project
+            </button>
+          </div>
+        ) : (
+          <div className="grid gap-2">
+            {projects.map(p => (
+              <button
+                key={p.id}
+                onClick={() => selectProject(p.id)}
+                className="flex items-center justify-between rounded-xl border border-stone-200 bg-white px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group text-left w-full"
+              >
+                <div>
+                  <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">
+                    {p.name}
+                  </p>
+                  <p className="text-xs text-stone-400 mt-0.5">
+                    {p.workflow_count} agent{p.workflow_count !== 1 ? "s" : ""} · created {timeAgo(p.created_at)}
+                  </p>
+                </div>
+                <span className="text-stone-300 group-hover:text-stone-500 transition-colors text-sm">→</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </main>
+
+      {showModal && (
+        <NewProjectModal
+          onClose={() => setShowModal(false)}
+          onCreate={(id) => selectProject(id)}
+        />
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/app/workflows/page.tsx
+++ b/apps/web/src/app/workflows/page.tsx
@@ -1,4 +1,9 @@
+"use client"
+
+import { useEffect, useState } from "react"
 import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@clerk/nextjs"
 import AuthButton from "@/components/AuthButton"
 
 interface Workflow {
@@ -7,16 +12,6 @@ interface Workflow {
   updated_at: string
   last_run_status: string | null
   last_run_at: string | null
-}
-
-async function getWorkflows(): Promise<Workflow[]> {
-  try {
-    const res = await fetch(`${process.env.API_URL}/workflows`, { cache: "no-store" })
-    if (!res.ok) return []
-    return res.json()
-  } catch {
-    return []
-  }
 }
 
 const RUN_STATUS: Record<string, { label: string; dot: string; text: string; bg: string }> = {
@@ -36,13 +31,65 @@ function timeAgo(ts: string): string {
   return `${Math.floor(hrs / 24)}d ago`
 }
 
-export default async function WorkflowsPage() {
-  const workflows = await getWorkflows()
+function getActiveProject(): string | null {
+  if (typeof document === "undefined") return null
+  const match = document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)
+  return match ? match[1] : null
+}
+
+export default function WorkflowsPage() {
+  const router = useRouter()
+  const { getToken, isLoaded, isSignedIn } = useAuth()
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+  const [workflows, setWorkflows] = useState<Workflow[]>([])
+  const [projectId, setProjectId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    if (clerkEnabled && isLoaded && !isSignedIn) {
+      router.replace("/")
+      return
+    }
+    if (!clerkEnabled || (isLoaded && isSignedIn)) {
+      const pid = getActiveProject()
+      setProjectId(pid)
+      loadWorkflows(pid)
+    }
+  }, [isLoaded, isSignedIn, clerkEnabled])
+
+  async function loadWorkflows(pid: string | null) {
+    try {
+      const headers: Record<string, string> = {}
+      if (clerkEnabled) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      if (pid) headers["X-Workspace-ID"] = pid
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows`, { headers })
+      if (res.ok) setWorkflows(await res.json())
+    } finally {
+      setLoading(false)
+    }
+  }
 
   return (
     <div className="min-h-screen bg-stone-50">
       <header className="border-b border-stone-200 bg-white px-6 py-3.5 flex items-center justify-between">
-        <span className="text-base font-bold text-stone-900 tracking-tight">Delegator</span>
+        <div className="flex items-center gap-3">
+          <Link href="/projects" className="text-base font-bold text-stone-900 tracking-tight hover:text-stone-600 transition-colors">
+            Delegator
+          </Link>
+          {projectId && (
+            <>
+              <span className="text-stone-300">/</span>
+              <Link href="/projects" className="text-sm text-stone-500 hover:text-stone-800 transition-colors">
+                Switch project
+              </Link>
+            </>
+          )}
+        </div>
         <div className="flex items-center gap-3">
           <Link href="/settings" className="text-sm text-stone-500 hover:text-stone-800 transition-colors">
             Integrations
@@ -53,7 +100,7 @@ export default async function WorkflowsPage() {
           >
             + New agent
           </Link>
-          <AuthButton afterSignOutUrl="/sign-in" />
+          {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
         </div>
       </header>
 
@@ -63,7 +110,13 @@ export default async function WorkflowsPage() {
           <span className="text-xs text-stone-400">{workflows.length} agent{workflows.length !== 1 ? "s" : ""}</span>
         </div>
 
-        {workflows.length === 0 ? (
+        {loading ? (
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => (
+              <div key={i} className="h-20 rounded-xl border border-stone-200 bg-white animate-pulse" />
+            ))}
+          </div>
+        ) : workflows.length === 0 ? (
           <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
             <p className="text-stone-800 font-medium mb-1">No agents yet</p>
             <p className="text-stone-400 text-sm mb-6">Build your first AI agent on the canvas</p>
@@ -88,9 +141,7 @@ export default async function WorkflowsPage() {
                     <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">
                       {w.name}
                     </p>
-                    <p className="text-xs text-stone-400 mt-0.5">
-                      edited {timeAgo(w.updated_at)}
-                    </p>
+                    <p className="text-xs text-stone-400 mt-0.5">edited {timeAgo(w.updated_at)}</p>
                   </div>
                   <div className="flex items-center gap-3">
                     {status ? (

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -1,0 +1,148 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAuth } from "@clerk/nextjs"
+
+interface Template {
+  id: string
+  slug: string
+  name: string
+  description: string
+}
+
+interface Props {
+  onClose: () => void
+  onCreate: (projectId: string) => void
+}
+
+export default function NewProjectModal({ onClose, onCreate }: Props) {
+  const { getToken } = useAuth()
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+  const [name, setName] = useState("")
+  const [templates, setTemplates] = useState<Template[]>([])
+  const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState("")
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects/templates`)
+      .then(r => r.json())
+      .then(setTemplates)
+      .catch(() => {})
+  }, [])
+
+  async function handleCreate() {
+    if (!name.trim()) { setError("Project name is required"); return }
+    setSaving(true)
+    setError("")
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json" }
+      if (clerkEnabled) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ name: name.trim(), template_id: selectedTemplate }),
+      })
+      if (!res.ok) throw new Error("Failed to create project")
+      const project = await res.json()
+      onCreate(project.id)
+    } catch {
+      setError("Failed to create project — please try again")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
+      <div
+        className="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 p-6"
+        onClick={e => e.stopPropagation()}
+      >
+        <h2 className="text-lg font-semibold text-stone-900 mb-4">New project</h2>
+
+        {/* Name */}
+        <div className="mb-5">
+          <label className="text-xs font-medium text-stone-500 block mb-1.5">Project name</label>
+          <input
+            autoFocus
+            type="text"
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => e.key === "Enter" && handleCreate()}
+            placeholder="e.g. Acme Backend, Mobile App, Delegator"
+            className="w-full border border-stone-200 rounded-lg px-3 py-2.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200"
+          />
+        </div>
+
+        {/* Template picker */}
+        <div className="mb-5">
+          <p className="text-xs font-medium text-stone-500 mb-2">Start from a template <span className="font-normal text-stone-400">(optional)</span></p>
+          <div className="grid gap-2">
+            <TemplateCard
+              id={null}
+              name="Blank"
+              description="Empty canvas — build your own agent from scratch"
+              selected={selectedTemplate === null}
+              onSelect={() => setSelectedTemplate(null)}
+            />
+            {templates.map(t => (
+              <TemplateCard
+                key={t.id}
+                id={t.id}
+                name={t.name}
+                description={t.description}
+                selected={selectedTemplate === t.id}
+                onSelect={() => setSelectedTemplate(t.id)}
+              />
+            ))}
+          </div>
+        </div>
+
+        {error && <p className="text-xs text-red-500 mb-3">{error}</p>}
+
+        <div className="flex gap-2">
+          <button
+            onClick={handleCreate}
+            disabled={saving}
+            className="rounded-lg bg-stone-900 px-5 py-2 text-sm font-medium text-white hover:bg-stone-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? "Creating…" : "Create project"}
+          </button>
+          <button
+            onClick={onClose}
+            className="rounded-lg border border-stone-200 px-5 py-2 text-sm text-stone-600 hover:bg-stone-50 transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function TemplateCard({ id, name, description, selected, onSelect }: {
+  id: string | null
+  name: string
+  description: string
+  selected: boolean
+  onSelect: () => void
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      className={`text-left rounded-lg border px-4 py-3 transition-all ${
+        selected
+          ? "border-indigo-400 bg-indigo-50 ring-1 ring-indigo-300"
+          : "border-stone-200 hover:border-stone-300"
+      }`}
+    >
+      <p className={`text-sm font-medium ${selected ? "text-indigo-900" : "text-stone-900"}`}>{name}</p>
+      <p className="text-xs text-stone-400 mt-0.5">{description}</p>
+    </button>
+  )
+}


### PR DESCRIPTION
## What

Users can now create named projects (workspaces), each with their own agents and credentials.

### Backend
- **Migration 0002**: adds `owner_id` to `workspaces`, creates `project_templates` table seeded with Autopilot and Story→PR graphs
- **`GET /projects`** — list user's projects (scoped by `owner_id`)
- **`POST /projects`** — create project, optionally seeding from a template
- **`GET /projects/templates`** — list available templates
- **`DELETE /projects/{id}`** — cascade-delete a project and all its data
- **`get_workspace_id()`** now also reads `X-Workspace-ID` header for explicit project selection
- **`get_user_id()`** new dependency returning Clerk `sub` (or `'dev'` locally)

### Frontend
- **`/projects`** — post-login home; lists user's projects, "New Project" button
- **`NewProjectModal`** — name input + template cards (Blank, Autopilot, Story→PR)
- Selecting a project sets `delegator_project_id` cookie, redirects to `/workflows`
- **`/workflows`** — converted to client component; reads cookie, passes `X-Workspace-ID` header to API
- Nav shows "Switch project" link back to `/projects`
- Landing page redirects to `/projects` after sign-in

## How it works locally (no Clerk)
- `/` redirects to `/projects`
- No auth, dev workspace (`00000000-0000-0000-0000-000000000001`) is used unless a project cookie is set
- Create projects at `/projects` — they'll appear under owner_id `'dev'`

## Test plan
- [ ] `alembic upgrade head` runs clean (migration 0002)
- [ ] `GET /projects/templates` returns 2 templates
- [ ] Create project without template → redirects to `/workflows` with empty agents list
- [ ] Create project with Autopilot template → redirects to `/workflows` with 1 agent seeded
- [ ] Project cookie persists across page refreshes
- [ ] "Switch project" nav link returns to `/projects`