### PR TITLE
feat: structured brain block prompts — system readonly + custom editable

### DIFF
--- a/apps/api/app/dsl/loader.py
+++ b/apps/api/app/dsl/loader.py
@@ -207,6 +207,8 @@ def _node_to_block_payload(
 
     elif underlying_type == "brain":
         payload["mode"] = "agentic" if data.get("isAgentic") else "single"
+        if data.get("custom_instructions"):
+            payload["custom_instructions"] = data["custom_instructions"]
         rh = config.get("remote_host")
         if isinstance(rh, dict) and rh.get("ip_ref"):
             payload["runs_on"] = {
@@ -368,6 +370,8 @@ def _block_to_node(block_id: str, block: Block, col: int) -> dict[str, Any]:
     elif block.type == "brain":
         # The executor reads ``isAgentic`` (legacy field name from the canvas).
         data["isAgentic"] = (block.mode == "agentic")
+        if block.custom_instructions:
+            data["custom_instructions"] = block.custom_instructions
         if block.runs_on:
             config["remote_host"] = {
                 "ip_ref": block.runs_on.ip,

--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -125,6 +125,7 @@ class Block(BaseModel):
     # — brain blocks —
     mode: Literal["single", "agentic"] | None = None
     runs_on: RunsOn | None = None
+    custom_instructions: str | None = None  # user-editable zone, appended to description at runtime
 
     # — logic blocks —
     condition: str | None = None

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -365,6 +365,9 @@ def _execute_brain(
 
     artifact = compiled_artifacts.get(block["id"], {})
     system_prompt = artifact.get("system_prompt", block["data"].get("description", ""))
+    custom = block["data"].get("custom_instructions", "") or ""
+    if custom.strip():
+        system_prompt = f"{system_prompt}\n\nAdditional instructions:\n{custom.strip()}"
     is_agentic = block["data"].get("isAgentic", False)
 
     # Resolve remote host (if the YAML's `runs_on:` was set on this block).

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -77,6 +77,38 @@ function WebhookRegisterButton({ owner, repo, getToken }: {
   )
 }
 
+// ── Ref chip renderer ─────────────────────────────────────────────────────────
+
+function SystemPromptWithChips({ text }: { text: string }) {
+  if (!text) return <span className="text-stone-400 italic">No system prompt defined.</span>
+
+  const parts = text.split(/({{[^}]+}})/)
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part.startsWith("{{") && part.endsWith("}}")) {
+          const ref = part.slice(2, -2)
+          const isLiteral = ref.startsWith("<") || ref.includes(" ")
+          return (
+            <span
+              key={i}
+              className={cn(
+                "inline-flex items-center rounded px-1 py-0.5 text-[11px] font-mono font-medium mx-0.5",
+                isLiteral
+                  ? "bg-red-100 text-red-600 border border-red-200"
+                  : "bg-violet-100 text-violet-700 border border-violet-200"
+              )}
+            >
+              {part}
+            </span>
+          )
+        }
+        return <span key={i}>{part}</span>
+      })}
+    </>
+  )
+}
+
 // ── helpers ───────────────────────────────────────────────────────────────────
 
 // Patterns that strongly suggest a hardcoded secret rather than a template ref.
@@ -422,8 +454,9 @@ export default function BlockEditor({
 
         {/* ── Plain English tab ── */}
         {tab === "plain" && (
-          <div className="flex gap-4">
-            <div className="w-40 shrink-0">
+          <div className="space-y-4">
+            {/* Name field — always editable */}
+            <div>
               <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">Name</label>
               <input
                 value={label}
@@ -431,18 +464,62 @@ export default function BlockEditor({
                 className="mt-1 w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
               />
             </div>
-            <div className="flex-1">
-              <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                What should this block do?
-              </label>
-              <textarea
-                value={description}
-                onChange={e => onChange(blockId, { ...blockData, description: e.target.value })}
-                rows={3}
-                placeholder="Describe in plain English…"
-                className="mt-1 w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
-              />
-            </div>
+
+            {blockType === "brain" ? (
+              <>
+                {/* System prompt — readonly, chips rendered */}
+                <div>
+                  <div className="flex items-center justify-between mb-1">
+                    <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
+                      System prompt
+                    </label>
+                    <span className="text-[10px] font-medium text-stone-400 bg-stone-100 px-1.5 py-0.5 rounded">
+                      read-only
+                    </span>
+                  </div>
+                  <div className="rounded-lg border border-stone-200 bg-stone-50 px-3 py-2.5 text-xs text-stone-600 leading-relaxed whitespace-pre-wrap min-h-[80px]">
+                    <SystemPromptWithChips text={description} />
+                  </div>
+                  <p className="text-[10px] text-stone-400 mt-1">
+                    <span className="inline-block w-2 h-2 rounded-sm bg-violet-200 border border-violet-300 mr-1 align-middle" />
+                    violet = template ref &nbsp;·&nbsp;
+                    <span className="inline-block w-2 h-2 rounded-sm bg-red-100 border border-red-200 mr-1 align-middle" />
+                    red = literal placeholder (check your YAML)
+                  </p>
+                </div>
+
+                {/* Custom instructions — user-editable */}
+                <div>
+                  <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
+                    Your instructions
+                  </label>
+                  <p className="text-[10px] text-stone-400 mt-0.5 mb-1">
+                    Added to the system prompt at runtime. Use this to add constraints, focus areas, or context.
+                  </p>
+                  <textarea
+                    value={(blockData.custom_instructions as string) || ""}
+                    onChange={e => onChange(blockId, { ...blockData, custom_instructions: e.target.value })}
+                    rows={4}
+                    placeholder="e.g. Focus only on TypeScript files. Skip test files. Keep changes minimal."
+                    className="w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
+                  />
+                </div>
+              </>
+            ) : (
+              /* Non-brain blocks — keep simple free-text description */
+              <div>
+                <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
+                  What should this block do?
+                </label>
+                <textarea
+                  value={description}
+                  onChange={e => onChange(blockId, { ...blockData, description: e.target.value })}
+                  rows={3}
+                  placeholder="Describe in plain English…"
+                  className="mt-1 w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
+                />
+              </div>
+            )}
           </div>
         )}
 


### PR DESCRIPTION
## What

Implements Option D from the brain block editing discussion — structured prompt builder.

## Changes

**Backend**
- `dsl/schema.py` — adds `custom_instructions: str | None` field to `Block`
- `dsl/loader.py` — YAML→graph and graph→YAML both carry `custom_instructions` through
- `runtime/executor.py` — appends `custom_instructions` to system prompt at runtime: `system_prompt + "\n\nAdditional instructions:\n" + custom`

**Frontend (`BlockEditor.tsx`)**
- Brain blocks: "Plain English" tab now shows two zones:
  - **System prompt** — readonly, `{{refs}}` rendered as colored chips (violet = valid ref, red = literal placeholder like `<clone_url>`)
  - **Your instructions** — free textarea, saved as `custom_instructions`, appended at runtime
- Non-brain blocks: unchanged free-text description

## Why

Users editing the system prompt (AI instructions) directly caused hard-to-debug errors — wrong refs, broken placeholders. This separates the platform-authored prompt from user customization.

## Test

1. Open a brain block in the canvas → Plain English tab
2. System prompt renders with `{{_trigger.repo_full_name}}` as violet chips
3. Type custom instructions → saved to `custom_instructions`
4. Run workflow → executor concatenates both sections