### PR TITLE
feat: Copilot/AI PR orchestration — closes #93

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -72,6 +72,7 @@ _TEMPLATE_PLAYBOOKS = {
     "dependency_updater": "dependency-updater.yaml",
     "release_notes":      "release-notes.yaml",
     "issue_triage":       "issue-triage.yaml",
+    "copilot_reviewer":   "copilot-reviewer.yaml",
 }
 
 _PLAYBOOK_META = {
@@ -84,6 +85,7 @@ _PLAYBOOK_META = {
     "ci_notify":          {"icon": "🚨", "tags": ["github", "notifications"],"featured": False, "description": "CI build fails → AI diagnoses the failed step → posts root cause and suggested fix to Slack."},
     "incident_responder": {"icon": "🔥", "tags": ["ops", "notifications"],   "featured": False, "description": "Alert fires → AI correlates recent commits and deploys → posts root cause hypothesis to #incidents."},
     "dependency_updater": {"icon": "📦", "tags": ["github", "ops"],          "featured": False, "description": "Weekly cron → AI scans for outdated deps → bumps patch/minor versions → opens a single clean PR."},
+    "copilot_reviewer":   {"icon": "🤖", "tags": ["github", "code-review", "approval"], "featured": True, "description": "PR opened by Copilot/Cursor/Claude Code → AI reviews the diff → human approves before merge. The orchestration layer above your AI coding tool."},
 }
 
 

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -1,0 +1,123 @@
+name: Copilot / AI PR Reviewer
+version: 1
+description: >
+  Triggered when a pull request is opened by an AI author (GitHub Copilot,
+  Cursor, Claude Code, or any bot). Reviews the diff for correctness, security,
+  and test coverage, posts a structured review comment, then pauses for a human
+  to approve before the PR can be merged.
+
+  Setup: GitHub repo → Settings → Webhooks → Add webhook.
+  Payload URL: https://<your-api>/webhooks/inbound/<this-workflow-id>
+  Content type: application/json
+  Event: Pull requests (pull_request.opened)
+
+  The agent checks whether the PR author is a bot before running.
+  Human-authored PRs are silently skipped.
+
+on:
+  webhook:
+    next: check_author
+
+blocks:
+  check_author:
+    type: logic
+    label: Is AI-authored PR?
+    description: >
+      Check whether the PR was opened by an AI/bot author.
+      GitHub Copilot PRs have user.type == "Bot" or login contains
+      "copilot", "cursor", "claude", or ends with "[bot]".
+    condition: >
+      {{_trigger.pull_request.user.type}} == "Bot"
+      OR {{_trigger.pull_request.user.login}} contains "copilot"
+      OR {{_trigger.pull_request.user.login}} contains "cursor"
+      OR {{_trigger.pull_request.user.login}} contains "claude"
+      OR {{_trigger.pull_request.user.login}} ends_with "[bot]"
+    next:
+      pass: review_pr
+      fail: skip_human_pr
+
+  skip_human_pr:
+    type: output
+    label: Skip — human PR
+    description: "PR #{{_trigger.number}} is human-authored — skipping AI review gate."
+    output:
+      via: none
+
+  review_pr:
+    type: brain
+    mode: agentic
+    label: Review AI-generated PR
+    description: |
+      You are a senior code reviewer auditing a pull request written by an AI coding assistant
+      (GitHub Copilot, Cursor, or Claude Code).
+
+      PR details:
+      - PR number: {{_trigger.number}}
+      - Title: {{_trigger.pull_request.title}}
+      - Author: {{_trigger.pull_request.user.login}} (AI-generated)
+      - Repo: {{_trigger.repository.full_name}}
+      - Diff URL: {{_trigger.pull_request.diff_url}}
+      - PR URL: {{_trigger.pull_request.html_url}}
+      - Base branch: {{_trigger.pull_request.base.ref}}
+
+      Steps:
+      1. Fetch the diff:
+         GET {{_trigger.pull_request.diff_url}}
+         Use Authorization: token <github_token> header
+      2. Review with extra scrutiny for AI-generated code:
+         - Correctness: does the change actually solve the stated problem?
+         - Security: hardcoded secrets, injection risks, insecure defaults
+         - Test coverage: are new code paths tested? Did the AI skip tests?
+         - Hallucinated APIs: calls to methods/packages that don't exist
+         - Over-engineering: unnecessary abstractions or complexity
+         - Breaking changes: interface changes that affect callers
+      3. Post a review comment via GitHub API:
+         POST https://api.github.com/repos/{{_trigger.repository.full_name}}/pulls/{{_trigger.number}}/reviews
+         {
+           "body": "<your structured review>",
+           "event": "COMMENT"
+         }
+         Use Authorization: token <github_token> header
+
+      Format your review with three sections:
+      🔴 Critical (must fix before merge)
+      🟡 Warning (should address)
+      🟢 Looks good (what the AI got right)
+
+      If there are no critical issues, say so clearly.
+
+      Output ONLY the following JSON on the last line:
+        {"review_url": "<PR URL>", "critical": <count>, "warnings": <count>}
+    next: gate_merge
+
+  gate_merge:
+    type: approval
+    label: Human approval required
+    description: >
+      AI PR #{{_trigger.number}} has been reviewed.
+      Critical issues: {{review_pr.critical}} · Warnings: {{review_pr.warnings}}
+
+      Review: {{review_pr.review_url}}
+
+      Approve to allow merge. Reject to request changes from the AI tool.
+    next:
+      approved: notify_approved
+      rejected: notify_rejected
+
+  notify_approved:
+    type: output
+    label: Notify — approved to merge
+    description: "✅ AI PR #{{_trigger.number}} approved after review. {{review_pr.critical}} critical, {{review_pr.warnings}} warnings. Ready to merge."
+    output:
+      via: slack
+      slack:
+        channel: "#engineering"
+
+  notify_rejected:
+    type: output
+    label: Notify — changes requested
+    description: "🚫 AI PR #{{_trigger.number}} rejected. {{review_pr.critical}} critical issues must be fixed before merge."
+    output:
+      via: slack
+      slack:
+        channel: "#engineering"

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -31,6 +31,7 @@ const FRIENDLY_NAMES: Record<string, string> = {
   ci_notify:          "CI Failure Alert",
   incident_responder: "Incident Responder",
   dependency_updater: "Dependency Updater",
+  copilot_reviewer:   "Copilot / AI PR Reviewer",
 }
 
 export default function MarketplacePage() {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -295,6 +295,40 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         </div>
       </section>
 
+      {/* Copilot / AI coding tools orchestration */}
+      <section className="bg-stone-900 px-6 py-20">
+        <div className="max-w-4xl mx-auto text-center">
+          <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-4">Works with GitHub Copilot · Cursor · Claude Code</p>
+          <h2 className="text-3xl font-bold text-white mb-4">
+            You have AI that writes code.<br />Conduct decides when it ships.
+          </h2>
+          <p className="text-stone-400 text-sm max-w-2xl mx-auto mb-10 leading-relaxed">
+            Every engineering team now has an AI writing code. Nobody has a system that governs when that code actually merges.
+            Conduct is the orchestration layer above Copilot, Cursor, and Claude Code — it catches AI-generated PRs, reviews the diff,
+            gates on a human approval, and posts structured findings to Slack before a single line hits main.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-left mb-10">
+            {[
+              { icon: "🔍", title: "Catch AI PRs automatically", body: "Trigger fires when Copilot, Cursor, or any bot opens a PR. Human PRs are skipped silently." },
+              { icon: "🧠", title: "Review with extra scrutiny", body: "Checks for hallucinated APIs, missing tests, security issues, and over-engineering — things humans miss in AI diffs." },
+              { icon: "✋", title: "Gate before merge", body: "Human approval required before the PR can land. One-click Approve or Reject in Slack." },
+            ].map(c => (
+              <div key={c.title} className="bg-stone-800 rounded-2xl p-5">
+                <span className="text-2xl block mb-3">{c.icon}</span>
+                <p className="text-white font-semibold text-sm mb-1">{c.title}</p>
+                <p className="text-stone-400 text-xs leading-relaxed">{c.body}</p>
+              </div>
+            ))}
+          </div>
+          <a
+            href="/marketplace"
+            className="inline-flex items-center gap-2 rounded-xl bg-white text-stone-900 px-6 py-3 text-sm font-semibold hover:bg-stone-100 transition-colors"
+          >
+            🤖 Install Copilot / AI PR Reviewer →
+          </a>
+        </div>
+      </section>
+
       {/* Why Conduct — the moat */}
       <section className="px-6 py-20">
         <div className="max-w-5xl mx-auto">


### PR DESCRIPTION
Closes #93

## What's in this PR

### New playbook: copilot-reviewer.yaml
- Trigger: PR opened by any AI author (Copilot, Cursor, Claude Code, any `[bot]`)
- Logic block: checks `user.type == Bot` or login contains copilot/cursor/claude — skips human PRs silently
- Brain block: reviews diff with AI-specific scrutiny (hallucinated APIs, missing tests, over-engineering)
- Approval block: human must approve before merge
- Output: Slack notification to #engineering with critical/warning counts

### Marketplace
- Registered as `copilot_reviewer` in `_TEMPLATE_PLAYBOOKS` and `_PLAYBOOK_META`
- Featured card: "The orchestration layer above your AI coding tool"
- Friendly name added to marketplace UI

### Landing page
- New dark section between 3-step setup and Why Conduct:
  **"You have AI that writes code. Conduct decides when it ships."**
- 3 feature cards: Catch AI PRs · Review with scrutiny · Gate before merge
- CTA: "Install Copilot / AI PR Reviewer →" links to /marketplace