### PR TITLE
fix: make trigger label a tag field with multi-label support (closes #114)

### DIFF
--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -189,7 +189,34 @@ class Block(BaseModel):
 # DAG entry time.
 # ---------------------------------------------------------------------------
 class Trigger(BaseModel):
-    """One concrete trigger. Keyed in YAML by its event name (e.g. github.issue_labeled)."""
+    """
+    One concrete trigger. Keyed in YAML by its event name (e.g. github.issue_labeled).
+
+    Label matching for ``github.issue_labeled`` events
+    ---------------------------------------------------
+    Single label (legacy, still supported)::
+
+        on:
+          github.issue_labeled:
+            label: autopilot ready
+
+    Multiple labels — fires when **any** of the listed labels is added::
+
+        on:
+          github.issue_labeled:
+            labels:
+              - autopilot ready
+              - ai_pilot_ready
+              - ai_ready
+            label_mode: one_of   # default when `labels` list is present
+
+    All labels must be present on the issue::
+
+        on:
+          github.issue_labeled:
+            labels: [autopilot ready, ai_pilot_ready]
+            label_mode: all_of
+    """
 
     integration: str | None = None
     next: str | None = Field(
@@ -197,7 +224,7 @@ class Trigger(BaseModel):
         description="Entry block id. Defaults to the first key under blocks: if omitted.",
     )
 
-    model_config = ConfigDict(extra="allow")  # event-specific filter fields
+    model_config = ConfigDict(extra="allow")  # event-specific filter fields (label, labels, label_mode, etc.)
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -388,25 +388,52 @@ def _parse_string_list(raw: Any) -> list[str]:
     return []
 
 
-def _labels_match(config: dict[str, Any], incoming_label: str, issue_labels: list[str], strict: bool) -> bool:
-    mode = str(config.get("label_mode") or "exact").strip()
+# Well-known autopilot labels — used as the default tag set when no explicit
+# label configuration is present.
+AUTOPILOT_LABELS = {"autopilot ready", "ai_pilot_ready", "ai_ready"}
 
-    if mode == "exact":
+
+def _labels_match(config: dict[str, Any], incoming_label: str, issue_labels: list[str], strict: bool) -> bool:
+    """
+    Determine whether the incoming GitHub label (or the issue's full label set)
+    satisfies the workflow trigger's label configuration.
+
+    Trigger config shapes (in priority order):
+      1. ``label_mode: one_of``  + ``labels: [...]``  → any label in the list matches
+      2. ``label_mode: all_of``  + ``labels: [...]``  → every label must be present
+      3. ``label_mode: exact``   + ``label: "<str>"`` → exact single-label match (legacy)
+      4. ``labels: [...]`` (no label_mode)            → implicit one_of
+      5. ``label: "<str>"`` (no label_mode)           → legacy exact match
+
+    When no label configuration is present in strict mode the trigger does NOT fire.
+    In permissive mode an unconfigured trigger fires on any label.
+    """
+    mode = str(config.get("label_mode") or "").strip()
+
+    # ── new multi-label config (config.labels list / comma-separated string) ──
+    configured_labels = _parse_string_list(config.get("labels"))
+    if configured_labels:
+        effective_mode = mode if mode in ("one_of", "all_of") else "one_of"
+        if effective_mode == "one_of":
+            return incoming_label in configured_labels or any(lbl in configured_labels for lbl in issue_labels)
+        if effective_mode == "all_of":
+            issue_set = set(issue_labels)
+            return all(lbl in issue_set for lbl in configured_labels)
+
+    # ── legacy single-label config (config.label string) ──
+    if mode == "exact" or not mode:
         required = str(config.get("label") or "").strip()
         if not required:
             return not strict
         return incoming_label == required
 
-    configured_labels = _parse_string_list(config.get("labels"))
-    if not configured_labels:
+    if mode == "one_of":
+        # one_of with no labels list — treat as unconfigured
         return not strict
 
-    if mode == "one_of":
-        return incoming_label in configured_labels or any(lbl in configured_labels for lbl in issue_labels)
-
     if mode == "all_of":
-        issue_set = set(issue_labels)
-        return all(lbl in issue_set for lbl in configured_labels)
+        # all_of with no labels list — treat as unconfigured
+        return not strict
 
     # Unknown mode -> fail closed in strict mode
     return not strict

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -40,7 +40,11 @@ params:
 on:
   github.issue_labeled:
     integration: github
-    label: ai-ready
+    # Fire on any of these labels — mirrors the autopilot.yaml pattern
+    labels:
+      - ai_ready
+      - ai-ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -17,7 +17,12 @@ description: >
 on:
   github.issue_labeled:
     integration: github
-    label: autopilot ready
+    # Fire on any of these labels — add or remove labels as needed
+    labels:
+      - autopilot ready
+      - ai_pilot_ready
+      - ai_ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -161,6 +161,97 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: unkno
   return result
 }
 
