### PR TITLE
fix: multi-label trigger support — closes #121 and #114

### DIFF
--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -389,27 +389,25 @@ def _parse_string_list(raw: Any) -> list[str]:
 
 
 def _labels_match(config: dict[str, Any], incoming_label: str, issue_labels: list[str], strict: bool) -> bool:
-    mode = str(config.get("label_mode") or "exact").strip()
-
-    if mode == "exact":
-        required = str(config.get("label") or "").strip()
-        if not required:
-            return not strict
-        return incoming_label == required
-
+    mode = str(config.get("label_mode") or "").strip()
     configured_labels = _parse_string_list(config.get("labels"))
-    if not configured_labels:
+
+    if configured_labels:
+        effective_mode = mode if mode in ("one_of", "all_of") else "one_of"
+        if effective_mode == "one_of":
+            return incoming_label in configured_labels or any(lbl in configured_labels for lbl in issue_labels)
+        # all_of: only fire when the triggering label is one we care about
+        if effective_mode == "all_of":
+            if incoming_label not in configured_labels:
+                return False
+            issue_set = set(issue_labels)
+            return all(lbl in issue_set for lbl in configured_labels)
+
+    # Legacy / fallback — handles label: singular and label_mode: one_of with no labels list
+    required = str(config.get("label") or "").strip()
+    if not required:
         return not strict
-
-    if mode == "one_of":
-        return incoming_label in configured_labels or any(lbl in configured_labels for lbl in issue_labels)
-
-    if mode == "all_of":
-        issue_set = set(issue_labels)
-        return all(lbl in issue_set for lbl in configured_labels)
-
-    # Unknown mode -> fail closed in strict mode
-    return not strict
+    return incoming_label == required
 
 
 def _repo_matches(config: dict[str, Any], incoming_repo: str, strict: bool) -> bool:

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -40,7 +40,10 @@ params:
 on:
   github.issue_labeled:
     integration: github
-    label: ai-ready
+    labels:
+      - ai_ready
+      - ai-ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -7,7 +7,11 @@ description: >
 on:
   github.issue_labeled:
     integration: github
-    label: autopilot ready
+    labels:
+      - autopilot ready
+      - ai_pilot_ready
+      - ai_ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -7,7 +7,11 @@ description: >
 on:
   github.issue_labeled:
     integration: github
-    label: autopilot ready
+    labels:
+      - autopilot ready
+      - ai_pilot_ready
+      - ai_ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -17,7 +17,11 @@ description: >
 on:
   github.issue_labeled:
     integration: github
-    label: autopilot ready
+    labels:
+      - autopilot ready
+      - ai_pilot_ready
+      - ai_ready
+    label_mode: one_of
     next: fetch_issue
 
 blocks:

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -161,6 +161,73 @@ function setNestedValue(obj: Record<string, unknown>, path: string, value: unkno
   return result
 }
 
