### PR TITLE
feat: structured logging across API (closes #151)

### DIFF
--- a/apps/api/app/compiler/compiler.py
+++ b/apps/api/app/compiler/compiler.py
@@ -8,7 +8,7 @@ Two-step process for Brain blocks:
 All other block types use lighter single-step compilation.
 """
 import json
-import logging
+import structlog
 from typing import Any
 
 import anthropic
@@ -19,7 +19,7 @@ from app.compiler.templates import (
     output_prompt, logic_prompt, generic_prompt,
 )
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 EXTRACTION_TOOL = {
     "name": "extract_block_slots",
@@ -167,7 +167,7 @@ def compile_block(block: dict[str, Any]) -> dict[str, Any] | None:
             }
 
     except Exception as e:
-        log.error("Compiler error for block %s: %s", block.get("id"), e)
+        log.error("compile.block_error", block_id=block.get("id"), error=str(e))
         return {
             "system_prompt": f"[Compiler error: {e}]\n\nOriginal description: {description}",
             "model": None,
@@ -191,6 +191,6 @@ def compile_workflow(graph: dict[str, Any]) -> dict[str, Any]:
         artifact = compile_block(node)
         if artifact:
             artifacts[block_id] = artifact
-            log.info("Compiled block %s (%s)", block_id, node.get("data", {}).get("type"))
+            log.info("compile.block_done", block_id=block_id, block_type=node.get("data", {}).get("type"))
 
     return artifacts

--- a/apps/api/app/compiler/stream.py
+++ b/apps/api/app/compiler/stream.py
@@ -3,14 +3,14 @@ Streaming compiler — generates a system prompt for a single block using Claude
 Returns an SSE generator for use with FastAPI StreamingResponse.
 """
 import json
-import logging
+import structlog
 from typing import Generator, Any
 
 import anthropic
 
 from app.core.config import settings
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 COMPILER_SYSTEM = """You are a system prompt compiler for an AI workflow platform called Delegator.
 

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -11,7 +11,7 @@ Usage in routes:
     # role-gated:
     _: str = Depends(require_workspace_role("admin"))
 """
-import logging
+import structlog
 from functools import lru_cache
 from typing import Annotated
 
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 from app.core.database import get_db
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
 DEV_USER_ID = "dev"

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -44,6 +44,9 @@ class Settings(BaseSettings):
     # Environment — used to gate dev-only defaults (e.g. encryption key check)
     environment: str = "development"
 
+    # Logging
+    log_level: str = "INFO"
+
     # Admin — used to approve waitlisted users via POST /projects/admin/approve
     admin_secret: str = ""
 

--- a/apps/api/app/core/email.py
+++ b/apps/api/app/core/email.py
@@ -9,7 +9,7 @@ Credential resolution order:
 1. Workspace email credential (stored in integrations table)
 2. Platform-level RESEND_API_KEY / EMAIL_FROM env vars
 """
-import logging
+import structlog
 from dataclasses import dataclass
 
 import httpx
@@ -17,7 +17,7 @@ from jinja2 import BaseLoader, Environment as JinjaEnv, TemplateError
 
 from app.core.config import settings
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 APP_URL = "https://conductai.ai"
 

--- a/apps/api/app/core/logging.py
+++ b/apps/api/app/core/logging.py
@@ -1,0 +1,45 @@
+import logging
+import structlog
+from app.core.config import settings
+
+
+def setup_logging() -> None:
+    level = getattr(logging, settings.log_level.upper(), logging.INFO)
+
+    shared_processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.stdlib.add_logger_name,
+        structlog.stdlib.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+        structlog.processors.StackInfoRenderer(),
+    ]
+
+    if settings.environment == "production":
+        renderer = structlog.processors.JSONRenderer()
+    else:
+        renderer = structlog.dev.ConsoleRenderer(colors=True)
+
+    structlog.configure(
+        processors=shared_processors + [
+            structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
+        ],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+    formatter = structlog.stdlib.ProcessorFormatter(
+        processor=renderer,
+        foreign_pre_chain=shared_processors,
+    )
+
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(level)
+
+    # Silence noisy third-party loggers
+    for noisy in ("uvicorn.access", "sqlalchemy.engine"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)

--- a/apps/api/app/dsl/sync.py
+++ b/apps/api/app/dsl/sync.py
@@ -19,7 +19,7 @@ versioned by git, reviewed in PRs.
 from __future__ import annotations
 
 import hashlib
-import logging
+import structlog
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -31,7 +31,7 @@ from app.models.integration import Integration
 from app.models.workflow import Workflow, WorkflowVersion
 from app.runtime.integrations import github
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 class SyncError(Exception):

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,16 +1,23 @@
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+import structlog
 from app.core.config import settings
+from app.core.logging import setup_logging
+from app.middleware.logging import LoggingMiddleware
 from app.routers import credentials, dashboard, email_templates, environments, projects, runs, webhooks, workflows
 from app.routers.organizations import router as organizations_router
 from app.routers.workspace_projects import router as workspace_projects_router
 from app.routers.runs import workspace_runs_router
 
+setup_logging()
+log = structlog.get_logger(__name__)
+
 app = FastAPI(title="Marshal API", version="0.1.0")
 
 _origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
 
+app.add_middleware(LoggingMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_origins,
@@ -21,10 +28,9 @@ app.add_middleware(
 
 @app.exception_handler(Exception)
 async def unhandled_exception_handler(request: Request, exc: Exception):
-    """Return CORS headers on 500 — log internally, never expose exc details."""
-    import logging, uuid
+    import uuid
     error_id = str(uuid.uuid4())[:8]
-    logging.getLogger("app").error("Unhandled error %s: %s", error_id, exc, exc_info=True)
+    log.error("unhandled_exception", error_id=error_id, exc_info=exc)
     origin = request.headers.get("origin", "")
     headers = {"Access-Control-Allow-Origin": origin} if origin in _origins else {}
     return JSONResponse(

--- a/apps/api/app/middleware/logging.py
+++ b/apps/api/app/middleware/logging.py
@@ -1,0 +1,32 @@
+import time
+import uuid
+import structlog
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+log = structlog.get_logger(__name__)
+
+
+class LoggingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        trace_id = str(uuid.uuid4())
+        structlog.contextvars.clear_contextvars()
+        structlog.contextvars.bind_contextvars(trace_id=trace_id)
+
+        start = time.monotonic()
+        response = await call_next(request)
+        duration_ms = int((time.monotonic() - start) * 1000)
+
+        # Skip health check noise
+        if request.url.path not in ("/health", "/health/sandbox"):
+            log.info(
+                "http.request",
+                method=request.method,
+                path=request.url.path,
+                status=response.status_code,
+                duration_ms=duration_ms,
+            )
+
+        response.headers["X-Trace-Id"] = trace_id
+        return response

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -9,7 +9,7 @@ POST /webhooks/inbound/{id}        — Generic inbound webhook trigger
 import hashlib
 import hmac
 import json
-import logging
+import structlog
 import time
 from typing import Any
 from urllib.parse import unquote_plus
@@ -24,7 +24,7 @@ from app.core.database import get_db
 from app.models.run import Run, RunEvent
 from app.models.workflow import Workflow, WorkflowVersion
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
 
 QUEUE_KEY = "marshal:runs:queue"
@@ -111,7 +111,7 @@ async def slack_interactions(request: Request, db: Session = Depends(get_db)):
 
     run = db.query(Run).filter(Run.id == run_id_str).first()
     if not run:
-        log.warning("Slack interaction for unknown run %s", run_id_str)
+        log.warning("slack.unknown_run", run_id=run_id_str)
         return {"ok": True}
 
     # Verify signature using workspace's Slack signing secret
@@ -141,11 +141,11 @@ async def slack_interactions(request: Request, db: Session = Depends(get_db)):
         run.paused_at = None
         db.commit()
         _redis().rpush(QUEUE_KEY, run_id_str)
-        log.info("Run %s approval gate: %s by %s — re-queued", run_id_str, decision, approver)
+        log.info("run.approval_gate", run_id=run_id_str, decision=decision, approver=approver)
     else:
         # Post-run feedback — just log the human verdict, don't re-queue
         db.commit()
-        log.info("Run %s post-run verdict: %s by %s", run_id_str, decision, approver)
+        log.info("run.post_run_verdict", run_id=run_id_str, decision=decision, approver=approver)
 
     return {"ok": True}
 
@@ -247,7 +247,7 @@ async def inbound_webhook(
     db.flush()
     db.commit()
     _redis().rpush(QUEUE_KEY, str(run.id))
-    log.info("Inbound webhook triggered run %s for workflow %s (max_turns=%s)", run.id, workflow_id, suggested_turns)
+    log.info("webhook.inbound_triggered", run_id=str(run.id), workflow_id=workflow_id, max_turns=suggested_turns)
     return {"ok": True}
 
 
@@ -298,7 +298,7 @@ def _trigger_webhook_workflows(
         db.commit()
         _redis().rpush(QUEUE_KEY, str(run.id))
         queued.append(str(run.id))
-        log.info("Webhook %s triggered run %s for version %s", event_type, run.id, version.id)
+        log.info("webhook.triggered", event_type=event_type, run_id=str(run.id), version_id=str(version.id))
 
     return queued
 
@@ -354,7 +354,7 @@ async def vercel_webhook(
         return {"ok": True, "queued": 0, "reason": f"event {event_type} not a trigger"}
 
     if not workspace_id:
-        log.warning("Vercel webhook received with no workspace_id — ignoring to prevent cross-tenant fanout")
+        log.warning("webhook.vercel_no_workspace")
         return {"ok": False, "reason": "workspace_id query param required; re-register the webhook URL with ?workspace_id=<your-workspace-id>"}
 
     queued = _trigger_webhook_workflows(db, event_type, initial_state, workspace_id=workspace_id)
@@ -538,7 +538,7 @@ def _trigger_github_workflows(
         db.commit()
         _redis().rpush(QUEUE_KEY, str(run.id))
         queued.append(str(run.id))
-        log.info("GitHub %s (label=%s repo=%s) triggered run %s for version %s", event_type, incoming_label, incoming_repo, run.id, version.id)
+        log.info("github.triggered", event_type=event_type, label=incoming_label, repo=incoming_repo, run_id=str(run.id))
 
     return queued
 

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1,4 +1,4 @@
-import logging
+import structlog
 from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, BackgroundTasks
 from fastapi.responses import PlainTextResponse, StreamingResponse
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session
 from app.core.auth import get_workspace_id, require_workspace_role
 from app.core.database import get_db
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 from app.dsl import (
     Workflow as DSLWorkflow,
     WorkflowValidationError,
@@ -38,8 +38,7 @@ def _run_compiler(version_id, graph: dict):
             version.compiled_artifacts = artifacts
             db.commit()
     except Exception as e:
-        import logging
-        logging.getLogger(__name__).error("Background compile failed: %s", e)
+        log.error("compile.background_failed", error=str(e))
     finally:
         db.close()
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -10,10 +10,10 @@ Execution model:
 - On any failure, mark the run failed and run cleanup blocks
 """
 import json
-import logging
 import os
 import re
 import subprocess
+import structlog
 from collections import defaultdict, deque
 from datetime import datetime, timezone
 from typing import Any
@@ -28,7 +28,7 @@ from app.models.integration import Integration
 from app.models.run import Run, RunEvent
 from app.models.workflow import WorkflowVersion
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 
 # ── helpers ──────────────────────────────────────────────────────────────────
@@ -138,9 +138,9 @@ def _emit_run_analytics(run, version, state: dict, db, *, outcome: str, error: s
             error=error[:2000] if error else None,
         ))
         db.commit()
