### PR TITLE
fix: sidebar auth dropdown + unified page layout

### DIFF
--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -85,8 +85,8 @@ function GlobalRunsContent({ getToken }: { getToken: (() => Promise<string | nul
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-4xl px-6 py-10">
-        <div className="flex items-center justify-between mb-6">
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <div className="flex items-center justify-between mb-5">
           <h1 className="text-xl font-semibold text-stone-900">Runs</h1>
           <span className="text-xs text-stone-400">{runs.length} run{runs.length !== 1 ? "s" : ""}</span>
         </div>

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState } from "react"
-import Link from "next/link"
 import AppShell from "@/components/AppShell"
 import CredentialsManager from "@/components/settings/CredentialsManager"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
@@ -13,13 +12,10 @@ export default function SettingsPage() {
 
   return (
     <AppShell>
-      <div className="mx-auto max-w-2xl px-6 py-12">
-        <div className="mb-8">
-          <h1 className="text-2xl font-semibold text-stone-900">Settings</h1>
-          <p className="text-sm text-stone-500 mt-1.5">
-            Manage your integrations and environments.
-            All tokens are encrypted with AES-256-GCM before storage.
-          </p>
+      <div className="mx-auto max-w-3xl px-6 py-10">
+        <div className="flex items-center justify-between mb-5">
+          <h1 className="text-xl font-semibold text-stone-900">Settings</h1>
+          <span className="text-xs text-stone-400">Tokens encrypted at rest</span>
         </div>
 
         {/* Tab bar */}
@@ -48,15 +44,6 @@ export default function SettingsPage() {
 
         {activeTab === "integrations" && <CredentialsManager />}
         {activeTab === "environments" && <EnvironmentsManager />}
-
-        <div className="mt-10 pt-8 border-t border-stone-200 text-right">
-          <Link
-            href="/workflows/new"
-            className="rounded-lg px-5 py-2.5 text-sm font-medium bg-stone-900 text-white hover:bg-stone-700 transition-colors"
-          >
-            Create your first agent →
-          </Link>
-        </div>
       </div>
     </AppShell>
   )

--- a/apps/web/src/components/AuthButton.tsx
+++ b/apps/web/src/components/AuthButton.tsx
@@ -40,7 +40,7 @@ function AccountMenu({ afterSignOutUrl, dropUp }: { afterSignOutUrl: string; dro
       </button>
 
       {open && (
-        <div className={`absolute right-0 w-52 bg-white border border-stone-200 rounded-xl shadow-lg py-1 z-50 ${dropUp ? "bottom-9" : "top-9"}`}>
+        <div className={`absolute w-52 bg-white border border-stone-200 rounded-xl shadow-lg py-1 z-50 ${dropUp ? "bottom-full mb-1 left-0" : "top-9 right-0"}`}>
           {email && (
             <>
               <p className="px-3 py-2 text-[11px] text-stone-400 truncate">{email}</p>


### PR DESCRIPTION
## Summary
- Auth dropdown in sidebar now opens upward and rightward (`bottom-full mb-1 left-0`) — was opening leftward off-screen
- Runs page: aligned to `max-w-3xl px-6 py-10` with `text-xl` header matching Agents page
- Settings page: same container/header style as Agents; removed stray "Create agent" CTA