### PR TITLE
fix: runs and settings pages stuck on loading spinner after network error (closes #194)

### DIFF
--- a/apps/web/src/app/workflows/[id]/runs/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/page.tsx
@@ -40,23 +40,26 @@ export default function RunsPage() {
 
   useEffect(() => {
     async function load() {
-      const token = await getToken()
-      const workspaceId = getCookie("delegator_project_id")
-      const headers: Record<string, string> = {}
-      if (token) headers["Authorization"] = `Bearer ${token}`
-      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
+      try {
+        const token = await getToken()
+        const workspaceId = getCookie("delegator_project_id")
+        const headers: Record<string, string> = {}
+        if (token) headers["Authorization"] = `Bearer ${token}`
+        if (workspaceId) headers["X-Workspace-Id"] = workspaceId
 
-      const [runsRes, wfRes] = await Promise.all([
-        fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs`, { headers }),
-        fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}`, { headers }),
-      ])
+        const [runsRes, wfRes] = await Promise.all([
+          fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs`, { headers }),
+          fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}`, { headers }),
+        ])
 
-      if (runsRes.ok) setRuns(await runsRes.json())
-      if (wfRes.ok) {
-        const wf = await wfRes.json()
-        setWorkflowName(wf.name ?? null)
+        if (runsRes.ok) setRuns(await runsRes.json())
+        if (wfRes.ok) {
+          const wf = await wfRes.json()
+          setWorkflowName(wf.name ?? null)
+        }
+      } finally {
+        setLoading(false)
       }
-      setLoading(false)
     }
     load()
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

Fixes the `load()` function in `apps/web/src/app/workflows/[id]/runs/page.tsx` to always call `setLoading(false)`, even when a network error or exception occurs.

## Problem

`setLoading(false)` was only called on the happy path. If either `fetch()` call threw (network error, CORS, timeout), the loading state was never cleared and the page stayed stuck showing a loading spinner forever.

## Fix

Wrapped the fetch logic in a `try/finally` block so `setLoading(false)` always runs — matching the pattern already used in `settings/page.tsx`.

```ts
async function load() {
  try {
    // ... fetch calls ...
  } finally {
    setLoading(false)
  }
}
```

Automated fix by Delegator.

Closes #194