### PR TITLE
fix: rebrand Delegator → Delegators

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -3,7 +3,7 @@ import "./globals.css"
 import { ClerkProvider } from "@clerk/nextjs"
 
 export const metadata: Metadata = {
-  title: "Delegator — AI engineer that opens draft PRs you approve",
+  title: "Delegators — AI engineer that opens draft PRs you approve",
   description:
     "Open-source AI engineer for small teams. Label a GitHub issue, get a tested draft PR — approved in Slack before anything merges.",
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -33,7 +33,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
               <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
             </svg>
           </div>
-          <span className="font-bold text-stone-900 text-base tracking-tight">Delegator</span>
+          <span className="font-bold text-stone-900 text-base tracking-tight">Delegators</span>
         </div>
         {isLoaded && (
           isSignedIn ? (
@@ -66,7 +66,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         </h1>
 
         <p className="mt-6 text-xl text-stone-500 max-w-2xl leading-relaxed">
-          Delegator ships with 9 ready-made agents — label a GitHub issue, get a PR.
+          Delegators ships with 9 ready-made agents — label a GitHub issue, get a PR.
           CI fails, get a diagnosis. Alert fires, get a hypothesis. All in Slack.
           Nothing merges without your approval.
         </p>
@@ -143,10 +143,10 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         </div>
       </section>
 
-      {/* Why Delegator — the moat */}
+      {/* Why Delegators — the moat */}
       <section className="px-6 py-20">
         <div className="max-w-5xl mx-auto">
-          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest text-center mb-3">Why Delegator</p>
+          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest text-center mb-3">Why Delegators</p>
           <h2 className="text-3xl font-bold text-stone-900 text-center mb-12">
             Not just another AI tool.<br />An AI teammate you can trust.
           </h2>
@@ -184,7 +184,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         <p className="text-stone-500 mb-8 max-w-md mx-auto">
           {isLoaded && isSignedIn
             ? "Head to your projects and connect your first repo."
-            : "Sign in with Google, connect your GitHub repo, and let Delegator pick up its first ticket."}
+            : "Sign in with Google, connect your GitHub repo, and let Delegators pick up its first ticket."}
         </p>
         {isLoaded && (
           isSignedIn ? (
@@ -209,7 +209,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
       </section>
 
       <footer className="border-t border-stone-100 py-8 text-center text-xs text-stone-400">
-        © {new Date().getFullYear()} Delegator · Built for engineering teams
+        © {new Date().getFullYear()} Delegators · Built for engineering teams
       </footer>
     </div>
   )
@@ -284,11 +284,11 @@ const TEMPLATES = [
 const HOW_IT_WORKS = [
   {
     title: "Connect your tools",
-    body: "Link GitHub, Slack, and Linear in five minutes. No migration, no new workflow — Delegator fits around what you already use.",
+    body: "Link GitHub, Slack, and Linear in five minutes. No migration, no new workflow — Delegators fits around what you already use.",
   },
   {
-    title: "Delegator picks up the work",
-    body: "Label an issue `ai-ready` or fire a webhook. Delegator spins up an ephemeral sandbox, clones your repo, implements the fix, and runs your tests.",
+    title: "Delegators picks up the work",
+    body: "Label an issue `ai-ready` or fire a webhook. Delegators spins up an ephemeral sandbox, clones your repo, implements the fix, and runs your tests.",
   },
   {
     title: "You approve in Slack",
@@ -325,7 +325,7 @@ const WHY_DELEGATOR = [
   {
     icon: "🧩",
     title: "Fits your existing stack",
-    body: "GitHub, Slack, PagerDuty, OpsGenie, email, and any inbound webhook. No new tools, no migration — Delegator plugs into what your team already uses.",
+    body: "GitHub, Slack, PagerDuty, OpsGenie, email, and any inbound webhook. No new tools, no migration — Delegators plugs into what your team already uses.",
   },
 ]
 

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -101,7 +101,7 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
   return (
     <div className="min-h-screen bg-stone-50">
       <header className="border-b border-stone-200 bg-white px-6 py-3.5 flex items-center justify-between">
-        <span className="text-base font-bold text-stone-900 tracking-tight">Delegator</span>
+        <span className="text-base font-bold text-stone-900 tracking-tight">Delegators</span>
         {clerkEnabled && <AuthButton afterSignOutUrl="/" />}
       </header>
 

--- a/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/web/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -5,7 +5,7 @@ export default function SignInPage() {
     <div className="min-h-screen flex items-center justify-center bg-stone-50">
       <div className="space-y-4 text-center">
         <div className="mb-6">
-          <h1 className="text-2xl font-bold text-stone-900">Delegator</h1>
+          <h1 className="text-2xl font-bold text-stone-900">Delegators</h1>
           <p className="text-sm text-stone-500 mt-1">AI agent orchestration for engineering teams</p>
         </div>
         <SignIn />

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -26,7 +26,7 @@ export default function AppShell({ children, noPadding }: { children: React.Reac
               <span className="text-white text-xs">⚡</span>
             </div>
             {!collapsed && (
-              <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Delegator</span>
+              <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Delegators</span>
             )}
           </Link>
         </div>

--- a/apps/web/src/lib/config-schemas.ts
+++ b/apps/web/src/lib/config-schemas.ts
@@ -322,7 +322,7 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       type: "text",
       required: true,
       placeholder: "https://hooks.example.com/...",
-      hint: "Delegator will POST the run result as JSON",
+      hint: "Delegators will POST the run result as JSON",
     },
     {
       key: "config.webhook_secret",
@@ -330,7 +330,7 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       type: "text",
       required: false,
       placeholder: "optional",
-      hint: "Signs the payload — receiver checks X-Delegator-Signature: sha256=<hmac>",
+      hint: "Signs the payload — receiver checks X-Delegators-Signature: sha256=<hmac>",
     },
   ],
 }


### PR DESCRIPTION
Replaces all UI-facing instances of "Delegator" with "Delegators" across:
- AppShell sidebar logo
- Landing page (hero, why section, footer, feature copy)
- Sign-in page
- Projects page
- Page `<title>` metadata
- config-schemas hint text (webhook signature header)