### PR TITLE
feat: Sentry SDK — auto-capture block/executor failures (#160)

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -58,6 +58,13 @@ class Settings(BaseSettings):
     modal_token_id: str = ""
     modal_token_secret: str = ""
 
+    # Sentry — leave blank to disable
+    sentry_dsn: str = ""
+    app_version: str = "1.0.0"
+
+    # Logging
+    log_level: str = "INFO"
+
     class Config:
         env_file = ".env"
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -13,6 +13,18 @@ from app.routers.runs import workspace_runs_router
 setup_logging()
 log = structlog.get_logger(__name__)
 
+if settings.sentry_dsn:
+    import sentry_sdk
+    from sentry_sdk.integrations.fastapi import FastApiIntegration
+    from sentry_sdk.integrations.starlette import StarletteIntegration
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        integrations=[FastApiIntegration(), StarletteIntegration()],
+        traces_sample_rate=0.1,
+        environment=settings.environment,
+        release=settings.app_version,
+    )
+
 app = FastAPI(title="Marshal API", version="0.1.0")
 
 _origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -1313,6 +1313,13 @@ def execute_run(run_id: str):
 
             except Exception as e:
                 log.exception("block.failed", block_id=block_id)
+                if settings.sentry_dsn:
+                    import sentry_sdk
+                    with sentry_sdk.push_scope() as scope:
+                        scope.set_tag("run_id", str(run_id))
+                        scope.set_tag("block_id", block_id)
+                        scope.set_tag("workspace_id", str(run.workspace_id) if hasattr(run, "workspace_id") else "")
+                        sentry_sdk.capture_exception(e)
                 failed = True
                 fail_error = str(e)
                 _emit(db, run_id, block_id, "block_failed", {"error": str(e)})
@@ -1342,6 +1349,11 @@ def execute_run(run_id: str):
 
     except Exception as e:
         log.exception("run.executor_crash", run_id=run_id)
+        if settings.sentry_dsn:
+            import sentry_sdk
+            with sentry_sdk.push_scope() as scope:
+                scope.set_tag("run_id", str(run_id))
+                sentry_sdk.capture_exception(e)
         try:
             run = db.query(Run).filter(Run.id == run_id).first()
             if run:

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -17,3 +17,4 @@ pytest==8.3.3
 pyyaml==6.0.2
 jinja2>=3.1.0
 structlog==24.4.0
+sentry-sdk[fastapi]==2.19.2


### PR DESCRIPTION
## Summary

- `sentry-sdk[fastapi]==2.19.2` added to requirements
- `SENTRY_DSN`, `APP_VERSION` settings added to `config.py` (empty = disabled, no-op)
- Sentry initialized in `main.py` with `FastApiIntegration` + `StarletteIntegration`; unhandled API exceptions captured automatically
- Block failure handler in `executor.py` calls `capture_exception` with `run_id`, `block_id`, `workspace_id` tags
- Executor crash handler also calls `capture_exception` with `run_id` tag

## Deployment

Set on Render production environment:
```
SENTRY_DSN=https://...@sentry.io/...
APP_VERSION=1.0.0
```

## Test plan

- [ ] Start API without `SENTRY_DSN` — no import errors, Sentry not initialized
- [ ] Set `SENTRY_DSN` and trigger a deliberate exception — verify it appears in Sentry within 30s with correct tags
- [ ] Fail a block run — verify `run_id` + `block_id` tags appear on the Sentry event

Closes #160