### PR TITLE
docs: Conduct README + CLI section on landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,53 @@
-# Delegator
+# Conduct
 
-> **Label a GitHub issue `ai-ready`. Delegator clones your repo, writes the fix,
-> runs tests on an ephemeral sandbox, and opens a draft PR — then DMs you in
-> Slack for one-click approval before anything merges.**
+> **AI agents that act inside your stack — GitHub, Slack, Linear, and beyond.**
 
-Open-source AI engineer for small teams. Config lives as YAML in your repo
-(`<project>-delegator.yml`), runs on your infrastructure, full audit trail,
-MIT licensed. Built for teams of 10–80 engineers who want to ship faster
-without giving an autonomous agent the keys to production.
+Conduct lets engineering teams build, run, and govern AI agents on a drag-and-drop canvas (or in YAML). Label a GitHub issue `ai-ready` → an agent clones your repo, writes the fix, runs tests, and opens a draft PR. One-click Approve or Reject in Slack before anything merges.
 
-**Why this and not Devin / Cursor agents?** Those are autonomous black boxes
-optimized for individual developers. Delegator is built for engineering
-*teams*: every change goes through a human approval gate, every action is
-event-sourced and audit-logged, and the workflow definition lives as a YAML
-file in your repo where it can be reviewed in PRs like any other config.
-
-**Why this and not Zapier / n8n?** Those don't have AI agents in the middle.
-Delegator's Brain blocks are agentic — Claude reads your codebase, writes
-the fix, iterates on test failures, then hands off to a human.
-
-![Simple webhook → tool → output workflow](docs/canvas-simple.png)
-
-![Full Story→PR reference workflow with 16 blocks](docs/canvas-story-pr.png)
+MIT licensed · Built for teams of 10–80 engineers · Every action is event-sourced and audit-logged.
 
 ---
 
-## What it does
+## Why Conduct
 
-Delegator lets you build agents on a drag-and-drop canvas (or write the YAML
-directly) by wiring together blocks:
+| Problem | Conduct's answer |
+|---------|-----------------|
+| Autonomous agents (Devin, Cursor) are black boxes | Every step is visible — live trace, event log, approval gates |
+| Zapier/n8n have no AI in the middle | Brain blocks are agentic — Claude reads your codebase, iterates, hands off |
+| One shared credential set across all agents | Per-agent environments — each agent gets its own scoped credentials |
+| Hard to move from demo to production | Human-in-the-loop by design — nothing merges without approval |
+
+---
+
+## What you can build
+
+9 ready-made agent templates ship out of the box:
+
+| Template | Trigger | What it does |
+|----------|---------|-------------|
+| **Autopilot Git → Slack** | GitHub issue label | Implements fix, opens PR, posts to Slack |
+| **Dependency Updater** | Weekly cron | Bumps patch/minor deps, opens PR |
+| **Incident Responder** | PagerDuty / OpsGenie webhook | Correlates commits, posts hypothesis to Slack |
+| **Release Notes** | Git tag webhook | Reads merged PRs, writes CHANGELOG, posts to #releases |
+| **Issue Triage** | GitHub issue.opened | Labels, prioritises, posts clarifying comment |
+| **Deploy Monitor** | Vercel / Railway webhook | Monitors deployment, alerts on failure |
+| **PR Review** | GitHub PR webhook | Reviews diff, posts structured feedback |
+| **Scheduled Report** | Daily cron | Aggregates Linear issues, emails summary |
+| **Custom Agent** | Any trigger | Build from scratch on the canvas |
+
+---
+
+## Block types
 
 | Block | Purpose |
 |-------|---------|
 | **Trigger** | Starts a run — webhook, schedule, or manual |
 | **Brain** | Agentic LLM step (Claude) with tool access and bounded autonomy |
-| **Tool** | Deterministic integration call (GitHub, Slack, Linear, Vercel, Railway, etc.) |
+| **Tool** | Deterministic integration call (GitHub, Slack, Linear, etc.) |
 | **Logic** | Conditional branch — pass / fail paths |
 | **Approval** | Pauses the run, sends a Slack DM with Approve / Reject buttons |
 | **Output** | Sends a formatted summary via Slack, Email, or both |
 | **Cleanup** | Always runs at the end — tear down sandboxes, close resources |
-
-Each block has a plain-English description field. The compiler turns it into a structured prompt + tool schema. Runs are logged event-by-event and viewable in a live trace UI.
 
 ---
 
