### PR TITLE
Fix #32: Rename "History" to "Activity" on workflow canvas

### DIFF
--- a/apps/web/src/app/workflows/[id]/runs/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/page.tsx
@@ -76,7 +76,7 @@ export default function RunsPage() {
       </header>
 
       <main className="mx-auto max-w-3xl px-6 py-10">
-        <h2 className="text-xl font-semibold text-stone-900 mb-6">Run history</h2>
+        <h2 className="text-xl font-semibold text-stone-900 mb-6">Run activity</h2>
 
         {loading ? (
           <p className="text-stone-400 text-sm">Loading…</p>

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -342,7 +342,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
             href={`/workflows/${workflowId}/runs`}
             className="text-xs text-stone-500 hover:text-stone-800 transition-colors px-2 py-1 rounded hover:bg-stone-100"
           >
-            History
+            Activity
           </a>
           <button
             onClick={() => startRun(true)}


### PR DESCRIPTION
## Summary

Closes #32

### Changes Made

Renamed the **"History"** label to **"Activity"** on the workflow page canvas as requested in issue #32.

**Files changed:**

1. **`apps/web/src/components/canvas/CanvasEditor.tsx`**
   - Changed the navigation button label from `History` → `Activity`
   - This is the button in the canvas toolbar header that links to `/workflows/[id]/runs`

2. **`apps/web/src/app/workflows/[id]/runs/page.tsx`**
   - Changed the page heading from `Run history` → `Run activity`
   - This is the `<h2>` heading on the runs listing page that the Activity button navigates to

### Testing
All 62 tests passed ✅
