### PR TITLE
feat: idea requests via GitHub Discussions + audience section

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -127,6 +127,26 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         )}
       </section>
 
+      {/* Audience */}
+      <section className="px-6 py-10">
+        <div className="max-w-3xl mx-auto">
+          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest text-center mb-6">Built for</p>
+          <div className="grid sm:grid-cols-4 gap-3">
+            {[
+              { label: "Vibe coders", desc: "Solo builders who want to ship faster without managing infrastructure" },
+              { label: "Teams of 2–5", desc: "Early-stage startups where every engineer counts — let agents handle the toil" },
+              { label: "Teams of 5–10", desc: "Growing teams drowning in issues, reviews, and incident triage" },
+              { label: "Teams of 10–15", desc: "Scaling teams who need consistent process without adding headcount" },
+            ].map(({ label, desc }) => (
+              <div key={label} className="rounded-xl border border-stone-200 bg-white px-4 py-4">
+                <p className="text-sm font-semibold text-stone-900 mb-1">{label}</p>
+                <p className="text-xs text-stone-400 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
       {/* Trust strip */}
       <div className="border-y border-stone-100 bg-stone-50 py-4 px-6">
         <div className="max-w-3xl mx-auto flex flex-wrap items-center justify-center gap-6 text-xs font-medium text-stone-500">

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -60,6 +60,20 @@ export default function AppShell({ children, noPadding }: { children: React.Reac
           <AuthButton afterSignOutUrl="/sign-in" dropUp />
         </div>
 
+        {/* Ideas link */}
+        <div className={`px-2 pb-1 flex ${collapsed ? "justify-center" : ""}`}>
+          <a
+            href="https://github.com/sseshachala/conductai/discussions/new?category=ideas"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={`flex items-center gap-1.5 text-xs text-stone-400 hover:text-stone-700 hover:bg-stone-100 rounded-lg px-2 py-1.5 transition-colors w-full ${collapsed ? "justify-center" : ""}`}
+            title="Request an integration or flow"
+          >
+            <span className="text-base leading-none">💡</span>
+            {!collapsed && <span>Request an idea</span>}
+          </a>
+        </div>
+
         {/* Collapse toggle — explicit button inside sidebar */}
         <div className={`px-2 pb-3 flex ${collapsed ? "justify-center" : ""}`}>
           <button


### PR DESCRIPTION
- GitHub Discussions enabled on repo
- Sidebar: '💡 Request an idea' link → opens new GitHub Discussion (Ideas category). Shows icon only when collapsed.
- Landing page: 'Built for' section with 4 audience cards — Vibe coders, 2–5, 5–10, 10–15 engineers