### PR TITLE
fix: approval blocks missing channel field in 2 playbooks

### DIFF
--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -73,6 +73,7 @@ blocks:
   approve_pr:
     type: approval
     label: Approve PR
+    channel: "#engineering"
     description: |
       Fix is ready for issue #{{fetch_issue.issue_number}}: {{fetch_issue.title}}
 

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -41,7 +41,9 @@ blocks:
     label: Skip — human PR
     description: "PR #{{_trigger.number}} is human-authored — skipping AI review gate."
     output:
-      via: none
+      via: slack
+      slack:
+        channel: "#engineering"
 
   review_pr:
     type: brain
@@ -93,6 +95,7 @@ blocks:
   gate_merge:
     type: approval
     label: Human approval required
+    channel: "#engineering"
     description: >
       AI PR #{{_trigger.number}} has been reviewed.
       Critical issues: {{review_pr.critical}} · Warnings: {{review_pr.warnings}}


### PR DESCRIPTION
autopilot-approved.yaml and copilot-reviewer.yaml failed yaml_to_graph validation — approval blocks require channel or slack_user. Added channel: '#engineering' to both. Also fixed skip_human_pr output via: none → via: slack.