@@ -48,14 +55,14 @@ Each block has a plain-English description field. The compiler turns it into a s
 
 ```
 apps/
-  web/      Next.js 14 + React Flow canvas + Tailwind
-  api/      FastAPI + SQLAlchemy + Alembic
-  api/      worker.py — background run executor (Redis queue)
+  web/          Next.js 14 — canvas UI, runs feed, settings
+  api/          FastAPI + SQLAlchemy + Alembic
+  api/worker.py Background run executor (Redis queue)
 packages/
-  shared/   TypeScript types shared between frontend packages
+  conduct-cli/  Python CLI — run agents from the terminal or CI
 ```
 
-**Infrastructure (local dev via Docker Compose)**
+**Infrastructure (local dev)**
 
 ```
 postgres   pgvector/pgvector:pg16
@@ -67,7 +74,7 @@ web        Next.js on :3000
 
 ---
 
-## Getting started
+## Getting started (UI)
 
 ### Prerequisites
 
@@ -82,7 +89,7 @@ cd delegator
 cp .env.example .env
 ```
 
-Edit `.env` and set at minimum:
+Edit `.env`:
 
 ```env
 ANTHROPIC_API_KEY=sk-ant-...
@@ -93,24 +100,76 @@ ENCRYPTION_KEY=<32-char random string>
 
 ```bash
 docker compose up -d
-```
-
-### 3. Run database migrations
-
-```bash
 docker compose exec api alembic upgrade head
 ```
 
-### 4. Open the app
+### 3. Open the app
 
 - **UI**: http://localhost:3000
 - **API docs**: http://localhost:8000/docs
+
+### 4. Create your first agent
+
+1. **Projects** → New project
+2. **Agents** → New agent (or pick a template)
+3. **Settings** → Environments → add GitHub + Slack credentials
+4. Assign the environment to your agent from the canvas dropdown
+5. Hit **Run**
+
+---
+
+## Getting started (CLI)
+
+The `conduct` CLI lets you trigger agents from your terminal, CI pipeline, or scripts.
+
+### Install
+
+```bash
+pip install conduct-cli
+```
+
+### Run an agent from a YAML file
+
+```bash
+conduct --server https://api.conductai.ai \
+        --api-key YOUR_CLI_API_KEY \
+        run autopilot.yaml
+```
+
+### YAML agent definition
+
+```yaml
+name: Fix GitHub Issue
+workflow_id: <your-workflow-id>
+workspace_id: <your-workspace-id>
+
+trigger:
+  event_type: github_issue_labeled
+  label: ai-ready
+  repo:
+    full_name: your-org/your-repo
+
+issue:
+  number: 42
+  title: "Button not responding on mobile"
+  body: "Tap on the submit button does nothing on iOS Safari."
+```
+
+### CLI flags
+
+| Flag | Description |
+|------|-------------|
+| `--server` | Conduct API URL (e.g. `https://api.conductai.ai`) |
+| `--api-key` | CLI API key — set `CLI_API_KEY` on the server |
+| `--token` | Bearer token for Clerk auth (alternative to api-key) |
+| `--workspace` | Workspace ID (overrides YAML `workspace_id`) |
 
 ---
 
 ## Integrations
 
-Configure credentials in Settings → each integration card expands inline.
+Configure credentials in **Settings → Environments → [environment]**.
+One credential per provider per environment. Need two GitHub accounts? Create two environments.
 
 | Integration | Actions |
 |-------------|---------|
@@ -126,25 +185,12 @@ Configure credentials in Settings → each integration card expands inline.
 
 ## Webhooks
 
-Delegator can trigger workflows from external deploy events.
-
 | Endpoint | Service | Events |
 |----------|---------|--------|
 | `POST /webhooks/vercel` | Vercel | deployment.succeeded, deployment.ready, deployment.failed |
 | `POST /webhooks/railway` | Railway | DEPLOY_SUCCESS, DEPLOY_FAILED, DEPLOY_CRASHED |
 | `POST /webhooks/slack/interactions` | Slack | Approval button clicks |
-
-To use: create a workflow with a **Trigger** block set to `event_type: webhook`, then paste your public API URL into the respective service's webhook settings.
-
----
-
-## Running workflows
-
-**Dry Run** — simulates the full execution without making real API calls. Useful for validating block wiring and config.
-
-**Run** — executes immediately against real integrations.
-
-The canvas validates all required fields before either run type starts. Errors are shown as clickable links that jump to the offending block.
+| `POST /webhooks/inbound/{workflow_id}` | Generic | Any JSON payload |
 
 ---
 
