### PR TITLE
feat: egress allowlist per environment (#206)

### DIFF
--- a/apps/api/alembic/versions/0019_environments_allowed_hosts.py
+++ b/apps/api/alembic/versions/0019_environments_allowed_hosts.py
@@ -1,0 +1,24 @@
+"""add allowed_hosts to environments for egress allowlist (#206)
+
+Revision ID: 0019
+Revises: 0018
+Create Date: 2026-05-25
+
+Nullable JSONB column — null means unrestricted (today's default).
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0019"
+down_revision = "0018"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("environments", sa.Column("allowed_hosts", JSONB(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("environments", "allowed_hosts")

--- a/apps/api/app/models/environment.py
+++ b/apps/api/app/models/environment.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.core.database import Base
 
@@ -13,6 +13,7 @@ class Environment(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
     name = Column(String(100), nullable=False)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    allowed_hosts = Column(JSONB, nullable=True)
 
     workspace = relationship("Workspace", back_populates="environments")
     integrations = relationship("Integration", back_populates="environment")

--- a/apps/api/app/routers/environments.py
+++ b/apps/api/app/routers/environments.py
@@ -24,15 +24,20 @@ class EnvironmentCreate(BaseModel):
     name: str
 
 
+class EnvironmentUpdate(BaseModel):
+    allowed_hosts: list[str] | None = None
+
+
 class EnvironmentOut(BaseModel):
     id: str
     name: str
     created_at: datetime
+    allowed_hosts: list[str] | None = None
     model_config = ConfigDict(from_attributes=True)
 
     @classmethod
     def from_orm_row(cls, row: Environment) -> "EnvironmentOut":
-        return cls(id=str(row.id), name=row.name, created_at=row.created_at)
+        return cls(id=str(row.id), name=row.name, created_at=row.created_at, allowed_hosts=row.allowed_hosts)
 
 
 @router.get("", response_model=list[EnvironmentOut])
@@ -71,6 +76,33 @@ def create_environment(
 
     env = Environment(workspace_id=workspace_id, name=name)
     db.add(env)
+    db.commit()
+    db.refresh(env)
+    return EnvironmentOut.from_orm_row(env)
+
+
+@router.patch("/{env_id}", response_model=EnvironmentOut)
+def update_environment(
+    env_id: UUID,
+    body: EnvironmentUpdate,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+):
+    env = (
+        db.query(Environment)
+        .filter(Environment.id == env_id, Environment.workspace_id == workspace_id)
+        .first()
+    )
+    if not env:
+        raise HTTPException(status_code=404, detail="Environment not found")
+
+    if body.allowed_hosts is not None:
+        cleaned = [h.strip().lower() for h in body.allowed_hosts if h.strip()]
+        env.allowed_hosts = cleaned if cleaned else None
+    else:
+        env.allowed_hosts = None
+
     db.commit()
     db.refresh(env)
     return EnvironmentOut.from_orm_row(env)

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -800,7 +800,30 @@ def _dry_run_mock(integration: str, action: str, params: dict) -> dict:
     }
 
 
-def _execute_tool(block: dict, state: dict, credentials: dict) -> dict:
+_INTEGRATION_HOSTS: dict[str, str] = {
+    "github": "api.github.com",
+    "slack": "slack.com",
+    "linear": "api.linear.app",
+    "digitalocean": "api.digitalocean.com",
+    "vercel": "api.vercel.com",
+    "railway": "backboard.railway.app",
+}
+
+
+def _check_egress(host: str, allowed_hosts: list[str] | None) -> None:
+    """Raise PermissionError if host is not in the environment's allowlist."""
+    if not allowed_hosts:
+        return
+    for pattern in allowed_hosts:
+        if pattern.startswith("*."):
+            if host == pattern[2:] or host.endswith("." + pattern[2:]):
+                return
+        elif host == pattern:
+            return
+    raise PermissionError(f"Host {host!r} is not in this environment's allowed_hosts list")
+
+
+def _execute_tool(block: dict, state: dict, credentials: dict, allowed_hosts: list[str] | None = None) -> dict:
     from app.runtime.integrations import github, slack, linear, digitalocean, vercel, railway
 
     dry_run = state.get("__dry_run", False)
@@ -823,6 +846,10 @@ def _execute_tool(block: dict, state: dict, credentials: dict) -> dict:
     creds = credentials.get(integration, {})
     if not creds:
         return {"skipped": True, "reason": f"No credentials for {integration}"}
+
+    target_host = _INTEGRATION_HOSTS.get(integration)
+    if target_host:
+        _check_egress(target_host, allowed_hosts)
 
     if integration == "github":
         return github.execute(action, params, creds)
@@ -1182,8 +1209,13 @@ def execute_run(run_id: str):
         env_id = version.workflow.environment_id
         workspace_id_str = version.workflow.workspace_id
 
-        # Load credentials from the workflow's environment
+        # Load credentials and egress allowlist from the workflow's environment
+        allowed_hosts: list[str] | None = None
         if env_id:
+            from app.models.environment import Environment as _Env
+            env_row = db.query(_Env).filter(_Env.id == env_id).first()
+            if env_row:
+                allowed_hosts = env_row.allowed_hosts or None
             cred_rows = db.query(Integration).filter(
                 Integration.workspace_id == workspace_id_str,
                 Integration.environment_id == env_id,
@@ -1200,7 +1232,6 @@ def execute_run(run_id: str):
         # Fallback: merge in any missing handles from the Default environment
         # so integrations connected globally are always available
         if env_id:
-            from app.models.environment import Environment as _Env
             default_env = db.query(_Env).filter(
                 _Env.workspace_id == workspace_id_str,
                 _Env.name == "Default",
@@ -1264,7 +1295,7 @@ def execute_run(run_id: str):
                                             db=db, run_id=run_id, block_id=block_id)
 
                 elif block_type == "tool":
-                    result = _execute_tool(block, state, credentials)
+                    result = _execute_tool(block, state, credentials, allowed_hosts=allowed_hosts)
 
                 elif block_type == "output":
                     wf_name = version.workflow.name if version.workflow else "Agent"
@@ -1311,6 +1342,20 @@ def execute_run(run_id: str):
                 log.info("run.paused", run_id=run_id, block_id=ap.block_id)
                 return  # Exit without marking failed
 
+            except PermissionError as e:
+                blocked_host = str(e).split("'")[1] if "'" in str(e) else "unknown"
+                log.warning("block.egress_blocked", block_id=block_id, host=blocked_host, run_id=run_id)
+                if settings.sentry_dsn:
+                    import sentry_sdk
+                    with sentry_sdk.push_scope() as scope:
+                        scope.set_tag("run_id", str(run_id))
+                        scope.set_tag("blocked_host", blocked_host)
+                        sentry_sdk.capture_exception(e)
+                failed = True
+                fail_error = str(e)
+                _emit(db, run_id, block_id, "block_failed", {"error": str(e)})
+                break
+
             except Exception as e:
                 log.exception("block.failed", block_id=block_id)
                 if settings.sentry_dsn:
@@ -1329,7 +1374,7 @@ def execute_run(run_id: str):
         for block in cleanup_blocks:
             try:
                 _emit(db, run_id, block["id"], "block_started", {"type": "cleanup"})
-                result = _execute_tool(block, state, credentials)
+                result = _execute_tool(block, state, credentials, allowed_hosts=allowed_hosts)
                 _emit(db, run_id, block["id"], "block_completed", {"output": result})
             except Exception as e:
                 _emit(db, run_id, block["id"], "block_failed", {"error": str(e)})

--- a/apps/web/src/components/settings/EnvironmentsManager.tsx
+++ b/apps/web/src/components/settings/EnvironmentsManager.tsx
@@ -7,6 +7,7 @@ interface Environment {
   id: string
   name: string
   created_at: string
+  allowed_hosts?: string[] | null
   connectedServices?: string[]
 }
 
@@ -145,7 +146,7 @@ function EnvironmentsManagerInner({ getToken, isAdmin }: { getToken: (() => Prom
           return { ...env, connectedServices: creds.map(c => c.service) }
         } catch { return env }
       }))
-      setEnvironments(enriched)
+      setEnvironments(enriched.map((env, i) => ({ ...env, allowed_hosts: envs[i]?.allowed_hosts ?? null })))
     } catch { /* silent */ }
   }, [buildHeaders])
 
