### PR TITLE
fix: selectedEnvId stale closure in startRun

### DIFF
--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -530,7 +530,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
     } catch {
       setRunning("idle")
     }
-  }, [workflowId, getToken, router, nodes])
+  }, [workflowId, getToken, router, nodes, selectedEnvId])
 
   const _fireRun = useCallback(async (
     headers: Record<string, string>,


### PR DESCRIPTION
selectedEnvId was missing from useCallback deps — startRun captured the initial empty string and never saw the selected value. One-line fix.