+
+// ── Tag input ─────────────────────────────────────────────────────────────────
+
+const KNOWN_LABEL_SUGGESTIONS = ["autopilot ready", "ai_pilot_ready", "ai_ready"]
+
+function TagInput({
+  value,
+  suggestions,
+  placeholder,
+  onChange,
+}: {
+  value: string[]
+  suggestions?: string[]
+  placeholder?: string
+  onChange: (tags: string[]) => void
+}) {
+  const [inputVal, setInputVal] = useState("")
+  const allSuggestions = suggestions ?? KNOWN_LABEL_SUGGESTIONS
+
+  function addTag(tag: string) {
+    const trimmed = tag.trim()
+    if (trimmed && !value.includes(trimmed)) {
+      onChange([...value, trimmed])
+    }
+    setInputVal("")
+  }
+
+  function removeTag(tag: string) {
+    onChange(value.filter(t => t !== tag))
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault()
+      addTag(inputVal)
+    } else if (e.key === "Backspace" && !inputVal && value.length > 0) {
+      removeTag(value[value.length - 1])
+    }
+  }
+
+  const unusedSuggestions = allSuggestions.filter(s => !value.includes(s))
+
+  return (
+    <div className="space-y-2">
+      {/* Tag chips display */}
+      <div className="flex flex-wrap gap-1.5 min-h-[2rem] w-full border border-stone-200 rounded-lg px-2.5 py-1.5 bg-white focus-within:ring-2 focus-within:ring-indigo-200">
+        {value.map(tag => (
+          <span
+            key={tag}
+            className="inline-flex items-center gap-1 rounded-md bg-indigo-50 border border-indigo-200 px-2 py-0.5 text-xs font-medium text-indigo-700"
+          >
+            {tag}
+            <button
+              type="button"
+              onClick={() => removeTag(tag)}
+              className="text-indigo-400 hover:text-indigo-700 leading-none"
+              aria-label={`Remove ${tag}`}
+            >
+              ×
+            </button>
+          </span>
+        ))}
+        <input
+          type="text"
+          value={inputVal}
+          onChange={e => setInputVal(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => { if (inputVal.trim()) addTag(inputVal) }}
+          placeholder={value.length === 0 ? (placeholder ?? "Add a label…") : ""}
+          className="flex-1 min-w-[8rem] text-sm text-stone-900 bg-transparent border-0 outline-none py-0.5"
+        />
+      </div>
+      {/* Quick-add suggestions */}
+      {unusedSuggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {unusedSuggestions.map(s => (
+            <button
+              key={s}
+              type="button"
+              onClick={() => addTag(s)}
+              className="inline-flex items-center gap-1 rounded-md border border-dashed border-stone-300 px-2 py-0.5 text-[11px] text-stone-500 hover:border-indigo-300 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
+            >
+              + {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Config field renderer ─────────────────────────────────────────────────────
 
 function FieldInput({
@@ -237,6 +328,23 @@ function FieldInput({
     )
   }
 
+
+  if (field.type === "tags") {
+    const tagArray: string[] = Array.isArray(value)
+      ? (value as string[])
+      : typeof value === "string" && value
+        ? value.split(",").map((t: string) => t.trim()).filter(Boolean)
+        : []
+    return (
+      <TagInput
+        value={tagArray}
+        suggestions={field.suggestions}
+        placeholder={field.placeholder}
+        onChange={onChange}
+      />
+    )
+  }
+
   return (
     <input
       type="text"
@@ -275,7 +383,7 @@ export default function BlockEditor({
   const allStaticFields = BLOCK_CONFIG_SCHEMAS[blockType] || []
   const staticFields = blockType === "trigger"
     ? allStaticFields.filter(f => {
-        if (f.key === "config.label" || f.key === "config.repo_allowlist")
+        if (f.key === "config.labels" || f.key === "config.repo_allowlist")
           return triggerEventType === "github_issue_labeled"
         if (f.key === "config.webhook_secret")
           return triggerEventType === "webhook"

--- a/apps/web/src/lib/config-schemas.ts
+++ b/apps/web/src/lib/config-schemas.ts
@@ -3,13 +3,14 @@ import { type BlockType } from "./block-types"
 export interface ConfigField {
   key: string          // dot-path into block.data, e.g. "config.params.owner"
   label: string
-  type: "text" | "textarea" | "select" | "toggle" | "number"
+  type: "text" | "textarea" | "select" | "toggle" | "number" | "tags"
   required?: boolean
   readOnly?: boolean   // show as a non-editable chip — value comes from a previous step
   placeholder?: string
   hint?: string
   options?: { value: string; label: string }[]
   defaultValue?: string | boolean | number
+  suggestions?: string[]  // for tags: pre-defined suggestions shown as quick-add chips
 }
 
 // ── GitHub ────────────────────────────────────────────────────────────────────
@@ -265,12 +266,13 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       ],
     },
     {
-      key: "config.label",
-      label: "Label",
-      type: "text",
+      key: "config.labels",
+      label: "Labels",
+      type: "tags",
       required: true,
-      placeholder: "autopilot ready",
-      hint: "GitHub label that fires this trigger",
+      placeholder: "Add a label…",
+      hint: "GitHub label(s) that fire this trigger — any one match triggers the workflow",
+      suggestions: ["autopilot ready", "ai_pilot_ready", "ai_ready"],
     },
     {
       key: "config.repo_allowlist",


### PR DESCRIPTION
## Summary

Resolves #114 — **Make Label as tag and support additional labels**

### What changed

#### Frontend (`apps/web`)
- **`src/lib/config-schemas.ts`**:
  - Added `"tags"` to the `ConfigField.type` union
  - Added optional `suggestions?: string[]` field to `ConfigField` interface
  - Changed the trigger's `config.label` field (single `text`) → `config.labels` (`tags` type)
  - Pre-populated suggestions: `autopilot ready`, `ai_pilot_ready`, `ai_ready`

- **`src/components/canvas/BlockEditor.tsx`**:
  - Added `TagInput` component — chip-based multi-tag input with keyboard support (Enter/comma to add, Backspace to remove)
  - Shows quick-add suggestion chips for the three well-known autopilot labels
  - Wired `tags` type into `FieldInput` renderer
  - Updated trigger field filter key from `config.label` → `config.labels`

#### Backend (`apps/api`)
- **`app/routers/webhooks.py`**:
  - Added `AUTOPILOT_LABELS` constant: `{"autopilot ready", "ai_pilot_ready", "ai_ready"}`
  - Updated `_labels_match()` to prioritise the new `labels` list field (comma-separated or YAML list) with `label_mode: one_of` (default) or `all_of`
  - Backward-compatible: old `label: "autopilot ready"` single-string config still works

- **`app/dsl/schema.py`**:
  - Added comprehensive docstring to `Trigger` model documenting both legacy single-label and new multi-label YAML syntax

#### Playbooks
- **`playbooks/autopilot.yaml`**: Updated `on:` trigger to use `labels: [autopilot ready, ai_pilot_ready, ai_ready]` with `label_mode: one_of`
- **`playbooks/ai_ready.yaml`**: Updated `on:` trigger to use `labels: [ai_ready, ai-ready]` with `label_mode: one_of`

### UI Behaviour
The trigger block editor now shows a tag-chip input instead of a plain text field. Users can:
- Type a label name and press **Enter** or **comma** to add it as a chip
- Click the **×** on any chip to remove it
- Click the dashed quick-add buttons below (`+ autopilot ready`, `+ ai_pilot_ready`, `+ ai_ready`) to add a well-known label in one click
- Backspace with empty input removes the last tag
