### PR TITLE
fix: remove hardcoded draft badge

### DIFF
--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -584,7 +584,6 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
             onChange={(e) => setWorkflowName(e.target.value)}
             className="text-base font-semibold text-stone-900 bg-transparent border-none outline-none focus:ring-0 w-64"
           />
-          <span className="text-xs text-stone-400 bg-stone-100 px-2 py-0.5 rounded-full">draft</span>
           {/* Environment picker */}
           <select
             value={selectedEnvId}


### PR DESCRIPTION
Hardcoded 'draft' label in canvas header — not connected to any model field (published_at is never set). Pure noise, removed.