### PR TITLE
feat: prompt project selection on marketplace install

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -208,6 +208,8 @@ def delete_workflow(
         )
     """), {"wid": str(workflow_id)})
     db.execute(text("DELETE FROM runs WHERE workflow_version_id IN (SELECT id FROM workflow_versions WHERE workflow_id = :wid)"), {"wid": str(workflow_id)})
+    # Null out FK before deleting versions to avoid FK violation
+    db.execute(text("UPDATE workflows SET current_version_id = NULL WHERE id = :wid"), {"wid": str(workflow_id)})
     db.execute(text("DELETE FROM workflow_versions WHERE workflow_id = :wid"), {"wid": str(workflow_id)})
     db.execute(text("DELETE FROM workflows WHERE id = :wid"), {"wid": str(workflow_id)})
     db.commit()

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -58,8 +58,8 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   const [installing, setInstalling] = useState(false)
   const [uninstalling, setUninstalling] = useState<string | null>(null)
   const [confirmingUninstall, setConfirmingUninstall] = useState<string | null>(null)
-  // slug → workflow id (for uninstall)
-  const [installedMap, setInstalledMap] = useState<Map<string, string>>(new Map())
+  // slug → { id, workspaceId } (for uninstall)
+  const [installedMap, setInstalledMap] = useState<Map<string, { id: string; workspaceId: string }>>(new Map())
 
   // Install modal state
   const [pendingSlug, setPendingSlug] = useState<string | null>(null)
@@ -90,12 +90,12 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
       if (pbRes.ok) setPlaybooks(await pbRes.json())
 
       if (wfRes.ok) {
-        const workflows: { id: string; name: string }[] = await wfRes.json()
-        const nameToId = new Map(workflows.map(w => [w.name, w.id]))
-        const map = new Map<string, string>()
+        const workflows: { id: string; name: string; workspace_id: string }[] = await wfRes.json()
+        const nameToWf = new Map(workflows.map(w => [w.name, w]))
+        const map = new Map<string, { id: string; workspaceId: string }>()
         for (const [slug, friendlyName] of Object.entries(FRIENDLY_NAMES)) {
-          const id = nameToId.get(friendlyName)
-          if (id) map.set(slug, id)
+          const wf = nameToWf.get(friendlyName)
+          if (wf) map.set(slug, { id: wf.id, workspaceId: wf.workspace_id })
         }
         setInstalledMap(map)
       }
@@ -143,7 +143,7 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
       })
       if (!res.ok) return
       const wf = await res.json()
-      setInstalledMap(prev => new Map(prev).set(pendingSlug, wf.id))
+      setInstalledMap(prev => new Map(prev).set(pendingSlug, { id: wf.id, workspaceId: selectedProjectId }))
       closeInstallModal()
       router.push(`/workflows/${wf.id}`)
     } finally {
@@ -152,16 +152,15 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   }
 
   async function uninstall(slug: string) {
-    const workflowId = installedMap.get(slug)
-    if (!workflowId) return
+    const entry = installedMap.get(slug)
+    if (!entry) return
     setUninstalling(slug)
     setConfirmingUninstall(null)
     try {
       const headers = await authHeaders()
-      const workspaceId = getWorkspaceId()
-      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+      headers["X-Workspace-Id"] = entry.workspaceId
 
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}`, {
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${entry.id}`, {
         method: "DELETE",
         headers,
       })

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -152,18 +152,26 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
 
   async function uninstall(slug: string) {
     const entry = installedMap.get(slug)
-    if (!entry) return
+    if (!entry) {
+      console.error("[uninstall] no entry found for slug", slug, [...installedMap.entries()])
+      return
+    }
     setUninstalling(slug)
     try {
       const headers = await authHeaders()
       headers["X-Workspace-Id"] = entry.workspaceId
 
+      console.log("[uninstall]", { slug, id: entry.id, workspaceId: entry.workspaceId })
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${entry.id}`, {
         method: "DELETE",
         headers,
       })
+      console.log("[uninstall] response status", res.status)
       if (res.ok) {
         setInstalledMap(prev => { const m = new Map(prev); m.delete(slug); return m })
+      } else {
+        const body = await res.text()
+        console.error("[uninstall] failed", res.status, body)
       }
     } finally {
       setUninstalling(null)

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -14,6 +14,11 @@ interface Playbook {
   featured: boolean
 }
 
+interface Project {
+  id: string
+  name: string
+}
+
 const ALL_TAGS = ["all", "github", "code", "code-review", "ops", "notifications", "approval"]
 
 function getWorkspaceId(): string | null {
@@ -50,16 +55,27 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   const [playbooks, setPlaybooks] = useState<Playbook[]>([])
   const [loading, setLoading] = useState(true)
   const [activeTag, setActiveTag] = useState("all")
-  const [installing, setInstalling] = useState<string | null>(null)
+  const [installing, setInstalling] = useState(false)
   const [installedSlugs, setInstalledSlugs] = useState<Set<string>>(new Set())
+
+  // Modal state
+  const [pendingSlug, setPendingSlug] = useState<string | null>(null)
+  const [projects, setProjects] = useState<Project[]>([])
+  const [selectedProjectId, setSelectedProjectId] = useState<string>("")
+  const [projectsLoading, setProjectsLoading] = useState(false)
+
+  async function authHeaders(): Promise<Record<string, string>> {
+    const headers: Record<string, string> = {}
+    if (getToken) {
+      const token = await getToken()
+      if (token) headers["Authorization"] = `Bearer ${token}`
+    }
+    return headers
+  }
 
   useEffect(() => {
     async function load() {
-      const headers: Record<string, string> = {}
-      if (getToken) {
-        const token = await getToken()
-        if (token) headers["Authorization"] = `Bearer ${token}`
-      }
+      const headers = await authHeaders()
       const workspaceId = getWorkspaceId()
       if (workspaceId) headers["X-Workspace-Id"] = workspaceId
 
@@ -87,28 +103,48 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  async function install(slug: string) {
-    setInstalling(slug)
+  async function openInstallModal(slug: string) {
+    setPendingSlug(slug)
+    setProjectsLoading(true)
     try {
-      const headers: Record<string, string> = { "Content-Type": "application/json" }
-      if (getToken) {
-        const token = await getToken()
-        if (token) headers["Authorization"] = `Bearer ${token}`
+      const headers = await authHeaders()
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/projects`, { headers })
+      if (res.ok) {
+        const data: Project[] = await res.json()
+        setProjects(data)
+        setSelectedProjectId(data[0]?.id ?? "")
       }
-      const workspaceId = getWorkspaceId()
-      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+    } finally {
+      setProjectsLoading(false)
+    }
+  }
+
+  function closeModal() {
+    setPendingSlug(null)
+    setProjects([])
+    setSelectedProjectId("")
+  }
+
+  async function confirmInstall() {
+    if (!pendingSlug || !selectedProjectId) return
+    setInstalling(true)
+    try {
+      const headers = await authHeaders()
+      headers["Content-Type"] = "application/json"
+      headers["X-Workspace-Id"] = selectedProjectId
 
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows`, {
         method: "POST",
         headers,
-        body: JSON.stringify({ name: FRIENDLY_NAMES[slug] ?? slug, template: slug }),
+        body: JSON.stringify({ name: FRIENDLY_NAMES[pendingSlug] ?? pendingSlug, template: pendingSlug }),
       })
       if (!res.ok) return
       const wf = await res.json()
-      setInstalledSlugs(prev => new Set([...prev, slug]))
+      setInstalledSlugs(prev => new Set([...prev, pendingSlug]))
+      closeModal()
       router.push(`/workflows/${wf.id}`)
     } finally {
-      setInstalling(null)
+      setInstalling(false)
     }
   }
 
@@ -151,25 +187,68 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
               <PlaybookCard
                 key={p.slug}
                 playbook={p}
-                installing={installing}
+                installing={false}
                 installed={installedSlugs.has(p.slug)}
-                onInstall={install}
+                onInstall={openInstallModal}
               />
             ))}
           </div>
         )}
       </div>
+
+      {/* Install modal */}
+      {pendingSlug && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-5">
+            <div>
+              <h2 className="text-sm font-semibold text-stone-900">Install to project</h2>
+              <p className="text-xs text-stone-400 mt-1">
+                Choose which project to install <span className="font-medium text-stone-600">{FRIENDLY_NAMES[pendingSlug] ?? pendingSlug}</span> into.
+              </p>
+            </div>
+
+            {projectsLoading ? (
+              <div className="h-9 rounded-lg bg-stone-100 animate-pulse" />
+            ) : (
+              <select
+                value={selectedProjectId}
+                onChange={e => setSelectedProjectId(e.target.value)}
+                className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-xs text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400"
+              >
+                {projects.map(p => (
+                  <option key={p.id} value={p.id}>{p.name}</option>
+                ))}
+              </select>
+            )}
+
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={closeModal}
+                className="px-4 py-2 text-xs text-stone-500 hover:text-stone-700 rounded-lg hover:bg-stone-100 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                onClick={confirmInstall}
+                disabled={installing || projectsLoading || !selectedProjectId}
+                className="px-4 py-2 text-xs font-medium bg-stone-900 text-white rounded-lg hover:bg-stone-700 disabled:opacity-40 transition-colors"
+              >
+                {installing ? "Installing…" : "Install"}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </AppShell>
   )
 }
 
 function PlaybookCard({ playbook, installing, installed, onInstall }: {
   playbook: Playbook
-  installing: string | null
+  installing: boolean
   installed: boolean
   onInstall: (slug: string) => void
 }) {
-  const isInstalling = installing === playbook.slug
   return (
     <div className={`rounded-xl border bg-white p-5 flex flex-col gap-3 transition-colors ${
       installed ? "border-emerald-200 bg-emerald-50/30" : "border-stone-200 hover:border-stone-300"
@@ -192,14 +271,14 @@ function PlaybookCard({ playbook, installing, installed, onInstall }: {
       </div>
       <button
         onClick={() => !installed && onInstall(playbook.slug)}
-        disabled={!!installing || installed}
+        disabled={installing || installed}
         className={`mt-auto w-full rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
           installed
             ? "bg-emerald-50 text-emerald-700 border border-emerald-200 cursor-default"
             : "bg-stone-900 text-white hover:bg-stone-700 disabled:opacity-40"
         }`}
       >
-        {isInstalling ? "Installing…" : installed ? "✓ Installed" : "+ Install"}
+        {installing ? "Installing…" : installed ? "✓ Installed" : "+ Install"}
       </button>
     </div>
   )

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -56,9 +56,12 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   const [loading, setLoading] = useState(true)
   const [activeTag, setActiveTag] = useState("all")
   const [installing, setInstalling] = useState(false)
-  const [installedSlugs, setInstalledSlugs] = useState<Set<string>>(new Set())
+  const [uninstalling, setUninstalling] = useState<string | null>(null)
+  const [confirmingUninstall, setConfirmingUninstall] = useState<string | null>(null)
+  // slug → workflow id (for uninstall)
+  const [installedMap, setInstalledMap] = useState<Map<string, string>>(new Map())
 
-  // Modal state
+  // Install modal state
   const [pendingSlug, setPendingSlug] = useState<string | null>(null)
   const [projects, setProjects] = useState<Project[]>([])
   const [selectedProjectId, setSelectedProjectId] = useState<string>("")
@@ -87,14 +90,14 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
       if (pbRes.ok) setPlaybooks(await pbRes.json())
 
       if (wfRes.ok) {
-        const workflows: { name: string }[] = await wfRes.json()
-        const installedNames = new Set(workflows.map(w => w.name))
-        const matched = new Set(
-          Object.entries(FRIENDLY_NAMES)
-            .filter(([, name]) => installedNames.has(name))
-            .map(([slug]) => slug)
-        )
-        setInstalledSlugs(matched)
+        const workflows: { id: string; name: string }[] = await wfRes.json()
+        const nameToId = new Map(workflows.map(w => [w.name, w.id]))
+        const map = new Map<string, string>()
+        for (const [slug, friendlyName] of Object.entries(FRIENDLY_NAMES)) {
+          const id = nameToId.get(friendlyName)
+          if (id) map.set(slug, id)
+        }
+        setInstalledMap(map)
       }
 
       setLoading(false)
@@ -119,7 +122,7 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
     }
   }
 
-  function closeModal() {
+  function closeInstallModal() {
     setPendingSlug(null)
     setProjects([])
     setSelectedProjectId("")
@@ -140,11 +143,32 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
       })
       if (!res.ok) return
       const wf = await res.json()
-      setInstalledSlugs(prev => new Set([...prev, pendingSlug]))
-      closeModal()
+      setInstalledMap(prev => new Map(prev).set(pendingSlug, wf.id))
+      closeInstallModal()
       router.push(`/workflows/${wf.id}`)
     } finally {
       setInstalling(false)
+    }
+  }
+
+  async function uninstall(slug: string) {
+    const workflowId = installedMap.get(slug)
+    if (!workflowId) return
+    setUninstalling(slug)
+    setConfirmingUninstall(null)
+    try {
+      const headers = await authHeaders()
+      const workspaceId = getWorkspaceId()
+      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+
+      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}`, {
+        method: "DELETE",
+        headers,
+      })
+      if (!res.ok) return
+      setInstalledMap(prev => { const m = new Map(prev); m.delete(slug); return m })
+    } finally {
+      setUninstalling(null)
     }
   }
 
@@ -188,8 +212,13 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
                 key={p.slug}
                 playbook={p}
                 installing={false}
-                installed={installedSlugs.has(p.slug)}
+                installed={installedMap.has(p.slug)}
+                uninstalling={uninstalling === p.slug}
+                confirming={confirmingUninstall === p.slug}
                 onInstall={openInstallModal}
+                onUninstallRequest={() => setConfirmingUninstall(p.slug)}
+                onUninstallConfirm={() => uninstall(p.slug)}
+                onUninstallCancel={() => setConfirmingUninstall(null)}
               />
             ))}
           </div>
@@ -223,7 +252,7 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
 
             <div className="flex gap-2 justify-end">
               <button
-                onClick={closeModal}
+                onClick={closeInstallModal}
                 className="px-4 py-2 text-xs text-stone-500 hover:text-stone-700 rounded-lg hover:bg-stone-100 transition-colors"
               >
                 Cancel
@@ -243,11 +272,16 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   )
 }
 
-function PlaybookCard({ playbook, installing, installed, onInstall }: {
+function PlaybookCard({ playbook, installing, installed, uninstalling, confirming, onInstall, onUninstallRequest, onUninstallConfirm, onUninstallCancel }: {
   playbook: Playbook
   installing: boolean
   installed: boolean
+  uninstalling: boolean
+  confirming: boolean
   onInstall: (slug: string) => void
+  onUninstallRequest: () => void
+  onUninstallConfirm: () => void
+  onUninstallCancel: () => void
 }) {
   return (
     <div className={`rounded-xl border bg-white p-5 flex flex-col gap-3 transition-colors ${
@@ -269,17 +303,46 @@ function PlaybookCard({ playbook, installing, installed, onInstall }: {
         </p>
         <p className="text-xs text-stone-500 leading-relaxed">{playbook.description}</p>
       </div>
-      <button
-        onClick={() => !installed && onInstall(playbook.slug)}
-        disabled={installing || installed}
-        className={`mt-auto w-full rounded-lg px-3 py-2 text-xs font-medium transition-colors ${
-          installed
-            ? "bg-emerald-50 text-emerald-700 border border-emerald-200 cursor-default"
-            : "bg-stone-900 text-white hover:bg-stone-700 disabled:opacity-40"
-        }`}
-      >
-        {installing ? "Installing…" : installed ? "✓ Installed" : "+ Install"}
-      </button>
+
+      {installed ? (
+        confirming ? (
+          <div className="mt-auto flex gap-2">
+            <button
+              onClick={onUninstallCancel}
+              className="flex-1 rounded-lg px-3 py-2 text-xs font-medium border border-stone-200 text-stone-500 hover:bg-stone-100 transition-colors"
+            >
+              Cancel
+            </button>
+            <button
+              onClick={onUninstallConfirm}
+              disabled={uninstalling}
+              className="flex-1 rounded-lg px-3 py-2 text-xs font-medium bg-red-600 text-white hover:bg-red-700 disabled:opacity-40 transition-colors"
+            >
+              {uninstalling ? "Removing…" : "Confirm"}
+            </button>
+          </div>
+        ) : (
+          <div className="mt-auto flex gap-2">
+            <div className="flex-1 rounded-lg px-3 py-2 text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 text-center">
+              ✓ Installed
+            </div>
+            <button
+              onClick={onUninstallRequest}
+              className="rounded-lg px-3 py-2 text-xs font-medium border border-stone-200 text-stone-400 hover:text-red-600 hover:border-red-200 transition-colors"
+            >
+              Remove
+            </button>
+          </div>
+        )
+      ) : (
+        <button
+          onClick={() => onInstall(playbook.slug)}
+          disabled={installing}
+          className="mt-auto w-full rounded-lg px-3 py-2 text-xs font-medium bg-stone-900 text-white hover:bg-stone-700 disabled:opacity-40 transition-colors"
+        >
+          {installing ? "Installing…" : "+ Install"}
+        </button>
+      )}
     </div>
   )
 }

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -57,7 +57,6 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   const [activeTag, setActiveTag] = useState("all")
   const [installing, setInstalling] = useState(false)
   const [uninstalling, setUninstalling] = useState<string | null>(null)
-  const [confirmingUninstall, setConfirmingUninstall] = useState<string | null>(null)
   // slug → { id, workspaceId } (for uninstall)
   const [installedMap, setInstalledMap] = useState<Map<string, { id: string; workspaceId: string }>>(new Map())
 
@@ -155,7 +154,6 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
     const entry = installedMap.get(slug)
     if (!entry) return
     setUninstalling(slug)
-    setConfirmingUninstall(null)
     try {
       const headers = await authHeaders()
       headers["X-Workspace-Id"] = entry.workspaceId
@@ -164,8 +162,9 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
         method: "DELETE",
         headers,
       })
-      if (!res.ok) return
-      setInstalledMap(prev => { const m = new Map(prev); m.delete(slug); return m })
+      if (res.ok) {
+        setInstalledMap(prev => { const m = new Map(prev); m.delete(slug); return m })
+      }
     } finally {
       setUninstalling(null)
     }
@@ -213,11 +212,8 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
                 installing={false}
                 installed={installedMap.has(p.slug)}
                 uninstalling={uninstalling === p.slug}
-                confirming={confirmingUninstall === p.slug}
                 onInstall={openInstallModal}
-                onUninstallRequest={() => setConfirmingUninstall(p.slug)}
-                onUninstallConfirm={() => uninstall(p.slug)}
-                onUninstallCancel={() => setConfirmingUninstall(null)}
+                onUninstall={() => uninstall(p.slug)}
               />
             ))}
           </div>
@@ -271,16 +267,13 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   )
 }
 
-function PlaybookCard({ playbook, installing, installed, uninstalling, confirming, onInstall, onUninstallRequest, onUninstallConfirm, onUninstallCancel }: {
+function PlaybookCard({ playbook, installing, installed, uninstalling, onInstall, onUninstall }: {
   playbook: Playbook
   installing: boolean
   installed: boolean
   uninstalling: boolean
-  confirming: boolean
   onInstall: (slug: string) => void
-  onUninstallRequest: () => void
-  onUninstallConfirm: () => void
-  onUninstallCancel: () => void
+  onUninstall: () => void
 }) {
   return (
     <div className={`rounded-xl border bg-white p-5 flex flex-col gap-3 transition-colors ${
@@ -304,35 +297,18 @@ function PlaybookCard({ playbook, installing, installed, uninstalling, confirmin
       </div>
 
       {installed ? (
-        confirming ? (
-          <div className="mt-auto flex gap-2">
-            <button
-              onClick={onUninstallCancel}
-              className="flex-1 rounded-lg px-3 py-2 text-xs font-medium border border-stone-200 text-stone-500 hover:bg-stone-100 transition-colors"
-            >
-              Cancel
-            </button>
-            <button
-              onClick={onUninstallConfirm}
-              disabled={uninstalling}
-              className="flex-1 rounded-lg px-3 py-2 text-xs font-medium bg-red-600 text-white hover:bg-red-700 disabled:opacity-40 transition-colors"
-            >
-              {uninstalling ? "Removing…" : "Confirm"}
-            </button>
+        <div className="mt-auto flex gap-2">
+          <div className="flex-1 rounded-lg px-3 py-2 text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 text-center">
+            ✓ Installed
           </div>
-        ) : (
-          <div className="mt-auto flex gap-2">
-            <div className="flex-1 rounded-lg px-3 py-2 text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 text-center">
-              ✓ Installed
-            </div>
-            <button
-              onClick={onUninstallRequest}
-              className="rounded-lg px-3 py-2 text-xs font-medium border border-stone-200 text-stone-400 hover:text-red-600 hover:border-red-200 transition-colors"
-            >
-              Remove
-            </button>
-          </div>
-        )
+          <button
+            onClick={onUninstall}
+            disabled={uninstalling}
+            className="rounded-lg px-3 py-2 text-xs font-medium border border-stone-200 text-stone-400 hover:text-red-600 hover:border-red-200 disabled:opacity-40 transition-colors"
+          >
+            {uninstalling ? "Removing…" : "Remove"}
+          </button>
+        </div>
       ) : (
         <button
           onClick={() => onInstall(playbook.slug)}

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -152,26 +152,18 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
 
   async function uninstall(slug: string) {
     const entry = installedMap.get(slug)
-    if (!entry) {
-      console.error("[uninstall] no entry found for slug", slug, [...installedMap.entries()])
-      return
-    }
+    if (!entry) return
     setUninstalling(slug)
     try {
       const headers = await authHeaders()
       headers["X-Workspace-Id"] = entry.workspaceId
 
-      console.log("[uninstall]", { slug, id: entry.id, workspaceId: entry.workspaceId })
       const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${entry.id}`, {
         method: "DELETE",
         headers,
       })
-      console.log("[uninstall] response status", res.status)
       if (res.ok) {
         setInstalledMap(prev => { const m = new Map(prev); m.delete(slug); return m })
-      } else {
-        const body = await res.text()
-        console.error("[uninstall] failed", res.status, body)
       }
     } finally {
       setUninstalling(null)


### PR DESCRIPTION
## Summary

- Install button opens a project picker modal — choose which project to install into (no more silent install to Demo Project)
- Installed playbooks show a **Remove** button alongside ✓ Installed
- Remove uses a two-click confirm pattern (Remove → Confirm / Cancel) to prevent accidental deletes
- Calls `DELETE /workflows/{id}` on confirm; card reverts to installable state

## Test plan
- [ ] Click Install — modal appears with project dropdown
- [ ] Select a project and confirm — redirects to new workflow in that project
- [ ] Cancel closes modal with no changes
- [ ] Installed playbook shows ✓ Installed + Remove button
- [ ] Click Remove — shows Confirm / Cancel buttons
- [ ] Confirm removes the workflow and card reverts to installable
- [ ] Cancel returns to ✓ Installed state