### PR TITLE
feat: outcome-based dashboard (issue #50)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from app.routers import credentials, environments, projects, runs, webhooks, workflows
+from app.routers import credentials, dashboard, environments, projects, runs, webhooks, workflows
 from app.routers.runs import workspace_runs_router
 
 app = FastAPI(title="Marshal API", version="0.1.0")
@@ -25,6 +25,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
     )
 
 app.include_router(projects.router)
+app.include_router(dashboard.router)
 app.include_router(workflows.router)
 app.include_router(runs.router)
 app.include_router(workspace_runs_router)

--- a/apps/api/app/routers/dashboard.py
+++ b/apps/api/app/routers/dashboard.py
@@ -1,0 +1,152 @@
+"""
+GET /dashboard  — outcome-based summary for the workspace
+"""
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id
+from app.core.database import get_db
+from app.models.run import Run
+from app.models.workflow import Workflow, WorkflowVersion
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+class WeekStats(BaseModel):
+    issues_picked_up: int
+    prs_opened: int
+    total_runs: int
+    succeeded_runs: int
+    failed_runs: int
+    success_rate: float  # 0–100
+
+
+class RecentRun(BaseModel):
+    run_id: str
+    workflow_id: str
+    workflow_name: str
+    status: str
+    issue_number: int | None
+    issue_title: str | None
+    pr_url: str | None
+    started_at: str | None
+    created_at: str
+
+
+class AgentStatus(BaseModel):
+    workflow_id: str
+    name: str
+    last_run_status: str | None
+    last_run_at: str | None
+
+
+class DashboardOut(BaseModel):
+    week: WeekStats
+    recent_runs: list[RecentRun]
+    agents: list[AgentStatus]
+
+
+@router.get("", response_model=DashboardOut)
+def get_dashboard(
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
+    # All workflow version IDs for this workspace
+    version_ids_sq = (
+        db.query(WorkflowVersion.id)
+        .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+        .filter(Workflow.workspace_id == workspace_id)
+        .subquery()
+    )
+
+    # ── This-week stats ──────────────────────────────────────────────────────
+    week_start = datetime.now(timezone.utc) - timedelta(days=7)
+    week_runs = (
+        db.query(Run)
+        .filter(
+            Run.workflow_version_id.in_(version_ids_sq),
+            Run.created_at >= week_start,
+        )
+        .all()
+    )
+
+    issues_picked_up = sum(
+        1 for r in week_runs
+        if (r.state or {}).get("_trigger", {}).get("issue_number")
+    )
+    prs_opened = sum(
+        1 for r in week_runs
+        if (r.state or {}).get("pr_url")
+    )
+    succeeded = sum(1 for r in week_runs if r.status == "succeeded")
+    failed = sum(1 for r in week_runs if r.status == "failed")
+    total = len(week_runs)
+    success_rate = round((succeeded / total) * 100, 1) if total else 0.0
+
+    week_stats = WeekStats(
+        issues_picked_up=issues_picked_up,
+        prs_opened=prs_opened,
+        total_runs=total,
+        succeeded_runs=succeeded,
+        failed_runs=failed,
+        success_rate=success_rate,
+    )
+
+    # ── Recent runs (last 10) ────────────────────────────────────────────────
+    recent = (
+        db.query(Run, Workflow.id.label("wf_id"), Workflow.name.label("wf_name"))
+        .join(WorkflowVersion, WorkflowVersion.id == Run.workflow_version_id)
+        .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+        .filter(
+            Run.workflow_version_id.in_(version_ids_sq),
+            Workflow.workspace_id == workspace_id,
+        )
+        .order_by(Run.created_at.desc())
+        .limit(10)
+        .all()
+    )
+
+    recent_runs = []
+    for run, wf_id, wf_name in recent:
+        state = run.state or {}
+        trigger = state.get("_trigger") or state.get("github_issue") or {}
+        recent_runs.append(RecentRun(
+            run_id=str(run.id),
+            workflow_id=str(wf_id),
+            workflow_name=wf_name,
+            status=run.status,
+            issue_number=trigger.get("issue_number"),
+            issue_title=trigger.get("title") or trigger.get("issue_title"),
+            pr_url=state.get("pr_url"),
+            started_at=run.started_at.isoformat() if run.started_at else None,
+            created_at=run.created_at.isoformat(),
+        ))
+
+    # ── Agent statuses ───────────────────────────────────────────────────────
+    workflows = (
+        db.query(Workflow)
+        .filter(Workflow.workspace_id == workspace_id)
+        .order_by(Workflow.updated_at.desc())
+        .all()
+    )
+
+    agents = []
+    for wf in workflows:
+        last_run = (
+            db.query(Run)
+            .join(WorkflowVersion, WorkflowVersion.id == Run.workflow_version_id)
+            .filter(WorkflowVersion.workflow_id == wf.id)
+            .order_by(Run.created_at.desc())
+            .first()
+        )
+        agents.append(AgentStatus(
+            workflow_id=str(wf.id),
+            name=wf.name,
+            last_run_status=last_run.status if last_run else None,
+            last_run_at=last_run.created_at.isoformat() if last_run else None,
+        ))
+
+    return DashboardOut(week=week_stats, recent_runs=recent_runs, agents=agents)

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -1,0 +1,289 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@clerk/nextjs"
+import AppShell from "@/components/AppShell"
+
+interface WeekStats {
+  issues_picked_up: number
+  prs_opened: number
+  total_runs: number
+  succeeded_runs: number
+  failed_runs: number
+  success_rate: number
+}
+
+interface RecentRun {
+  run_id: string
+  workflow_id: string
+  workflow_name: string
+  status: string
+  issue_number: number | null
+  issue_title: string | null
+  pr_url: string | null
+  started_at: string | null
+  created_at: string
+}
+
+interface AgentStatus {
+  workflow_id: string
+  name: string
+  last_run_status: string | null
+  last_run_at: string | null
+}
+
+interface DashboardData {
+  week: WeekStats
+  recent_runs: RecentRun[]
+  agents: AgentStatus[]
+}
+
+const STATUS_DOT: Record<string, string> = {
+  succeeded: "bg-emerald-400",
+  failed:    "bg-red-400",
+  running:   "bg-blue-400 animate-pulse",
+  pending:   "bg-stone-300",
+  cancelled: "bg-stone-300",
+}
+
+const STATUS_TEXT: Record<string, string> = {
+  succeeded: "text-emerald-700 bg-emerald-50",
+  failed:    "text-red-600 bg-red-50",
+  running:   "text-blue-700 bg-blue-50",
+  pending:   "text-stone-500 bg-stone-100",
+  cancelled: "text-stone-400 bg-stone-100",
+}
+
+function timeAgo(ts: string): string {
+  const diff = Date.now() - new Date(ts).getTime()
+  const mins = Math.floor(diff / 60000)
+  if (mins < 1) return "just now"
+  if (mins < 60) return `${mins}m ago`
+  const hrs = Math.floor(mins / 60)
+  if (hrs < 24) return `${hrs}h ago`
+  return `${Math.floor(hrs / 24)}d ago`
+}
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return m ? decodeURIComponent(m[1]) : null
+}
+
+export default function DashboardPage() {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (clerkEnabled) return <DashboardWithAuth />
+  return <DashboardContent getToken={null} />
+}
+
+function DashboardWithAuth() {
+  const router = useRouter()
+  const { getToken, isLoaded, isSignedIn } = useAuth()
+  useEffect(() => {
+    if (isLoaded && !isSignedIn) router.replace("/")
+  }, [isLoaded, isSignedIn, router])
+  if (!isLoaded) return null
+  return <DashboardContent getToken={getToken} />
+}
+
+function DashboardContent({ getToken }: { getToken: (() => Promise<string | null>) | null }) {
+  const [data, setData] = useState<DashboardData | null>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    async function load() {
+      const headers: Record<string, string> = {}
+      if (getToken) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      const workspaceId = getCookie("delegator_project_id")
+      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/dashboard`, { headers })
+        if (res.ok) setData(await res.json())
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  }, [getToken])
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-4xl px-6 py-10">
+        <div className="flex items-center justify-between mb-8">
+          <div>
+            <h1 className="text-xl font-semibold text-stone-900">Dashboard</h1>
+            <p className="text-xs text-stone-400 mt-0.5">Last 7 days</p>
+          </div>
+          <Link href="/workflows/new" className="rounded-lg bg-stone-900 px-4 py-2 text-sm font-medium text-white hover:bg-stone-700 transition-colors">
+            + New agent
+          </Link>
+        </div>
+
+        {loading ? (
+          <div className="space-y-4">
+            <div className="grid grid-cols-4 gap-4">
+              {[1,2,3,4].map(i => <div key={i} className="h-20 rounded-xl bg-stone-100 animate-pulse" />)}
+            </div>
+            <div className="h-64 rounded-xl bg-stone-100 animate-pulse" />
+          </div>
+        ) : !data ? (
+          <p className="text-stone-400 text-sm">Could not load dashboard.</p>
+        ) : (
+          <div className="space-y-8">
+
+            {/* Section 1 — This week */}
+            <div>
+              <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">This week</p>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+                <StatCard label="Issues picked up" value={data.week.issues_picked_up} />
+                <StatCard label="PRs opened" value={data.week.prs_opened} />
+                <StatCard
+                  label="Success rate"
+                  value={`${data.week.success_rate}%`}
+                  sub={`${data.week.succeeded_runs} of ${data.week.total_runs} runs`}
+                  highlight={data.week.success_rate >= 80 ? "green" : data.week.success_rate >= 50 ? "amber" : "red"}
+                />
+                <StatCard
+                  label="Failed runs"
+                  value={data.week.failed_runs}
+                  highlight={data.week.failed_runs > 0 ? "red" : "green"}
+                  href={data.week.failed_runs > 0 ? "/runs" : undefined}
+                />
+              </div>
+            </div>
+
+            {/* Section 2 — Recent runs */}
+            <div>
+              <div className="flex items-center justify-between mb-3">
+                <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest">Recent runs</p>
+                <Link href="/runs" className="text-xs text-stone-400 hover:text-stone-700 transition-colors">View all →</Link>
+              </div>
+              {data.recent_runs.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-stone-300 p-10 text-center">
+                  <p className="text-stone-400 text-sm">No runs yet — <Link href="/workflows" className="underline hover:text-stone-700">open an agent</Link> and hit Run.</p>
+                </div>
+              ) : (
+                <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
+                  <table className="w-full text-sm">
+                    <thead>
+                      <tr className="border-b border-stone-100 text-left">
+                        <th className="px-4 py-3 text-xs font-medium text-stone-500">Agent</th>
+                        <th className="px-4 py-3 text-xs font-medium text-stone-500">Status</th>
+                        <th className="px-4 py-3 text-xs font-medium text-stone-500">Issue</th>
+                        <th className="px-4 py-3 text-xs font-medium text-stone-500">PR</th>
+                        <th className="px-4 py-3 text-xs font-medium text-stone-500">When</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {data.recent_runs.map(run => {
+                        const dot = STATUS_DOT[run.status] ?? "bg-stone-300"
+                        const badge = STATUS_TEXT[run.status] ?? "text-stone-500 bg-stone-100"
+                        return (
+                          <tr
+                            key={run.run_id}
+                            onClick={() => window.location.href = `/workflows/${run.workflow_id}/runs/${run.run_id}`}
+                            className="border-b border-stone-100 last:border-0 hover:bg-stone-50 cursor-pointer transition-colors"
+                          >
+                            <td className="px-4 py-3">
+                              <Link
+                                href={`/workflows/${run.workflow_id}`}
+                                onClick={e => e.stopPropagation()}
+                                className="font-medium text-stone-900 hover:text-indigo-600 transition-colors"
+                              >
+                                {run.workflow_name}
+                              </Link>
+                            </td>
+                            <td className="px-4 py-3">
+                              <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${badge}`}>
+                                <span className={`w-1.5 h-1.5 rounded-full ${dot}`} />
+                                {run.status}
+                              </span>
+                            </td>
+                            <td className="px-4 py-3 text-stone-500 text-xs">
+                              {run.issue_number
+                                ? <span>#{run.issue_number}{run.issue_title ? ` — ${run.issue_title}` : ""}</span>
+                                : <span className="text-stone-300">—</span>}
+                            </td>
+                            <td className="px-4 py-3">
+                              {run.pr_url
+                                ? <a href={run.pr_url} target="_blank" rel="noopener noreferrer" onClick={e => e.stopPropagation()} className="text-xs text-indigo-600 hover:underline">View PR →</a>
+                                : <span className="text-stone-300 text-xs">—</span>}
+                            </td>
+                            <td className="px-4 py-3 text-stone-400 text-xs">
+                              {timeAgo(run.started_at ?? run.created_at)}
+                            </td>
+                          </tr>
+                        )
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </div>
+
+            {/* Section 3 — Agent statuses */}
+            <div>
+              <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">Agents</p>
+              {data.agents.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-stone-300 p-10 text-center">
+                  <p className="text-stone-400 text-sm"><Link href="/workflows/new" className="underline hover:text-stone-700">Create your first agent</Link> to see it here.</p>
+                </div>
+              ) : (
+                <div className="grid gap-2">
+                  {data.agents.map(agent => {
+                    const dot = agent.last_run_status ? STATUS_DOT[agent.last_run_status] : "bg-stone-200"
+                    return (
+                      <div key={agent.workflow_id} className="flex items-center justify-between rounded-xl border border-stone-200 bg-white px-4 py-3 hover:border-stone-300 transition-colors">
+                        <div className="flex items-center gap-3">
+                          <span className={`w-2 h-2 rounded-full shrink-0 ${dot}`} />
+                          <span className="text-sm font-medium text-stone-900">{agent.name}</span>
+                        </div>
+                        <div className="flex items-center gap-4 text-xs text-stone-400">
+                          {agent.last_run_at
+                            ? <span>last run {timeAgo(agent.last_run_at)}</span>
+                            : <span className="italic">never run</span>}
+                          <Link href={`/workflows/${agent.workflow_id}`} className="text-stone-500 hover:text-stone-900 transition-colors">Canvas →</Link>
+                          <Link href={`/workflows/${agent.workflow_id}/runs`} className="text-stone-500 hover:text-stone-900 transition-colors">History →</Link>
+                        </div>
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+function StatCard({ label, value, sub, highlight, href }: {
+  label: string
+  value: string | number
+  sub?: string
+  highlight?: "green" | "amber" | "red"
+  href?: string
+}) {
+  const colors = {
+    green: "text-emerald-700",
+    amber: "text-amber-600",
+    red:   "text-red-600",
+  }
+  const valueClass = highlight ? colors[highlight] : "text-stone-900"
+  const card = (
+    <div className="rounded-xl border border-stone-200 bg-white px-4 py-4 hover:border-stone-300 transition-colors">
+      <p className="text-xs text-stone-400 mb-1.5">{label}</p>
+      <p className={`text-2xl font-bold ${valueClass}`}>{value}</p>
+      {sub && <p className="text-xs text-stone-400 mt-0.5">{sub}</p>}
+    </div>
+  )
+  if (href) return <Link href={href}>{card}</Link>
+  return card
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -44,7 +44,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
           {isLoaded && (
             isSignedIn ? (
               <button
-                onClick={() => router.push("/projects")}
+                onClick={() => router.push("/dashboard")}
                 className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors"
               >
                 Open app →
@@ -82,7 +82,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
           {isLoaded && (
             isSignedIn ? (
               <button
-                onClick={() => router.push("/projects")}
+                onClick={() => router.push("/dashboard")}
                 className="inline-flex items-center gap-2 bg-stone-900 hover:bg-stone-700 text-white font-semibold px-7 py-3.5 rounded-xl text-sm transition-colors shadow-sm"
               >
                 Open app →
@@ -118,7 +118,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
               ))}
             </ol>
             <button
-              onClick={() => router.push("/projects")}
+              onClick={() => router.push("/dashboard")}
               className="mt-4 text-sm font-medium text-stone-900 hover:text-stone-600 transition-colors"
             >
               Go to Projects →
@@ -270,7 +270,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         {isLoaded && (
           isSignedIn ? (
             <button
-              onClick={() => router.push("/projects")}
+              onClick={() => router.push("/dashboard")}
               className="inline-flex items-center gap-2 bg-stone-900 hover:bg-stone-700 text-white font-semibold px-7 py-3.5 rounded-xl text-sm transition-colors"
             >
               Open app →

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -6,10 +6,11 @@ import { usePathname } from "next/navigation"
 import AuthButton from "@/components/AuthButton"
 
 const NAV = [
-  { href: "/projects",  label: "Projects", icon: "◈" },
-  { href: "/workflows", label: "Agents",   icon: "⚡" },
-  { href: "/runs",      label: "Runs",     icon: "▶" },
-  { href: "/settings",  label: "Settings", icon: "⚙" },
+  { href: "/dashboard", label: "Dashboard", icon: "◎" },
+  { href: "/projects",  label: "Projects",  icon: "◈" },
+  { href: "/workflows", label: "Agents",    icon: "⚡" },
+  { href: "/runs",      label: "Runs",      icon: "▶" },
+  { href: "/settings",  label: "Settings",  icon: "⚙" },
 ]
 
 export default function AppShell({ children, noPadding }: { children: React.ReactNode; noPadding?: boolean }) {
@@ -22,7 +23,7 @@ export default function AppShell({ children, noPadding }: { children: React.Reac
 
         {/* Logo */}
         <div className={`px-3 py-4 border-b border-stone-100 flex items-center ${collapsed ? "justify-center" : "gap-2"}`}>
-          <Link href="/workflows" className="flex items-center gap-2 min-w-0">
+          <Link href="/dashboard" className="flex items-center gap-2 min-w-0">
             <img src="/icon.svg" alt="Conduct" className="w-6 h-6 shrink-0" />
             {!collapsed && (
               <span className="font-bold text-stone-900 text-sm tracking-tight truncate">Conduct</span>


### PR DESCRIPTION
Closes #50

## What's in this PR

**API — `GET /dashboard`** (`apps/api/app/routers/dashboard.py`)
- This-week stats: issues picked up, PRs opened, total/succeeded/failed runs, success rate
- Recent runs (last 10): agent name, status, issue number + title, PR link, time ago
- Agent statuses: every agent with last run time + status

**Frontend — `/dashboard`** (`apps/web/src/app/dashboard/page.tsx`)
- Section 1: 4 stat cards — Issues, PRs, Success rate (colour-coded), Failed runs
- Section 2: recent runs table with issue + PR columns
- Section 3: agent status list with Canvas → and History → quick links
- Skeleton loading state, empty states with CTAs

**Navigation**
- Dashboard added as first item in sidebar nav (◎)
- Logo click → `/dashboard`
- Post-login redirect from landing page → `/dashboard` instead of `/projects`

## What's NOT here (per spec)
- Token/cost charts
- Turn counts
- PR merge status (needs GitHub webhook polling — follow-up)