### PR TITLE
ux: Conduct logo + favicon

### DIFF
--- a/apps/web/public/icon.svg
+++ b/apps/web/public/icon.svg
@@ -1,0 +1,8 @@
+<svg width="32" height="32" viewBox="0 0 32 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="32" height="32" rx="7" fill="#09090b"/>
+  <!-- Bold C arc — conductor's baton sweep -->
+  <path d="M22 10C20 8.7 17.7 8 15.5 8C10.8 8 7 11.8 7 16.5C7 21.2 10.8 25 15.5 25C17.7 25 20 24.3 22 23"
+        stroke="white" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  <!-- Baton tip -->
+  <circle cx="23.5" cy="22.5" r="2" fill="white"/>
+</svg>

--- a/apps/web/public/logo.svg
+++ b/apps/web/public/logo.svg
@@ -1,0 +1,10 @@
+<svg width="140" height="32" viewBox="0 0 140 32" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <!-- Icon mark -->
+  <rect width="32" height="32" rx="7" fill="#09090b"/>
+  <path d="M22 10C20 8.7 17.7 8 15.5 8C10.8 8 7 11.8 7 16.5C7 21.2 10.8 25 15.5 25C17.7 25 20 24.3 22 23"
+        stroke="white" stroke-width="2.8" stroke-linecap="round" fill="none"/>
+  <circle cx="23.5" cy="22.5" r="2" fill="white"/>
+  <!-- Wordmark -->
+  <text x="42" y="21" font-family="-apple-system, BlinkMacSystemFont, 'Inter', sans-serif"
+        font-size="15" font-weight="700" letter-spacing="-0.3" fill="#09090b">Conduct</text>
+</svg>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -6,6 +6,11 @@ export const metadata: Metadata = {
   title: "Conduct — AI agents that act inside your stack",
   description:
     "Open-source AI engineer for small teams. Label a GitHub issue, get a tested draft PR — approved in Slack before anything merges.",
+  icons: {
+    icon: "/icon.svg",
+    shortcut: "/icon.svg",
+    apple: "/icon.svg",
+  },
 }
 
 const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -23,9 +23,7 @@ export default function AppShell({ children, noPadding }: { children: React.Reac
         {/* Logo */}
         <div className={`px-3 py-4 border-b border-stone-100 flex items-center ${collapsed ? "justify-center" : "gap-2"}`}>
           <Link href="/workflows" className="flex items-center gap-2 min-w-0">
-            <div className="w-6 h-6 rounded-md bg-stone-900 flex items-center justify-center shrink-0">
-              <span className="text-white text-xs">⚡</span>
-            </div>
+            <img src="/icon.svg" alt="Conduct" className="w-6 h-6 shrink-0" />
             {!collapsed && (
               <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Conduct</span>
             )}


### PR DESCRIPTION
- `public/icon.svg` — bold C arc with baton-tip dot in dark rounded square, scales cleanly to 16px
- `public/logo.svg` — icon mark + Conduct wordmark for marketing use
- AppShell sidebar logo replaced: dark square + emoji → SVG icon
- layout.tsx metadata: icon/shortcut/apple all point to `/icon.svg`