### PR TITLE
ux: smoother canvas block connections

### DIFF
--- a/apps/web/src/components/canvas/BlockNode.tsx
+++ b/apps/web/src/components/canvas/BlockNode.tsx
@@ -36,7 +36,7 @@ const INTEGRATION_COLORS: Record<string, string> = {
 }
 
 function handleClass(color: string) {
-  return `!w-2.5 !h-2.5 !border-2 !border-white !shadow-sm !transition-transform hover:!scale-125 ${color}`
+  return `!w-4 !h-4 !border-2 !border-white !shadow-md !transition-all !opacity-0 group-hover:!opacity-100 hover:!scale-125 hover:!shadow-lg ${color}`
 }
 
 function BlockNode({ data, selected }: NodeProps) {
@@ -58,7 +58,7 @@ function BlockNode({ data, selected }: NodeProps) {
     <div
       style={{ width: 200 }}
       className={cn(
-        "rounded-xl border-2 px-3 py-2.5 cursor-pointer transition-all shadow-sm",
+        "group rounded-xl border-2 px-3 py-2.5 cursor-pointer transition-all shadow-sm",
         style.bg,
         style.border,
         selected

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -13,6 +13,9 @@ import {
   useEdgesState,
   useReactFlow,
   ReactFlowProvider,
+  ConnectionMode,
+  ConnectionLineType,
+  MarkerType,
   type Connection,
   type Node,
   type Edge,
@@ -218,17 +221,28 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
           )
           const allSameY = graph.nodes.length > 1 &&
             graph.nodes.every((n: Node) => n.position?.y === graph.nodes[0].position?.y)
+          const styledEdges = (es: Edge[]) => es.map(e => ({
+            ...e,
+            type: e.type ?? "smoothstep",
+            markerEnd: e.markerEnd ?? { type: MarkerType.ArrowClosed, width: 16, height: 16, color: "#a8a29e" },
+            style: e.style ?? { stroke: "#a8a29e", strokeWidth: 2 },
+          }))
           if (allAtOrigin || allSameY) {
             const laid = autoLayout(graph.nodes, graph.edges)
             setNodes(laid.nodes)
-            setEdges(laid.edges)
+            setEdges(styledEdges(laid.edges))
           } else {
             setNodes(graph.nodes)
-            setEdges(graph.edges)
+            setEdges(styledEdges(graph.edges))
           }
         } else {
           if (graph?.nodes) setNodes(graph.nodes)
-          if (graph?.edges) setEdges(graph.edges)
+          if (graph?.edges) setEdges(graph.edges.map((e: Edge) => ({
+            ...e,
+            type: e.type ?? "smoothstep",
+            markerEnd: e.markerEnd ?? { type: MarkerType.ArrowClosed, width: 16, height: 16, color: "#a8a29e" },
+            style: e.style ?? { stroke: "#a8a29e", strokeWidth: 2 },
+          })))
         }
         setTimeout(() => { isFirstLoad.current = false }, 100)
         setCanvasLoading(false)
@@ -291,7 +305,12 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
   }, [nodes, edges, workflowName, save])
 
   const onConnect = useCallback(
-    (connection: Connection) => setEdges((eds) => addEdge(connection, eds)),
+    (connection: Connection) => setEdges((eds) => addEdge({
+      ...connection,
+      type: "smoothstep",
+      markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: "#a8a29e" },
+      style: { stroke: "#a8a29e", strokeWidth: 2 },
+    }, eds)),
     [setEdges]
   )
 
@@ -716,6 +735,16 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
                 maxZoom={2}
                 deleteKeyCode="Backspace"
                 proOptions={{ hideAttribution: true }}
+                connectionMode={ConnectionMode.Loose}
+                connectionLineType={ConnectionLineType.SmoothStep}
+                connectionRadius={40}
+                snapGrid={[16, 16]}
+                snapToGrid
+                defaultEdgeOptions={{
+                  type: "smoothstep",
+                  markerEnd: { type: MarkerType.ArrowClosed, width: 16, height: 16, color: "#a8a29e" },
+                  style: { stroke: "#a8a29e", strokeWidth: 2 },
+                }}
               >
                 <Background variant={BackgroundVariant.Dots} gap={20} size={1} color="#E7E5E4" />
                 <Controls className="!shadow-none !border !border-stone-200 !rounded-xl" showInteractive={false} />


### PR DESCRIPTION
## Problem
Connecting blocks was fiddly — small handles, no snap, straight-ish lines, had to hit the exact handle pixel.

## Changes

**BlockNode.tsx**
- Handles: `w-2.5 h-2.5` → `w-4 h-4` (60% larger hit target)
- Handles hidden at rest, fade in on node hover (`group`/`group-hover`) — less visual noise, obvious when you need them
- Hover scale effect kept

**CanvasEditor.tsx**
- `ConnectionMode.Loose` — you can start a connection from anywhere on the node, not just the exact handle pixel
- `ConnectionLineType.SmoothStep` — the in-progress connection line curves smoothly while dragging
- `connectionRadius={40}` — snaps to a handle within 40px, forgiving for near-misses
- `snapGrid={[16,16]}` + `snapToGrid` — nodes snap to a 16px grid, so blocks align cleanly after dragging
- `defaultEdgeOptions` — all new edges get `smoothstep` type + arrow marker + stone color
- Existing edges patched on load to match the same style (no mix of old straight + new curved)