### PR TITLE
fix: remove credential exposure from security-scanner playbook (closes #148)

### DIFF
--- a/apps/api/playbooks/security-scanner.yaml
+++ b/apps/api/playbooks/security-scanner.yaml
@@ -25,8 +25,13 @@ blocks:
     type: brain
     mode: agentic
     label: Fetch PR diff
+    # Credentials are injected by the runtime via the assigned environment.
+    # Do NOT log, echo, or include credential values in any output.
+    credentials:
+      github: github
     description: |
       Fetch the pull request diff and metadata for security analysis.
+      Use the GitHub integration credential (injected by the runtime — never log or output the token).
 
       Repo: {{_trigger.repository.full_name}}
       PR number: {{_trigger.number}}
@@ -34,14 +39,17 @@ blocks:
       Author: {{_trigger.pull_request.user.login}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
-      2. Fetch the PR diff:
-         GET https://api.github.com/repos/{{_trigger.repository.full_name}}/pulls/{{_trigger.number}}/files
-         Headers: Authorization: token <github_token>, Accept: application/vnd.github.v3+json
-      3. For each changed file, record: filename, status (added/modified/removed), patch (the diff).
-      4. Fetch the PR details for context:
-         GET https://api.github.com/repos/{{_trigger.repository.full_name}}/pulls/{{_trigger.number}}
-         Headers: Authorization: token <github_token>
+      1. Use the GitHub tool to fetch changed files for PR #{{_trigger.number}}:
+         - Tool: github.list_pull_request_files
+         - Repo: {{_trigger.repository.full_name}}
+         - PR: {{_trigger.number}}
+      2. Use the GitHub tool to fetch PR details:
+         - Tool: github.get_pull_request
+         - Repo: {{_trigger.repository.full_name}}
+         - PR: {{_trigger.number}}
+      3. For each changed file, record: filename, status, patch (diff).
+
+      IMPORTANT: Do NOT include any credential values, tokens, or secrets in your output.
 
       Output ONLY the following JSON on the last line:
         {"files_changed": <number>, "additions": <number>, "deletions": <number>, "pr_url": "<html_url>"}
@@ -51,10 +59,15 @@ blocks:
     type: brain
     mode: agentic
     label: Run security scan
+    credentials:
+      github: github
     description: |
       You are an expert security engineer performing a focused security review.
       Analyse ONLY the changed lines in the PR diff. Do not flag issues in
       unchanged code.
+
+      IMPORTANT: Do NOT include any credential values, tokens, or secrets in your output or in any
+      API call bodies. Use the GitHub tool for all GitHub API interactions.
 
       Repo: {{_trigger.repository.full_name}}
       PR: {{_trigger.pull_request.html_url}}
@@ -139,10 +152,12 @@ blocks:
       ---
       *Powered by [Conduct AI](https://conductai.ai) · Security Scanner*
 
-      After writing the review comment, post it to GitHub:
-      POST https://api.github.com/repos/{{_trigger.repository.full_name}}/pulls/{{_trigger.number}}/reviews
-      Headers: Authorization: token <github_token>, Content-Type: application/json
-      Body: {"body": "<the formatted comment above>", "event": "COMMENT"}
+      After writing the review comment, post it using the GitHub tool:
+      - Tool: github.create_pull_request_review
+      - Repo: {{_trigger.repository.full_name}}
+      - PR: {{_trigger.number}}
+      - Event: COMMENT
+      - Body: <the formatted comment above>
 
       Output ONLY the following JSON on the last line:
         {"review_url": "<PR URL>", "critical": <count of 🔴 findings>, "high": <count of 🟠 findings>, "medium": <count of 🟡 findings>, "total": <total findings>}
@@ -160,18 +175,20 @@ blocks:
     type: brain
     mode: agentic
     label: Check for existing security issue
+    credentials:
+      github: github
     description: |
       Check if a security fix issue already exists for this PR to avoid duplicates.
+      Use the GitHub tool for all API calls. Do NOT log or output any credential values.
 
       Repo: {{_trigger.repository.full_name}}
       PR number: {{_trigger.number}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
-      2. Search for existing open issues:
-         GET https://api.github.com/search/issues?q=repo:{{_trigger.repository.full_name}}+is:issue+is:open+"security"+"%23{{_trigger.number}}"+in:title
-         Headers: Authorization: token <github_token>
-      3. If any issue title contains both "security" and "#{{_trigger.number}}", it already exists.
+      1. Use the GitHub tool to search for existing open issues:
+         - Tool: github.search_issues
+         - Query: repo:{{_trigger.repository.full_name}} is:issue is:open "security" "#{{_trigger.number}}" in:title
+      2. If any issue title contains both "security" and "#{{_trigger.number}}", it already exists.
 
       Output ONLY the following JSON on the last line:
         {"exists": true, "issue_url": "<url>", "issue_number": <number>} if found
@@ -190,23 +207,26 @@ blocks:
     type: brain
     mode: agentic
     label: Append findings to existing issue
+    credentials:
+      github: github
     description: |
       A re-scan found new critical vulnerabilities on the same PR.
       Append findings to the existing issue and re-trigger Autopilot.
+      Use the GitHub tool for all API calls. Do NOT log or output any credential values.
 
       Existing issue: {{check_existing_issue.issue_url}}
       Issue number: {{check_existing_issue.issue_number}}
       Repo: {{_trigger.repository.full_name}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
-      2. Append a comment:
-         POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues/{{check_existing_issue.issue_number}}/comments
-         Headers: Authorization: token <github_token>, Content-Type: application/json
-         Body: {"body": "## Re-scan findings\n\nPR #{{_trigger.number}} was re-scanned. {{security_scan.critical}} critical and {{security_scan.high}} high severity issue(s) found.\n\nSee PR review: {{security_scan.review_url}}"}
-      3. Remove label then re-add to re-trigger Autopilot:
-         DELETE .../issues/{{check_existing_issue.issue_number}}/labels/autopilot%20ready
-         POST   .../issues/{{check_existing_issue.issue_number}}/labels  {"labels": ["autopilot ready"]}
+      1. Add a comment using the GitHub tool:
+         - Tool: github.create_issue_comment
+         - Repo: {{_trigger.repository.full_name}}
+         - Issue: {{check_existing_issue.issue_number}}
+         - Body: "## Re-scan findings\n\nPR #{{_trigger.number}} was re-scanned. {{security_scan.critical}} critical and {{security_scan.high}} high severity issue(s) found.\n\nSee PR review: {{security_scan.review_url}}"
+      2. Remove then re-add the autopilot label to re-trigger:
+         - Tool: github.remove_label, then github.add_label
+         - Label: "autopilot ready"
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "{{check_existing_issue.issue_url}}", "issue_number": {{check_existing_issue.issue_number}}}
@@ -216,9 +236,12 @@ blocks:
     type: brain
     mode: agentic
     label: Create security fix issue
+    credentials:
+      github: github
     description: |
       Critical security vulnerabilities were found in PR #{{_trigger.number}}.
       Create a GitHub issue so Autopilot can fix them.
+      Use the GitHub tool for all API calls. Do NOT log or output any credential values.
 
       IMPORTANT: Create the issue WITHOUT labels first, then add the label separately
       so GitHub fires the issues.labeled webhook and Autopilot picks it up.
@@ -228,19 +251,16 @@ blocks:
       Critical: {{security_scan.critical}}  High: {{security_scan.high}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
-      2. Create the issue (no labels):
-         POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues
-         Headers: Authorization: token <github_token>, Content-Type: application/json
-         Body:
-         {
-           "title": "fix: address critical security findings on PR #{{_trigger.number}}",
-           "body": "## Security scan findings\n\nPR #{{_trigger.number}} was scanned and {{security_scan.critical}} critical vulnerability(s) were found.\n\nSecurity review: {{security_scan.review_url}}\n\n## Task\nRead the security review comment on the PR, identify all 🔴 Critical and 🟠 High findings, and implement fixes.\n\nPrioritise: injection flaws, hardcoded secrets, authentication bypasses."
-         }
+      1. Create the issue using the GitHub tool (no labels):
+         - Tool: github.create_issue
+         - Repo: {{_trigger.repository.full_name}}
+         - Title: "fix: address critical security findings on PR #{{_trigger.number}}"
+         - Body: "## Security scan findings\n\nPR #{{_trigger.number}} was scanned and {{security_scan.critical}} critical vulnerability(s) were found.\n\nSecurity review: {{security_scan.review_url}}\n\n## Task\nRead the security review comment on the PR, identify all 🔴 Critical and 🟠 High findings, and implement fixes.\n\nPrioritise: injection flaws, hardcoded secrets, authentication bypasses."
          Save the returned issue number.
-      3. Add label in a separate call:
-         POST .../issues/<issue_number>/labels
-         Body: {"labels": ["autopilot ready"]}
+      2. Add label in a separate call:
+         - Tool: github.add_label
+         - Issue: <issue_number>
+         - Label: "autopilot ready"
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<url>", "issue_number": <number>}


### PR DESCRIPTION
## Summary
- Removes `Authorization: token <github_token>` literal token instructions from all brain block prompts — these would appear in execution logs
- Replaces raw HTTP call instructions with GitHub tool references (`github.list_pull_request_files`, `github.create_pull_request_review`, etc.)
- Adds `credentials:` section to each block so the runtime injects credentials without exposing them to the LLM prompt
- Adds explicit "Do NOT log or output any credential values" instruction to every block

Fixes #148