### PR TITLE
feat: run traces — full AI conversation replay (closes #161)

### DIFF
--- a/apps/api/alembic/versions/0017_run_traces.py
+++ b/apps/api/alembic/versions/0017_run_traces.py
@@ -1,0 +1,44 @@
+"""add run_traces table for full AI conversation replay
+
+Revision ID: 0017
+Revises: 0016
+Create Date: 2026-05-26
+
+One row per turn per role inside an agentic brain block.
+Enables full conversation replay, prompt debugging, and audit log.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+revision = "0017"
+down_revision = "0016"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "run_traces",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("run_id", UUID(as_uuid=True), sa.ForeignKey("runs.id", ondelete="CASCADE"), nullable=False),
+        sa.Column("block_id", sa.String(255), nullable=False),
+        sa.Column("turn", sa.Integer(), nullable=False),
+        sa.Column("role", sa.String(50), nullable=False),
+        sa.Column("content", sa.Text(), nullable=True),
+        sa.Column("tool_name", sa.String(255), nullable=True),
+        sa.Column("tool_input", JSONB(), nullable=True),
+        sa.Column("tool_use_id", sa.String(255), nullable=True),
+        sa.Column("input_tokens", sa.Integer(), nullable=True),
+        sa.Column("output_tokens", sa.Integer(), nullable=True),
+        sa.Column("duration_ms", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_run_traces_run_id", "run_traces", ["run_id"])
+    op.create_index("ix_run_traces_run_id_block_turn", "run_traces", ["run_id", "block_id", "turn"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_run_traces_run_id_block_turn", table_name="run_traces")
+    op.drop_index("ix_run_traces_run_id", table_name="run_traces")
+    op.drop_table("run_traces")

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -7,10 +7,11 @@ from app.models.workflow import Workflow, WorkflowVersion
 from app.models.integration import Integration
 from app.models.run import Run, RunEvent
 from app.models.run_analytics_event import RunAnalyticsEvent
+from app.models.run_trace import RunTrace
 from app.models.email_template import EmailTemplate
 
 __all__ = [
     "Organization", "Workspace", "User", "WorkspaceUser", "Project",
     "Workflow", "WorkflowVersion", "Integration", "Run", "RunEvent",
-    "RunAnalyticsEvent", "EmailTemplate",
+    "RunAnalyticsEvent", "RunTrace", "EmailTemplate",
 ]

--- a/apps/api/app/models/run_trace.py
+++ b/apps/api/app/models/run_trace.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime, timezone
+import sqlalchemy as sa
+from sqlalchemy import Column, String, DateTime, Integer, Text, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.orm import relationship
+from app.core.database import Base
+
+
+class RunTrace(Base):
+    __tablename__ = "run_traces"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id = Column(UUID(as_uuid=True), ForeignKey("runs.id", ondelete="CASCADE"), nullable=False)
+    block_id = Column(String(255), nullable=False)
+    turn = Column(Integer, nullable=False)
+    role = Column(String(50), nullable=False)   # user | assistant | tool_use | tool_result
+    content = Column(Text, nullable=True)
+    tool_name = Column(String(255), nullable=True)
+    tool_input = Column(JSONB, nullable=True)
+    tool_use_id = Column(String(255), nullable=True)
+    input_tokens = Column(Integer, nullable=True)
+    output_tokens = Column(Integer, nullable=True)
+    duration_ms = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    run = relationship("Run", backref="traces")

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -335,6 +335,43 @@ class ApprovalDecision(BaseModel):
     approver: str | None = None
 
 
+@router.get("/{run_id}/trace")
+def get_run_trace(
+    workflow_id: UUID,
+    run_id: UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
+):
+    """Return the full AI conversation trace for a run — ordered by turn and role."""
+    _get_workflow(workflow_id, workspace_id, db)
+    _get_run(run_id, workflow_id, db)
+    from app.models.run_trace import RunTrace
+    rows = (
+        db.query(RunTrace)
+        .filter(RunTrace.run_id == run_id)
+        .order_by(RunTrace.block_id, RunTrace.turn, RunTrace.created_at)
+        .all()
+    )
+    return [
+        {
+            "id": str(r.id),
+            "block_id": r.block_id,
+            "turn": r.turn,
+            "role": r.role,
+            "content": r.content,
+            "tool_name": r.tool_name,
+            "tool_input": r.tool_input,
+            "tool_use_id": r.tool_use_id,
+            "input_tokens": r.input_tokens,
+            "output_tokens": r.output_tokens,
+            "duration_ms": r.duration_ms,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in rows
+    ]
+
+
 @router.post("/{run_id}/cancel")
 def cancel_run(
     workflow_id: UUID,

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -67,6 +67,19 @@ def _redact_payload(payload: dict) -> dict:
     return out
 
 
+def _write_trace(db, run_id, block_id: str, turn: int, role: str, **kwargs) -> None:
+    """Write one run_trace row. Fire-and-forget — never raises."""
+    try:
+        from app.models.run_trace import RunTrace
+        db.add(RunTrace(run_id=run_id, block_id=block_id, turn=turn, role=role, **kwargs))
+        db.commit()
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+
 def _emit(db, run_id, block_id: str | None, kind: str, payload: dict):
     event = RunEvent(run_id=run_id, block_id=block_id, kind=kind, payload=_redact_payload(payload))
     db.add(event)
@@ -587,6 +600,13 @@ def _execute_brain(
 
         model_id = block["data"].get("model") or "claude-sonnet-4-6"
         while turns < max_turns:
+            # Trace: user turn
+            if db and run_id and block_id:
+                turn_msg = messages[-1] if messages else {}
+                user_content = turn_msg.get("content", "") if isinstance(turn_msg.get("content"), str) else ""
+                _write_trace(db, run_id, block_id, turns + 1, "user",
+                             content=user_content[:8000] if user_content else None)
+
             response = client.messages.create(
                 model=model_id,
                 max_tokens=4096,
@@ -595,14 +615,22 @@ def _execute_brain(
                 messages=messages,
             )
             turns += 1
-            if hasattr(response, "usage") and response.usage:
-                total_input_tokens += getattr(response.usage, "input_tokens", 0)
-                total_output_tokens += getattr(response.usage, "output_tokens", 0)
+            in_tok = getattr(getattr(response, "usage", None), "input_tokens", 0)
+            out_tok = getattr(getattr(response, "usage", None), "output_tokens", 0)
+            if in_tok or out_tok:
+                total_input_tokens += in_tok
+                total_output_tokens += out_tok
 
             # Collect tool calls from response
             tool_calls = [b for b in response.content if b.type == "tool_use"]
             text_blocks = [b for b in response.content if b.type == "text"]
             final_text = " ".join(b.text for b in text_blocks)
+
+            # Trace: assistant response
+            if db and run_id and block_id:
+                _write_trace(db, run_id, block_id, turns, "assistant",
+                             content=final_text[:8000] if final_text else None,
+                             input_tokens=in_tok, output_tokens=out_tok)
 
             # First-turn sufficiency check — fail fast before any tools are used
             if turns == 1 and final_text.strip().startswith("NEEDS_CLARIFICATION:"):
@@ -667,14 +695,19 @@ def _execute_brain(
             # Execute tool calls and build tool_result message
             tool_results = []
             for tc in tool_calls:
+                # Trace: tool_use
+                if db and run_id and block_id:
+                    _write_trace(db, run_id, block_id, turns, "tool_use",
+                                 tool_name=tc.name,
+                                 tool_input=dict(tc.input) if tc.input else None,
+                                 tool_use_id=tc.id)
+
                 # Track working dir if Brain runs shell commands
                 if tc.name == "run_shell" and tc.input.get("working_dir"):
                     working_dir = tc.input["working_dir"]
                 try:
                     result_content = _local_dispatch(tc.name, tc.input)
                 except RuntimeError as sandbox_err:
-                    # Surface Modal/sandbox errors into the run trace so they're
-                    # visible in the RunDrawer instead of silently failing.
                     if db and run_id:
                         _emit(db, run_id, block_id, "brain_tool_call", {
                             "tool": "modal_error",
@@ -687,6 +720,11 @@ def _execute_brain(
                     "tool_use_id": tc.id,
                     "content": result_content,
                 })
+                # Trace: tool_result
+                if db and run_id and block_id:
+                    _write_trace(db, run_id, block_id, turns, "tool_result",
+                                 content=result_content[:8000] if result_content else None,
+                                 tool_use_id=tc.id)
                 if db and run_id:
                     _emit(db, run_id, block_id, "brain_tool_call", {
                         "tool": tc.name,

--- a/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
 import Link from "next/link"
 import RunTrace from "@/components/runs/RunTrace"
+import ConversationTrace from "@/components/runs/ConversationTrace"
 import AppShell from "@/components/AppShell"
 
 function getCookie(name: string): string | null {
@@ -34,6 +35,7 @@ export default function RunDetailPage() {
   const [workflowName, setWorkflowName] = useState<string | null>(null)
   const [agentModel, setAgentModel] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
+  const [activeTab, setActiveTab] = useState<"timeline" | "trace">("timeline")
 
   useEffect(() => {
     if (!isLoaded) return  // wait for Clerk to initialize before fetching
@@ -156,22 +158,47 @@ export default function RunDetailPage() {
           </button>
         </div>
 
+        {/* Tab bar */}
+        <div className="flex gap-1 border-b border-stone-200 mb-4">
+          {(["timeline", "trace"] as const).map(tab => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-xs font-medium capitalize rounded-t-lg transition-colors ${
+                activeTab === tab
+                  ? "bg-white border border-b-white border-stone-200 text-stone-900 -mb-px"
+                  : "text-stone-400 hover:text-stone-600"
+              }`}
+            >
+              {tab === "trace" ? "AI Trace" : "Timeline"}
+            </button>
+          ))}
+        </div>
+
         <div className="bg-white rounded-xl border border-stone-200 p-6">
-          <RunTrace
-            workflowId={workflowId}
-            runId={runId}
-            initialStatus={run.status}
-            initialMeta={{
-              triggered_by: run.triggered_by,
-              started_at: run.started_at,
-              completed_at: run.completed_at,
-              paused_at: run.paused_at,
-              current_block_id: run.current_block_id,
-              workflow_version_id: run.workflow_version_id ?? null,
-            }}
-            maxTurns={run.max_turns ?? null}
-            getToken={getToken}
-          />
+          {activeTab === "timeline" ? (
+            <RunTrace
+              workflowId={workflowId}
+              runId={runId}
+              initialStatus={run.status}
+              initialMeta={{
+                triggered_by: run.triggered_by,
+                started_at: run.started_at,
+                completed_at: run.completed_at,
+                paused_at: run.paused_at,
+                current_block_id: run.current_block_id,
+                workflow_version_id: run.workflow_version_id ?? null,
+              }}
+              maxTurns={run.max_turns ?? null}
+              getToken={getToken}
+            />
+          ) : (
+            <ConversationTrace
+              workflowId={workflowId}
+              runId={runId}
+              getToken={getToken}
+            />
+          )}
         </div>
       </div>
     </AppShell>

--- a/apps/web/src/components/runs/ConversationTrace.tsx
+++ b/apps/web/src/components/runs/ConversationTrace.tsx
@@ -1,0 +1,163 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+interface TraceRow {
+  id: string
+  block_id: string
+  turn: number
+  role: "user" | "assistant" | "tool_use" | "tool_result"
+  content: string | null
+  tool_name: string | null
+  tool_input: Record<string, unknown> | null
+  tool_use_id: string | null
+  input_tokens: number | null
+  output_tokens: number | null
+  created_at: string | null
+}
+
+interface Props {
+  workflowId: string
+  runId: string
+  getToken?: (() => Promise<string | null>) | null
+}
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return m ? decodeURIComponent(m[1]) : null
+}
+
+async function buildHeaders(getToken?: (() => Promise<string | null>) | null): Promise<Record<string, string>> {
+  const h: Record<string, string> = {}
+  if (getToken) {
+    const token = await getToken()
+    if (token) h["Authorization"] = `Bearer ${token}`
+  }
+  const ws = getCookie("delegator_project_id")
+  if (ws) h["X-Workspace-Id"] = ws
+  return h
+}
+
+const ROLE_STYLES: Record<string, { bg: string; label: string; dot: string }> = {
+  user:        { bg: "bg-blue-50 border-blue-100",   label: "User",        dot: "bg-blue-400"   },
+  assistant:   { bg: "bg-purple-50 border-purple-100", label: "Assistant", dot: "bg-purple-400" },
+  tool_use:    { bg: "bg-amber-50 border-amber-100",  label: "Tool Call",  dot: "bg-amber-400"  },
+  tool_result: { bg: "bg-stone-50 border-stone-200",  label: "Result",     dot: "bg-stone-300"  },
+}
+
+function TraceRow({ row }: { row: TraceRow }) {
+  const [expanded, setExpanded] = useState(false)
+  const style = ROLE_STYLES[row.role] ?? ROLE_STYLES.user
+  const hasLongContent = (row.content?.length ?? 0) > 400
+
+  return (
+    <div className={`rounded-lg border px-3 py-2 text-xs ${style.bg}`}>
+      <div className="flex items-center gap-2 mb-1">
+        <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${style.dot}`} />
+        <span className="font-semibold text-stone-600 uppercase tracking-wider text-[9px]">{style.label}</span>
+        {row.tool_name && (
+          <span className="font-mono text-amber-700 text-[10px]">{row.tool_name}</span>
+        )}
+        <span className="ml-auto text-stone-400 font-mono text-[9px]">turn {row.turn}</span>
+        {row.input_tokens != null && row.input_tokens > 0 && (
+          <span className="text-stone-400 font-mono text-[9px]">{row.input_tokens}↑ {row.output_tokens}↓</span>
+        )}
+      </div>
+
+      {/* Tool input */}
+      {row.role === "tool_use" && row.tool_input && (
+        <pre className="font-mono text-[10px] text-stone-600 bg-white/60 rounded p-1.5 overflow-x-auto whitespace-pre-wrap max-h-40">
+          {JSON.stringify(row.tool_input, null, 2)}
+        </pre>
+      )}
+
+      {/* Content */}
+      {row.content && (
+        <>
+          <p className={`text-stone-700 leading-relaxed whitespace-pre-wrap ${!expanded && hasLongContent ? "line-clamp-4" : ""}`}>
+            {row.content}
+          </p>
+          {hasLongContent && (
+            <button
+              onClick={() => setExpanded(e => !e)}
+              className="mt-1 text-[10px] text-stone-400 hover:text-stone-600"
+            >
+              {expanded ? "▾ collapse" : "▸ expand"}
+            </button>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+export default function ConversationTrace({ workflowId, runId, getToken }: Props) {
+  const [rows, setRows] = useState<TraceRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const headers = await buildHeaders(getToken)
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs/${runId}/trace`,
+          { headers }
+        )
+        if (!res.ok) throw new Error(`${res.status}`)
+        setRows(await res.json())
+      } catch (e) {
+        setError(String(e))
+      } finally {
+        setLoading(false)
+      }
+    }
+    load()
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowId, runId])
+
+  if (loading) return <p className="text-sm text-stone-400 py-6 text-center">Loading trace…</p>
+  if (error) return <p className="text-sm text-red-500 py-6 text-center">Failed to load trace: {error}</p>
+  if (rows.length === 0) return (
+    <p className="text-sm text-stone-400 py-6 text-center">
+      No trace data — only agentic brain blocks generate traces.
+    </p>
+  )
+
+  // Group by block_id for section headers
+  const blocks: { blockId: string; rows: TraceRow[] }[] = []
+  for (const row of rows) {
+    const last = blocks[blocks.length - 1]
+    if (last?.blockId === row.block_id) {
+      last.rows.push(row)
+    } else {
+      blocks.push({ blockId: row.block_id, rows: [row] })
+    }
+  }
+
+  const totalInput = rows.reduce((a, r) => a + (r.input_tokens ?? 0), 0)
+  const totalOutput = rows.reduce((a, r) => a + (r.output_tokens ?? 0), 0)
+  const totalCost = ((totalInput * 3 + totalOutput * 15) / 1_000_000)
+
+  return (
+    <div className="space-y-4">
+      {/* Summary */}
+      <div className="flex items-center gap-4 text-xs text-stone-500 border-b border-stone-100 pb-3">
+        <span>{rows.length} trace rows</span>
+        {totalInput > 0 && <span>{(totalInput + totalOutput).toLocaleString()} tokens · ${totalCost.toFixed(4)}</span>}
+      </div>
+
+      {blocks.map(({ blockId, rows: blockRows }) => (
+        <div key={blockId}>
+          <p className="text-[9px] font-bold uppercase tracking-widest text-stone-400 mb-2 font-mono">
+            {blockId}
+          </p>
+          <div className="space-y-1.5">
+            {blockRows.map(row => <TraceRow key={row.id} row={row} />)}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- New `run_traces` table (migration 0017) — one row per turn per role inside an agentic brain block
- Executor writes trace rows at every turn: user prompt, assistant response (with token counts), tool_use (with tool name + input), tool_result (with output content)
- GET /workflows/{id}/runs/{run_id}/trace endpoint returns ordered trace for a run
- Run detail page gains a Timeline / AI Trace tab switcher
- ConversationTrace component: color-coded rows by role, token counts per assistant turn, total cost at top, collapsible long content, grouped by block_id

## What this unlocks
- Full AI conversation replay for debugging and prompt improvement
- Audit log: every tool call (file reads, shell commands, writes) is timestamped and queryable
- Exact token usage per run, per block

## Files changed
- apps/api/app/models/run_trace.py (new) — ORM model
- apps/api/alembic/versions/0017_run_traces.py (new) — migration
- apps/api/app/models/__init__.py — exports RunTrace
- apps/api/app/runtime/executor.py — writes trace rows in agentic loop
- apps/api/app/routers/runs.py — GET /{run_id}/trace endpoint
- apps/web/src/components/runs/ConversationTrace.tsx (new) — trace viewer
- apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx — tab switcher

## Test plan
- [ ] Run an agentic workflow, open run detail, AI Trace tab shows rows
- [ ] Verify user/assistant/tool_use/tool_result rows in order
- [ ] Token counts shown per assistant turn
- [ ] tool_input JSON shown for tool_use rows
- [ ] Non-agentic run shows "No trace data" message
- [ ] GET /runs/{id}/trace returns 200 with ordered rows