### PR TITLE
feat: playbook marketplace

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -74,6 +74,34 @@ _TEMPLATE_PLAYBOOKS = {
     "issue_triage":       "issue-triage.yaml",
 }
 
+_PLAYBOOK_META = {
+    "autopilot_quick":    {"icon": "⚡", "tags": ["github", "code"],        "featured": True,  "description": "GitHub issue labeled → implement fix → open PR. No test step — CI runs tests on the PR."},
+    "autopilot_full":     {"icon": "🤖", "tags": ["github", "code"],        "featured": True,  "description": "GitHub issue labeled → implement fix → run tests with retry → open PR."},
+    "autopilot_approved": {"icon": "✋", "tags": ["github", "code", "approval"], "featured": True, "description": "Implement fix → run tests → human approves in Slack → open PR. Nothing ships without a gate."},
+    "pr_reviewer":        {"icon": "🔍", "tags": ["github", "code-review"], "featured": True,  "description": "Any PR opened → AI reviews the diff for bugs, security issues, and style → posts a review comment."},
+    "issue_triage":       {"icon": "🏷",  "tags": ["github", "ops"],         "featured": True,  "description": "New issue opened → AI classifies type and priority → adds labels → posts a clarifying comment if vague."},
+    "release_notes":      {"icon": "📝", "tags": ["github", "notifications"],"featured": False, "description": "Git tag pushed → AI reads merged PRs → groups by type → writes CHANGELOG entry → posts to Slack."},
+    "ci_notify":          {"icon": "🚨", "tags": ["github", "notifications"],"featured": False, "description": "CI build fails → AI diagnoses the failed step → posts root cause and suggested fix to Slack."},
+    "incident_responder": {"icon": "🔥", "tags": ["ops", "notifications"],   "featured": False, "description": "Alert fires → AI correlates recent commits and deploys → posts root cause hypothesis to #incidents."},
+    "dependency_updater": {"icon": "📦", "tags": ["github", "ops"],          "featured": False, "description": "Weekly cron → AI scans for outdated deps → bumps patch/minor versions → opens a single clean PR."},
+}
+
+
+@router.get("/playbooks")
+def list_playbooks():
+    return [
+        {
+            "slug": slug,
+            "name": slug.replace("_", " ").title(),
+            "icon": _PLAYBOOK_META[slug]["icon"],
+            "description": _PLAYBOOK_META[slug]["description"],
+            "tags": _PLAYBOOK_META[slug]["tags"],
+            "featured": _PLAYBOOK_META[slug]["featured"],
+        }
+        for slug in _TEMPLATE_PLAYBOOKS
+        if slug in _PLAYBOOK_META
+    ]
+
 
 @router.post("", response_model=WorkflowDetailOut, status_code=201)
 def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspace_id: str = Depends(get_workspace_id)):

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -1,0 +1,178 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useAuth } from "@clerk/nextjs"
+import AppShell from "@/components/AppShell"
+
+interface Playbook {
+  slug: string
+  name: string
+  icon: string
+  description: string
+  tags: string[]
+  featured: boolean
+}
+
+const ALL_TAGS = ["all", "github", "code", "code-review", "ops", "notifications", "approval"]
+
+function getWorkspaceId(): string | null {
+  if (typeof document === "undefined") return null
+  return document.cookie.split("; ").find(r => r.startsWith("delegator_project_id="))?.split("=")[1] ?? null
+}
+
+const FRIENDLY_NAMES: Record<string, string> = {
+  autopilot_quick:    "Autopilot Quick",
+  autopilot_full:     "Autopilot Full",
+  autopilot_approved: "Autopilot + Approval",
+  pr_reviewer:        "PR Reviewer",
+  issue_triage:       "Issue Triage",
+  release_notes:      "Release Notes",
+  ci_notify:          "CI Failure Alert",
+  incident_responder: "Incident Responder",
+  dependency_updater: "Dependency Updater",
+}
+
+export default function MarketplacePage() {
+  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+  if (clerkEnabled) return <MarketplaceWithAuth />
+  return <MarketplaceContent getToken={null} />
+}
+
+function MarketplaceWithAuth() {
+  const { getToken } = useAuth()
+  return <MarketplaceContent getToken={getToken} />
+}
+
+function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | null>) | null }) {
+  const router = useRouter()
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([])
+  const [loading, setLoading] = useState(true)
+  const [activeTag, setActiveTag] = useState("all")
+  const [installing, setInstalling] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/playbooks`)
+      .then(r => r.json())
+      .then(data => setPlaybooks(data))
+      .finally(() => setLoading(false))
+  }, [])
+
+  async function install(slug: string) {
+    setInstalling(slug)
+    try {
+      const headers: Record<string, string> = { "Content-Type": "application/json" }
+      if (getToken) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      const workspaceId = getWorkspaceId()
+      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ name: FRIENDLY_NAMES[slug] ?? slug, template: slug }),
+      })
+      if (!res.ok) return
+      const wf = await res.json()
+      router.push(`/workflows/${wf.id}`)
+    } finally {
+      setInstalling(null)
+    }
+  }
+
+  const filtered = activeTag === "all" ? playbooks : playbooks.filter(p => p.tags.includes(activeTag))
+  const featured = filtered.filter(p => p.featured)
+  const rest = filtered.filter(p => !p.featured)
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-4xl px-6 py-10">
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-xl font-semibold text-stone-900">Playbooks</h1>
+          <p className="text-xs text-stone-400 mt-0.5">Pre-built agent workflows — install in one click, configure and run</p>
+        </div>
+
+        {/* Tag filters */}
+        <div className="flex flex-wrap gap-2 mb-8">
+          {ALL_TAGS.map(tag => (
+            <button
+              key={tag}
+              onClick={() => setActiveTag(tag)}
+              className={`px-3 py-1 rounded-full text-xs font-medium transition-colors ${
+                activeTag === tag
+                  ? "bg-stone-900 text-white"
+                  : "bg-stone-100 text-stone-500 hover:bg-stone-200"
+              }`}
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+
+        {loading ? (
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[1,2,3,4,5,6].map(i => <div key={i} className="h-44 rounded-xl bg-stone-100 animate-pulse" />)}
+          </div>
+        ) : (
+          <div className="space-y-8">
+            {featured.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">Featured</p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {featured.map(p => <PlaybookCard key={p.slug} playbook={p} installing={installing} onInstall={install} />)}
+                </div>
+              </div>
+            )}
+            {rest.length > 0 && (
+              <div>
+                <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">More playbooks</p>
+                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                  {rest.map(p => <PlaybookCard key={p.slug} playbook={p} installing={installing} onInstall={install} />)}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}
+
+function PlaybookCard({ playbook, installing, onInstall }: {
+  playbook: Playbook
+  installing: string | null
+  onInstall: (slug: string) => void
+}) {
+  const isInstalling = installing === playbook.slug
+  return (
+    <div className="rounded-xl border border-stone-200 bg-white p-5 flex flex-col gap-3 hover:border-stone-300 transition-colors">
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-2xl leading-none">{playbook.icon}</span>
+        <div className="flex flex-wrap gap-1 justify-end">
+          {playbook.tags.map(tag => (
+            <span key={tag} className="text-[10px] bg-stone-100 text-stone-500 px-1.5 py-0.5 rounded">
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+      <div>
+        <p className="text-sm font-semibold text-stone-900 mb-1">
+          {FRIENDLY_NAMES[playbook.slug] ?? playbook.name}
+        </p>
+        <p className="text-xs text-stone-500 leading-relaxed">{playbook.description}</p>
+      </div>
+      <button
+        onClick={() => onInstall(playbook.slug)}
+        disabled={!!installing}
+        className="mt-auto w-full rounded-lg bg-stone-900 px-3 py-2 text-xs font-medium text-white hover:bg-stone-700 transition-colors disabled:opacity-40"
+      >
+        {isInstalling ? "Installing…" : "+ Install"}
+      </button>
+    </div>
+  )
+}

--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -5,6 +5,12 @@ import { useRouter } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
 import Link from "next/link"
 
+const FEATURED = [
+  { id: "autopilot_quick",    icon: "⚡", label: "Autopilot Quick",    description: "Issue labeled → implement fix → open PR." },
+  { id: "pr_reviewer",        icon: "🔍", label: "PR Reviewer",        description: "PR opened → AI reviews diff → posts comment." },
+  { id: "autopilot_approved", icon: "✋", label: "Autopilot + Approval",description: "Fix → tests → human approves → open PR." },
+]
+
 const TEMPLATES = [
   {
     id: "autopilot_quick",
@@ -133,6 +139,31 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
       </header>
 
       <main className="mx-auto max-w-xl px-6 py-12">
+
+        {/* Quick-start featured playbooks */}
+        <div className="mb-8">
+          <div className="flex items-center justify-between mb-3">
+            <p className="text-xs font-semibold text-stone-400 uppercase tracking-wide">Quick start</p>
+            <Link href="/marketplace" className="text-xs text-stone-400 hover:text-stone-700 transition-colors">Browse all →</Link>
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            {FEATURED.map(f => (
+              <button
+                key={f.id}
+                onClick={() => setTemplate(f.id)}
+                className={`text-left rounded-xl border p-3 transition-all ${
+                  template === f.id
+                    ? "border-stone-900 bg-white shadow-sm ring-1 ring-stone-900"
+                    : "border-stone-200 bg-white hover:border-stone-300"
+                }`}
+              >
+                <span className="text-xl leading-none block mb-2">{f.icon}</span>
+                <p className={`text-xs font-semibold mb-1 ${template === f.id ? "text-stone-900" : "text-stone-700"}`}>{f.label}</p>
+                <p className="text-[10px] text-stone-400 leading-relaxed">{f.description}</p>
+              </button>
+            ))}
+          </div>
+        </div>
 
         {/* Name */}
         <div className="mb-8">

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -6,11 +6,12 @@ import { usePathname } from "next/navigation"
 import AuthButton from "@/components/AuthButton"
 
 const NAV = [
-  { href: "/dashboard", label: "Dashboard", icon: "◎" },
-  { href: "/projects",  label: "Projects",  icon: "◈" },
-  { href: "/workflows", label: "Agents",    icon: "⚡" },
-  { href: "/runs",      label: "Runs",      icon: "▶" },
-  { href: "/settings",  label: "Settings",  icon: "⚙" },
+  { href: "/dashboard",   label: "Dashboard",  icon: "◎" },
+  { href: "/projects",    label: "Projects",   icon: "◈" },
+  { href: "/workflows",   label: "Agents",     icon: "⚡" },
+  { href: "/marketplace", label: "Playbooks",  icon: "📦" },
+  { href: "/runs",        label: "Runs",       icon: "▶" },
+  { href: "/settings",    label: "Settings",   icon: "⚙" },
 ]
 
 export default function AppShell({ children, noPadding }: { children: React.ReactNode; noPadding?: boolean }) {


### PR DESCRIPTION
## Summary
- `GET /workflows/playbooks` — returns metadata for all 9 playbooks (icon, tags, description, featured flag)
- `/marketplace` page — card grid with tag filters, Install button (calls existing `POST /workflows`), redirects to canvas on install
- `Playbooks 📦` added to AppShell nav
- `/workflows/new` — 3 featured quick-start cards at top with "Browse all →" link to marketplace

## How install works
Install button → `POST /workflows { name, template }` (existing endpoint) → redirect to `/workflows/{id}` canvas. Zero new backend complexity.

## Test plan
- [ ] Nav shows Playbooks entry
- [ ] /marketplace loads card grid with tag filters
- [ ] Click a tag — cards filter correctly
- [ ] Click Install → spinner → lands on canvas with pre-wired graph
- [ ] /workflows/new shows 3 quick-start cards, selecting one pre-selects template below
- [ ] "Browse all →" link navigates to /marketplace