### PR TITLE
fix: register GitHub issues webhooks to /webhooks/github — enforces label filter

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -152,13 +152,20 @@ def _register_git_webhook(
     provider: str = "github",
     project_slug: str | None = None,
     secret: str | None = None,
+    workspace_id: str | None = None,
 ) -> tuple[str | None, str | None]:
     """Register a webhook on the git provider. Returns (hook_id, error_message)."""
     import httpx
     from app.core.config import settings
 
-    slug_segment = f"{project_slug}/" if project_slug else ""
-    webhook_url = f"{settings.api_base_url}/webhooks/inbound/{slug_segment}{workflow_id}"
+    # GitHub issue-based triggers must use /webhooks/github so label filtering
+    # (ai-ready, etc.) is enforced. The generic /webhooks/inbound endpoint has
+    # no label awareness and fires on every issues event.
+    if provider == "github" and "issues" in events and workspace_id:
+        webhook_url = f"{settings.api_base_url}/webhooks/github?workspace_id={workspace_id}"
+    else:
+        slug_segment = f"{project_slug}/" if project_slug else ""
+        webhook_url = f"{settings.api_base_url}/webhooks/inbound/{slug_segment}{workflow_id}"
 
     if provider == "gitlab":
         return _register_gitlab_webhook(token, repo, webhook_url, events, secret)
@@ -491,6 +498,7 @@ def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspa
                 provider=provider,
                 project_slug=project_slug,
                 secret=webhook_secret,
+                workspace_id=str(workspace_id),
             )
             if hook_id:
                 workflow.github_hook_id = hook_id


### PR DESCRIPTION
## Problem

When a workflow was installed with a GitHub repo trigger (autopilot_quick, issue_triage, etc.), the webhook was registered to `/webhooks/inbound/{workflow_id}` — the generic endpoint that fires on **every issues event** with no label filtering.

Result: every issue opened, closed, commented, or labeled (with anything) triggered an agent run, burning turn budget and queuing spurious runs.

## Fix

For GitHub + issues events, register the webhook to `/webhooks/github?workspace_id={id}` instead. That endpoint has full label filtering (`ai-ready` check, `_labels_match` logic) and only queues runs for the configured label.

Non-GitHub providers (GitLab, Bitbucket) and non-issues events (pull_request, workflow_run, etc.) continue using `/webhooks/inbound/` as before.

## After merging

Reinstall any existing Autopilot / Issue Triage workflows to re-register the webhook to the correct URL. Existing webhooks pointing to `/webhooks/inbound/` will need to be deleted from GitHub repo Settings → Webhooks.

Closes the misfiring runs seen in production on 2026-05-25.