-        log.debug("RunAnalyticsEvent written for run %s (outcome=%s)", run.id, outcome)
+        log.debug("run_analytics.written", run_id=str(run.id), outcome=outcome)
     except Exception:
-        log.exception("_emit_run_analytics failed — ignoring")
+        log.exception("run_analytics.failed")
 
 
 def _resolve_refs(value: Any, state: dict) -> Any:
@@ -394,17 +394,14 @@ def _resolve_remote_host(
     ip = _resolve_refs(ip_ref, state) if isinstance(ip_ref, str) else ip_ref
     if not ip or (isinstance(ip, str) and ip.startswith("{{")):
         # Couldn't resolve — fall back to local execution rather than fail the block.
-        log.warning("Brain block %s remote_host ip_ref did not resolve: %r", block.get("id"), ip_ref)
+        log.warning("brain.remote_host_unresolved", block_id=block.get("id"), ip_ref=ip_ref)
         return None
 
     handle = rh.get("credentials_from") or "digitalocean"
     creds = credentials.get(handle, {}) if isinstance(credentials, dict) else {}
     private_key = creds.get("ssh_private_key") or rh.get("private_key")
     if not private_key:
-        log.warning(
-            "Brain block %s declared remote_host but no ssh_private_key in '%s' credentials",
-            block.get("id"), handle,
-        )
+        log.warning("brain.remote_host_no_key", block_id=block.get("id"), credentials_from=handle)
         return None
 
     return {
@@ -1074,7 +1071,7 @@ def _execute_approval(block: dict, state: dict, credentials: dict, run_id: str) 
                     slack_creds,
                 )
             except Exception as e:
-                log.warning("Approval Slack send failed: %s", e)
+                log.warning("approval.slack_failed", error=str(e))
 
     # ── Email ──────────────────────────────────────────────────────────────────
     if via in ("email", "both") and approval_email:
@@ -1098,7 +1095,7 @@ def _execute_approval(block: dict, state: dict, credentials: dict, run_id: str) 
                 email_creds,
             )
         except Exception as e:
