### PR TITLE
fix: guard useAuth calls behind ClerkProvider check

### DIFF
--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -23,10 +23,26 @@ function timeAgo(ts: string): string {
 }
 
 export default function ProjectsPage() {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (clerkEnabled) return <ProjectsWithAuth />
+  return <ProjectsContent getToken={null} />
+}
+
+function ProjectsWithAuth() {
   const router = useRouter()
   const { getToken, isLoaded, isSignedIn } = useAuth()
-  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) router.replace("/")
+  }, [isLoaded, isSignedIn, router])
+
+  if (!isLoaded) return null
+  return <ProjectsContent getToken={getToken} />
+}
+
+function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>) | null }) {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  const router = useRouter()
   const [projects, setProjects] = useState<Project[]>([])
   const [loading, setLoading] = useState(true)
   const [showModal, setShowModal] = useState(false)
@@ -34,7 +50,7 @@ export default function ProjectsPage() {
   async function fetchProjects() {
     try {
       const headers: Record<string, string> = {}
-      if (clerkEnabled) {
+      if (getToken) {
         const token = await getToken()
         if (token) headers["Authorization"] = `Bearer ${token}`
       }
@@ -45,13 +61,7 @@ export default function ProjectsPage() {
     }
   }
 
-  useEffect(() => {
-    if (!clerkEnabled || (isLoaded && isSignedIn)) {
-      fetchProjects()
-    } else if (isLoaded && !isSignedIn) {
-      router.replace("/")
-    }
-  }, [isLoaded, isSignedIn, clerkEnabled])
+  useEffect(() => { fetchProjects() }, [])
 
   function selectProject(id: string) {
     document.cookie = `delegator_project_id=${id}; path=/; max-age=31536000`
@@ -62,9 +72,7 @@ export default function ProjectsPage() {
     <div className="min-h-screen bg-stone-50">
       <header className="border-b border-stone-200 bg-white px-6 py-3.5 flex items-center justify-between">
         <span className="text-base font-bold text-stone-900 tracking-tight">Delegator</span>
-        <div className="flex items-center gap-3">
-          {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
-        </div>
+        {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
       </header>
 
       <main className="mx-auto max-w-3xl px-6 py-10">
@@ -83,9 +91,7 @@ export default function ProjectsPage() {
 
         {loading ? (
           <div className="space-y-2">
-            {[1, 2].map(i => (
-              <div key={i} className="h-20 rounded-xl border border-stone-200 bg-white animate-pulse" />
-            ))}
+            {[1, 2].map(i => <div key={i} className="h-20 rounded-xl border border-stone-200 bg-white animate-pulse" />)}
           </div>
         ) : projects.length === 0 ? (
           <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
@@ -107,9 +113,7 @@ export default function ProjectsPage() {
                 className="flex items-center justify-between rounded-xl border border-stone-200 bg-white px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group text-left w-full"
               >
                 <div>
-                  <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">
-                    {p.name}
-                  </p>
+                  <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">{p.name}</p>
                   <p className="text-xs text-stone-400 mt-0.5">
                     {p.workflow_count} agent{p.workflow_count !== 1 ? "s" : ""} · created {timeAgo(p.created_at)}
                   </p>
@@ -123,6 +127,7 @@ export default function ProjectsPage() {
 
       {showModal && (
         <NewProjectModal
+          getToken={getToken}
           onClose={() => setShowModal(false)}
           onCreate={(id) => selectProject(id)}
         />

--- a/apps/web/src/app/workflows/page.tsx
+++ b/apps/web/src/app/workflows/page.tsx
@@ -38,30 +38,39 @@ function getActiveProject(): string | null {
 }
 
 export default function WorkflowsPage() {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (clerkEnabled) return <WorkflowsWithAuth />
+  return <WorkflowsContent getToken={null} />
+}
+
+function WorkflowsWithAuth() {
   const router = useRouter()
   const { getToken, isLoaded, isSignedIn } = useAuth()
-  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
 
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) router.replace("/")
+  }, [isLoaded, isSignedIn, router])
+
+  if (!isLoaded) return null
+  return <WorkflowsContent getToken={getToken} />
+}
+
+function WorkflowsContent({ getToken }: { getToken: (() => Promise<string | null>) | null }) {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   const [workflows, setWorkflows] = useState<Workflow[]>([])
   const [projectId, setProjectId] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    if (clerkEnabled && isLoaded && !isSignedIn) {
-      router.replace("/")
-      return
-    }
-    if (!clerkEnabled || (isLoaded && isSignedIn)) {
-      const pid = getActiveProject()
-      setProjectId(pid)
-      loadWorkflows(pid)
-    }
-  }, [isLoaded, isSignedIn, clerkEnabled])
+    const pid = getActiveProject()
+    setProjectId(pid)
+    loadWorkflows(pid)
+  }, [])
 
   async function loadWorkflows(pid: string | null) {
     try {
       const headers: Record<string, string> = {}
-      if (clerkEnabled) {
+      if (getToken) {
         const token = await getToken()
         if (token) headers["Authorization"] = `Bearer ${token}`
       }
@@ -138,9 +147,7 @@ export default function WorkflowsPage() {
                   className="flex items-center justify-between rounded-xl border border-stone-200 bg-white px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group"
                 >
                   <div>
-                    <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">
-                      {w.name}
-                    </p>
+                    <p className="font-semibold text-stone-900 group-hover:text-stone-700 transition-colors">{w.name}</p>
                     <p className="text-xs text-stone-400 mt-0.5">edited {timeAgo(w.updated_at)}</p>
                   </div>
                   <div className="flex items-center gap-3">
@@ -152,9 +159,7 @@ export default function WorkflowsPage() {
                     ) : (
                       <span className="text-xs text-stone-400 italic">never run</span>
                     )}
-                    {w.last_run_at && (
-                      <span className="text-xs text-stone-400">{timeAgo(w.last_run_at)}</span>
-                    )}
+                    {w.last_run_at && <span className="text-xs text-stone-400">{timeAgo(w.last_run_at)}</span>}
                     <span className="text-stone-300 group-hover:text-stone-500 transition-colors text-sm">→</span>
                   </div>
                 </Link>

--- a/apps/web/src/components/NewProjectModal.tsx
+++ b/apps/web/src/components/NewProjectModal.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useEffect, useState } from "react"
-import { useAuth } from "@clerk/nextjs"
 
 interface Template {
   id: string
@@ -11,14 +10,12 @@ interface Template {
 }
 
 interface Props {
+  getToken: (() => Promise<string | null>) | null
   onClose: () => void
   onCreate: (projectId: string) => void
 }
 
-export default function NewProjectModal({ onClose, onCreate }: Props) {
-  const { getToken } = useAuth()
-  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-
+export default function NewProjectModal({ getToken, onClose, onCreate }: Props) {
   const [name, setName] = useState("")
   const [templates, setTemplates] = useState<Template[]>([])
   const [selectedTemplate, setSelectedTemplate] = useState<string | null>(null)
@@ -38,7 +35,7 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
     setError("")
     try {
       const headers: Record<string, string> = { "Content-Type": "application/json" }
-      if (clerkEnabled) {
+      if (getToken) {
         const token = await getToken()
         if (token) headers["Authorization"] = `Bearer ${token}`
       }
@@ -47,7 +44,7 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
         headers,
         body: JSON.stringify({ name: name.trim(), template_id: selectedTemplate }),
       })
-      if (!res.ok) throw new Error("Failed to create project")
+      if (!res.ok) throw new Error("Failed")
       const project = await res.json()
       onCreate(project.id)
     } catch {
@@ -59,13 +56,9 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40" onClick={onClose}>
-      <div
-        className="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 p-6"
-        onClick={e => e.stopPropagation()}
-      >
+      <div className="bg-white rounded-2xl shadow-xl w-full max-w-lg mx-4 p-6" onClick={e => e.stopPropagation()}>
         <h2 className="text-lg font-semibold text-stone-900 mb-4">New project</h2>
 
-        {/* Name */}
         <div className="mb-5">
           <label className="text-xs font-medium text-stone-500 block mb-1.5">Project name</label>
           <input
@@ -74,31 +67,19 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
             value={name}
             onChange={e => setName(e.target.value)}
             onKeyDown={e => e.key === "Enter" && handleCreate()}
-            placeholder="e.g. Acme Backend, Mobile App, Delegator"
+            placeholder="e.g. Acme Backend, Mobile App"
             className="w-full border border-stone-200 rounded-lg px-3 py-2.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200"
           />
         </div>
 
-        {/* Template picker */}
         <div className="mb-5">
-          <p className="text-xs font-medium text-stone-500 mb-2">Start from a template <span className="font-normal text-stone-400">(optional)</span></p>
+          <p className="text-xs font-medium text-stone-500 mb-2">
+            Start from a template <span className="font-normal text-stone-400">(optional)</span>
+          </p>
           <div className="grid gap-2">
-            <TemplateCard
-              id={null}
-              name="Blank"
-              description="Empty canvas — build your own agent from scratch"
-              selected={selectedTemplate === null}
-              onSelect={() => setSelectedTemplate(null)}
-            />
+            <TemplateCard id={null} name="Blank" description="Empty canvas — build your own agent from scratch" selected={selectedTemplate === null} onSelect={() => setSelectedTemplate(null)} />
             {templates.map(t => (
-              <TemplateCard
-                key={t.id}
-                id={t.id}
-                name={t.name}
-                description={t.description}
-                selected={selectedTemplate === t.id}
-                onSelect={() => setSelectedTemplate(t.id)}
-              />
+              <TemplateCard key={t.id} id={t.id} name={t.name} description={t.description} selected={selectedTemplate === t.id} onSelect={() => setSelectedTemplate(t.id)} />
             ))}
           </div>
         </div>
@@ -106,17 +87,10 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
         {error && <p className="text-xs text-red-500 mb-3">{error}</p>}
 
         <div className="flex gap-2">
-          <button
-            onClick={handleCreate}
-            disabled={saving}
-            className="rounded-lg bg-stone-900 px-5 py-2 text-sm font-medium text-white hover:bg-stone-700 disabled:opacity-50 transition-colors"
-          >
+          <button onClick={handleCreate} disabled={saving} className="rounded-lg bg-stone-900 px-5 py-2 text-sm font-medium text-white hover:bg-stone-700 disabled:opacity-50 transition-colors">
             {saving ? "Creating…" : "Create project"}
           </button>
-          <button
-            onClick={onClose}
-            className="rounded-lg border border-stone-200 px-5 py-2 text-sm text-stone-600 hover:bg-stone-50 transition-colors"
-          >
+          <button onClick={onClose} className="rounded-lg border border-stone-200 px-5 py-2 text-sm text-stone-600 hover:bg-stone-50 transition-colors">
             Cancel
           </button>
         </div>
@@ -126,21 +100,10 @@ export default function NewProjectModal({ onClose, onCreate }: Props) {
 }
 
 function TemplateCard({ id, name, description, selected, onSelect }: {
-  id: string | null
-  name: string
-  description: string
-  selected: boolean
-  onSelect: () => void
+  id: string | null; name: string; description: string; selected: boolean; onSelect: () => void
 }) {
   return (
-    <button
-      onClick={onSelect}
-      className={`text-left rounded-lg border px-4 py-3 transition-all ${
-        selected
-          ? "border-indigo-400 bg-indigo-50 ring-1 ring-indigo-300"
-          : "border-stone-200 hover:border-stone-300"
-      }`}
-    >
+    <button onClick={onSelect} className={`text-left rounded-lg border px-4 py-3 transition-all ${selected ? "border-indigo-400 bg-indigo-50 ring-1 ring-indigo-300" : "border-stone-200 hover:border-stone-300"}`}>
       <p className={`text-sm font-medium ${selected ? "text-indigo-900" : "text-stone-900"}`}>{name}</p>
       <p className="text-xs text-stone-400 mt-0.5">{description}</p>
     </button>


### PR DESCRIPTION
useAuth() throws when called outside ClerkProvider. Split each affected page into a shell component (no hooks) + a WithAuth sub-component only rendered when Clerk is enabled. Also passes getToken down as a prop so NewProjectModal doesn't need useAuth directly.