### PR TITLE
fix: HIGH ux — error retry, canvas pan-to-block, post-signin guidance

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -100,6 +100,31 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
             <p className="text-xs text-stone-400">No credit card · No setup · Just your Google account</p>
           )}
         </div>
+
+        {/* Post-sign-in next steps — only shown when signed in */}
+        {isLoaded && isSignedIn && (
+          <div className="mt-8 bg-stone-50 border border-stone-200 rounded-2xl px-6 py-5 max-w-md w-full text-left">
+            <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">Get started in 3 steps</p>
+            <ol className="space-y-2.5">
+              {[
+                { n: "1", text: "Create a project and connect your GitHub repo" },
+                { n: "2", text: "Pick an agent template (Autopilot is a good first one)" },
+                { n: "3", text: "Add your credentials in Settings → Environments, then hit Run" },
+              ].map(({ n, text }) => (
+                <li key={n} className="flex items-start gap-3 text-sm text-stone-600">
+                  <span className="w-5 h-5 rounded-full bg-stone-900 text-white text-[10px] font-bold flex items-center justify-center shrink-0 mt-0.5">{n}</span>
+                  {text}
+                </li>
+              ))}
+            </ol>
+            <button
+              onClick={() => router.push("/projects")}
+              className="mt-4 text-sm font-medium text-stone-900 hover:text-stone-600 transition-colors"
+            >
+              Go to Projects →
+            </button>
+          </div>
+        )}
       </section>
 
       {/* Trust strip */}

--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -184,7 +184,22 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
         </div>
 
         {error && (
-          <p className="mb-4 text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-4 py-2">{error}</p>
+          <div className="mb-4 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+            <p className="text-sm text-red-600 mb-2">{error}</p>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleCreate}
+                disabled={!name.trim() || loading}
+                className="text-xs font-medium text-red-700 hover:text-red-900 underline underline-offset-2"
+              >
+                Try again
+              </button>
+              <span className="text-red-200">·</span>
+              <Link href="/workflows" className="text-xs font-medium text-red-700 hover:text-red-900 underline underline-offset-2">
+                Back to agents
+              </Link>
+            </div>
+          </div>
         )}
 
         {/* Create button */}

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -123,7 +123,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstLoad = useRef(true)
-  const { screenToFlowPosition } = useReactFlow()
+  const { screenToFlowPosition, setCenter } = useReactFlow()
   const router = useRouter()
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
   const [activeRunId, setActiveRunId] = useState<string | null>(null)
@@ -811,7 +811,13 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                     key={e.blockId}
                     onClick={() => {
                       const node = nodes.find(n => n.id === e.blockId)
-                      if (node) { setSelectedNode(node); setRightOpen(true) }
+                      if (node) {
+                        setSelectedNode(node)
+                        setRightOpen(true)
+                        const x = (node.position.x ?? 0) + (node.width ?? 200) / 2
+                        const y = (node.position.y ?? 0) + (node.height ?? 80) / 2
+                        setCenter(x, y, { zoom: 1, duration: 400 })
+                      }
                     }}
                     className="text-xs text-red-600 hover:text-red-800 hover:underline text-left"
                   >


### PR DESCRIPTION
## Fixes

**1. New agent error state** (`workflows/new/page.tsx`)
- Error banner now shows "Try again" (re-triggers `handleCreate`) and "Back to agents" link
- User is never left in a dead end after a failure

**2. Canvas validation errors** (`CanvasEditor.tsx`)
- Clicking a validation error now calls `setCenter(x, y, { zoom: 1, duration: 400 })` to animate the canvas to the offending block, then selects it and opens the config panel
- Works even if the block is off-screen

**3. Landing page post-sign-in** (`page.tsx`)
- Signed-in users see a 3-step "Get started" card below the hero CTA
- Steps: create project → pick template → add credentials → run
- "Go to Projects →" link at the bottom of the card

## Test plan
- [ ] New agent: trigger a server error (bad network) — confirm "Try again" and "Back to agents" appear
- [ ] Canvas: add a Tool block, leave integration unset, hit Run — confirm clicking error scrolls canvas to that block
- [ ] Landing: sign in — confirm 3-step card appears below CTA