### PR TITLE
feat: Google auth as access gate + use cases on landing page

### DIFF
--- a/apps/api/app/routers/projects.py
+++ b/apps/api/app/routers/projects.py
@@ -1,9 +1,9 @@
 """
-Projects (workspaces) CRUD + template listing + waitlist approval.
+Projects (workspaces) CRUD + template listing.
 
 A "project" is a workspace owned by a single user. Workflows and credentials
-are scoped to a project. New users get a pending workspace (is_approved=False)
-until manually approved via the admin endpoint.
+are scoped to a project. Google sign-in is the access gate — all signed-in
+users get immediate access with no waitlist.
 """
 import json
 import uuid
@@ -75,16 +75,16 @@ def list_projects(
         ORDER BY w.created_at DESC
     """), {"owner_id": user_id}).fetchall()
 
-    # Auto-register new users with a pending workspace
+    # Auto-register new users with an approved workspace — Google auth is the gate
     if not rows:
         project_id, now = uuid.uuid4(), datetime.utcnow()
         db.execute(text("""
             INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at)
-            VALUES (:id, 'My Workspace', :owner_id, 'free', false, :now, :now)
+            VALUES (:id, 'My Workspace', :owner_id, 'free', true, :now, :now)
         """), {"id": str(project_id), "owner_id": user_id, "now": now})
         db.commit()
         return [ProjectOut(id=str(project_id), name="My Workspace", owner_id=user_id,
-                           is_approved=False, created_at=now, workflow_count=0)]
+                           is_approved=True, created_at=now, workflow_count=0)]
 
     return [
         ProjectOut(
@@ -105,18 +105,11 @@ def create_project(
     if not body.name.strip():
         raise HTTPException(status_code=422, detail="Project name cannot be empty")
 
-    # New projects inherit approval from first project (if user is already approved)
-    first = db.execute(text(
-        "SELECT is_approved FROM workspaces WHERE owner_id = :uid ORDER BY created_at LIMIT 1"
-    ), {"uid": user_id}).fetchone()
-    inherit_approval = bool(first and first.is_approved)
-
     project_id, now = uuid.uuid4(), datetime.utcnow()
     db.execute(text("""
         INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at)
