### PR TITLE
fix: add workspace_id guard to GET /workflows/{id} endpoint

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -79,8 +79,11 @@ def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspa
 
 
 @router.get("/{workflow_id}", response_model=WorkflowDetailOut)
-def get_workflow(workflow_id: UUID, db: Session = Depends(get_db)):
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+def get_workflow(workflow_id: UUID, db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
     return workflow


### PR DESCRIPTION
## Summary

Fixes #39

### Problem

The `GET /workflows/{id}` endpoint was missing a `workspace_id` filter in the database query. This meant any authenticated user who knew a workflow UUID could fetch workflow details from another workspace, bypassing workspace isolation.

```python
# Bug: no workspace filter
workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
```

### Fix

Added `workspace_id` as a dependency parameter and included it in the database query filter, consistent with all other workflow endpoints (list, delete, validate, etc.).

```python
# Fix: add workspace guard
workflow = db.query(Workflow).filter(
    Workflow.id == workflow_id,
    Workflow.workspace_id == workspace_id,
).first()
```

### Changes

- **`apps/api/app/routers/workflows.py`** (line 81–86):
  - Added `workspace_id: str = Depends(get_workspace_id)` to `get_workflow()` signature
  - Added `Workflow.workspace_id == workspace_id` to the query filter

### Security Impact

This prevents unauthorized cross-workspace data access on the workflow detail endpoint, enforcing the same workspace isolation that all other endpoints already implement.
