### PR TITLE
feat: run audit trail — trigger context, export JSON, colored diff

### DIFF
--- a/apps/api/alembic/versions/0007_run_max_turns.py
+++ b/apps/api/alembic/versions/0007_run_max_turns.py
@@ -1,0 +1,22 @@
+"""add max_turns to runs
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-22
+"""
+from typing import Sequence, Union
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0007"
+down_revision: Union[str, None] = "0006"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("runs", sa.Column("max_turns", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("runs", "max_turns")

--- a/apps/api/app/models/run.py
+++ b/apps/api/app/models/run.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+import sqlalchemy as sa
 from sqlalchemy import Column, String, DateTime, ForeignKey
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
@@ -17,6 +18,7 @@ class Run(Base):
     paused_at = Column(DateTime(timezone=True), nullable=True)
     completed_at = Column(DateTime(timezone=True), nullable=True)
     current_block_id = Column(String(255), nullable=True)
+    max_turns = Column(sa.Integer, nullable=True)
     state = Column(JSONB, nullable=False, default=dict)  # accumulated block outputs
     created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
 

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -127,6 +127,7 @@ def create_run(
         triggered_by=body.triggered_by,
         status="pending",
         state=initial_state,
+        max_turns=body.max_turns or None,
     )
     db.add(run)
     db.commit()

--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -41,6 +41,7 @@ class RunOut(BaseModel):
 
 class RunDetailOut(RunOut):
     events: list[RunEventOut] = []
+    state: Optional[dict[str, Any]] = None
 
 
 class RunWithWorkflowOut(RunOut):

--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -33,6 +33,7 @@ class RunOut(BaseModel):
     paused_at: Optional[datetime] = None
     completed_at: Optional[datetime] = None
     current_block_id: Optional[str] = None
+    max_turns: Optional[int] = None
     created_at: datetime
 
     class Config:

--- a/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
@@ -22,6 +22,7 @@ interface RunMeta {
   current_block_id: string | null
   workflow_version_id: string
   state?: Record<string, unknown> | null
+  max_turns?: number | null
 }
 
 export default function RunDetailPage() {
@@ -153,6 +154,7 @@ export default function RunDetailPage() {
               current_block_id: run.current_block_id,
               workflow_version_id: run.workflow_version_id ?? null,
             }}
+            maxTurns={run.max_turns ?? null}
             getToken={getToken}
           />
         </div>

--- a/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
@@ -21,6 +21,7 @@ interface RunMeta {
   paused_at: string | null
   current_block_id: string | null
   workflow_version_id: string
+  state?: Record<string, unknown> | null
 }
 
 export default function RunDetailPage() {
@@ -45,7 +46,10 @@ export default function RunDetailPage() {
         fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}`, { headers }),
       ])
 
-      if (runRes.ok) setRun(await runRes.json())
+      if (runRes.ok) {
+          const runData = await runRes.json()
+          setRun(runData)
+        }
       if (wfRes.ok) {
         const wf = await wfRes.json()
         setWorkflowName(wf.name ?? null)
@@ -90,9 +94,50 @@ export default function RunDetailPage() {
       </header>
 
       <main className="mx-auto max-w-3xl px-6 py-10">
-        <div className="mb-6">
-          <h2 className="text-xl font-semibold text-stone-900">Run trace</h2>
-          <p className="text-sm text-stone-400 mt-1 font-mono">{run.id}</p>
+        <div className="mb-6 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="text-xl font-semibold text-stone-900">Run trace</h2>
+            <p className="text-sm text-stone-400 mt-1 font-mono">{run.id}</p>
+            {/* Trigger context */}
+            {(() => {
+              const trigger = (run.state as Record<string, unknown> | null | undefined)
+              const t = (trigger?._trigger ?? trigger?.github_issue ?? {}) as Record<string, unknown>
+              const issueNum = t.issue_number as number | undefined
+              const issueTitle = (t.title ?? t.issue_title) as string | undefined
+              const prUrl = (trigger?.pr_url) as string | undefined
+              if (!issueNum && !prUrl) return null
+              return (
+                <div className="flex items-center gap-3 mt-2 flex-wrap">
+                  {issueNum && (
+                    <span className="text-xs text-stone-500 bg-stone-100 px-2 py-0.5 rounded">
+                      Issue #{issueNum}{issueTitle ? ` — ${issueTitle}` : ""}
+                    </span>
+                  )}
+                  {prUrl && (
+                    <a href={prUrl} target="_blank" rel="noopener noreferrer"
+                      className="text-xs text-indigo-600 hover:underline font-medium">
+                      View PR →
+                    </a>
+                  )}
+                </div>
+              )
+            })()}
+          </div>
+          {/* Export button */}
+          <button
+            onClick={() => {
+              const blob = new Blob([JSON.stringify(run, null, 2)], { type: "application/json" })
+              const url = URL.createObjectURL(blob)
+              const a = document.createElement("a")
+              a.href = url
+              a.download = `run-${run.id.slice(0, 8)}.json`
+              a.click()
+              URL.revokeObjectURL(url)
+            }}
+            className="shrink-0 text-xs text-stone-400 hover:text-stone-700 border border-stone-200 hover:border-stone-300 rounded-lg px-3 py-1.5 transition-colors"
+          >
+            ↓ Export JSON
+          </button>
         </div>
 
         <div className="bg-white rounded-xl border border-stone-200 p-6">

--- a/apps/web/src/app/workflows/[id]/runs/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/page.tsx
@@ -19,6 +19,7 @@ interface Run {
   started_at: string | null
   completed_at: string | null
   created_at: string
+  max_turns: number | null
 }
 
 const STATUS_STYLES: Record<string, string> = {
@@ -106,9 +107,16 @@ export default function RunsPage() {
                     <span className="text-xs text-stone-400">{run.triggered_by}</span>
                   )}
                 </div>
-                <span className="text-xs text-stone-400">
-                  {new Date(run.created_at).toLocaleString()}
-                </span>
+                <div className="flex items-center gap-4">
+                  {run.max_turns != null && (
+                    <span className="text-xs text-stone-400 font-mono">
+                      est. {run.max_turns} turns
+                    </span>
+                  )}
+                  <span className="text-xs text-stone-400">
+                    {new Date(run.created_at).toLocaleString()}
+                  </span>
+                </div>
               </Link>
             ))}
           </div>

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -24,6 +24,7 @@ interface Props {
   runId: string
   initialStatus: string
   initialMeta: RunMeta
+  maxTurns?: number | null
   getToken?: (() => Promise<string | null>) | null
 }
 
@@ -318,7 +319,7 @@ async function buildHeaders(getToken?: (() => Promise<string | null>) | null): P
   return h
 }
 
-export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, getToken }: Props) {
+export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, maxTurns, getToken }: Props) {
   const [events, setEvents] = useState<RunEvent[]>([])
   const [status, setStatus] = useState(initialStatus)
   const [meta, setMeta] = useState<RunMeta>(initialMeta)
@@ -465,6 +466,11 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   const totalTokens = blockRows.reduce((acc, r) => acc + (r.inputTokens ?? 0) + (r.outputTokens ?? 0), 0)
   const totalCost   = blockRows.reduce((acc, r) => acc + (r.costUsd ?? 0), 0)
 
+  // Actual turns = highest turn number seen across all brain_tool_call events
+  const actualTurns = events
+    .filter(e => e.kind === "brain_tool_call" && typeof e.payload?.turn === "number")
+    .reduce((max, e) => Math.max(max, e.payload.turn as number), 0)
+
   const handleApproval = async (decision: "approved" | "rejected") => {
     setApprovalSubmitting(true)
     try {
@@ -490,10 +496,23 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       )}
 
       {/* Summary stats grid */}
-      <div className="grid grid-cols-4 gap-3 rounded-xl border border-stone-100 bg-stone-50 px-4 py-3">
+      <div className="grid grid-cols-5 gap-3 rounded-xl border border-stone-100 bg-stone-50 px-4 py-3">
         <div>
           <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-0.5">Duration</p>
           <p className="text-sm font-semibold text-stone-800">{totalDur ?? (done ? "—" : "…")}</p>
+        </div>
+        <div>
+          <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-0.5">Turns</p>
+          <p className="text-sm font-semibold text-stone-800">
+            {actualTurns > 0 ? (
+              maxTurns ? (
+                <span>
+                  {actualTurns}
+                  <span className="text-stone-400 font-normal"> / {maxTurns} est.</span>
+                </span>
+              ) : actualTurns
+            ) : "—"}
+          </p>
         </div>
         <div>
           <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-0.5">Tokens</p>

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -254,12 +254,23 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
               <>
                 <button onClick={() => setDiffExpanded(d => !d)}
                   className="mt-1 text-[10px] text-stone-400 hover:text-stone-600">
-                  {diffExpanded ? "▾ hide diff stat" : "▸ diff stat"}
+                  {diffExpanded ? "▾ hide diff" : "▸ show diff"}
                 </button>
                 {diffExpanded && (
-                  <pre className="mt-1 text-[10px] font-mono text-stone-500 bg-stone-50 border border-stone-200 rounded p-2 overflow-x-auto whitespace-pre">
-                    {row.diffStat}
-                  </pre>
+                  <div className="mt-1 rounded border border-stone-200 overflow-x-auto bg-stone-50">
+                    {row.diffStat.split("\n").map((line, i) => {
+                      const cls =
+                        line.startsWith("+") && !line.startsWith("+++") ? "bg-emerald-50 text-emerald-700" :
+                        line.startsWith("-") && !line.startsWith("---") ? "bg-red-50 text-red-600" :
+                        line.startsWith("@@") ? "bg-blue-50 text-blue-600" :
+                        "text-stone-500"
+                      return (
+                        <div key={i} className={`font-mono text-[10px] px-2 py-0.5 whitespace-pre ${cls}`}>
+                          {line || " "}
+                        </div>
+                      )
+                    })}
+                  </div>
                 )}
               </>
             )}


### PR DESCRIPTION
Closes #91

## What's added
- **Trigger context**: run detail header shows Issue #N — title and a View PR → link when available (read from run.state._trigger)
- **Export JSON**: ↓ Export JSON button downloads the full run + events as a JSON file
- **Colored diff**: diff_stat now renders as a proper colored diff (green +, red -, blue @@ hunks) instead of plain text

## Schema change
`RunDetailOut` gains an optional `state` field so the frontend can read trigger metadata without a separate API call.

## Test plan
- [ ] Open a completed run — header shows issue # and PR link if triggered by GitHub
- [ ] Click Export JSON — downloads `run-<id>.json` with full events
- [ ] Open a brain block that produced a diff — "show diff" expands with colored +/- lines