### PR TITLE
fix: API security hardening — CORS, remove unused webhooks, workspace auth

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -36,6 +36,9 @@ class Settings(BaseSettings):
     railway_backend_service_id: str = ""   # delegator-backend service ID
     railway_frontend_service_id: str = ""  # delegator-ui service ID
 
+    # CORS — comma-separated allowed origins; defaults to all in dev
+    allowed_origins: str = "*"
+
     # Admin — used to approve waitlisted users via POST /projects/admin/approve
     admin_secret: str = ""
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,14 +1,17 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+from app.core.config import settings
 from app.routers import credentials, dashboard, environments, projects, runs, webhooks, workflows
 from app.routers.runs import workspace_runs_router
 
 app = FastAPI(title="Marshal API", version="0.1.0")
 
+_origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_origins,
     allow_credentials=False,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -3,8 +3,8 @@ Webhook endpoints for external services.
 
 POST /webhooks/slack/interactions  — Slack approval button clicks
 POST /webhooks/vercel              — Vercel deployment events (deployment.succeeded etc.)
-POST /webhooks/railway             — Railway deployment events
 POST /webhooks/github              — GitHub issue/PR events (issues.labeled, etc.)
+POST /webhooks/inbound/{id}        — Generic inbound webhook trigger
 """
 import hashlib
 import hmac
@@ -276,46 +276,6 @@ async def vercel_webhook(request: Request, db: Session = Depends(get_db)):
     return {"ok": True, "queued": len(queued), "run_ids": queued}
 
 
-@router.post("/railway")
-async def railway_webhook(request: Request, db: Session = Depends(get_db)):
-    """
-    Receive Railway deployment webhooks.
-    Configure in Railway → Project → Settings → Webhooks.
-    Events: DEPLOY_SUCCESS, DEPLOY_FAILED, etc.
-    """
-    body = await request.body()
-
-    try:
-        payload = json.loads(body)
-    except json.JSONDecodeError:
-        raise HTTPException(status_code=400, detail="Invalid JSON")
-
-    event_type = payload.get("type", "UNKNOWN")
-    deployment = payload.get("deployment", {})
-    service = payload.get("service", {})
-    project = payload.get("project", {})
-
-    initial_state = {
-        "railway_webhook": {
-            "event": event_type,
-            "deployment_id": deployment.get("id"),
-            "status": deployment.get("status"),
-            "url": deployment.get("url"),
-            "service_name": service.get("name"),
-            "service_id": service.get("id"),
-            "project_name": project.get("name"),
-            "environment": payload.get("environment", {}).get("name"),
-        }
-    }
-
-    trigger_on = {"DEPLOY_SUCCESS", "DEPLOY_FAILED", "DEPLOY_CRASHED"}
-    if event_type not in trigger_on:
-        return {"ok": True, "queued": 0, "reason": f"event {event_type} not a trigger"}
-
-    queued = _trigger_webhook_workflows(db, event_type, initial_state)
-    return {"ok": True, "queued": len(queued), "run_ids": queued}
-
-
 # ── GitHub webhook ────────────────────────────────────────────────────────────
 
 def _verify_github_signature(body: bytes, signature: str) -> bool:
@@ -559,30 +519,4 @@ async def github_webhook(
     }
 
 
-# ── Deploy Delegator manual trigger ──────────────────────────────────────────
-
-@router.post("/deploy-delegator")
-async def deploy_delegator(request: Request, db: Session = Depends(get_db)):
-    """
-    Manually trigger the Deploy Delegator workflow (deploys delegator-backend
-    and delegator-ui to Railway). Looks for workflows with trigger block
-    event_type = 'deploy_delegator'.
-
-    Optionally accepts a JSON body: {"ref": "main", "triggered_by": "user"}
-    """
-    try:
-        body = await request.body()
-        payload = json.loads(body) if body else {}
-    except json.JSONDecodeError:
-        payload = {}
-
-    initial_state = {
-        "deploy_trigger": {
-            "ref": payload.get("ref", "main"),
-            "triggered_by": payload.get("triggered_by", "manual"),
-        }
-    }
-
-    queued = _trigger_webhook_workflows(db, "deploy_delegator", initial_state)
-    return {"ok": True, "queued": len(queued), "run_ids": queued}
 

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -314,8 +314,20 @@ class BlockCompileRequest(BaseModel):
 
 
 @router.post("/{workflow_id}/blocks/{block_id}/compile/stream")
-def stream_block_compile(workflow_id: UUID, block_id: str, body: BlockCompileRequest):
+def stream_block_compile(
+    workflow_id: UUID,
+    block_id: str,
+    body: BlockCompileRequest,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+):
     """Stream the compiled prompt for a single block using the current editor state."""
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
+    if not workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
     block = {
         "id": block_id,
         "data": {
@@ -532,6 +544,7 @@ def estimate_workflow_cost(
     workflow_id: UUID,
     issues: int = 1,
     db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
 ):
     """
     Estimate token usage and cost for this workflow.
@@ -539,7 +552,10 @@ def estimate_workflow_cost(
     ?issues=N multiplies cost by number of matching GitHub issues.
     Pricing: Claude Sonnet 4.6 — $3/1M input, $15/1M output.
     """
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
     if not workflow.current_version_id:
@@ -910,9 +926,13 @@ def update_workflow_source(
     workflow_id: UUID,
     body: WorkflowSourceRequest,
     db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
 ):
     """Configure (or clear) the GitHub-repo source binding for a workflow."""
-    workflow = db.query(Workflow).filter(Workflow.id == workflow_id).first()
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
     workflow.source_repo = body.source_repo or None


### PR DESCRIPTION
## Changes

### 1. CORS locked to explicit origins
- Added `allowed_origins` setting to `config.py` (comma-separated, defaults to `*` in dev)
- `main.py` reads `ALLOWED_ORIGINS` env var — set to `https://conductai.ai` on Render

### 2. Removed unused webhook endpoints
- `DELETE POST /webhooks/railway` — not in use, no signature verification
- `DELETE POST /webhooks/deploy-delegator` — leftover from Railway era, completely open

### 3. Workspace ownership checks on 3 unprotected routes
- `POST /{workflow_id}/blocks/{block_id}/compile/stream` — now verifies `workspace_id` ownership
- `GET /{workflow_id}/estimate` — now verifies `workspace_id` ownership  
- `PUT /{workflow_id}/source` — now verifies `workspace_id` ownership

Previously, anyone who knew a workflow UUID could call these endpoints.

## Render action required
Set env var on Render:
```
ALLOWED_ORIGINS=https://conductai.ai
```