### PR TITLE
fix: GitHub shows not connected despite token in environment

### DIFF
--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -1177,6 +1177,8 @@ function EnvironmentPanel({
 }) {
   const env = environments.find(e => e.id === selectedEnvId)
   const connectedServices = new Set(credentials.map(c => c.service))
+  // "git" handle covers GitHub/GitLab/Bitbucket — treat as "github" for display
+  if (connectedServices.has("git")) connectedServices.add("github")
 
   // Derive the services this workflow actually uses from block integrations
   const usedServices = Array.from(


### PR DESCRIPTION
## Problem

GitHub shows \"not connected\" in the canvas sidebar even when `GITHUB_TOKEN` is set in the environment.

## Root cause

`GITHUB_TOKEN` is stored via `_ENV_VAR_MAP` with `handle = "git"` → so `service = "git"` in the DB. The canvas checks `connectedServices.has("github")` — which never matches.

## Fix

After building `connectedServices` from credentials, if `"git"` is present, also add `"github"`. One line — the `"git"` handle covers GitHub, GitLab, and Bitbucket tokens.