### PR TITLE
feat: inline run drawer — SSE streaming + canvas node highlighting

### DIFF
--- a/apps/web/src/components/canvas/BlockNode.tsx
+++ b/apps/web/src/components/canvas/BlockNode.tsx
@@ -12,6 +12,7 @@ export interface BlockNodeData {
   isAgentic?: boolean
   integration?: string
   config?: { action?: string }
+  runStatus?: "running" | "completed" | "failed" | "skipped"
   [key: string]: unknown
 }
 
@@ -47,6 +48,13 @@ function BlockNode({ data, selected }: NodeProps) {
   const integration = nodeData.integration as string | undefined
   const action = nodeData.config?.action
 
+  const runStatus = nodeData.runStatus
+  const runRing =
+    runStatus === "running"   ? "ring-2 ring-violet-400 ring-offset-2 shadow-violet-100 shadow-lg" :
+    runStatus === "completed" ? "ring-2 ring-emerald-400 ring-offset-2" :
+    runStatus === "failed"    ? "ring-2 ring-red-400 ring-offset-2" :
+    runStatus === "skipped"   ? "opacity-40" : ""
+
   const effectiveIntegration = integration || (nodeData.type === "output" ? "slack" : undefined)
   const integrationLabel = effectiveIntegration ? INTEGRATION_LABELS[effectiveIntegration] ?? effectiveIntegration : null
   const integrationColor = effectiveIntegration ? (INTEGRATION_COLORS[effectiveIntegration] ?? "bg-stone-500 text-white") : ""
@@ -58,14 +66,19 @@ function BlockNode({ data, selected }: NodeProps) {
     <div
       style={{ width: 200 }}
       className={cn(
-        "rounded-xl border-2 px-3 py-2.5 cursor-pointer transition-all shadow-sm",
+        "relative rounded-xl border-2 px-3 py-2.5 cursor-pointer transition-all shadow-sm",
         style.bg,
         style.border,
+        runStatus ? runRing :
         selected
           ? "ring-2 ring-indigo-400 ring-offset-2 shadow-md"
           : "hover:shadow-md hover:ring-1 hover:ring-stone-300 hover:ring-offset-1"
       )}
     >
+      {/* Running pulse indicator */}
+      {runStatus === "running" && (
+        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 rounded-full bg-violet-500 animate-ping" />
+      )}
       {/* Target handle (top) */}
       <Handle
         type="target"

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
 import AuthButton from "@/components/AuthButton"
+import RunDrawer from "./RunDrawer"
 import {
   ReactFlow,
   Background,
@@ -126,6 +127,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const { screenToFlowPosition } = useReactFlow()
   const router = useRouter()
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
+  const [activeRunId, setActiveRunId] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
   const [sidebarOpen, setSidebarOpen] = useState(true)
   const [editorExpanded, setEditorExpanded] = useState(false)
@@ -273,11 +275,29 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
       )
       if (!res.ok) throw new Error("Failed to start run")
       const run = await res.json()
-      router.push(`/workflows/${workflowId}/runs/${run.id}`)
+      if (dryRun) {
+        router.push(`/workflows/${workflowId}/runs/${run.id}`)
+      } else {
+        setActiveRunId(run.id)
+        setRunning("idle")
+      }
     } catch {
       setRunning("idle")
     }
   }, [workflowId, getToken, router, nodes])
