### PR TITLE
fix: protect environment and credential deletion when in use

### DIFF
--- a/apps/api/app/routers/credentials.py
+++ b/apps/api/app/routers/credentials.py
@@ -15,6 +15,7 @@ from app.core.auth import get_workspace_id
 from app.core.crypto import decrypt, encrypt
 from app.core.database import get_db
 from app.models.integration import Integration
+from app.models.workflow import Workflow
 
 GITHUB_API = "https://api.github.com"
 
@@ -120,6 +121,21 @@ def delete_credential(handle: str, db: Session = Depends(get_db), workspace_id: 
     ).first()
     if not row:
         raise HTTPException(status_code=404, detail="Credential not found")
+
+    # Block deletion if this integration's environment is assigned to any workflow
+    if row.environment_id:
+        agents = (
+            db.query(Workflow)
+            .filter(Workflow.environment_id == row.environment_id)
+            .all()
+        )
+        if agents:
+            names = ", ".join(a.name for a in agents)
+            raise HTTPException(
+                status_code=409,
+                detail=f"This credential's environment is used by {len(agents)} agent(s): {names}. Remove the environment from those agents first.",
+            )
+
     db.delete(row)
     db.commit()
 

--- a/apps/api/app/routers/environments.py
+++ b/apps/api/app/routers/environments.py
@@ -88,15 +88,22 @@ def delete_environment(
     if not env:
         raise HTTPException(status_code=404, detail="Environment not found")
 
-    # Nullify environment_id on any integrations assigned to this environment
+    # Block deletion if any workflows are still assigned to this environment
+    agents = (
+        db.query(Workflow)
+        .filter(Workflow.environment_id == env_id)
+        .all()
+    )
+    if agents:
+        names = ", ".join(a.name for a in agents)
+        raise HTTPException(
+            status_code=409,
+            detail=f"Remove this environment from {len(agents)} agent(s) first: {names}",
+        )
+
+    # Safe to delete — remove any dangling integration references and the env
     db.query(Integration).filter(Integration.environment_id == env_id).update(
         {"environment_id": None}, synchronize_session=False
     )
-
-    # Nullify environment_id on any workflows assigned to this environment
-    db.query(Workflow).filter(Workflow.environment_id == env_id).update(
-        {"environment_id": None}, synchronize_session=False
-    )
-
     db.delete(env)
     db.commit()

--- a/apps/web/src/components/settings/CredentialsManager.tsx
+++ b/apps/web/src/components/settings/CredentialsManager.tsx
@@ -157,9 +157,15 @@ function CredentialsManagerInner({ getToken }: { getToken: (() => Promise<string
 
   async function handleRemove(handle: string) {
     setDeleting(handle)
+    setError("")
     try {
       const headers = await buildHeaders()
-      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/credentials/${handle}`, { method: "DELETE", headers })
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/credentials/${handle}`, { method: "DELETE", headers })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setError(body.detail ?? "Failed to remove credential")
+        return
+      }
       setCredentials(prev => prev.filter(c => c.handle !== handle))
     } finally {
       setDeleting(null)

--- a/apps/web/src/components/settings/EnvironmentsManager.tsx
+++ b/apps/web/src/components/settings/EnvironmentsManager.tsx
@@ -161,7 +161,12 @@ function EnvironmentsManagerInner({ getToken }: { getToken: (() => Promise<strin
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/environments/${id}`, {
         method: "DELETE", headers,
       })
-      if (!res.ok) throw new Error("Failed to delete environment")
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        setListError(body.detail ?? "Failed to delete environment")
+        setConfirmDelete(null)
+        return
+      }
       setEnvironments(prev => prev.filter(e => e.id !== id))
       setConfirmDelete(null)
     } catch {


### PR DESCRIPTION
## Problem
Environments and credentials could be silently deleted even when assigned to active agents, orphaning those agents.

## Changes

**API**
- `DELETE /environments/{id}` — queries workflows with that `environment_id`. If any exist, returns `409` with agent names: *"Remove this environment from 2 agent(s) first: Autopilot, PR Reviewer"*
- `DELETE /credentials/{handle}` — if the credential's environment is assigned to any workflow, returns `409` with agent names

**Frontend**
- `EnvironmentsManager`: reads the `409` body and surfaces it as the list error below the environment row
- `CredentialsManager`: reads the `409` body and surfaces it in the existing `error` state

## Result
User sees: *"Remove this environment from 2 agent(s) first: Autopilot, PR Reviewer"* — knows exactly what to fix before deleting.