### PR TITLE
feat: approval blocks — slack, email, or both

### DIFF
--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -131,8 +131,10 @@ class Block(BaseModel):
     condition: str | None = None
 
     # — approval blocks —
+    via: Literal["slack", "email", "both"] | None = None  # default: slack if channel/slack_user set
     channel: str | None = None
     slack_user: str | None = None
+    approval_email: str | None = None  # email address to send approve/reject link
     message: str | None = None
 
     # — output blocks —
@@ -165,10 +167,15 @@ class Block(BaseModel):
                     "logic blocks need `next: { pass: <block>, fail: <block> }`"
                 )
         elif t == "approval":
-            if not self.channel and not self.slack_user:
-                raise ValueError(
-                    "approval blocks require either `channel` or `slack_user`"
-                )
+            via = self.via or "slack"
+            has_slack = bool(self.channel or self.slack_user)
+            has_email = bool(self.approval_email)
+            if via in ("slack", "both") and not has_slack:
+                raise ValueError("approval blocks with via=slack/both require `channel` or `slack_user`")
+            if via in ("email", "both") and not has_email:
+                raise ValueError("approval blocks with via=email/both require `approval_email`")
+            if not has_slack and not has_email:
+                raise ValueError("approval blocks require at least one of: `channel`, `slack_user`, or `approval_email`")
         elif t == "output":
             if not self.output:
                 raise ValueError("output blocks require an `output:` section")

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -905,44 +905,60 @@ def _execute_approval(block: dict, state: dict, credentials: dict, run_id: str) 
             raise ValueError(f"Approval rejected for block {block_id}")
         return {"decision": "approved", "resumed": True}
 
-    # First encounter — send Slack DM and pause
+    # First encounter — send Slack/email/both notification and pause
     data = block["data"]
     config = data.get("config", {})
     message = _resolve_refs(
         config.get("message", data.get("description", "Approval required to continue.")),
         state,
     )
+    via = config.get("via", "slack")
     slack_user = config.get("slack_user")
     channel = config.get("channel", "#general")
+    approval_email = config.get("approval_email")
+    callback_url = f"{settings.api_base_url}/runs/{run_id}/approve"
 
-    creds = credentials.get("slack", {})
-    if creds:
-        callback_url = f"{settings.api_base_url}/runs/{run_id}/approve"
+    # ── Slack ──────────────────────────────────────────────────────────────────
+    if via in ("slack", "both"):
+        slack_creds = credentials.get("slack", {})
+        if slack_creds:
+            try:
+                slack.execute(
+                    "post_approval_message",
+                    {
+                        "channel": slack_user or channel,
+                        "text": message,
+                        "run_id": run_id,
+                        "callback_url": callback_url,
+                    },
+                    slack_creds,
+                )
+            except Exception as e:
+                log.warning("Approval Slack send failed: %s", e)
+
+    # ── Email ──────────────────────────────────────────────────────────────────
+    if via in ("email", "both") and approval_email:
         try:
-            if slack_user:
-                slack.execute(
-                    "post_approval_message",
-                    {
-                        "channel": slack_user,
-                        "text": message,
-                        "run_id": run_id,
-                        "callback_url": callback_url,
-                    },
-                    creds,
-                )
-            else:
-                slack.execute(
-                    "post_approval_message",
-                    {
-                        "channel": channel,
-                        "text": message,
-                        "run_id": run_id,
-                        "callback_url": callback_url,
-                    },
-                    creds,
-                )
+            from app.runtime.integrations import email as email_int
+            approve_url = f"{callback_url}?run_id={run_id}&decision=approved"
+            reject_url  = f"{callback_url}?run_id={run_id}&decision=rejected"
+            email_body = (
+                f"{message}\n\n"
+                f"Approve: {approve_url}\n"
+                f"Reject:  {reject_url}\n"
+            )
+            email_creds = credentials.get("email", credentials.get("resend", {}))
+            email_int.execute(
+                "send",
+                {
+                    "to": approval_email,
+                    "subject": f"Approval required — run {run_id[:8]}",
+                    "body": email_body,
+                },
+                email_creds,
+            )
         except Exception as e:
-            log.warning("Approval Slack send failed: %s", e)
+            log.warning("Approval email send failed: %s", e)
 
     raise ApprovalRequired(block_id, message)
 

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -73,7 +73,9 @@ blocks:
   approve_pr:
     type: approval
     label: Approve PR
+    via: slack          # options: slack | email | both
     channel: "#engineering"
+    # approval_email: "team@yourcompany.com"  # uncomment to also send email
     description: |
       Fix is ready for issue #{{fetch_issue.issue_number}}: {{fetch_issue.title}}
 

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -95,7 +95,9 @@ blocks:
   gate_merge:
     type: approval
     label: Human approval required
+    via: slack          # options: slack | email | both
     channel: "#engineering"
+    # approval_email: "team@yourcompany.com"  # uncomment to also send email
     description: >
       AI PR #{{_trigger.number}} has been reviewed.
       Critical issues: {{review_pr.critical}} · Warnings: {{review_pr.warnings}}


### PR DESCRIPTION
## What
Approval blocks now support three notification modes:

\`\`\`yaml
type: approval
via: slack          # default — existing behaviour
channel: "#engineering"

# or
via: email
approval_email: "team@company.com"

# or
via: both
channel: "#engineering"
approval_email: "team@company.com"
\`\`\`

## Changes
- **DSL schema**: added \`via\` and \`approval_email\` fields to approval blocks; validator updated to check appropriate fields per via mode
- **Runtime**: \`_execute_approval\` now sends email with approve/reject links when \`via\` includes email
- **Playbooks**: autopilot-approved.yaml and copilot-reviewer.yaml updated with \`via: slack\` + commented \`approval_email\` example