### PR TITLE
ux: unified shell layout — sidebar on canvas page

### DIFF
--- a/apps/web/src/app/workflows/[id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/page.tsx
@@ -1,3 +1,4 @@
+import AppShell from "@/components/AppShell"
 import CanvasEditor from "@/components/canvas/CanvasEditor"
 
 interface Props {
@@ -5,5 +6,9 @@ interface Props {
 }
 
 export default function WorkflowPage({ params }: Props) {
-  return <CanvasEditor workflowId={params.id} />
+  return (
+    <AppShell noPadding>
+      <CanvasEditor workflowId={params.id} />
+    </AppShell>
+  )
 }

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
 import AuthButton from "@/components/AuthButton"
@@ -12,18 +13,24 @@ const NAV = [
 
 export default function AppShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const [collapsed, setCollapsed] = useState(false)
+
   return (
     <div className="flex h-screen bg-stone-50">
-      <aside className="w-44 shrink-0 bg-white border-r border-stone-200 flex flex-col">
+      <aside className={`relative shrink-0 bg-white border-r border-stone-200 flex flex-col transition-all duration-200 ${collapsed ? "w-14" : "w-44"}`}>
+
         {/* Logo */}
-        <div className="px-4 py-5 border-b border-stone-100">
-          <Link href="/workflows" className="flex items-center gap-2">
-            <div className="w-6 h-6 rounded-md bg-stone-900 flex items-center justify-center">
+        <div className={`px-3 py-4 border-b border-stone-100 flex items-center ${collapsed ? "justify-center" : "gap-2"}`}>
+          <Link href="/workflows" className="flex items-center gap-2 min-w-0">
+            <div className="w-6 h-6 rounded-md bg-stone-900 flex items-center justify-center shrink-0">
               <span className="text-white text-xs">⚡</span>
             </div>
-            <span className="font-bold text-stone-900 text-sm tracking-tight">Delegator</span>
+            {!collapsed && (
+              <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Delegator</span>
+            )}
           </Link>
         </div>
+
         {/* Nav items */}
         <nav className="flex-1 px-2 py-3 space-y-0.5">
           {NAV.map(item => {
@@ -32,23 +39,37 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
               <Link
                 key={item.href}
                 href={item.href}
-                className={`flex items-center gap-2.5 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
+                title={collapsed ? item.label : undefined}
+                className={`flex items-center gap-2.5 px-2 py-2 rounded-lg text-sm font-medium transition-colors ${
+                  collapsed ? "justify-center" : ""
+                } ${
                   active
                     ? "bg-stone-100 text-stone-900"
                     : "text-stone-500 hover:text-stone-800 hover:bg-stone-50"
                 }`}
               >
-                <span className="text-base leading-none">{item.icon}</span>
-                {item.label}
+                <span className="text-base leading-none shrink-0">{item.icon}</span>
+                {!collapsed && item.label}
               </Link>
             )
           })}
         </nav>
+
         {/* User */}
-        <div className="px-3 py-3 border-t border-stone-100">
+        <div className={`px-2 py-3 border-t border-stone-100 flex ${collapsed ? "justify-center" : ""}`}>
           <AuthButton afterSignOutUrl="/sign-in" dropUp />
         </div>
+
+        {/* Collapse toggle — sits on the right edge */}
+        <button
+          onClick={() => setCollapsed(v => !v)}
+          className="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors z-10"
+          title={collapsed ? "Expand" : "Collapse"}
+        >
+          {collapsed ? "›" : "‹"}
+        </button>
       </aside>
+
       <main className="flex-1 overflow-auto">{children}</main>
     </div>
   )

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -11,7 +11,7 @@ const NAV = [
   { href: "/settings",  label: "Settings", icon: "⚙" },
 ]
 
-export default function AppShell({ children }: { children: React.ReactNode }) {
+export default function AppShell({ children, noPadding }: { children: React.ReactNode; noPadding?: boolean }) {
   const pathname = usePathname()
   const [collapsed, setCollapsed] = useState(false)
 
@@ -70,7 +70,7 @@ export default function AppShell({ children }: { children: React.ReactNode }) {
         </button>
       </aside>
 
-      <main className="flex-1 overflow-auto">{children}</main>
+      <main className={`flex-1 min-h-0 ${noPadding ? "overflow-hidden flex flex-col" : "overflow-auto"}`}>{children}</main>
     </div>
   )
 }

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
-import AuthButton from "@/components/AuthButton"
 import {
   ReactFlow,
   Background,
@@ -570,11 +569,10 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const selectedData = selectedNode?.data as BlockNodeData | undefined
 
   return (
-    <div className="flex flex-col h-screen bg-stone-50">
+    <div className="flex flex-col h-full bg-stone-50">
       {/* Top bar */}
       <header className="flex items-center justify-between px-5 py-3 bg-white border-b border-stone-200 shrink-0">
         <div className="flex items-center gap-3">
-          <a href="/workflows" className="text-stone-400 hover:text-stone-700 text-sm">←</a>
           <input
             value={workflowName}
             onChange={(e) => setWorkflowName(e.target.value)}
@@ -652,7 +650,6 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
           >
             {running === "live" ? "Starting…" : activeRunId ? "▶ Running…" : "▶ Run"}
           </button>
-          <AuthButton afterSignOutUrl="/sign-in" />
         </div>
       </header>
 


### PR DESCRIPTION
## Summary
- Canvas editor (`/workflows/[id]`) now renders inside AppShell
- Persistent sidebar (Agents / Runs / Settings) visible on all pages
- Removed duplicate back arrow and AuthButton from canvas top bar — sidebar provides both
- Added `noPadding` prop to AppShell so canvas can use full remaining height without scroll

## Before / After
- Before: canvas had its own full-screen layout with no sidebar
- After: sidebar is always present; canvas fills the main content area