### PR TITLE
ux: three-panel layout — left palette, center canvas, right config

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -260,7 +260,7 @@ export default function BlockEditor({
   onChange,
   getToken,
 }: BlockEditorProps) {
-  const [tab, setTab] = useState<"plain" | "config" | "advanced">("config")
+  const [promptOpen, setPromptOpen] = useState(false)
   const [streamedPrompt, setStreamedPrompt] = useState<string>("")
   const [isStreaming, setIsStreaming] = useState(false)
   const abortRef = useRef<AbortController | null>(null)
@@ -361,9 +361,9 @@ export default function BlockEditor({
     )
   }
 
-  // Stream whenever Advanced tab is open
+  // Stream compiled prompt when preview section is open
   useEffect(() => {
-    if (tab !== "advanced") return
+    if (!promptOpen) return
     if (abortRef.current) abortRef.current.abort()
     const abort = new AbortController()
     abortRef.current = abort
@@ -412,269 +412,215 @@ export default function BlockEditor({
     })()
 
     return () => abort.abort()
-  }, [tab, blockId, workflowId, description])
+  }, [promptOpen, blockId, workflowId, description])
 
   useEffect(() => {
-    setTab("config")
+    setPromptOpen(false)
     setStreamedPrompt("")
     setIsStreaming(false)
   }, [blockId])
 
