### PR TITLE
fix: redirect unauthenticated users to / not /sign-in

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,9 +8,7 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
 
   const { userId } = await auth()
   if (!userId) {
-    const signInUrl = new URL("/sign-in", req.url)
-    signInUrl.searchParams.set("redirect_url", req.url)
-    return NextResponse.redirect(signInUrl)
+    return NextResponse.redirect(new URL("/", req.url))
   }
 })
 


### PR DESCRIPTION
Any unauthenticated visit to a protected route (e.g. /projects) now lands on the landing page instead of Clerk's hosted sign-in page.