### PR TITLE
ux: block palette icons + collapsed icon-only view

### DIFF
--- a/apps/web/src/components/canvas/BlockPalette.tsx
+++ b/apps/web/src/components/canvas/BlockPalette.tsx
@@ -3,11 +3,43 @@
 import { BLOCK_LIBRARY, BLOCK_STYLES } from "@/lib/block-types"
 import { cn } from "@/lib/utils"
 
-export default function BlockPalette({ getToken }: { getToken?: (() => Promise<string | null>) | null }) {
+export default function BlockPalette({
+  getToken,
+  collapsed,
+}: {
+  getToken?: (() => Promise<string | null>) | null
+  collapsed?: boolean
+}) {
+  if (collapsed) {
+    return (
+      <aside className="w-12 bg-white flex flex-col items-center py-3 gap-1 overflow-y-auto shrink-0 h-full">
+        {BLOCK_LIBRARY.map((block) => {
+          const style = BLOCK_STYLES[block.type]
+          return (
+            <div
+              key={block.title}
+              draggable
+              onDragStart={(e) => {
+                e.dataTransfer.setData("application/marshal-block-type", block.type)
+                e.dataTransfer.setData("application/marshal-block-title", block.title)
+                e.dataTransfer.effectAllowed = "move"
+              }}
+              title={block.title}
+              className={cn(
+                "w-8 h-8 flex items-center justify-center rounded-lg border-2 cursor-grab active:cursor-grabbing select-none transition-all hover:shadow-sm text-base",
+                style.buttonClass
+              )}
+            >
+              {style.icon}
+            </div>
+          )
+        })}
+      </aside>
+    )
+  }
 
   return (
     <aside className="w-44 bg-white flex flex-col overflow-y-auto shrink-0 h-full">
-      {/* Block Library */}
       <div className="px-3 py-3">
         <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-2">Blocks</p>
         <div className="grid grid-cols-2 gap-1.5">
@@ -29,16 +61,13 @@ export default function BlockPalette({ getToken }: { getToken?: (() => Promise<s
                   style.buttonClass
                 )}
               >
-                <span className={cn("text-[8px] font-bold tracking-widest uppercase", style.text)}>
-                  {style.labelText}
-                </span>
+                <span className="text-base leading-none">{style.icon}</span>
                 <span className="text-[11px] font-semibold text-stone-800 leading-tight">{shortName}</span>
               </div>
             )
           })}
         </div>
       </div>