+
+  const handleBlockStatus = useCallback((blockId: string, status: "running" | "completed" | "failed" | "skipped") => {
+    setNodes(nds => nds.map(n =>
+      n.id === blockId ? { ...n, data: { ...n.data, runStatus: status } } : n
+    ))
+  }, [setNodes])
+
+  const handleDrawerClose = useCallback(() => {
+    setActiveRunId(null)
+    setRunning("idle")
+    // Clear run status highlights from all nodes
+    setNodes(nds => nds.map(n => ({ ...n, data: { ...n.data, runStatus: undefined } })))
+  }, [setNodes])
 
   const handleBlockChange = useCallback(
     (blockId: string, changes: Record<string, unknown>) => {
@@ -352,11 +372,11 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
             {running === "dry" ? "Simulating…" : "Dry run"}
           </button>
           <button
-            onClick={() => startRun(false)}
-            disabled={running !== "idle"}
+            onClick={() => activeRunId ? handleDrawerClose() : startRun(false)}
+            disabled={running === "live" || running === "dry"}
             className="rounded-lg bg-violet-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-violet-700 transition-colors disabled:opacity-50"
           >
-            {running === "live" ? "Starting…" : "▶ Run"}
+            {running === "live" ? "Starting…" : activeRunId ? "■ Stop" : "▶ Run"}
           </button>
           <AuthButton afterSignOutUrl="/sign-in" />
         </div>
@@ -387,6 +407,15 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                 <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#E7E5E4" />
                 <Controls className="!shadow-none !border !border-stone-200 !rounded-xl" showInteractive={false} />
               </ReactFlow>
+              {activeRunId && (
+                <RunDrawer
+                  workflowId={workflowId}
+                  runId={activeRunId}
+                  getToken={getToken}
+                  onBlockStatus={handleBlockStatus}
+                  onClose={handleDrawerClose}
+                />
+              )}
             </div>
             <div className={`relative flex shrink-0 transition-all duration-200 ${sidebarOpen ? "w-52" : "w-8"}`}>
               <button

--- a/apps/web/src/components/canvas/RunDrawer.tsx
+++ b/apps/web/src/components/canvas/RunDrawer.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { cn } from "@/lib/utils"
+
+type BlockStatus = "running" | "completed" | "failed" | "skipped"
+
+interface BlockRow {
+  blockId: string
+  label: string
+  type: string
+  status: BlockStatus
+  output?: string
+  error?: string
+  costUsd?: number
+}
+
+interface RunDrawerProps {
+  workflowId: string
+  runId: string
+  getToken?: (() => Promise<string | null>) | null
+  onBlockStatus: (blockId: string, status: BlockStatus) => void
+  onClose: () => void
+}
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`))
+  return m ? m[1] : null
+}
+
+function statusIcon(status: BlockStatus) {
+  if (status === "running")   return <span className="inline-block w-3 h-3 rounded-full border-2 border-violet-500 border-t-transparent animate-spin" />
+  if (status === "completed") return <span className="text-emerald-500 font-bold text-xs">✓</span>
+  if (status === "failed")    return <span className="text-red-500 font-bold text-xs">✗</span>
+  if (status === "skipped")   return <span className="text-stone-400 text-xs">—</span>
+}
+
+function statusColor(status: BlockStatus) {
+  if (status === "running")   return "border-l-violet-400 bg-violet-50/50"
+  if (status === "completed") return "border-l-emerald-400 bg-emerald-50/50"
+  if (status === "failed")    return "border-l-red-400 bg-red-50/50"
+  return "border-l-stone-200 bg-stone-50/50"
+}
+
+export default function RunDrawer({ workflowId, runId, getToken, onBlockStatus, onClose }: RunDrawerProps) {
+  const [rows, setRows] = useState<BlockRow[]>([])
+  const [done, setDone] = useState(false)
+  const [runStatus, setRunStatus] = useState<"running" | "succeeded" | "failed">("running")
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const rowMapRef = useRef<Record<string, BlockRow>>({})
+
+  useEffect(() => {
+    let es: EventSource | null = null
+    let cancelled = false
+
+    async function connect() {
+      const wsId = getCookie("delegator_project_id")
+      const params = new URLSearchParams()
+      if (wsId) params.set("workspace_id", wsId)
+
+      if (getToken) {
+        const token = await getToken()
+        if (token) params.set("token", token)
+      }
+
+      if (cancelled) return
+      const qs = params.toString() ? `?${params.toString()}` : ""
+      es = new EventSource(
+        `${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs/${runId}/stream${qs}`
+      )
+
+      es.onmessage = (e) => {
+        if (e.data === "[DONE]") { setDone(true); es?.close(); return }
+
+        let event: { kind: string; block_id?: string; payload: Record<string, unknown> }
+        try { event = JSON.parse(e.data) } catch { return }
+
+        const { kind, block_id, payload } = event
+
+        if (kind === "block_started" && block_id) {
+          const row: BlockRow = {
+            blockId: block_id,
+            label: (payload.label as string) || block_id,
+            type: (payload.type as string) || "tool",
+            status: "running",
+          }
+          rowMapRef.current[block_id] = row
+          setRows(prev => [...prev, row])
+          onBlockStatus(block_id, "running")
+        }
+
+        if (kind === "block_completed" && block_id && rowMapRef.current[block_id]) {
+          const out = payload.output as Record<string, unknown> | undefined
+          let outputSnippet = ""
+          if (out?.output && typeof out.output === "string") {
+            outputSnippet = out.output.slice(0, 120).replace(/\n/g, " ")
+          }
+          rowMapRef.current[block_id] = {
+            ...rowMapRef.current[block_id],
+            status: "completed",
+            output: outputSnippet,
+            costUsd: typeof out?.cost_usd === "number" ? out.cost_usd : undefined,
+          }
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "completed")
+        }
+
+        if (kind === "block_failed" && block_id && rowMapRef.current[block_id]) {
+          rowMapRef.current[block_id] = {
+            ...rowMapRef.current[block_id],
+            status: "failed",
+            error: (payload.error as string) || "Unknown error",
+          }
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "failed")
+        }
+
+        if (kind === "block_skipped" && block_id) {
+          const row: BlockRow = {
+            blockId: block_id,
+            label: (payload.label as string) || block_id,
+            type: (payload.type as string) || "tool",
+            status: "skipped",
+          }
+          rowMapRef.current[block_id] = row
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "skipped")
+        }
+
+        if (kind === "run_completed") setRunStatus("succeeded")
+        if (kind === "run_failed")    setRunStatus("failed")
+      }
+
+      es.onerror = () => { es?.close(); setDone(true) }
+    }
+
+    connect()
+    return () => { cancelled = true; es?.close() }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowId, runId])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [rows])
+
+  const statusBanner = done
+    ? runStatus === "succeeded"
+      ? "bg-emerald-50 border-t border-emerald-200 text-emerald-700"
+      : "bg-red-50 border-t border-red-200 text-red-700"
+    : "bg-violet-50 border-t border-violet-200 text-violet-700"
+
+  const statusLabel = done
+    ? runStatus === "succeeded" ? "Run completed" : "Run failed"
+    : "Running…"
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-xl border border-stone-200 bg-white shadow-2xl"
+      style={{ height: "42%" }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-stone-100 shrink-0">
+        <div className="flex items-center gap-2">
+          {!done && <span className="inline-block w-2 h-2 rounded-full bg-violet-500 animate-pulse" />}
+          <span className="text-sm font-semibold text-stone-800">{statusLabel}</span>
+          <span className="text-xs text-stone-400">{rows.length} block{rows.length !== 1 ? "s" : ""}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href={`/workflows/${workflowId}/runs/${runId}`}
+            target="_blank"
+            className="text-xs text-violet-600 hover:text-violet-800 font-medium"
+          >
+            Full trace →
+          </a>
+          <button onClick={onClose} className="text-stone-400 hover:text-stone-700 text-lg leading-none">×</button>
+        </div>
+      </div>
+
+      {/* Block rows */}
+      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-1.5">
+        {rows.length === 0 && !done && (
+          <p className="text-xs text-stone-400 py-4 text-center animate-pulse">Starting run…</p>
+        )}
+        {rows.map(row => (
+          <div key={row.blockId} className={cn(
+            "flex items-start gap-2.5 rounded-lg border-l-4 px-3 py-2 text-xs",
+            statusColor(row.status)
+          )}>
+            <span className="mt-0.5 w-4 shrink-0 flex items-center justify-center">
+              {statusIcon(row.status)}
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-stone-700 truncate">{row.label}</span>
+                {row.costUsd !== undefined && (
+                  <span className="text-stone-400 shrink-0">${row.costUsd.toFixed(3)}</span>
+                )}
+              </div>
+              {row.output && (
+                <p className="text-stone-500 mt-0.5 truncate">{row.output}</p>
+              )}
+              {row.error && (
+                <p className="text-red-600 mt-0.5 truncate">{row.error}</p>
+              )}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Footer status bar */}
+      <div className={cn("px-4 py-1.5 text-xs font-medium shrink-0", statusBanner)}>
+        {statusLabel}
+        {!done && " — keep this panel open to stream events"}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Run button now streams live in the canvas instead of redirecting to run history.

## Changes

**`RunDrawer.tsx`** (new)
- Slide-up bottom panel (42% height) anchored to canvas
- SSE stream: same endpoint as RunTrace, same event format
- Block rows with status icon (spinner/✓/✗/—), output snippet, cost
- "Full trace →" link opens the run history page in new tab
- Close button clears run status highlights from all nodes

**`BlockNode.tsx`**
- New `runStatus` field on node data
- Running → violet pulse ring + ping dot in corner
- Completed → emerald ring
- Failed → red ring  
- Skipped → 40% opacity

**`CanvasEditor.tsx`**
- `startRun(false)` → sets `activeRunId`, opens drawer (no redirect)
- `startRun(true)` → dry run still redirects to trace page
- `handleBlockStatus` → updates node `runStatus` as SSE events arrive
- `handleDrawerClose` → clears drawer + resets all node highlights
- Run button becomes "■ Stop" while drawer is open

## UX

```
Canvas (nodes highlight as blocks run)
┌─────────────────────────────────────┐
│  [_trigger] ●  [a2] ✓  [a3] ⏳      │
├─────────────────────────────────────┤  ← drawer
│ ✓  github_issue_labeled             │
│ ✓  Fetch issue                      │
│ ⏳ Implement fix          $0.23     │
│                    Full trace →  ×  │
└─────────────────────────────────────┘
```