### PR TITLE
fix: failed runs stat card sub-label

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -151,6 +151,7 @@ function DashboardContent({ getToken }: { getToken: (() => Promise<string | null
                 <StatCard
                   label="Failed runs"
                   value={data.week.failed_runs}
+                  sub={data.week.failed_runs > 0 ? "View traces →" : "All clear"}
                   highlight={data.week.failed_runs > 0 ? "red" : "green"}
                   href={data.week.failed_runs > 0 ? "/runs" : undefined}
                 />


### PR DESCRIPTION
Adds 'View traces →' sub-label when failed > 0, 'All clear' when 0. Consistent with Success rate card pattern.