-
     </aside>
   )
 }

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -691,7 +691,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
         {activeView === "canvas" ? (
           <>
             {/* Left panel — block palette */}
-            <div className={`relative flex shrink-0 transition-all duration-200 border-r border-stone-200 ${leftOpen ? "w-44" : "w-8"}`}>
+            <div className={`relative flex shrink-0 transition-all duration-200 border-r border-stone-200 ${leftOpen ? "w-44" : "w-12"}`}>
               <button
                 onClick={() => setLeftOpen(v => !v)}
                 className="absolute -right-3 top-1/2 -translate-y-1/2 z-10 w-6 h-6 rounded-full bg-white border border-stone-200 shadow-sm flex items-center justify-center text-stone-400 hover:text-stone-700 transition-colors"
@@ -699,7 +699,7 @@ function CanvasEditorInner({ workflowId, getToken }: CanvasEditorProps) {
               >
                 {leftOpen ? "‹" : "›"}
               </button>
-              {leftOpen && <BlockPalette getToken={getToken} />}
+              <BlockPalette getToken={getToken} collapsed={!leftOpen} />
             </div>
 
             {/* Center — canvas */}

--- a/apps/web/src/lib/block-types.ts
+++ b/apps/web/src/lib/block-types.ts
@@ -14,19 +14,20 @@ export interface BlockStyle {
   label: string
   labelText: string
   text: string
+  icon: string
   // Combined classes for use in sidebar buttons (explicit strings for Tailwind JIT)
   buttonClass: string
 }
 
 export const BLOCK_STYLES: Record<BlockType, BlockStyle> = {
-  trigger:  { bg: "bg-blue-50",   border: "border-blue-200",   label: "bg-blue-50 text-blue-700",    labelText: "TRIGGER",  text: "text-blue-700",   buttonClass: "bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100"   },
-  brain:    { bg: "bg-purple-50", border: "border-purple-300", label: "bg-purple-50 text-purple-700",labelText: "BRAIN",    text: "text-purple-700", buttonClass: "bg-purple-50 border-purple-300 text-purple-700 hover:bg-purple-100" },
-  tool:     { bg: "bg-green-50",  border: "border-green-200",  label: "bg-green-50 text-green-700",  labelText: "TOOL",     text: "text-green-700",  buttonClass: "bg-green-50 border-green-200 text-green-700 hover:bg-green-100"   },
-  logic:    { bg: "bg-gray-50",   border: "border-gray-200",   label: "bg-gray-50 text-gray-600",    labelText: "LOGIC",    text: "text-gray-600",   buttonClass: "bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100"       },
-  memory:   { bg: "bg-amber-50",  border: "border-amber-200",  label: "bg-amber-50 text-amber-700",  labelText: "MEMORY",   text: "text-amber-700",  buttonClass: "bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100"   },
-  approval: { bg: "bg-orange-50", border: "border-orange-200", label: "bg-orange-50 text-orange-700",labelText: "APPROVAL", text: "text-orange-700", buttonClass: "bg-orange-50 border-orange-200 text-orange-700 hover:bg-orange-100" },
-  output:   { bg: "bg-rose-50",   border: "border-rose-200",   label: "bg-rose-50 text-rose-700",    labelText: "OUTPUT",   text: "text-rose-700",   buttonClass: "bg-rose-50 border-rose-200 text-rose-700 hover:bg-rose-100"       },
-  cleanup:  { bg: "bg-yellow-50", border: "border-yellow-200", label: "bg-yellow-50 text-yellow-700",labelText: "CLEANUP",  text: "text-yellow-700", buttonClass: "bg-yellow-50 border-yellow-200 text-yellow-700 hover:bg-yellow-100" },
+  trigger:  { bg: "bg-blue-50",   border: "border-blue-200",   label: "bg-blue-50 text-blue-700",    labelText: "TRIGGER",  text: "text-blue-700",   icon: "⚡", buttonClass: "bg-blue-50 border-blue-200 text-blue-700 hover:bg-blue-100"   },
+  brain:    { bg: "bg-purple-50", border: "border-purple-300", label: "bg-purple-50 text-purple-700",labelText: "BRAIN",    text: "text-purple-700", icon: "🧠", buttonClass: "bg-purple-50 border-purple-300 text-purple-700 hover:bg-purple-100" },
+  tool:     { bg: "bg-green-50",  border: "border-green-200",  label: "bg-green-50 text-green-700",  labelText: "TOOL",     text: "text-green-700",  icon: "🔧", buttonClass: "bg-green-50 border-green-200 text-green-700 hover:bg-green-100"   },
+  logic:    { bg: "bg-gray-50",   border: "border-gray-200",   label: "bg-gray-50 text-gray-600",    labelText: "LOGIC",    text: "text-gray-600",   icon: "⤵",  buttonClass: "bg-gray-50 border-gray-200 text-gray-600 hover:bg-gray-100"       },
+  memory:   { bg: "bg-amber-50",  border: "border-amber-200",  label: "bg-amber-50 text-amber-700",  labelText: "MEMORY",   text: "text-amber-700",  icon: "💾", buttonClass: "bg-amber-50 border-amber-200 text-amber-700 hover:bg-amber-100"   },
+  approval: { bg: "bg-orange-50", border: "border-orange-200", label: "bg-orange-50 text-orange-700",labelText: "APPROVAL", text: "text-orange-700", icon: "✋", buttonClass: "bg-orange-50 border-orange-200 text-orange-700 hover:bg-orange-100" },
+  output:   { bg: "bg-rose-50",   border: "border-rose-200",   label: "bg-rose-50 text-rose-700",    labelText: "OUTPUT",   text: "text-rose-700",   icon: "📤", buttonClass: "bg-rose-50 border-rose-200 text-rose-700 hover:bg-rose-100"       },
+  cleanup:  { bg: "bg-yellow-50", border: "border-yellow-200", label: "bg-yellow-50 text-yellow-700",labelText: "CLEANUP",  text: "text-yellow-700", icon: "🧹", buttonClass: "bg-yellow-50 border-yellow-200 text-yellow-700 hover:bg-yellow-100" },
 }
 
 export const BLOCK_LIBRARY: { type: BlockType; title: string; description: string }[] = [


### PR DESCRIPTION
## Summary
- Added `icon` field to `BlockStyle` and `BLOCK_STYLES` (⚡🧠🔧⤵💾✋📤🧹)
- Expanded palette: icon shown above block name in the 2-col grid
- Collapsed palette: vertical icon-only list (w-12), each icon still draggable onto canvas
- `CanvasEditor` always renders `<BlockPalette collapsed={!leftOpen} />` (no conditional mount)

## Test plan
- [ ] Open canvas → palette shows icons + names in grid
- [ ] Collapse palette → vertical icon strip appears, drag any icon onto canvas to create block
- [ ] Expand again → full grid restores