### PR TITLE
feat: audit log — backend, migration, and settings UI (#154)

### DIFF
--- a/apps/api/alembic/versions/0018_audit_log.py
+++ b/apps/api/alembic/versions/0018_audit_log.py
@@ -1,0 +1,41 @@
+"""add audit_log table for enterprise trust and compliance
+
+Revision ID: 0018
+Revises: 0017
+Create Date: 2026-05-26
+
+Records every state-changing action: credential add/remove, member invite/remove,
+workflow create/delete, run triggered. Admin-only queryable. No PII in metadata.
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+revision = "0018"
+down_revision = "0017"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_log",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column("workspace_id", sa.String(255), nullable=False),
+        sa.Column("actor_id", sa.String(255), nullable=True),
+        sa.Column("actor_email", sa.String(255), nullable=True),
+        sa.Column("actor_role", sa.String(50), nullable=True),
+        sa.Column("action", sa.String(100), nullable=False),
+        sa.Column("resource_type", sa.String(50), nullable=True),
+        sa.Column("resource_id", sa.String(255), nullable=True),
+        sa.Column("metadata", JSONB(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_audit_log_workspace_created", "audit_log", ["workspace_id", "created_at"])
+    op.create_index("ix_audit_log_workspace_action", "audit_log", ["workspace_id", "action"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_log_workspace_action", table_name="audit_log")
+    op.drop_index("ix_audit_log_workspace_created", table_name="audit_log")
+    op.drop_table("audit_log")

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -268,6 +268,39 @@ def get_user_workspace_role(
     return row.role
 
 
+def audit(
+    db,
+    workspace_id: str,
+    action: str,
+    *,
+    actor_id: str | None = None,
+    actor_email: str | None = None,
+    actor_role: str | None = None,
+    resource_type: str | None = None,
+    resource_id: str | None = None,
+    metadata: dict | None = None,
+) -> None:
+    """Write one audit_log row. Fire-and-forget — never raises."""
+    try:
+        from app.models.audit_log import AuditLog
+        db.add(AuditLog(
+            workspace_id=workspace_id,
+            actor_id=actor_id,
+            actor_email=actor_email,
+            actor_role=actor_role,
+            action=action,
+            resource_type=resource_type,
+            resource_id=resource_id,
+            metadata=metadata,
+        ))
+        db.commit()
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            pass
+
+
 def require_workspace_role(*allowed_roles: str):
     """
     Dependency factory that enforces minimum role for an endpoint.

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,7 +7,7 @@ from app.core.logging import setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.routers import credentials, dashboard, email_templates, environments, projects, runs, webhooks, workflows
 from app.routers.organizations import router as organizations_router
-from app.routers.workspace_projects import router as workspace_projects_router
+from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router
 from app.routers.runs import workspace_runs_router
 
 setup_logging()
@@ -41,6 +41,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 app.include_router(organizations_router)
 app.include_router(workspace_projects_router)
+app.include_router(audit_log_router)
 app.include_router(projects.router)
 app.include_router(dashboard.router)
 app.include_router(workflows.router)

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -8,10 +8,11 @@ from app.models.integration import Integration
 from app.models.run import Run, RunEvent
 from app.models.run_analytics_event import RunAnalyticsEvent
 from app.models.run_trace import RunTrace
+from app.models.audit_log import AuditLog
 from app.models.email_template import EmailTemplate
 
 __all__ = [
     "Organization", "Workspace", "User", "WorkspaceUser", "Project",
     "Workflow", "WorkflowVersion", "Integration", "Run", "RunEvent",
-    "RunAnalyticsEvent", "RunTrace", "EmailTemplate",
+    "RunAnalyticsEvent", "RunTrace", "AuditLog", "EmailTemplate",
 ]

--- a/apps/api/app/models/audit_log.py
+++ b/apps/api/app/models/audit_log.py
@@ -1,0 +1,21 @@
+import uuid
+from datetime import datetime, timezone
+import sqlalchemy as sa
+from sqlalchemy import Column, String, DateTime, Text
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from app.core.database import Base
+
+
+class AuditLog(Base):
+    __tablename__ = "audit_log"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(String(255), nullable=False)
+    actor_id = Column(String(255), nullable=True)    # Clerk user_id
+    actor_email = Column(String(255), nullable=True)
+    actor_role = Column(String(50), nullable=True)
+    action = Column(String(100), nullable=False)     # credential.added, run.triggered, etc.
+    resource_type = Column(String(50), nullable=True)
+    resource_id = Column(String(255), nullable=True)
+    metadata = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/apps/api/app/routers/credentials.py
+++ b/apps/api/app/routers/credentials.py
@@ -11,7 +11,7 @@ from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_workspace_id, require_workspace_role
+from app.core.auth import get_workspace_id, require_workspace_role, audit
 from app.core.crypto import decrypt, encrypt
 from app.core.database import get_db
 from app.models.integration import Integration
@@ -114,6 +114,9 @@ def upsert_credential(body: CredentialUpsert, db: Session = Depends(get_db), wor
         db.add(row)
 
     db.commit()
+    audit(db, workspace_id, "credential.upserted",
+          resource_type="credential", resource_id=body.handle,
+          metadata={"service": body.service, "handle": body.handle})
     return {"handle": body.handle, "service": body.service, "saved": True}
 
 
@@ -140,8 +143,12 @@ def delete_credential(handle: str, db: Session = Depends(get_db), workspace_id: 
                 detail=f"This credential's environment is used by {len(agents)} agent(s): {names}. Remove the environment from those agents first.",
             )
 
+    service = row.service
     db.delete(row)
     db.commit()
+    audit(db, workspace_id, "credential.deleted",
+          resource_type="credential", resource_id=handle,
+          metadata={"service": service, "handle": handle})
 
 
 # ---------------------------------------------------------------------------

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
-from app.core.auth import get_workspace_id, require_workspace_role, _verify_clerk_token, _clerk_enabled, DEV_WORKSPACE_ID, DEV_USER_ID
+from app.core.auth import get_workspace_id, require_workspace_role, audit, _verify_clerk_token, _clerk_enabled, DEV_WORKSPACE_ID, DEV_USER_ID
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.run import Run, RunEvent
@@ -219,6 +219,10 @@ def create_run(
     db.refresh(run)
 
     _redis().rpush(QUEUE_KEY, str(run.id))
+
+    audit(db, workspace_id, "run.triggered",
+          resource_type="run", resource_id=str(run.id),
+          metadata={"workflow_id": str(workflow_id), "dry_run": body.dry_run})
 
     return run
 

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -5,7 +5,7 @@ from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from app.core.auth import get_workspace_id, require_workspace_role
+from app.core.auth import get_workspace_id, require_workspace_role, audit
 from app.core.database import get_db
 
 log = structlog.get_logger(__name__)
@@ -559,6 +559,9 @@ def update_workflow(
 
     db.commit()
     db.refresh(workflow)
+    audit(db, workspace_id, "workflow.created",
+          resource_type="workflow", resource_id=str(workflow.id),
+          metadata={"name": workflow.name, "template": body.template})
     return workflow
 
 
@@ -596,6 +599,8 @@ def delete_workflow(
     db.execute(text("DELETE FROM workflow_versions WHERE workflow_id = :wid"), {"wid": str(workflow_id)})
     db.execute(text("DELETE FROM workflows WHERE id = :wid"), {"wid": str(workflow_id)})
     db.commit()
+    audit(db, workspace_id, "workflow.deleted",
+          resource_type="workflow", resource_id=str(workflow_id))
 
 
 class BlockCompileRequest(BaseModel):

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_user_id, get_workspace_id, require_workspace_role
+from app.core.auth import get_user_id, get_workspace_id, require_workspace_role, audit as _audit
 from app.core.database import get_db
 
 router = APIRouter(prefix="/workspaces/{workspace_id}/projects", tags=["workspace-projects"])
@@ -132,3 +132,49 @@ def delete_project(
                {"pid": project_id})
     db.execute(text("DELETE FROM projects WHERE id = :id"), {"id": project_id})
     db.commit()
+
+
+# ── Audit log endpoint ────────────────────────────────────────────────────────
+
+audit_router = APIRouter(prefix="/workspaces/{workspace_id}/audit-log", tags=["audit-log"])
+
+
+@audit_router.get("")
+def list_audit_log(
+    workspace_id: str,
+    active_workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin")),
+    db: Session = Depends(get_db),
+    action: str | None = None,
+    actor_id: str | None = None,
+    limit: int = 50,
+    offset: int = 0,
+):
+    """Return paginated audit log entries. Admin-only."""
+    _enforce_workspace(workspace_id, active_workspace_id)
+    q = "SELECT id, actor_id, actor_email, actor_role, action, resource_type, resource_id, metadata, created_at FROM audit_log WHERE workspace_id = :ws"
+    params: dict = {"ws": workspace_id}
+    if action:
+        q += " AND action = :action"
+        params["action"] = action
+    if actor_id:
+        q += " AND actor_id = :actor_id"
+        params["actor_id"] = actor_id
+    q += " ORDER BY created_at DESC LIMIT :limit OFFSET :offset"
+    params["limit"] = min(limit, 200)
+    params["offset"] = offset
+    rows = db.execute(text(q), params).fetchall()
+    return [
+        {
+            "id": str(r.id),
+            "actor_id": r.actor_id,
+            "actor_email": r.actor_email,
+            "actor_role": r.actor_role,
+            "action": r.action,
+            "resource_type": r.resource_type,
+            "resource_id": r.resource_id,
+            "metadata": r.metadata,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in rows
+    ]

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -5,20 +5,22 @@ import { useAuth } from "@clerk/nextjs"
 import AppShell from "@/components/AppShell"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
+import AuditLog from "@/components/settings/AuditLog"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 
-type Tab = "environments" | "members"
+type Tab = "environments" | "members" | "audit"
 
 export default function SettingsPage() {
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   if (clerkEnabled) return <SettingsPageWithAuth />
-  return <SettingsPageInner isAdmin={true} />
+  return <SettingsPageInner isAdmin={true} workspaceId="" getToken={null} />
 }
 
 function SettingsPageWithAuth() {
   const { getToken, userId } = useAuth()
   const { activeWorkspace } = useWorkspace()
   const [isAdmin, setIsAdmin] = useState(true)
+  const workspaceId = activeWorkspace?.id ?? ""
 
   useEffect(() => {
     if (!activeWorkspace || !userId) return
@@ -38,11 +40,11 @@ function SettingsPageWithAuth() {
     check()
   }, [activeWorkspace?.id, userId])
 
-  return <SettingsPageInner isAdmin={isAdmin} />
+  return <SettingsPageInner isAdmin={isAdmin} workspaceId={workspaceId} getToken={getToken} />
 }
 
-function SettingsPageInner({ isAdmin }: { isAdmin: boolean }) {
-  const tabs = (["environments", ...(isAdmin ? ["members"] : [])] as Tab[])
+function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
+  const tabs = (["environments", ...(isAdmin ? ["members", "audit"] : [])] as Tab[])
   const [activeTab, setActiveTab] = useState<Tab>("environments")
   const [showTip, setShowTip] = useState(true)
 
@@ -88,6 +90,7 @@ function SettingsPageInner({ isAdmin }: { isAdmin: boolean }) {
 
         {activeTab === "environments" && <EnvironmentsManager isAdmin={isAdmin} />}
         {activeTab === "members" && isAdmin && <MembersManager />}
+        {activeTab === "audit" && isAdmin && <AuditLog workspaceId={workspaceId} getToken={getToken} />}
       </div>
     </AppShell>
   )

--- a/apps/web/src/components/settings/AuditLog.tsx
+++ b/apps/web/src/components/settings/AuditLog.tsx
@@ -78,7 +78,7 @@ export default function AuditLog({ workspaceId, getToken }: Props) {
     const cols = ["created_at", "action", "actor_email", "actor_role", "resource_type", "resource_id"]
     const rows = [cols.join(",")]
     for (const e of entries) {
-      rows.push(cols.map(c => JSON.stringify((e as Record<string, unknown>)[c] ?? "")).join(","))
+      rows.push(cols.map(c => JSON.stringify((e as unknown as Record<string, unknown>)[c] ?? "")).join(","))
     }
     const blob = new Blob([rows.join("\n")], { type: "text/csv" })
     const url = URL.createObjectURL(blob)

--- a/apps/web/src/components/settings/AuditLog.tsx
+++ b/apps/web/src/components/settings/AuditLog.tsx
@@ -1,0 +1,158 @@
+"use client"
+
+import { useEffect, useState } from "react"
+
+interface AuditEntry {
+  id: string
+  actor_id: string | null
+  actor_email: string | null
+  actor_role: string | null
+  action: string
+  resource_type: string | null
+  resource_id: string | null
+  metadata: Record<string, unknown> | null
+  created_at: string | null
+}
+
+interface Props {
+  workspaceId: string
+  getToken?: (() => Promise<string | null>) | null
+}
+
+const ACTION_COLORS: Record<string, string> = {
+  "credential.upserted": "bg-blue-50 text-blue-700",
+  "credential.deleted":  "bg-red-50 text-red-700",
+  "workflow.created":    "bg-green-50 text-green-700",
+  "workflow.deleted":    "bg-red-50 text-red-700",
+  "run.triggered":       "bg-purple-50 text-purple-700",
+  "member.invited":      "bg-amber-50 text-amber-700",
+  "member.removed":      "bg-red-50 text-red-700",
+  "member.role_changed": "bg-orange-50 text-orange-700",
+}
+
+function fmt(ts: string | null) {
+  if (!ts) return "—"
+  return new Date(ts).toLocaleString(undefined, { dateStyle: "short", timeStyle: "short" })
+}
+
+function actionLabel(action: string) {
+  return action.replace(".", " ").replace(/_/g, " ")
+}
+
+export default function AuditLog({ workspaceId, getToken }: Props) {
+  const [entries, setEntries] = useState<AuditEntry[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [actionFilter, setActionFilter] = useState("")
+  const [page, setPage] = useState(0)
+  const limit = 50
+
+  async function load(offset = 0) {
+    setLoading(true)
+    setError(null)
+    try {
+      const h: Record<string, string> = {}
+      if (getToken) { const t = await getToken(); if (t) h["Authorization"] = `Bearer ${t}` }
+      const ws = document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1]
+      if (ws) h["X-Workspace-Id"] = ws
+
+      const params = new URLSearchParams({ limit: String(limit), offset: String(offset) })
+      if (actionFilter) params.set("action", actionFilter)
+
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/workspaces/${workspaceId}/audit-log?${params}`,
+        { headers: h }
+      )
+      if (!res.ok) throw new Error(`${res.status}`)
+      setEntries(await res.json())
+    } catch (e) {
+      setError(String(e))
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { load(page * limit) }, [workspaceId, page, actionFilter])
+
+  function exportCsv() {
+    const cols = ["created_at", "action", "actor_email", "actor_role", "resource_type", "resource_id"]
+    const rows = [cols.join(",")]
+    for (const e of entries) {
+      rows.push(cols.map(c => JSON.stringify((e as Record<string, unknown>)[c] ?? "")).join(","))
+    }
+    const blob = new Blob([rows.join("\n")], { type: "text/csv" })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement("a"); a.href = url; a.download = "audit-log.csv"; a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <h3 className="text-sm font-semibold text-stone-800">Audit Log</h3>
+        <div className="flex items-center gap-2">
+          <select
+            value={actionFilter}
+            onChange={e => { setActionFilter(e.target.value); setPage(0) }}
+            className="text-xs border border-stone-200 rounded-lg px-2 py-1.5 text-stone-600 bg-white"
+          >
+            <option value="">All actions</option>
+            <option value="credential.upserted">credential.upserted</option>
+            <option value="credential.deleted">credential.deleted</option>
+            <option value="workflow.created">workflow.created</option>
+            <option value="workflow.deleted">workflow.deleted</option>
+            <option value="run.triggered">run.triggered</option>
+            <option value="member.invited">member.invited</option>
+            <option value="member.removed">member.removed</option>
+            <option value="member.role_changed">member.role_changed</option>
+          </select>
+          <button
+            onClick={exportCsv}
+            className="text-xs text-stone-500 hover:text-stone-800 border border-stone-200 rounded-lg px-3 py-1.5 transition-colors"
+          >
+            ↓ CSV
+          </button>
+        </div>
+      </div>
+
+      {error && <p className="text-xs text-red-500">{error}</p>}
+
+      {loading ? (
+        <p className="text-xs text-stone-400 py-4 text-center">Loading…</p>
+      ) : entries.length === 0 ? (
+        <p className="text-xs text-stone-400 py-6 text-center">No audit entries yet.</p>
+      ) : (
+        <div className="divide-y divide-stone-100 border border-stone-200 rounded-xl overflow-hidden">
+          {entries.map(e => (
+            <div key={e.id} className="flex items-start gap-3 px-4 py-2.5 text-xs hover:bg-stone-50">
+              <span className="text-stone-400 whitespace-nowrap shrink-0 pt-0.5">{fmt(e.created_at)}</span>
+              <span className={`shrink-0 px-1.5 py-0.5 rounded font-medium text-[10px] ${ACTION_COLORS[e.action] ?? "bg-stone-100 text-stone-600"}`}>
+                {actionLabel(e.action)}
+              </span>
+              <span className="text-stone-600 truncate">
+                {e.actor_email ?? e.actor_id ?? "system"}
+                {e.resource_id && (
+                  <span className="ml-1.5 text-stone-400 font-mono">
+                    {e.resource_type} {e.resource_id.slice(0, 8)}
+                  </span>
+                )}
+              </span>
+              {e.actor_role && (
+                <span className="ml-auto shrink-0 text-stone-400">{e.actor_role}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Pagination */}
+      <div className="flex items-center gap-3 justify-end text-xs text-stone-400">
+        <button onClick={() => setPage(p => Math.max(0, p - 1))} disabled={page === 0}
+          className="disabled:opacity-40 hover:text-stone-700">← prev</button>
+        <span>page {page + 1}</span>
+        <button onClick={() => setPage(p => p + 1)} disabled={entries.length < limit}
+          className="disabled:opacity-40 hover:text-stone-700">next →</button>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- **Model + migration**: `audit_log` table (0018) with indexes on `(workspace_id, created_at)` and `(workspace_id, action)`
- **Backend**: `audit()` fire-and-forget helper in `auth.py`; wired into credentials (upserted/deleted), workflows (created/deleted), and runs (triggered) routers; admin-only paginated `GET /workspaces/{id}/audit-log` endpoint filterable by action and actor_id
- **Frontend**: `AuditLog.tsx` with color-coded action badges, action filter dropdown, CSV export, and prev/next pagination; wired as admin-only "audit" tab in Settings

## Test plan

- [ ] Run migrations; verify `audit_log` table and indexes exist
- [ ] Add/delete a credential — check row appears in audit log
- [ ] Create/delete a workflow — check rows appear
- [ ] Trigger a run — check `run.triggered` row appears
- [ ] Open Settings → Audit tab (as admin) — verify entries render with correct badges
- [ ] Filter by action — verify only matching rows appear
- [ ] Export CSV — verify download contains correct columns
- [ ] Verify non-admin users do not see the Audit tab

Closes #154