@@ -157,6 +203,7 @@ The canvas validates all required fields before either run type starts. Errors a
 | `DATABASE_URL` | Yes | Postgres connection string |
 | `REDIS_URL` | Yes | Redis connection string |
 | `API_BASE_URL` | Yes | Public URL of the API (for webhook callbacks) |
+| `CLI_API_KEY` | Optional | Shared secret for CLI / CI access |
 | `SLACK_SIGNING_SECRET` | Optional | Verifies Slack interactive component payloads |
 | `RESEND_API_KEY` | Optional | Resend key for email output |
 | `VERCEL_WEBHOOK_SECRET` | Optional | Verifies Vercel webhook signatures |
@@ -167,18 +214,20 @@ The canvas validates all required fields before either run type starts. Errors a
 
 ## Deployment
 
-### Railway (API + worker)
+### Render (API + worker)
 
-1. New project → Deploy from GitHub → root directory: `apps/api`
-2. Add a **PostgreSQL** plugin
+1. New Web Service → connect GitHub → root directory: `apps/api`
+2. Add a **PostgreSQL** database
 3. Add a second service (same repo, root `apps/api`, start command: `python -m app.worker`)
 4. Set environment variables
-5. After first deploy: run `alembic upgrade head` via Railway shell
+5. After first deploy: run `alembic upgrade head` via Render shell
+6. Custom domain: add CNAME `api.conductai.ai → your-service.onrender.com`
 
 ### Vercel (frontend)
 
 1. Connect GitHub repo → root directory: `apps/web`
-2. Set `NEXT_PUBLIC_API_URL` to your Railway API URL
+2. Set `NEXT_PUBLIC_API_URL=https://api.conductai.ai`
+3. Preview deployments automatically created for each PR
 
 ---
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -204,6 +204,38 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         )}
       </section>
 
+      {/* CLI section */}
+      <section className="border-t border-stone-100 py-16 px-6">
+        <div className="mx-auto max-w-3xl">
+          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">CLI & CI</p>
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Run agents from your terminal</h2>
+          <p className="text-stone-500 mb-8 text-sm leading-relaxed">
+            The <code className="bg-stone-100 px-1.5 py-0.5 rounded text-stone-700 font-mono text-xs">conduct</code> CLI
+            lets you trigger any agent from your terminal, a GitHub Action, or a CI pipeline — no browser required.
+          </p>
+          <div className="grid md:grid-cols-2 gap-4">
+            <div className="rounded-xl bg-stone-950 p-5 font-mono text-sm">
+              <p className="text-stone-500 text-xs mb-3"># Install</p>
+              <p className="text-emerald-400">pip install conduct-cli</p>
+              <p className="text-stone-500 text-xs mt-4 mb-3"># Run an agent</p>
+              <p className="text-white">conduct --server https://api.conductai.ai \</p>
+              <p className="text-white pl-4">--api-key YOUR_KEY \</p>
+              <p className="text-white pl-4">run autopilot.yaml</p>
+            </div>
+            <div className="rounded-xl bg-stone-950 p-5 font-mono text-sm">
+              <p className="text-stone-500 text-xs mb-3"># autopilot.yaml</p>
+              <p className="text-violet-400">name<span className="text-white">: Fix GitHub Issue</span></p>
+              <p className="text-violet-400">workflow_id<span className="text-white">: abc-123</span></p>
+              <p className="text-violet-400">trigger<span className="text-white">:</span></p>
+              <p className="text-white pl-4">event_type<span className="text-stone-400">: github_issue_labeled</span></p>
+              <p className="text-white pl-4">label<span className="text-stone-400">: ai-ready</span></p>
+              <p className="text-white pl-4">repo<span className="text-stone-400">:</span></p>
+              <p className="text-white pl-8">full_name<span className="text-stone-400">: your-org/repo</span></p>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <footer className="border-t border-stone-100 py-8 text-center text-xs text-stone-400">
         © {new Date().getFullYear()} Conduct · Built for engineering teams
       </footer>


### PR DESCRIPTION
## README
- Full rewrite under Conduct brand (was Delegator)
- Added CLI getting started section with install + YAML example + flag table
- Updated architecture to show conduct-cli package
- Updated deployment section (Render + Vercel, custom domain)
- 9 agent templates table, block types, integrations, webhooks, env vars

## Landing page
- New CLI & CI section above footer
- Two dark code panels: install + run command, and YAML example
- Links `conduct` CLI clearly to the product