+// ── Tag input ─────────────────────────────────────────────────────────────────
+
+function TagInput({
+  value,
+  suggestions,
+  placeholder,
+  onChange,
+}: {
+  value: string[]
+  suggestions?: string[]
+  placeholder?: string
+  onChange: (tags: string[]) => void
+}) {
+  const [inputVal, setInputVal] = useState("")
+  const unusedSuggestions = (suggestions ?? []).filter(s => !value.includes(s))
+
+  function addTag(tag: string) {
+    const trimmed = tag.trim()
+    if (trimmed && !value.includes(trimmed)) onChange([...value, trimmed])
+    setInputVal("")
+  }
+
+  function removeTag(tag: string) {
+    onChange(value.filter(t => t !== tag))
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent<HTMLInputElement>) {
+    if (e.key === "Enter" || e.key === ",") {
+      e.preventDefault()
+      addTag(inputVal)
+    } else if (e.key === "Backspace" && !inputVal && value.length > 0) {
+      removeTag(value[value.length - 1])
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1.5 min-h-[34px] border border-stone-200 rounded-lg px-2.5 py-1.5 bg-white focus-within:ring-2 focus-within:ring-indigo-200">
+        {value.map(tag => (
+          <span key={tag} className="inline-flex items-center gap-1 bg-indigo-50 text-indigo-700 text-xs font-medium px-2 py-0.5 rounded-full">
+            {tag}
+            <button type="button" onClick={() => removeTag(tag)} className="text-indigo-400 hover:text-indigo-700 leading-none">×</button>
+          </span>
+        ))}
+        <input
+          value={inputVal}
+          onChange={e => setInputVal(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onBlur={() => { if (inputVal.trim()) addTag(inputVal) }}
+          placeholder={value.length === 0 ? placeholder : ""}
+          className="flex-1 min-w-[80px] text-sm text-stone-900 bg-transparent outline-none"
+        />
+      </div>
+      {unusedSuggestions.length > 0 && (
+        <div className="flex flex-wrap gap-1">
+          {unusedSuggestions.map(s => (
+            <button key={s} type="button" onClick={() => addTag(s)}
+              className="text-[11px] px-2 py-0.5 rounded-full border border-stone-200 text-stone-500 hover:border-indigo-300 hover:text-indigo-600 transition-colors">
+              + {s}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
 // ── Config field renderer ─────────────────────────────────────────────────────
 
 function FieldInput({
@@ -200,6 +267,18 @@ function FieldInput({
           boolVal ? "translate-x-4.5" : "translate-x-0.5"
         )} />
       </button>
+    )
+  }
+
+  if (field.type === "tags") {
+    const tags = Array.isArray(value) ? (value as string[]) : (typeof value === "string" && value ? value.split(",").map(s => s.trim()).filter(Boolean) : [])
+    return (
+      <TagInput
+        value={tags}
+        suggestions={field.suggestions}
+        placeholder={field.placeholder}
+        onChange={onChange}
+      />
     )
   }
 
@@ -275,7 +354,7 @@ export default function BlockEditor({
   const allStaticFields = BLOCK_CONFIG_SCHEMAS[blockType] || []
   const staticFields = blockType === "trigger"
     ? allStaticFields.filter(f => {
-        if (f.key === "config.label" || f.key === "config.repo_allowlist")
+        if (f.key === "config.labels" || f.key === "config.repo_allowlist")
           return triggerEventType === "github_issue_labeled"
         if (f.key === "config.webhook_secret" || f.key === "config.test_repo" || f.key === "config.test_pr_number")
           return triggerEventType === "webhook"

--- a/apps/web/src/lib/config-schemas.ts
+++ b/apps/web/src/lib/config-schemas.ts
@@ -3,12 +3,13 @@ import { type BlockType } from "./block-types"
 export interface ConfigField {
   key: string          // dot-path into block.data, e.g. "config.params.owner"
   label: string
-  type: "text" | "textarea" | "select" | "toggle" | "number"
+  type: "text" | "textarea" | "select" | "toggle" | "number" | "tags"
   required?: boolean
   readOnly?: boolean   // show as a non-editable chip — value comes from a previous step
   placeholder?: string
   hint?: string
   options?: { value: string; label: string }[]
+  suggestions?: string[]
   defaultValue?: string | boolean | number
 }
 
@@ -265,12 +266,13 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       ],
     },
     {
-      key: "config.label",
-      label: "Label",
-      type: "text",
+      key: "config.labels",
+      label: "Labels",
+      type: "tags",
       required: true,
-      placeholder: "autopilot ready",
-      hint: "GitHub label that fires this trigger",
+      placeholder: "Add a label…",
+      hint: "GitHub labels that fire this trigger — any match triggers the workflow",
+      suggestions: ["autopilot ready", "ai_pilot_ready", "ai_ready"],
     },
     {
       key: "config.repo_allowlist",


### PR DESCRIPTION
## Summary

- Fixes `_labels_match` regression (issue #121): checks `config.labels` list first, then falls back to legacy `config.label` — eliminates the silent failure when `label_mode: one_of` is set but only `label:` (singular) is present
- `all_of` mode: adds `incoming_label in configured_labels` guard to prevent duplicate runs when unrelated labels are added
- Removes unused `AUTOPILOT_LABELS` constant
- `config-schemas.ts`: adds `tags` field type with `suggestions` support; swaps `config.label` (text) → `config.labels` (tags)  
- `BlockEditor.tsx`: adds `TagInput` chip component with keyboard support (Enter/comma to add, Backspace to remove); quick-add suggestion chips from `field.suggestions`; no hardcoded constant
- Playbooks (`autopilot`, `autopilot-quick`, `autopilot-approved`, `ai_ready`): all updated to `labels:` list + `label_mode: one_of`

## Test plan

- [ ] Trigger block in canvas shows chip-based label input with autopilot ready / ai_pilot_ready / ai_ready suggestions
- [ ] Adding/removing chips works (keyboard + click)
- [ ] Existing workflow with `config.label: "autopilot ready"` still fires (legacy fallback)
- [ ] `label_mode: one_of` + `labels: [...]` fires on any matching label
- [ ] `label_mode: all_of` + `labels: [a, b]` only fires when incoming label is in the list AND all labels are present on the issue
- [ ] PR #117 (old branch deleted) superseded by this PR — close #117

Closes #121, closes #114