### PR TITLE
ux: canvas navigation — fitView on load, Fit button, MiniMap

### DIFF
--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -7,6 +7,7 @@ import {
   ReactFlow,
   Background,
   Controls,
+  MiniMap,
   addEdge,
   useNodesState,
   useEdgesState,
@@ -123,7 +124,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstLoad = useRef(true)
-  const { screenToFlowPosition, setCenter } = useReactFlow()
+  const { screenToFlowPosition, setCenter, fitView } = useReactFlow()
   const router = useRouter()
   const [canvasLoading, setCanvasLoading] = useState(true)
   const [running, setRunning] = useState<"idle" | "dry" | "live">("idle")
@@ -231,6 +232,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
         }
         setTimeout(() => { isFirstLoad.current = false }, 100)
         setCanvasLoading(false)
+        setTimeout(() => fitView({ padding: 0.2, duration: 300 }), 50)
       })
       .catch(() => { isFirstLoad.current = false; setCanvasLoading(false) })
     )
@@ -642,6 +644,13 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
             History
           </a>
           <button
+            onClick={() => fitView({ padding: 0.2, duration: 300 })}
+            title="Fit all blocks into view"
+            className="rounded-lg border border-stone-200 px-3 py-1.5 text-xs font-medium text-stone-500 hover:bg-stone-50 transition-colors"
+          >
+            ⊡ Fit
+          </button>
+          <button
             onClick={() => startRun(true)}
             disabled={running !== "idle"}
             className="rounded-lg border border-stone-200 px-3 py-1.5 text-xs font-medium text-stone-500 hover:bg-stone-50 transition-colors disabled:opacity-50"
@@ -710,6 +719,13 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
               >
                 <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#E7E5E4" />
                 <Controls className="!shadow-none !border !border-stone-200 !rounded-xl" showInteractive={false} />
+                <MiniMap
+                  nodeColor="#e7e5e4"
+                  maskColor="rgba(250,250,249,0.7)"
+                  className="!border !border-stone-200 !rounded-xl !shadow-none"
+                  pannable
+                  zoomable
+                />
               </ReactFlow>
               {activeRunId && drawerVisible && (
                 <RunDrawer


### PR DESCRIPTION
## Problem
Users had to press "-" repeatedly to zoom out to see all nodes. No way to get a quick overview of the whole graph.

## Changes
- **fitView on load** — after workflow data loads, canvas auto-fits all nodes with 300ms ease. No more opening to a partially visible graph.
- **⊡ Fit button** in toolbar — click at any time to re-center all nodes. Sits between History and Dry run.
- **MiniMap** — bottom-right overview panel, pannable and zoomable. Click anywhere on it to jump to that area of the canvas.