-        VALUES (:id, :name, :owner_id, 'free', :approved, :now, :now)
-    """), {"id": str(project_id), "name": body.name.strip(), "owner_id": user_id,
-           "approved": inherit_approval, "now": now})
+        VALUES (:id, :name, :owner_id, 'free', true, :now, :now)
+    """), {"id": str(project_id), "name": body.name.strip(), "owner_id": user_id, "now": now})
 
     if body.template_id:
         tmpl = db.execute(text(
@@ -127,7 +120,7 @@ def create_project(
 
     db.commit()
     return ProjectOut(id=str(project_id), name=body.name.strip(), owner_id=user_id,
-                      is_approved=inherit_approval, created_at=now,
+                      is_approved=True, created_at=now,
                       workflow_count=1 if body.template_id else 0)
 
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -47,7 +47,7 @@ function LandingPage() {
       <section className="flex-1 flex flex-col items-center justify-center px-6 pt-16 pb-24 text-center">
         <div className="inline-flex items-center gap-2 bg-stone-100 text-stone-600 text-xs font-medium px-3 py-1.5 rounded-full mb-8">
           <span className="w-1.5 h-1.5 rounded-full bg-green-500 inline-block" />
-          Now in early access — request your invite
+          Now in early access — sign in to try it free
         </div>
 
         <h1 className="text-5xl sm:text-6xl font-bold text-stone-900 leading-[1.1] tracking-tight max-w-3xl">
@@ -64,10 +64,29 @@ function LandingPage() {
           <SignInButton mode="modal">
             <button className="inline-flex items-center gap-3 bg-stone-900 hover:bg-stone-700 text-white font-semibold px-7 py-3.5 rounded-xl text-sm transition-colors shadow-sm">
               <GoogleIcon />
-              Request early access
+              Sign in with Google — it&apos;s free
             </button>
           </SignInButton>
-          <p className="text-xs text-stone-400">Free during early access · No credit card</p>
+          <p className="text-xs text-stone-400">No credit card · No setup · Just your Google account</p>
+        </div>
+      </section>
+
+      {/* Use cases */}
+      <section className="px-6 py-20">
+        <div className="max-w-5xl mx-auto">
+          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest text-center mb-3">What Delegator does</p>
+          <h2 className="text-3xl font-bold text-stone-900 text-center mb-12">
+            Real engineering work, done by AI.<br />Approved by you.
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-5">
+            {USE_CASES.map(uc => (
+              <div key={uc.title} className="bg-stone-50 rounded-2xl p-6">
+                <div className="text-2xl mb-3">{uc.icon}</div>
+                <p className="font-semibold text-stone-900 mb-1.5">{uc.title}</p>
+                <p className="text-sm text-stone-500 leading-relaxed">{uc.body}</p>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
 
@@ -94,7 +113,7 @@ function LandingPage() {
         <div className="max-w-5xl mx-auto">
           <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest text-center mb-3">Why Delegator</p>
           <h2 className="text-3xl font-bold text-stone-900 text-center mb-12">
-            Not just another AI tool.<br />An AI teammate.
+            Not just another AI tool.<br />An AI teammate you can trust.
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
             {WHY_DELEGATOR.map(f => (
@@ -124,16 +143,17 @@ function LandingPage() {
 
       {/* Bottom CTA */}
       <section className="px-6 py-20 text-center">
-        <h2 className="text-3xl font-bold text-stone-900 mb-4">Ready to delegate?</h2>
+        <h2 className="text-3xl font-bold text-stone-900 mb-4">Try it in 30 seconds</h2>
         <p className="text-stone-500 mb-8 max-w-md mx-auto">
-          Join engineering teams using Delegator to ship faster without losing control.
+          Sign in with Google, connect your GitHub repo, and let Delegator pick up its first ticket.
         </p>
         <SignInButton mode="modal">
           <button className="inline-flex items-center gap-3 bg-stone-900 hover:bg-stone-700 text-white font-semibold px-7 py-3.5 rounded-xl text-sm transition-colors">
             <GoogleIcon />
-            Request early access
+            Get started — it&apos;s free
           </button>
         </SignInButton>
+        <p className="text-xs text-stone-400 mt-4">No credit card · Instant access · Sign in with Google</p>
       </section>
 
       <footer className="border-t border-stone-100 py-8 text-center text-xs text-stone-400">
@@ -142,6 +162,24 @@ function LandingPage() {
     </div>
   )
 }
+
+const USE_CASES = [
+  {
+    icon: "🎫",
+    title: "Ticket → Pull Request",
+    body: "Label a GitHub issue 'autopilot ready'. Delegator reads the ticket, clones the repo, writes the fix, runs tests, and opens a PR — while you sleep.",
+  },
+  {
+    icon: "🚀",
+    title: "Story → Deployed feature",
+    body: "Drop a Linear story into Delegator. It breaks it into subtasks, implements each one, runs your CI, and notifies you on Slack when it's ready to review.",
+  },
+  {
+    icon: "🔥",
+    title: "Incident → Root cause",
+    body: "Page fires at 2am. Delegator reads logs, identifies the regression, opens a hotfix PR with the patch, and pings the on-call engineer with a full trace.",
+  },
+]
 
 const HOW_IT_WORKS = [
   {
@@ -171,7 +209,7 @@ const WHY_DELEGATOR = [
   },
   {
     icon: "🔍",
-    title: "Full audit trail",
+    title: "Full audit trail, zero surprises",
     body: "Every action is logged — what the AI read, what it wrote, what it ran, how long it took, what it cost. Debug any run in seconds.",
   },
   {

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -69,9 +69,6 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
     router.push("/workflows")
   }
 
-  const approvedProjects = projects.filter(p => p.is_approved)
-  const isPending = !loading && projects.length > 0 && approvedProjects.length === 0
-
   if (loading) {
     return (
       <div className="min-h-screen bg-stone-50 flex items-center justify-center">
@@ -79,8 +76,6 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
       </div>
     )
   }
-
-  if (isPending) return <WaitlistScreen />
 
   return (
     <div className="min-h-screen bg-stone-50">
@@ -103,7 +98,7 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
           </button>
         </div>
 
-        {approvedProjects.length === 0 ? (
+        {projects.length === 0 ? (
           <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
             <p className="text-stone-800 font-medium mb-1">No projects yet</p>
             <p className="text-stone-400 text-sm mb-6">Create your first project to get started</p>
@@ -116,7 +111,7 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
           </div>
         ) : (
           <div className="grid gap-2">
-            {approvedProjects.map(p => (
+            {projects.map(p => (
               <button
                 key={p.id}
                 onClick={() => selectProject(p.id)}
@@ -142,45 +137,6 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
           onCreate={(id) => selectProject(id)}
         />
       )}
-    </div>
-  )
-}
-
-function WaitlistScreen() {
-  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-  return (
-    <div className="min-h-screen bg-stone-50 flex flex-col">
-      <header className="px-6 py-4 flex items-center justify-between max-w-5xl mx-auto w-full">
-        <span className="font-bold text-stone-900 text-lg tracking-tight">Delegator</span>
-        {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
-      </header>
-
-      <main className="flex-1 flex flex-col items-center justify-center px-6 text-center">
-        <div className="w-14 h-14 rounded-2xl bg-indigo-50 flex items-center justify-center mb-6">
-          <svg className="w-7 h-7 text-indigo-600" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-            <path strokeLinecap="round" strokeLinejoin="round" d="M9 12.75L11.25 15 15 9.75M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
-          </svg>
-        </div>
-
-        <h1 className="text-2xl font-bold text-stone-900 mb-2">You&apos;re on the list</h1>
-        <p className="text-stone-500 max-w-sm leading-relaxed">
-          Thanks for signing up. We&apos;re onboarding teams gradually — we&apos;ll email you as soon as your access is ready.
-        </p>
-
-        <div className="mt-8 bg-white border border-stone-200 rounded-xl px-6 py-5 max-w-sm w-full text-left space-y-3">
-          <p className="text-xs font-semibold text-stone-400 uppercase tracking-wide">While you wait</p>
-          {[
-            "Star the repo on GitHub",
-            "Join our Slack community",
-            "Read the docs",
-          ].map(item => (
-            <div key={item} className="flex items-center gap-2.5 text-sm text-stone-600">
-              <span className="w-1.5 h-1.5 rounded-full bg-indigo-400 shrink-0" />
-              {item}
-            </div>
-          ))}
-        </div>
-      </main>
     </div>
   )
 }


### PR DESCRIPTION
## What changed

**Access model**
- Removed waitlist gate — Google sign-in is now the only gate
- All new workspaces auto-approved on creation
- All app routes still require auth (middleware unchanged)

**Landing page**
- New "What Delegator does" use cases section: Ticket→PR, Story→Feature, Incident→RCA
- Updated CTAs: "Sign in with Google — it's free" / "Get started — it's free"
- Badge updated: "sign in to try it free" (not "request your invite")
- Why Delegator section headline sharpened

**Projects page**
- Removed WaitlistScreen component and all `is_approved` gating logic
- Simplified — signed-in users see their projects immediately

## Test plan
- [ ] Sign in with Google → lands on /projects (no waitlist screen)
- [ ] New user gets "My Workspace" auto-created and can access it
- [ ] Unauthenticated → redirected to / (landing page)
- [ ] Landing page shows use cases section above "How it works"
- [ ] Both CTAs trigger Google sign-in modal