@@ -229,17 +230,21 @@ function EnvironmentsManagerInner({ getToken, isAdmin }: { getToken: (() => Prom
               </span>
               <div>
                 <p className="text-sm font-medium text-stone-900">{env.name}</p>
-                {env.connectedServices && env.connectedServices.length > 0 ? (
-                  <div className="flex items-center gap-1 mt-1 flex-wrap">
-                    {env.connectedServices.map(svc => (
-                      <span key={svc} className="text-[10px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-100 px-1.5 py-0.5 rounded-full">
-                        {svc}
-                      </span>
-                    ))}
-                  </div>
-                ) : (
-                  <p className="text-xs text-stone-400 mt-0.5">No integrations yet · click to add</p>
-                )}
+                <div className="flex items-center gap-1 mt-1 flex-wrap">
+                  {env.connectedServices && env.connectedServices.length > 0
+                    ? env.connectedServices.map(svc => (
+                        <span key={svc} className="text-[10px] font-medium bg-emerald-50 text-emerald-700 border border-emerald-100 px-1.5 py-0.5 rounded-full">
+                          {svc}
+                        </span>
+                      ))
+                    : <span className="text-xs text-stone-400">No integrations yet · click to add</span>
+                  }
+                  {env.allowed_hosts && env.allowed_hosts.length > 0 && (
+                    <span className="text-[10px] font-medium bg-amber-50 text-amber-700 border border-amber-100 px-1.5 py-0.5 rounded-full">
+                      restricted
+                    </span>
+                  )}
+                </div>
               </div>
             </button>
 
@@ -329,6 +334,37 @@ function EnvironmentDetail({
   const [showNew, setShowNew] = useState(false)
   const [showPaste, setShowPaste] = useState(false)
   const [pasteText, setPasteText] = useState("")
+
+  // Egress allowlist chip state
+  const [hosts, setHosts] = useState<string[]>(environment.allowed_hosts ?? [])
+  const [hostInput, setHostInput] = useState("")
+  const [hostSaving, setHostSaving] = useState(false)
+
+  async function saveHosts(updated: string[]) {
+    setHostSaving(true)
+    try {
+      const headers = await buildHeaders(true)
+      await fetch(`${process.env.NEXT_PUBLIC_API_URL}/environments/${environment.id}`, {
+        method: "PATCH", headers,
+        body: JSON.stringify({ allowed_hosts: updated.length > 0 ? updated : null }),
+      })
+    } finally { setHostSaving(false) }
+  }
+
+  function addHost() {
+    const h = hostInput.trim().toLowerCase().replace(/^https?:\/\//, "").replace(/\/.*$/, "")
+    if (!h || hosts.includes(h)) { setHostInput(""); return }
+    const updated = [...hosts, h]
+    setHosts(updated)
+    setHostInput("")
+    saveHosts(updated)
+  }
+
+  function removeHost(h: string) {
+    const updated = hosts.filter(x => x !== h)
+    setHosts(updated)
+    saveHosts(updated)
+  }
 
   const load = useCallback(async () => {
     setLoading(true)
@@ -544,6 +580,57 @@ function EnvironmentDetail({
             </button>
           </div>
         ))}
+      </div>
+
+      {/* Egress allowlist */}
+      <div className="mt-6">
+        <div className="flex items-center justify-between mb-2">
+          <div>
+            <p className="text-sm font-medium text-stone-900">Allowed hosts</p>
+            <p className="text-xs text-stone-400">Leave empty for unrestricted outbound access. Use <span className="font-mono">*.example.com</span> for subdomains.</p>
+          </div>
+          {hostSaving && <span className="text-[10px] text-stone-400">Saving…</span>}
+        </div>
+        <div className="rounded-xl border border-stone-200 bg-white px-4 py-3 space-y-3">
+          {hosts.length > 0 && (
+            <div className="flex flex-wrap gap-2">
+              {hosts.map(h => (
+                <span key={h} className="inline-flex items-center gap-1.5 text-xs font-mono bg-amber-50 text-amber-800 border border-amber-100 px-2.5 py-1 rounded-full">
+                  {h}
+                  {isAdmin && (
+                    <button
+                      onClick={() => removeHost(h)}
+                      className="text-amber-400 hover:text-amber-700 leading-none transition-colors"
+                    >
+                      ×
+                    </button>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
+          {isAdmin && (
+            <div className="flex gap-2">
+              <input
+                value={hostInput}
+                onChange={e => setHostInput(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter") { e.preventDefault(); addHost() } }}
+                placeholder="e.g. api.github.com or *.slack.com"
+                className="flex-1 font-mono text-xs text-stone-800 border border-stone-200 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-amber-200 placeholder:text-stone-300"
+              />
+              <button
+                onClick={addHost}
+                disabled={!hostInput.trim()}
+                className="text-xs font-medium bg-stone-900 text-white hover:bg-stone-700 px-3 py-2 rounded-lg transition-colors disabled:opacity-40"
+              >
+                Add
+              </button>
+            </div>
+          )}
+          {hosts.length === 0 && !isAdmin && (
+            <p className="text-xs text-stone-400">No restrictions — agents can reach any host.</p>
+          )}
+        </div>
       </div>
     </div>
   )

--- a/apps/web/src/components/settings/EnvironmentsManager.tsx
+++ b/apps/web/src/components/settings/EnvironmentsManager.tsx
@@ -587,7 +587,7 @@ function EnvironmentDetail({
         <div className="flex items-center justify-between mb-2">
           <div>
             <p className="text-sm font-medium text-stone-900">Allowed hosts</p>
-            <p className="text-xs text-stone-400">Leave empty for unrestricted outbound access. Use <span className="font-mono">*.example.com</span> for subdomains.</p>
+            <p className="text-xs text-stone-400">Leave empty for unrestricted outbound access. Use <span className="font-mono">*.example.com</span> for subdomains. Applies to integration blocks only — shell commands in AI blocks are not network-restricted.</p>
           </div>
           {hostSaving && <span className="text-[10px] text-stone-400">Saving…</span>}
         </div>


### PR DESCRIPTION
## What

Implements per-environment egress allowlist from issue #206.

## Changes

**Migration** (`0019`) — nullable `allowed_hosts` JSONB column on `environments`. Null = unrestricted (default).

**API** — `PATCH /environments/{id}` saves the list. `GET /environments` returns `allowed_hosts` on every row.

**Executor** — before every Tool block dispatch, `_check_egress(target_host, allowed_hosts)` is called. Supports exact match and `*.domain.com` wildcard prefix. `PermissionError` is caught in a dedicated handler with structured log + Sentry tag `blocked_host`.

**UI** — chip input in the environment detail view. Type a host → Enter or Add. Click × to remove. Auto-saves via PATCH on each change. The environment list card shows an amber "restricted" badge when `allowed_hosts` is set.

## Behavior

- `allowed_hosts = null` → unrestricted (existing default)
- `allowed_hosts = ["api.github.com", "slack.com"]` → only those two hosts allowed for Tool blocks
- Wildcards: `*.internal.co` matches `api.internal.co`, `app.internal.co`, etc.
- Brain `run_shell` commands are not network-intercepted (requires OS-level enforcement)

## Test plan

- [ ] Create environment, add `api.github.com` to allowed hosts, verify a Slack tool block fails with egress error
- [ ] Verify null allowed_hosts allows all integrations through
- [ ] Verify `restricted` badge appears on env card
- [ ] Verify chip add/remove saves via PATCH