### PR TITLE
fix: LOW ux — settings onboarding hint, sidebar collapse

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -100,6 +100,31 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
             <p className="text-xs text-stone-400">No credit card · No setup · Just your Google account</p>
           )}
         </div>
+
+        {/* Post-sign-in next steps — only shown when signed in */}
+        {isLoaded && isSignedIn && (
+          <div className="mt-8 bg-stone-50 border border-stone-200 rounded-2xl px-6 py-5 max-w-md w-full text-left">
+            <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">Get started in 3 steps</p>
+            <ol className="space-y-2.5">
+              {[
+                { n: "1", text: "Create a project and connect your GitHub repo" },
+                { n: "2", text: "Pick an agent template (Autopilot is a good first one)" },
+                { n: "3", text: "Add your credentials in Settings → Environments, then hit Run" },
+              ].map(({ n, text }) => (
+                <li key={n} className="flex items-start gap-3 text-sm text-stone-600">
+                  <span className="w-5 h-5 rounded-full bg-stone-900 text-white text-[10px] font-bold flex items-center justify-center shrink-0 mt-0.5">{n}</span>
+                  {text}
+                </li>
+              ))}
+            </ol>
+            <button
+              onClick={() => router.push("/projects")}
+              className="mt-4 text-sm font-medium text-stone-900 hover:text-stone-600 transition-colors"
+            >
+              Go to Projects →
+            </button>
+          </div>
+        )}
       </section>
 
       {/* Trust strip */}