+  const section = "px-4 py-3 space-y-3 border-b border-stone-100"
+  const sectionLabel = "text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-2 block"
+  const inputBase = "w-full border border-stone-200 rounded-lg px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200 bg-white"
+
   return (
-    <div className="bg-white">
+    <div className="bg-white flex flex-col h-full overflow-y-auto">
+
       {/* Header */}
-      <div className="flex items-center justify-between px-5 py-2.5 border-b border-stone-100">
-        <div className="flex items-center gap-2">
-          <span className={cn("text-[9px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded", style.label)}>
-            {style.labelText}
-          </span>
-          <span className="text-sm font-medium text-stone-700">{label}</span>
-        </div>
-        <div className="flex rounded-lg border border-stone-200 overflow-hidden text-xs">
-          {(["config", "plain", "advanced"] as const).map(t => (
-            <button
-              key={t}
-              onClick={() => setTab(t)}
-              className={cn("px-3 py-1.5 font-medium capitalize transition-colors",
-                tab === t ? "bg-stone-900 text-white" : "text-stone-500 hover:text-stone-700"
-              )}
-            >
-              {t === "advanced" ? (
-                <>Advanced {isStreaming && tab === "advanced" && (
-                  <span className="ml-1.5 inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse" />
-                )}</>
-              ) : t === "config" ? "Config" : "Plain English"}
-            </button>
-          ))}
-        </div>
+      <div className="flex items-center gap-2 px-4 py-3 border-b border-stone-100 shrink-0">
+        <span className={cn("text-[9px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded shrink-0", style.label)}>
+          {style.labelText}
+        </span>
+        <input
+          value={label}
+          onChange={e => onChange(blockId, { ...blockData, label: e.target.value })}
+          className="flex-1 text-sm font-medium text-stone-800 bg-transparent border-0 outline-none focus:bg-stone-50 rounded px-1 -mx-1 min-w-0"
+          placeholder="Block name"
+        />
       </div>
 
-      {/* Body */}
-      <div className="px-5 py-3">
-
-        {/* ── Plain English tab ── */}
-        {tab === "plain" && (
-          <div className="space-y-4">
-            {/* Name field — always editable */}
-            <div>
-              <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">Name</label>
-              <input
-                value={label}
-                onChange={e => onChange(blockId, { ...blockData, label: e.target.value })}
-                className="mt-1 w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300"
-              />
+      {/* ── Brain blocks: system prompt + custom instructions ── */}
+      {blockType === "brain" && (
+        <>
+          <div className={section}>
+            <div className="flex items-center justify-between">
+              <span className={sectionLabel}>System prompt</span>
+              <span className="text-[10px] text-stone-400 bg-stone-100 px-1.5 py-0.5 rounded mb-2">read-only</span>
             </div>
+            <div className="rounded-lg border border-stone-200 bg-stone-50 px-3 py-2.5 text-xs text-stone-600 leading-relaxed whitespace-pre-wrap max-h-48 overflow-y-auto">
+              <SystemPromptWithChips text={description} />
+            </div>
+            <p className="text-[10px] text-stone-400 mt-1 flex items-center gap-2">
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-sm bg-violet-200 border border-violet-300" />
+                template ref
+              </span>
+              <span className="inline-flex items-center gap-1">
+                <span className="inline-block w-2 h-2 rounded-sm bg-red-100 border border-red-200" />
+                literal placeholder
+              </span>
+            </p>
+          </div>
 
-            {blockType === "brain" ? (
-              <>
-                {/* System prompt — readonly, chips rendered */}
-                <div>
-                  <div className="flex items-center justify-between mb-1">
-                    <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                      System prompt
-                    </label>
-                    <span className="text-[10px] font-medium text-stone-400 bg-stone-100 px-1.5 py-0.5 rounded">
-                      read-only
-                    </span>
-                  </div>
-                  <div className="rounded-lg border border-stone-200 bg-stone-50 px-3 py-2.5 text-xs text-stone-600 leading-relaxed whitespace-pre-wrap min-h-[80px]">
-                    <SystemPromptWithChips text={description} />
-                  </div>
-                  <p className="text-[10px] text-stone-400 mt-1">
-                    <span className="inline-block w-2 h-2 rounded-sm bg-violet-200 border border-violet-300 mr-1 align-middle" />
-                    violet = template ref &nbsp;·&nbsp;
-                    <span className="inline-block w-2 h-2 rounded-sm bg-red-100 border border-red-200 mr-1 align-middle" />
-                    red = literal placeholder (check your YAML)
-                  </p>
-                </div>
+          <div className={section}>
+            <span className={sectionLabel}>Your instructions</span>
+            <textarea
+              value={(blockData.custom_instructions as string) || ""}
+              onChange={e => onChange(blockId, { ...blockData, custom_instructions: e.target.value })}
+              rows={3}
+              placeholder="Add constraints or focus areas. Avoid overriding steps from the system prompt above."
+              className={cn(inputBase, "resize-none")}
+            />
+          </div>
 
-                {/* Custom instructions — user-editable */}
-                <div>
-                  <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                    Your instructions
-                  </label>
-                  <p className="text-[10px] text-stone-400 mt-0.5 mb-1">
-                    Added to the system prompt at runtime. Use this to add constraints, focus areas, or context.
-                  </p>
-                  <textarea
-                    value={(blockData.custom_instructions as string) || ""}
-                    onChange={e => onChange(blockId, { ...blockData, custom_instructions: e.target.value })}
-                    rows={4}
-                    placeholder="e.g. Focus only on TypeScript files. Skip test files. Keep changes minimal."
-                    className="w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
-                  />
+          <div className={section}>
+            <span className={sectionLabel}>Mode</span>
+            {BLOCK_CONFIG_SCHEMAS.brain?.map(field => (
+              <div key={field.key}>
+                <div className="flex items-center justify-between">
+                  <span className="text-xs text-stone-600">{field.label}</span>
+                  <FieldInput field={field} value={blockData.isAgentic} onChange={v => onChange(blockId, { ...blockData, isAgentic: v })} />
                 </div>
-              </>
-            ) : (
-              /* Non-brain blocks — keep simple free-text description */
-              <div>
-                <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                  What should this block do?
-                </label>
-                <textarea
-                  value={description}
-                  onChange={e => onChange(blockId, { ...blockData, description: e.target.value })}
-                  rows={3}
-                  placeholder="Describe in plain English…"
-                  className="mt-1 w-full rounded-lg border border-stone-200 px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-300 resize-none"
-                />
+                {field.hint && <p className="text-[10px] text-stone-400 mt-1">{field.hint}</p>}
               </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* ── Tool blocks: integration + action + params ── */}
+      {isToolLike && (
+        <div className={section}>
+          <span className={sectionLabel}>Integration</span>
+          <div className="space-y-2">
+            <select
+              value={integration}
+              onChange={e => {
+                const updated = setNestedValue({ ...blockData }, "integration", e.target.value)
+                onChange(blockId, setNestedValue(updated, "config.action", ""))
+              }}
+              className={inputBase}
+            >
+              <option value="">— pick integration —</option>
+              {INTEGRATIONS.map(i => <option key={i.value} value={i.value}>{i.label}</option>)}
+            </select>
+
+            {integration && (
+              <select
+                value={action}
+                onChange={e => handleFieldChange("config.action", e.target.value)}
+                className={inputBase}
+              >
+                <option value="">— pick action —</option>
+                {(INTEGRATION_ACTIONS[integration] || []).map(a => (
+                  <option key={a.value} value={a.value}>{a.label}</option>
+                ))}
+              </select>
             )}
           </div>
-        )}
 
-        {/* ── Config tab ── */}
-        {tab === "config" && (
-          <div className="space-y-3">
-
-            {/* Integration + Action pickers for tool-like blocks */}
-            {isToolLike && (
-              <div className="flex gap-3">
-                <div className="flex-1">
-                  <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide block mb-1">Integration</label>
-                  <select
-                    value={integration}
-                    onChange={e => {
-                      const updated = setNestedValue({ ...blockData }, "integration", e.target.value)
-                      const withAction = setNestedValue(updated, "config.action", "")
-                      onChange(blockId, withAction)
-                    }}
-                    className="w-full border border-stone-200 rounded-lg px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200 bg-white"
-                  >
-                    <option value="">— pick one —</option>
-                    {INTEGRATIONS.map(i => (
-                      <option key={i.value} value={i.value}>{i.label}</option>
-                    ))}
-                  </select>
-                </div>
-
-                {integration && (
-                  <div className="flex-1">
-                    <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide block mb-1">Action</label>
-                    <select
-                      value={action}
-                      onChange={e => handleFieldChange("config.action", e.target.value)}
-                      className="w-full border border-stone-200 rounded-lg px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200 bg-white"
-                    >
-                      <option value="">— pick one —</option>
-                      {(INTEGRATION_ACTIONS[integration] || []).map(a => (
-                        <option key={a.value} value={a.value}>{a.label}</option>
-                      ))}
-                    </select>
+          {/* Params */}
+          {actionFields.length > 0 && (
+            <div className="space-y-2 pt-2">
+              <span className={sectionLabel}>Parameters</span>
+              {actionFields.map(field => {
+                const rendered = renderField(field)
+                if (rendered === null) return null
+                return (
+                  <div key={field.key}>
+                    <div className="flex items-center gap-1.5 mb-1">
+                      <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">{field.label}</label>
+                      {field.required && <span className="text-red-500 text-[10px] font-bold">*</span>}
+                      {field.hint && <span className="text-[10px] text-stone-400">{field.hint}</span>}
+                    </div>
+                    {rendered}
                   </div>
-                )}
-              </div>
-            )}
+                )
+              })}
+              <p className="text-[10px] text-stone-400 pt-1">
+                Tip: reference previous blocks with <code className="bg-stone-100 px-1 rounded">{"{{block_id.field}}"}</code>
+              </p>
+            </div>
+          )}
 
-            {/* Static fields for this block type */}
+          {/* GitHub webhook — auto-register info (no button, fires on Run) */}
+          {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (() => {
+            const repoAllowlist = (getNestedValue(blockData, "config.repo_allowlist") as string) || ""
+            const firstRepo = repoAllowlist.split(",")[0].trim()
+            const [owner, repo] = firstRepo.includes("/") ? firstRepo.split("/") : ["", ""]
+            if (!owner || !repo) return null
+            return (
+              <div className="rounded-lg border border-indigo-100 bg-indigo-50 px-3 py-2 text-xs text-indigo-700 mt-2">
+                Webhook on <span className="font-mono font-medium">{owner}/{repo}</span> will be registered automatically when you run.
+              </div>
+            )
+          })()}
+
+          {/* Secret warning */}
+          {(() => {
+            const leaked = findHardcodedSecrets(getNestedValue(blockData, "config.params"))
+            return leaked.length > 0 ? (
+              <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 text-xs text-red-800 mt-2">
+                <p className="font-semibold mb-1">⚠ Secret in params: {leaked.join(", ")}</p>
+                <p>Save credentials in <a href="/settings" className="underline">Settings</a> instead.</p>
+              </div>
+            ) : null
+          })()}
+        </div>
+      )}
+
+      {/* ── Static config fields (trigger, logic, output, approval) ── */}
+      {staticFields.length > 0 && !isToolLike && (
+        <div className={section}>
+          <span className={sectionLabel}>Configuration</span>
+          <div className="space-y-3">
             {staticFields.map(field => {
               const rendered = renderField(field)
               if (rendered === null) return null
               return (
                 <div key={field.key}>
                   <div className="flex items-center gap-1.5 mb-1">
-                    <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                      {field.label}
-                    </label>
-                    {field.required && <span className="text-red-500 text-[10px] font-bold leading-none">*</span>}
-                    {field.hint && (
-                      <span className="text-[10px] text-stone-400">{field.hint}</span>
-                    )}
+                    <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">{field.label}</label>
+                    {field.required && <span className="text-red-500 text-[10px] font-bold">*</span>}
+                    {field.hint && <span className="text-[10px] text-stone-400">{field.hint}</span>}
                   </div>
                   {rendered}
                 </div>
               )
             })}
-
-
-            {/* GitHub webhook auto-registration */}
-            {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (() => {
-              const repoAllowlist = (getNestedValue(blockData, "config.repo_allowlist") as string) || ""
-              const firstRepo = repoAllowlist.split(",")[0].trim()
-              const [owner, repo] = firstRepo.includes("/") ? firstRepo.split("/") : ["", ""]
-              if (!owner || !repo) return null
-              return <WebhookRegisterButton owner={owner} repo={repo} getToken={getToken} />
-            })()}
-
-            {/* Hardcoded-secret warning */}
-            {(() => {
-              const params = getNestedValue(blockData, "config.params")
-              const leaked = findHardcodedSecrets(params)
-              return leaked.length > 0 ? (
-                <div className="rounded-lg border border-red-200 bg-red-50 px-3 py-2.5 text-xs text-red-800">
-                  <p className="font-semibold mb-1">⚠ Secret detected in params: {leaked.join(", ")}</p>
-                  <p className="leading-relaxed text-red-700">
-                    Hardcoded tokens are exported in the YAML file and can leak if committed to a repo.
-                    Save this credential in <a href="/settings" className="underline font-medium">Integrations → Settings</a> and
-                    reference it via the <span className="font-mono bg-red-100 px-0.5 rounded">integration:</span> field instead.
-                  </p>
-                </div>
-              ) : null
-            })()}
-
-            {/* Action-specific param fields */}
-            {actionFields.length > 0 && (
-              <div className="pt-1 border-t border-stone-100 space-y-3">
-                <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">Parameters</p>
-                {actionFields.map(field => {
-                  const rendered = renderField(field)
-                  if (rendered === null) return null
-                  return (
-                    <div key={field.key}>
-                      <div className="flex items-center gap-1.5 mb-1">
-                        <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                          {field.label}
-                        </label>
-                        {field.required && <span className="text-red-500 text-[10px] font-bold leading-none">*</span>}
-                        {field.hint && (
-                          <span className="text-[10px] text-stone-400">{field.hint}</span>
-                        )}
-                      </div>
-                      {rendered}
-                    </div>
-                  )
-                })}
-                <p className="text-[10px] text-stone-400 pt-1">
-                  Tip: reference previous blocks with <code className="bg-stone-100 px-1 rounded">{"{{block_id.field}}"}</code>
-                </p>
-              </div>
-            )}
-
-            {/* Empty state */}
-            {!isToolLike && staticFields.length === 0 && (
-              <p className="text-sm text-stone-400 py-2">No configuration for this block type.</p>
-            )}
           </div>
-        )}
+        </div>
+      )}
 
-        {/* ── Advanced tab ── */}
-        {tab === "advanced" && (
-          <div className="relative">
-            <div className="flex items-center justify-between mb-1.5">
-              <label className="text-[10px] font-semibold text-stone-400 uppercase tracking-wide">
-                Compiled prompt — auto-generated
-              </label>
-              {isStreaming && (
-                <span className="text-[10px] text-amber-500 font-medium animate-pulse">Compiling…</span>
-              )}
-            </div>
+      {/* ── Brain: compiled prompt preview (collapsed by default) ── */}
+      {blockType === "brain" && (
+        <div className="px-4 py-3">
+          <button
+            onClick={() => setPromptOpen(v => !v)}
+            className="flex items-center gap-1.5 text-[10px] font-semibold text-stone-400 uppercase tracking-wider hover:text-stone-600 transition-colors"
+          >
+            <span>{promptOpen ? "▾" : "▸"}</span>
+            Preview compiled prompt
+            {isStreaming && <span className="inline-block w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse ml-1" />}
+          </button>
+          {promptOpen && (
             <div className={cn(
-              "min-h-28 rounded-lg border bg-stone-950 px-3 py-2.5 text-xs font-mono text-green-300 leading-relaxed whitespace-pre-wrap",
+              "mt-2 rounded-lg border bg-stone-950 px-3 py-2.5 text-xs font-mono text-green-300 leading-relaxed whitespace-pre-wrap max-h-64 overflow-y-auto",
               isStreaming ? "border-amber-300/30" : "border-stone-700"
             )}>
-              {streamedPrompt || (
-                isStreaming
-                  ? <span className="text-stone-500">Generating<span className="animate-pulse">…</span></span>
-                  : <span className="text-stone-500">Switch to Plain English, add a description, then come back here.</span>
+              {streamedPrompt || (isStreaming
+                ? <span className="text-stone-500">Generating…</span>
+                : <span className="text-stone-500">Add a description to preview the prompt.</span>
               )}
               {isStreaming && streamedPrompt && (
                 <span className="inline-block w-1.5 h-3.5 bg-green-400 ml-0.5 animate-pulse align-middle" />
               )}
             </div>
-          </div>
-        )}
+          )}
+        </div>
+      )}
 
-      </div>
     </div>
   )
 }

--- a/apps/web/src/components/canvas/BlockPalette.tsx
+++ b/apps/web/src/components/canvas/BlockPalette.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { BLOCK_LIBRARY, BLOCK_STYLES } from "@/lib/block-types"
+import { cn } from "@/lib/utils"
+
+const INTEGRATION_LIST = [
+  { handle: "github",       label: "GitHub" },
+  { handle: "slack",        label: "Slack" },
+  { handle: "linear",       label: "Linear" },
+  { handle: "digitalocean", label: "DigitalOcean" },
+  { handle: "vercel",       label: "Vercel" },
+  { handle: "railway",      label: "Railway" },
+]
+
+function getWorkspaceId(): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)
+  return m ? m[1] : null
+}
+
+export default function BlockPalette({ getToken }: { getToken?: (() => Promise<string | null>) | null }) {
+  const [connectedHandles, setConnectedHandles] = useState<Set<string>>(new Set())
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const headers: Record<string, string> = {}
+        if (getToken) {
+          const token = await getToken()
+          if (token) headers["Authorization"] = `Bearer ${token}`
+        }
+        const ws = getWorkspaceId()
+        if (ws) headers["X-Workspace-Id"] = ws
+        const r = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/credentials`, { headers })
+        if (r.ok) {
+          const creds: { handle: string }[] = await r.json()
+          setConnectedHandles(new Set(creds.map(c => c.handle.toLowerCase())))
+        }
+      } catch { /* network error */ }
+    })()
+  }, [])
+
+  return (
+    <aside className="w-44 bg-white flex flex-col overflow-y-auto shrink-0 h-full">
+      {/* Block Library */}
+      <div className="px-3 py-3">
+        <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-2">Blocks</p>
+        <div className="grid grid-cols-2 gap-1.5">
+          {BLOCK_LIBRARY.map((block) => {
+            const style = BLOCK_STYLES[block.type]
+            const shortName = block.title.split(" · ")[1] ?? block.title
+            return (
+              <div
+                key={block.title}
+                draggable
+                onDragStart={(e) => {
+                  e.dataTransfer.setData("application/marshal-block-type", block.type)
+                  e.dataTransfer.setData("application/marshal-block-title", block.title)
+                  e.dataTransfer.effectAllowed = "move"
+                }}
+                style={{ aspectRatio: "1 / 1" }}
+                className={cn(
+                  "flex flex-col justify-between p-2 rounded-lg border-2 cursor-grab active:cursor-grabbing select-none transition-all hover:shadow-sm",
+                  style.buttonClass
+                )}
+              >
+                <span className={cn("text-[8px] font-bold tracking-widest uppercase", style.text)}>
+                  {style.labelText}
+                </span>
+                <span className="text-[11px] font-semibold text-stone-800 leading-tight">{shortName}</span>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+
+      {/* Integrations */}
+      <div className="px-3 py-3 border-t border-stone-100 mt-auto">
+        <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-2">Integrations</p>
+        <div className="space-y-1.5">
+          {INTEGRATION_LIST.map((i) => {
+            const connected = connectedHandles.has(i.handle)
+            return (
+              <div key={i.handle} className="flex items-center justify-between">
+                <span className="text-xs text-stone-600">{i.label}</span>
+                {connected ? (
+                  <span className="flex items-center gap-1 text-[10px] font-medium text-emerald-600">
+                    <span className="w-1.5 h-1.5 rounded-full bg-emerald-400 shrink-0" />
+                  </span>
+                ) : (
+                  <a href="/settings" className="text-[10px] font-medium text-indigo-500 hover:underline">
+                    connect
+                  </a>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -22,7 +22,8 @@ import "@xyflow/react/dist/style.css"
 
 import BlockNode, { type BlockNodeData } from "./BlockNode"
 import BlockEditor from "./BlockEditor"
-import Sidebar from "./Sidebar"
+import BlockPalette from "./BlockPalette"
+import RunDrawer from "./RunDrawer"
 import CostEstimate from "./CostEstimate"
 import YamlPanel from "./YamlPanel"
 import { autoLayout } from "@/lib/auto-layout"
@@ -126,9 +127,10 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const { screenToFlowPosition } = useReactFlow()
   const router = useRouter()
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
+  const [activeRunId, setActiveRunId] = useState<string | null>(null)
   const [validationErrors, setValidationErrors] = useState<ValidationError[]>([])
-  const [sidebarOpen, setSidebarOpen] = useState(true)
-  const [editorExpanded, setEditorExpanded] = useState(false)
+  const [leftOpen, setLeftOpen] = useState(true)
+  const [rightOpen, setRightOpen] = useState(true)
   const [activeView, setActiveView] = useState<"canvas" | "yaml">("canvas")
 
   // Load workflow on mount. When a graph arrives without meaningful positions
@@ -219,6 +221,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
 
   const onNodeClick = useCallback((_: React.MouseEvent, node: Node) => {
     setSelectedNode(node)
+    setRightOpen(true)
   }, [])
 
   const onPaneClick = useCallback(() => setSelectedNode(null), [])
@@ -273,11 +276,29 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
       )
       if (!res.ok) throw new Error("Failed to start run")
       const run = await res.json()
-      router.push(`/workflows/${workflowId}/runs/${run.id}`)
+      if (dryRun) {
+        router.push(`/workflows/${workflowId}/runs/${run.id}`)
+      } else {
+        setActiveRunId(run.id)
+        setRightOpen(true)
+        setRunning("idle")
+      }
     } catch {
       setRunning("idle")
     }
   }, [workflowId, getToken, router, nodes])
+
+  const handleBlockStatus = useCallback((blockId: string, status: "running" | "completed" | "failed" | "skipped") => {
+    setNodes(nds => nds.map(n =>
+      n.id === blockId ? { ...n, data: { ...n.data, runStatus: status } } : n
+    ))
+  }, [setNodes])
+
+  const handleDrawerClose = useCallback(() => {
+    setActiveRunId(null)
+    setRunning("idle")
+    setNodes(nds => nds.map(n => ({ ...n, data: { ...n.data, runStatus: undefined } })))
+  }, [setNodes])
 
   const handleBlockChange = useCallback(
     (blockId: string, changes: Record<string, unknown>) => {
@@ -352,20 +373,33 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
             {running === "dry" ? "Simulating…" : "Dry run"}
           </button>
           <button
-            onClick={() => startRun(false)}
-            disabled={running !== "idle"}
+            onClick={() => activeRunId ? handleDrawerClose() : startRun(false)}
+            disabled={running === "live" || running === "dry"}
             className="rounded-lg bg-violet-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-violet-700 transition-colors disabled:opacity-50"
           >
-            {running === "live" ? "Starting…" : "▶ Run"}
+            {running === "live" ? "Starting…" : activeRunId ? "■ Stop" : "▶ Run"}
           </button>
           <AuthButton afterSignOutUrl="/sign-in" />
         </div>
       </header>
 
-      {/* Canvas + Sidebar (or YAML view) */}
+      {/* Three-panel layout (or YAML view) */}
       <div className="flex flex-1 overflow-hidden">
         {activeView === "canvas" ? (
           <>
+            {/* Left panel — block palette */}
+            <div className={`relative flex shrink-0 transition-all duration-200 border-r border-stone-200 ${leftOpen ? "w-44" : "w-8"}`}>
+              <button
+                onClick={() => setLeftOpen(v => !v)}
+                className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors"
+                title={leftOpen ? "Collapse palette" : "Expand palette"}
+              >
+                {leftOpen ? "‹" : "›"}
+              </button>
+              {leftOpen && <BlockPalette getToken={getToken} />}
+            </div>
+
+            {/* Center — canvas */}
             <div className="flex-1 relative min-w-0">
               <ReactFlow
                 nodes={nodes}
@@ -387,16 +421,47 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                 <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#E7E5E4" />
                 <Controls className="!shadow-none !border !border-stone-200 !rounded-xl" showInteractive={false} />
               </ReactFlow>
+              {activeRunId && (
+                <RunDrawer
+                  workflowId={workflowId}
+                  runId={activeRunId}
+                  getToken={getToken}
+                  onBlockStatus={handleBlockStatus}
+                  onClose={handleDrawerClose}
+                />
+              )}
             </div>
-            <div className={`relative flex shrink-0 transition-all duration-200 ${sidebarOpen ? "w-52" : "w-8"}`}>
+
+            {/* Right panel — block config */}
+            <div className={`relative flex shrink-0 transition-all duration-200 border-l border-stone-200 bg-white ${rightOpen ? "w-72" : "w-8"}`}>
               <button
-                onClick={() => setSidebarOpen(v => !v)}
+                onClick={() => setRightOpen(v => !v)}
                 className="absolute -left-3 top-1/2 -translate-y-1/2 z-10 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors"
-                title={sidebarOpen ? "Collapse sidebar" : "Expand sidebar"}
+                title={rightOpen ? "Collapse config" : "Expand config"}
               >
-                {sidebarOpen ? "›" : "‹"}
+                {rightOpen ? "›" : "‹"}
               </button>
-              {sidebarOpen && <Sidebar getToken={getToken} />}
+              {rightOpen && (
+                selectedNode && selectedData ? (
+                  <div className="flex-1 overflow-y-auto min-w-0">
+                    <BlockEditor
+                      workflowId={workflowId}
+                      blockId={selectedNode.id}
+                      blockType={selectedData.type}
+                      label={selectedData.label}
+                      description={(selectedData.description as string) ?? ""}
+                      blockData={selectedNode.data as Record<string, unknown>}
+                      onChange={handleBlockChange}
+                      getToken={getToken}
+                    />
+                  </div>
+                ) : (
+                  <div className="flex-1 flex flex-col items-center justify-center gap-2 text-center px-4">
+                    <span className="text-2xl">←</span>
+                    <p className="text-xs text-stone-400 leading-relaxed">Click a block on the canvas to configure it</p>
+                  </div>
+                )
+              )}
             </div>
           </>
         ) : (
@@ -426,7 +491,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                     key={e.blockId}
                     onClick={() => {
                       const node = nodes.find(n => n.id === e.blockId)
-                      if (node) { setSelectedNode(node) }
+                      if (node) { setSelectedNode(node); setRightOpen(true) }
                     }}
                     className="text-xs text-red-600 hover:text-red-800 hover:underline text-left"
                   >
@@ -436,39 +501,8 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                 ))}
               </div>
             </div>
-            <button
-              onClick={() => setValidationErrors([])}
-              className="text-red-300 hover:text-red-500 text-lg leading-none shrink-0 mt-0.5"
-            >
-              ×
-            </button>
+            <button onClick={() => setValidationErrors([])} className="text-red-300 hover:text-red-500 text-lg leading-none shrink-0 mt-0.5">×</button>
           </div>
-        </div>
-      )}
-
-      {/* Block editor bottom panel */}
-      {selectedNode && selectedData && (
-        <div className={`shrink-0 overflow-y-auto border-t border-stone-200 transition-all duration-200 ${editorExpanded ? "max-h-[520px]" : "max-h-72"}`}>
-          <div className="flex items-center justify-between px-4 py-1 bg-stone-50 border-b border-stone-100">
-            <span className="text-[10px] text-stone-400 font-medium uppercase tracking-wide">Block config</span>
-            <button
-              onClick={() => setEditorExpanded(v => !v)}
-              className="text-stone-400 hover:text-stone-700 text-xs px-1.5 py-0.5 rounded hover:bg-stone-100 transition-colors"
-              title={editorExpanded ? "Collapse" : "Expand"}
-            >
-              {editorExpanded ? "▾ Less" : "▴ More"}
-            </button>
-          </div>
-          <BlockEditor
-            workflowId={workflowId}
-            blockId={selectedNode.id}
-            blockType={selectedData.type}
-            label={selectedData.label}
-            description={(selectedData.description as string) ?? ""}
-            blockData={selectedNode.data as Record<string, unknown>}
-            onChange={handleBlockChange}
-            getToken={getToken}
-          />
         </div>
       )}
     </div>

--- a/apps/web/src/components/canvas/RunDrawer.tsx
+++ b/apps/web/src/components/canvas/RunDrawer.tsx
@@ -1,0 +1,219 @@
+"use client"
+
+import { useEffect, useRef, useState } from "react"
+import { cn } from "@/lib/utils"
+
+type BlockStatus = "running" | "completed" | "failed" | "skipped"
+
+interface BlockRow {
+  blockId: string
+  label: string
+  type: string
+  status: BlockStatus
+  output?: string
+  error?: string
+  costUsd?: number
+}
+
+interface RunDrawerProps {
+  workflowId: string
+  runId: string
+  getToken?: (() => Promise<string | null>) | null
+  onBlockStatus: (blockId: string, status: BlockStatus) => void
+  onClose: () => void
+}
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(new RegExp(`(?:^|;\\s*)${name}=([^;]+)`))
+  return m ? m[1] : null
+}
+
+function statusIcon(status: BlockStatus) {
+  if (status === "running")   return <span className="inline-block w-3 h-3 rounded-full border-2 border-violet-500 border-t-transparent animate-spin" />
+  if (status === "completed") return <span className="text-emerald-500 font-bold text-xs">✓</span>
+  if (status === "failed")    return <span className="text-red-500 font-bold text-xs">✗</span>
+  if (status === "skipped")   return <span className="text-stone-400 text-xs">—</span>
+}
+
+function statusColor(status: BlockStatus) {
+  if (status === "running")   return "border-l-violet-400 bg-violet-50/50"
+  if (status === "completed") return "border-l-emerald-400 bg-emerald-50/50"
+  if (status === "failed")    return "border-l-red-400 bg-red-50/50"
+  return "border-l-stone-200 bg-stone-50/50"
+}
+
+export default function RunDrawer({ workflowId, runId, getToken, onBlockStatus, onClose }: RunDrawerProps) {
+  const [rows, setRows] = useState<BlockRow[]>([])
+  const [done, setDone] = useState(false)
+  const [runStatus, setRunStatus] = useState<"running" | "succeeded" | "failed">("running")
+  const bottomRef = useRef<HTMLDivElement>(null)
+  const rowMapRef = useRef<Record<string, BlockRow>>({})
+
+  useEffect(() => {
+    let es: EventSource | null = null
+    let cancelled = false
+
+    async function connect() {
+      const wsId = getCookie("delegator_project_id")
+      const params = new URLSearchParams()
+      if (wsId) params.set("workspace_id", wsId)
+
+      if (getToken) {
+        const token = await getToken()
+        if (token) params.set("token", token)
+      }
+
+      if (cancelled) return
+      const qs = params.toString() ? `?${params.toString()}` : ""
+      es = new EventSource(
+        `${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs/${runId}/stream${qs}`
+      )
+
+      es.onmessage = (e) => {
+        if (e.data === "[DONE]") { setDone(true); es?.close(); return }
+
+        let event: { kind: string; block_id?: string; payload: Record<string, unknown> }
+        try { event = JSON.parse(e.data) } catch { return }
+
+        const { kind, block_id, payload } = event
+
+        if (kind === "block_started" && block_id) {
+          const row: BlockRow = {
+            blockId: block_id,
+            label: (payload.label as string) || block_id,
+            type: (payload.type as string) || "tool",
+            status: "running",
+          }
+          rowMapRef.current[block_id] = row
+          setRows(prev => [...prev, row])
+          onBlockStatus(block_id, "running")
+        }
+
+        if (kind === "block_completed" && block_id && rowMapRef.current[block_id]) {
+          const out = payload.output as Record<string, unknown> | undefined
+          let outputSnippet = ""
+          if (out?.output && typeof out.output === "string") {
+            outputSnippet = out.output.slice(0, 120).replace(/\n/g, " ")
+          }
+          rowMapRef.current[block_id] = {
+            ...rowMapRef.current[block_id],
+            status: "completed",
+            output: outputSnippet,
+            costUsd: typeof out?.cost_usd === "number" ? out.cost_usd : undefined,
+          }
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "completed")
+        }
+
+        if (kind === "block_failed" && block_id && rowMapRef.current[block_id]) {
+          rowMapRef.current[block_id] = {
+            ...rowMapRef.current[block_id],
+            status: "failed",
+            error: (payload.error as string) || "Unknown error",
+          }
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "failed")
+        }
+
+        if (kind === "block_skipped" && block_id) {
+          const row: BlockRow = {
+            blockId: block_id,
+            label: (payload.label as string) || block_id,
+            type: (payload.type as string) || "tool",
+            status: "skipped",
+          }
+          rowMapRef.current[block_id] = row
+          setRows(Object.values(rowMapRef.current))
+          onBlockStatus(block_id, "skipped")
+        }
+
+        if (kind === "run_completed") setRunStatus("succeeded")
+        if (kind === "run_failed")    setRunStatus("failed")
+      }
+
+      es.onerror = () => { es?.close(); setDone(true) }
+    }
+
+    connect()
+    return () => { cancelled = true; es?.close() }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowId, runId])
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [rows])
+
+  const statusBanner = done
+    ? runStatus === "succeeded"
+      ? "bg-emerald-50 border-t border-emerald-200 text-emerald-700"
+      : "bg-red-50 border-t border-red-200 text-red-700"
+    : "bg-violet-50 border-t border-violet-200 text-violet-700"
+
+  const statusLabel = done
+    ? runStatus === "succeeded" ? "Run completed" : "Run failed"
+    : "Running…"
+
+  return (
+    <div className="absolute bottom-0 left-0 right-0 z-50 flex flex-col rounded-t-xl border border-stone-200 bg-white shadow-2xl"
+      style={{ height: "42%" }}
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 py-2.5 border-b border-stone-100 shrink-0">
+        <div className="flex items-center gap-2">
+          {!done && <span className="inline-block w-2 h-2 rounded-full bg-violet-500 animate-pulse" />}
+          <span className="text-sm font-semibold text-stone-800">{statusLabel}</span>
+          <span className="text-xs text-stone-400">{rows.length} block{rows.length !== 1 ? "s" : ""}</span>
+        </div>
+        <div className="flex items-center gap-3">
+          <a
+            href={`/workflows/${workflowId}/runs/${runId}`}
+            target="_blank"
+            className="text-xs text-violet-600 hover:text-violet-800 font-medium"
+          >
+            Full trace →
+          </a>
+          <button onClick={onClose} className="text-stone-400 hover:text-stone-700 text-lg leading-none">×</button>
+        </div>
+      </div>
+
+      {/* Block rows */}
+      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-1.5">
+        {rows.length === 0 && !done && (
+          <p className="text-xs text-stone-400 py-4 text-center animate-pulse">Starting run…</p>
+        )}
+        {rows.map(row => (
+          <div key={row.blockId} className={cn(
+            "flex items-start gap-2.5 rounded-lg border-l-4 px-3 py-2 text-xs",
+            statusColor(row.status)
+          )}>
+            <span className="mt-0.5 w-4 shrink-0 flex items-center justify-center">
+              {statusIcon(row.status)}
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="font-semibold text-stone-700 truncate">{row.label}</span>
+                {row.costUsd !== undefined && (
+                  <span className="text-stone-400 shrink-0">${row.costUsd.toFixed(3)}</span>
+                )}
+              </div>
+              {row.output && (
+                <p className="text-stone-500 mt-0.5 truncate">{row.output}</p>
+              )}
+              {row.error && (
+                <p className="text-red-600 mt-0.5 truncate">{row.error}</p>
+              )}
+            </div>
+          </div>
+        ))}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* Footer status bar */}
+      <div className={cn("px-4 py-1.5 text-xs font-medium shrink-0", statusBanner)}>
+        {statusLabel}
+        {!done && " — keep this panel open to stream events"}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Implements Option A — the standard node editor layout (Figma/n8n pattern).

## Layout

```
┌──────────┬─────────────────────┬──────────────────┐
│  Blocks  │                     │  Block config    │
│  ──────  │      Canvas         │  (on selection)  │
│  Brain   │                     │                  │
│  Tool    │                     │  Empty state     │
│  Logic   │                     │  when nothing    │
│  Output  │                     │  selected        │
│          │                     │                  │
│  ─────── │                     │                  │
│  Integr. │                     │                  │
└──────────┴─────────────────────┴──────────────────┘
```

Both panels collapse to 32px with a toggle button — full canvas when needed.

## Changes

**`BlockPalette.tsx`** (new) — extracted from Sidebar, now left panel
- Block library drag tiles (2-col grid)
- Integration connection status at bottom

**`BlockEditor.tsx`** — no more tabs
- Single scrollable view, sections replace Config / Plain English / Advanced tabs
- Brain blocks: System prompt (readonly+chips) → Your instructions → Mode toggle → Compiled prompt (collapsed accordion)
- Tool blocks: Integration → Action → Params (all visible at once)
- Other blocks: Configuration section
- Name editable inline in header

**`CanvasEditor.tsx`**
- Left panel: BlockPalette (w-44, collapsible)
- Center: ReactFlow canvas
- Right panel: BlockEditor when node selected, empty state otherwise (w-72, collapsible)
- Clicking a block auto-opens right panel
- Clicking a validation error opens the block + right panel
- Bottom panel removed entirely
- RunDrawer + node highlighting included (from feat/run-drawer)

## Behaviour notes
- Dry run → still redirects to full trace page
- Live run → opens RunDrawer inline at bottom of canvas, nodes highlight
- Run button becomes "■ Stop" while drawer is open