-            log.warning("Approval email send failed: %s", e)
+            log.warning("approval.email_failed", error=str(e))
 
     raise ApprovalRequired(block_id, message)
 
@@ -1117,7 +1114,7 @@ def execute_run(run_id: str):
     try:
         run = db.query(Run).filter(Run.id == run_id).first()
         if not run:
-            log.error("Run %s not found", run_id)
+            log.error("run.not_found", run_id=run_id)
             return
 
         from sqlalchemy.orm import joinedload
@@ -1187,7 +1184,7 @@ def execute_run(run_id: str):
             # Check if user cancelled the run between blocks
             db.refresh(run)
             if run.status == "cancelled":
-                log.info("Run %s cancelled by user", run_id)
+                log.info("run.cancelled", run_id=run_id)
                 return
 
             block_id = block["id"]
@@ -1195,7 +1192,7 @@ def execute_run(run_id: str):
 
             # Skip blocks already completed in a previous run segment (resume support)
             if block_id in state:
-                log.debug("Block %s already in state — skipping (resume)", block_id)
+                log.debug("block.skipped_resume", block_id=block_id)
                 if block_type == "logic":
                     logic_routes[block_id] = state[block_id].get("route", "pass")
                 continue
@@ -1238,7 +1235,7 @@ def execute_run(run_id: str):
                         result = _execute_output(block, state, credentials, workflow_name=wf_name, trace_url=trace_url, run_id=run_id)
                     except Exception as out_err:
                         # Notification failures are non-fatal — the real work already succeeded.