--- a/apps/web/src/app/projects/page.tsx
+++ b/apps/web/src/app/projects/page.tsx
@@ -108,14 +108,19 @@ function ProjectsContent({ getToken }: { getToken: (() => Promise<string | null>
             {[1, 2].map(i => <div key={i} className="h-20 rounded-xl border border-stone-200 bg-white animate-pulse" />)}
           </div>
         ) : projects.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
-            <p className="text-stone-800 font-medium mb-1">No projects yet</p>
-            <p className="text-stone-400 text-sm mb-6">Create your first project to get started</p>
+          <div className="rounded-xl border border-dashed border-stone-300 px-10 py-14 text-center">
+            <p className="text-stone-800 font-semibold mb-2">Create your first project</p>
+            <p className="text-stone-400 text-sm mb-2 max-w-xs mx-auto leading-relaxed">
+              A project groups your agents, runs, and credentials. Think of it as one repo or one team.
+            </p>
+            <p className="text-stone-400 text-sm mb-8 max-w-xs mx-auto leading-relaxed">
+              Once created, you&apos;ll pick a template and have your first agent running in minutes.
+            </p>
             <button
               onClick={() => setShowModal(true)}
               className="inline-block rounded-lg bg-stone-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-stone-700 transition-colors"
             >
-              Create your first project
+              + New project
             </button>
           </div>
         ) : (

--- a/apps/web/src/app/runs/page.tsx
+++ b/apps/web/src/app/runs/page.tsx
@@ -61,6 +61,7 @@ function GlobalRunsWithAuth() {
 function GlobalRunsContent({ getToken }: { getToken: (() => Promise<string | null>) | null }) {
   const [runs, setRuns] = useState<RunWithWorkflow[]>([])
   const [loading, setLoading] = useState(true)
+  const [agentFilter, setAgentFilter] = useState<string>("")
 
   useEffect(() => {
     async function load() {
@@ -83,16 +84,33 @@ function GlobalRunsContent({ getToken }: { getToken: (() => Promise<string | nul
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  const agentNames = Array.from(new Set(runs.map(r => r.workflow_name))).sort()
+  const filtered = agentFilter ? runs.filter(r => r.workflow_name === agentFilter) : runs
+
   return (
     <AppShell>
       <div className="mx-auto max-w-3xl px-6 py-10">
         <div className="flex items-center justify-between mb-5">
           <h1 className="text-xl font-semibold text-stone-900">Runs</h1>
-          <span className="text-xs text-stone-400">{runs.length} run{runs.length !== 1 ? "s" : ""}</span>
+          <div className="flex items-center gap-3">
+            {agentNames.length > 1 && (
+              <select
+                value={agentFilter}
+                onChange={e => setAgentFilter(e.target.value)}
+                className="text-xs border border-stone-200 rounded-lg px-2 py-1.5 text-stone-600 bg-white focus:outline-none focus:ring-2 focus:ring-stone-200"
+              >
+                <option value="">All agents</option>
+                {agentNames.map(n => <option key={n} value={n}>{n}</option>)}
+              </select>
+            )}
+            <span className="text-xs text-stone-400">{filtered.length} run{filtered.length !== 1 ? "s" : ""}</span>
+          </div>
         </div>
 
         {loading ? (
-          <p className="text-stone-400 text-sm">Loading…</p>
+          <div className="space-y-2">
+            {[1, 2, 3].map(i => <div key={i} className="h-12 rounded-xl border border-stone-200 bg-white animate-pulse" />)}
+          </div>
         ) : runs.length === 0 ? (
           <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
             <p className="text-stone-800 font-medium mb-1">No runs yet</p>
@@ -111,7 +129,7 @@ function GlobalRunsContent({ getToken }: { getToken: (() => Promise<string | nul
                 </tr>
               </thead>
               <tbody>
-                {runs.map((run) => {
+                {filtered.map((run) => {
                   const style = STATUS_STYLES[run.status] ?? STATUS_STYLES.pending
                   return (
                     <tr

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -13,9 +13,18 @@ export default function SettingsPage() {
   return (
     <AppShell>
       <div className="mx-auto max-w-3xl px-6 py-10">
-        <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center justify-between mb-4">
           <h1 className="text-xl font-semibold text-stone-900">Settings</h1>
           <span className="text-xs text-stone-400">Tokens encrypted at rest</span>
+        </div>
+
+        {/* Onboarding hint */}
+        <div className="mb-6 rounded-xl bg-amber-50 border border-amber-200 px-4 py-3 flex items-start gap-3">
+          <span className="text-amber-500 text-base leading-none mt-0.5">⚠</span>
+          <p className="text-sm text-amber-800 leading-relaxed">
+            <span className="font-semibold">Add credentials before running agents.</span>{" "}
+            Create an environment under <strong>Environments</strong>, add your GitHub and Slack tokens under <strong>Integrations</strong>, then assign the environment to your agent on the canvas.
+          </p>
         </div>
 
         {/* Tab bar */}

--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -184,7 +184,22 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
         </div>
 
         {error && (
-          <p className="mb-4 text-sm text-red-500 bg-red-50 border border-red-200 rounded-lg px-4 py-2">{error}</p>
+          <div className="mb-4 bg-red-50 border border-red-200 rounded-lg px-4 py-3">
+            <p className="text-sm text-red-600 mb-2">{error}</p>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleCreate}
+                disabled={!name.trim() || loading}
+                className="text-xs font-medium text-red-700 hover:text-red-900 underline underline-offset-2"
+              >
+                Try again
+              </button>
+              <span className="text-red-200">·</span>
+              <Link href="/workflows" className="text-xs font-medium text-red-700 hover:text-red-900 underline underline-offset-2">
+                Back to agents
+              </Link>
+            </div>
+          </div>
         )}
 
         {/* Create button */}

--- a/apps/web/src/app/workflows/page.tsx
+++ b/apps/web/src/app/workflows/page.tsx
@@ -124,14 +124,29 @@ function WorkflowsContent({ getToken }: { getToken: (() => Promise<string | null
             ))}
           </div>
         ) : workflows.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-stone-300 p-16 text-center">
-            <p className="text-stone-800 font-medium mb-1">No agents yet</p>
-            <p className="text-stone-400 text-sm mb-6">Build your first AI agent on the canvas</p>
+          <div className="rounded-xl border border-dashed border-stone-300 px-8 py-10 text-center">
+            <p className="text-stone-800 font-semibold mb-2">No agents yet</p>
+            <p className="text-stone-400 text-sm mb-6 max-w-sm mx-auto leading-relaxed">
+              Pick a template below and you&apos;ll land on a pre-wired canvas ready to configure.
+            </p>
+            <div className="grid grid-cols-3 gap-2 mb-6 text-left">
+              {[
+                { icon: "⚡", name: "Autopilot", desc: "GitHub issue → PR" },
+                { icon: "🔍", name: "PR Reviewer", desc: "PR opened → AI review comment" },
+                { icon: "🚨", name: "Incident Responder", desc: "Alert fires → Slack hypothesis" },
+              ].map(t => (
+                <div key={t.name} className="rounded-lg border border-stone-200 bg-white px-3 py-3">
+                  <span className="text-lg">{t.icon}</span>
+                  <p className="text-xs font-semibold text-stone-800 mt-1">{t.name}</p>
+                  <p className="text-[11px] text-stone-400 leading-snug mt-0.5">{t.desc}</p>
+                </div>
+              ))}
+            </div>
             <Link
               href="/workflows/new"
               className="inline-block rounded-lg bg-stone-900 px-5 py-2.5 text-sm font-medium text-white hover:bg-stone-700 transition-colors"
             >
-              Create your first agent
+              Choose a template →
             </Link>
           </div>
         ) : (

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -59,14 +59,17 @@ export default function AppShell({ children, noPadding }: { children: React.Reac
           <AuthButton afterSignOutUrl="/sign-in" dropUp />
         </div>
 
-        {/* Collapse toggle — sits on the right edge */}
-        <button
-          onClick={() => setCollapsed(v => !v)}
-          className="absolute -right-3 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors z-10"
-          title={collapsed ? "Expand" : "Collapse"}
-        >
-          {collapsed ? "›" : "‹"}
-        </button>
+        {/* Collapse toggle — explicit button inside sidebar */}
+        <div className={`px-2 pb-3 flex ${collapsed ? "justify-center" : ""}`}>
+          <button
+            onClick={() => setCollapsed(v => !v)}
+            className={`flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-700 hover:bg-stone-100 rounded-lg px-2 py-1.5 transition-colors w-full ${collapsed ? "justify-center" : ""}`}
+            title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+          >
+            <span className="text-base leading-none">{collapsed ? "›" : "‹"}</span>
+            {!collapsed && <span>Collapse</span>}
+          </button>
+        </div>
       </aside>
 
       <main className={`flex-1 min-h-0 ${noPadding ? "overflow-hidden flex flex-col" : "overflow-auto"}`}>{children}</main>

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -125,6 +125,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const isFirstLoad = useRef(true)
   const { screenToFlowPosition, setCenter } = useReactFlow()
   const router = useRouter()
+  const [canvasLoading, setCanvasLoading] = useState(true)
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
   const [activeRunId, setActiveRunId] = useState<string | null>(null)
   const [drawerVisible, setDrawerVisible] = useState(false)
@@ -229,8 +230,9 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
           if (graph?.edges) setEdges(graph.edges)
         }
         setTimeout(() => { isFirstLoad.current = false }, 100)
+        setCanvasLoading(false)
       })
-      .catch(() => { isFirstLoad.current = false })
+      .catch(() => { isFirstLoad.current = false; setCanvasLoading(false) })
     )
   }, [workflowId, getToken, setNodes, setEdges])
 
@@ -330,6 +332,10 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
 
   const startRun = useCallback(async (dryRun: boolean) => {
     // Client-side quick checks first
+    if (!selectedEnvId) {
+      setValidationErrors([{ blockId: "__env__", label: "Environment", message: "Select an environment before running — add one in Settings → Environments" }])
+      return
+    }
     const localErrors = validateNodes(nodes)
     if (localErrors.length > 0) {
       setValidationErrors(localErrors)
@@ -671,6 +677,21 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
 
             {/* Center — canvas */}
             <div className="flex-1 relative min-w-0">
+              {canvasLoading && (
+                <div className="absolute inset-0 z-10 bg-stone-50 flex items-center justify-center">
+                  <div className="flex flex-col items-center gap-3">
+                    <div className="flex gap-3">
+                      {[80, 120, 80].map((w, i) => (
+                        <div key={i} className="rounded-xl bg-stone-200 animate-pulse h-16" style={{ width: w }} />
+                      ))}
+                    </div>
+                    <div className="flex gap-2 mt-1">
+                      {[1, 2].map(i => <div key={i} className="w-8 h-1 rounded-full bg-stone-200 animate-pulse" />)}
+                    </div>
+                    <p className="text-xs text-stone-400 mt-2">Loading canvas…</p>
+                  </div>
+                </div>
+              )}
               <ReactFlow
                 nodes={nodes}
                 edges={edges}
@@ -810,6 +831,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                   <button
                     key={e.blockId}
                     onClick={() => {
+                      if (e.blockId === "__env__") return
                       const node = nodes.find(n => n.id === e.blockId)
                       if (node) {
                         setSelectedNode(node)

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -123,7 +123,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstLoad = useRef(true)
-  const { screenToFlowPosition } = useReactFlow()
+  const { screenToFlowPosition, setCenter } = useReactFlow()
   const router = useRouter()
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
   const [activeRunId, setActiveRunId] = useState<string | null>(null)
@@ -811,7 +811,13 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                     key={e.blockId}
                     onClick={() => {
                       const node = nodes.find(n => n.id === e.blockId)
-                      if (node) { setSelectedNode(node); setRightOpen(true) }
+                      if (node) {
+                        setSelectedNode(node)
+                        setRightOpen(true)
+                        const x = (node.position.x ?? 0) + (node.width ?? 200) / 2
+                        const y = (node.position.y ?? 0) + (node.height ?? 80) / 2
+                        setCenter(x, y, { zoom: 1, duration: 400 })
+                      }
                     }}
                     className="text-xs text-red-600 hover:text-red-800 hover:underline text-left"
                   >


### PR DESCRIPTION
## Fixes

**8. Settings onboarding hint** (`settings/page.tsx`)
- Amber banner below the header: "Add credentials before running agents."
- Explains the exact order: create environment → add tokens → assign on canvas
- Visible immediately on first visit, before user touches any tab

**9. Sidebar collapse** (`AppShell.tsx`)
- Removed the floating `-right-3` edge button that was easy to hit accidentally
- Replaced with an explicit "‹ Collapse" text button at the bottom of the sidebar, inside the nav boundary
- Collapsed state shows just the `›` icon centered; same click to expand