### PR TITLE
feat: collapsible sidebar

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import AuthButton from "@/components/AuthButton"
@@ -12,18 +13,24 @@ const NAV = [
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const [collapsed, setCollapsed] = useState(false)
+
   return (
     <div className="flex h-screen bg-stone-50">
-      <aside className="w-44 shrink-0 bg-white border-r border-stone-200 flex flex-col">
+      <aside className={`relative shrink-0 bg-white border-r border-stone-200 flex flex-col transition-all duration-200 ${collapsed ? "w-14" : "w-44"}`}>
+
         {/* Logo */}
-        <div className="px-4 py-5 border-b border-stone-100">
-          <Link href="/workflows" className="flex items-center gap-2">
-            <div className="w-6 h-6 rounded-md bg-stone-900 flex items-center justify-center">
+        <div className={`px-3 py-4 border-b border-stone-100 flex items-center ${collapsed ? "justify-center" : "gap-2"}`}>
+          <Link href="/workflows" className="flex items-center gap-2 min-w-0">
+            <div className="w-6 h-6 rounded-md bg-stone-900 flex items-center justify-center shrink-0">
               <span className="text-white text-xs">⚡</span>
             </div>
-            <span className="font-bold text-stone-900 text-sm tracking-tight">Delegator</span>
+            {!collapsed && (
+              <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Delegator</span>
+            )}
           </Link>
         </div>
+
         {/* Nav items */}
         <nav className="flex-1 px-2 py-3 space-y-0.5">
           {NAV.map(item => {
@@ -32,23 +39,37 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               <Link
                 key={item.href}
                 href={item.href}
-                className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                title={collapsed ? item.label : undefined}
+                className={`flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  collapsed ? "justify-center" : ""
+                } ${
                   active
                     ? "bg-stone-100 text-stone-900"
                     : "text-stone-500 hover:text-stone-800 hover:bg-stone-50"
                 }`}
               >
-                <span className="text-base leading-none">{item.icon}</span>
-                {item.label}
+                <span className="text-base leading-none shrink-0">{item.icon}</span>
+                {!collapsed && item.label}
               </Link>
             )
           })}
         </nav>
+
         {/* User */}
-        <div className="px-3 py-3 border-t border-stone-100">
+        <div className={`px-2 py-3 border-t border-stone-100 flex ${collapsed ? "justify-center" : ""}`}>
           <AuthButton afterSignOutUrl="/sign-in" dropUp />
         </div>
+
+        {/* Collapse toggle — sits on the right edge */}
+        <button
+          onClick={() => setCollapsed(v => !v)}
+          className="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors z-10"
+          title={collapsed ? "Expand" : "Collapse"}
+        >
+          {collapsed ? "›" : "‹"}
+        </button>
       </aside>
+
       <main className="flex-1 overflow-auto">{children}</main>
     </div>
   )


### PR DESCRIPTION
## Summary
- Adds collapse toggle button (‹/›) on the right edge of the sidebar
- Collapsed state: `w-14` icons-only with tooltips; expanded: `w-44` with labels
- Smooth 200ms transition between states
- Auth button and logo both adapt to collapsed mode

Closes #49