### PR TITLE
feat: security scanner playbook + registry fixes + all 11 playbooks on home/compare

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -76,6 +76,7 @@ _TEMPLATE_PLAYBOOKS = {
     "release_notes":      "release-notes.yaml",
     "issue_triage":       "issue-triage.yaml",
     "copilot_reviewer":   "copilot-reviewer.yaml",
+    "security_scanner":   "security-scanner.yaml",
 }
 
 _PLAYBOOK_META = {
@@ -89,6 +90,7 @@ _PLAYBOOK_META = {
     "incident_responder": {"icon": "🔥", "tags": ["ops", "notifications"],   "featured": False, "description": "Alert fires → AI correlates recent commits and deploys → posts root cause hypothesis to #incidents."},
     "dependency_updater": {"icon": "📦", "tags": ["github", "ops"],          "featured": False, "description": "Weekly cron → AI scans for outdated deps → bumps patch/minor versions → opens a single clean PR."},
     "copilot_reviewer":   {"icon": "🤖", "tags": ["github", "code-review", "approval"], "featured": True, "description": "PR opened by Copilot/Cursor/Claude Code → AI reviews the diff → human approves before merge. The orchestration layer above your AI coding tool."},
+    "security_scanner":   {"icon": "🔒", "tags": ["github", "code-review", "code"],    "featured": True, "description": "PR opened → AI scans for OWASP Top 10, hardcoded secrets, auth bypasses, weak crypto → posts structured security report → creates fix issue for critical findings."},
 }
 
 
@@ -102,6 +104,7 @@ _GITHUB_WEBHOOK_EVENTS: dict[str, list[str]] = {
     "autopilot_quick":    ["issues"],
     "autopilot_full":     ["issues"],
     "autopilot_approved": ["issues"],
+    "security_scanner":   ["pull_request"],
 }
 
 

--- a/apps/web/src/app/compare/page.tsx
+++ b/apps/web/src/app/compare/page.tsx
@@ -489,7 +489,7 @@ const FEATURE_GROUPS = [
       {
         name: "Pre-built playbooks / agents",
         note: "Install and run without building from scratch",
-        values: { conduct: "✅ 9", copilot: "🟡", devin: "❌", linearb: "🟡", bito: "❌", amazonq: "🟡", coderabbit: "❌", xhawk: "🟡" },
+        values: { conduct: "✅ 11", copilot: "🟡", devin: "❌", linearb: "🟡", bito: "❌", amazonq: "🟡", coderabbit: "❌", xhawk: "🟡" },
       },
       {
         name: "Custom workflow builder",

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -602,6 +602,13 @@ const TEMPLATES = [
     what: "PR opened → AI scans the diff for OWASP Top 10 vulnerabilities, hardcoded secrets, injection flaws, and insecure dependencies → posts a structured security report as a review comment.",
     scenario: "Dev opens a PR at midnight. By morning it has a security review flagging a hardcoded API key and a missing auth check — before any human looked at it.",
   },
+  {
+    icon: "🤖",
+    name: "Copilot / AI PR Reviewer",
+    trigger: "PR opened",
+    what: "PR opened by Copilot, Cursor, or Claude Code → AI reviews the diff with extra scrutiny for hallucinated APIs, missing tests, and over-engineering → human approves in Slack before merge.",
+    scenario: "Cursor opens a PR fixing a bug. AI flags a hallucinated method that doesn't exist in the codebase. Human reviews and rejects before it ever hits CI.",
+  },
 ]
 
 


### PR DESCRIPTION
## Summary
- Add `security-scanner.yaml` playbook — OWASP Top 10, secrets, auth bypass, weak crypto scanning on every PR
- Register `security_scanner` in API playbook registry (`_TEMPLATE_PLAYBOOKS`, `_PLAYBOOK_META`, `_GITHUB_WEBHOOK_EVENTS`) — was missing, only 10 showed in marketplace
- Add Copilot / AI PR Reviewer card to home page `TEMPLATES` array — was missing, now all 11 show
- Update compare page pre-built playbooks count: `✅ 9` → `✅ 11`

## Test plan
- [ ] Marketplace shows all 11 playbooks
- [ ] Home page shows all 11 playbook cards
- [ ] Compare page shows ✅ 11 for Conduct AI pre-built playbooks row
- [ ] Security Scanner installs via marketplace and registers GitHub webhook on selected repo