-                        log.warning("Output block %s failed (non-fatal): %s", block_id, out_err)
+                        log.warning("block.output_failed", block_id=block_id, error=str(out_err))
                         result = {"sent": False, "error": str(out_err)}
                         _emit(db, run_id, block_id, "block_completed", {"output": result, "warning": str(out_err)})
                         state[block_id] = result
@@ -1273,11 +1270,11 @@ def execute_run(run_id: str):
                     "block_id": ap.block_id,
                     "message": ap.message,
                 })
-                log.info("Run %s paused at approval block %s", run_id, ap.block_id)
+                log.info("run.paused", run_id=run_id, block_id=ap.block_id)
                 return  # Exit without marking failed
 
             except Exception as e:
-                log.exception("Block %s failed", block_id)
+                log.exception("block.failed", block_id=block_id)
                 failed = True
                 fail_error = str(e)
                 _emit(db, run_id, block_id, "block_failed", {"error": str(e)})
@@ -1302,11 +1299,11 @@ def execute_run(run_id: str):
             "status": run.status,
             "error": fail_error,
         })
-        log.info("Run %s finished: %s", run_id, run.status)
+        log.info("run.finished", run_id=run_id, status=run.status)
         _emit_run_analytics(run, version, state, db, outcome=run.status, error=fail_error)
 
     except Exception as e:
-        log.exception("Executor crash for run %s", run_id)
+        log.exception("run.executor_crash", run_id=run_id)
         try:
             run = db.query(Run).filter(Run.id == run_id).first()
             if run:

--- a/apps/api/app/runtime/remote_sandbox.py
+++ b/apps/api/app/runtime/remote_sandbox.py
@@ -25,12 +25,12 @@ Brain block can route results back to Claude as a `tool_result`.
 from __future__ import annotations
 
 import io
-import logging
+import structlog
 import re
 import shlex
 from typing import Any
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 # Same denylist as the local/Modal paths so behaviour is consistent.
 _FORBIDDEN_SHELL_PATTERNS = [

--- a/apps/api/app/runtime/sandbox.py
+++ b/apps/api/app/runtime/sandbox.py
@@ -8,12 +8,12 @@ destroyed after the block completes.
 When those env vars are NOT set (local dev), falls back to direct subprocess
 execution on the host (existing behaviour).
 """
-import logging
 import os
 import re
+import structlog
 import subprocess
 
-log = logging.getLogger(__name__)
+log = structlog.get_logger(__name__)
 
 # Shared across local and Modal execution paths — single source of truth.
 _FORBIDDEN_SHELL_PATTERNS = [

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -1,38 +1,37 @@
 """
 Runtime worker — polls Redis queue and executes runs.
 """
-import logging
 import time
-
 import redis
+import structlog
 
 from app.core.config import settings
+from app.core.logging import setup_logging
 from app.runtime.executor import execute_run
 
-logging.basicConfig(level=logging.INFO)
-log = logging.getLogger(__name__)
+setup_logging()
+log = structlog.get_logger(__name__)
 
 QUEUE_KEY = "marshal:runs:queue"
 
 
 def main():
-    log.info("Marshal worker starting — polling %s", QUEUE_KEY)
+    log.info("worker.starting", queue=QUEUE_KEY)
     r = redis.from_url(settings.redis_url, decode_responses=True)
 
     while True:
         try:
-            # BLPOP blocks up to 5s, returns (key, value) or None on timeout
             item = r.blpop(QUEUE_KEY, timeout=5)
             if item is None:
                 continue
             _, run_id = item
-            log.info("Dequeued run %s", run_id)
+            log.info("worker.dequeued", run_id=run_id)
             execute_run(run_id)
         except redis.exceptions.ConnectionError:
-            log.warning("Redis connection lost, retrying in 3s…")
+            log.warning("worker.redis_disconnected", retry_in=3)
             time.sleep(3)
         except Exception:
-            log.exception("Worker loop error")
+            log.exception("worker.loop_error")
             time.sleep(1)
 
 

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -16,3 +16,4 @@ paramiko==3.5.0
 pytest==8.3.3
 pyyaml==6.0.2
 jinja2>=3.1.0
+structlog==24.4.0


### PR DESCRIPTION
## Summary
- Adds `structlog` — JSON output in prod, colored text in dev, controlled by `LOG_LEVEL` env var
- `LoggingMiddleware` logs every HTTP request (method, path, status, duration_ms) and attaches `X-Trace-Id` header to every response
- `trace_id` propagated via contextvars so all log lines within a request share it
- Replaces all `logging.getLogger` + `basicConfig` calls across 12 files with `structlog.get_logger`
- Structured keyword-arg log events: `run.started`, `block.failed`, `webhook.triggered`, `run.executor_crash`, etc.

## Files changed
- `apps/api/app/core/logging.py` (new) — `setup_logging()` 
- `apps/api/app/middleware/logging.py` (new) — HTTP request middleware
- `apps/api/app/core/config.py` — `LOG_LEVEL` setting
- `apps/api/app/main.py` — wires up `setup_logging()` and `LoggingMiddleware`
- `apps/api/requirements.txt` — adds `structlog==24.4.0`
- 12 backend files migrated from `logging.getLogger` to `structlog.get_logger`

## Test plan
- [ ] Start API locally, verify colored structured logs in dev mode
- [ ] Check `X-Trace-Id` header on any API response
- [ ] Trigger a webhook run, verify `webhook.inbound_triggered` log line with `run_id`
- [ ] Cause a block failure, verify `block.failed` with `block_id` field