### PR TITLE
fix: Narratr embed brand slug conductai

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -80,7 +80,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           <body>
             {children}
             <Script src="https://narratr.ai/widget.js" data-brand-key="c7ae7b0c-2b6" strategy="afterInteractive" />
-            <Script src="https://narratr.ai/embed.js" data-brand="conduct-agentic" strategy="afterInteractive" />
+            <Script src="https://narratr.ai/embed.js" data-brand="conductai" strategy="afterInteractive" />
           </body>
         </html>
       </ClerkProvider>


### PR DESCRIPTION
Changes data-brand from conduct-agentic to conductai so the Narratr badge renders correctly on the site.