### PR TITLE
fix: Block schema extra=ignore for YAML annotation fields

### DIFF
--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -147,7 +147,7 @@ class Block(BaseModel):
     # or    next: { pass: push_pr, fail: notify_failure }
     next: Union[str, dict[str, str]] | None = None
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="ignore")  # ignore unknown keys e.g. `credentials` in YAML
 
     # ----- per-type validation ---------------------------------------------
     @model_validator(mode="after")


### PR DESCRIPTION
security-scanner.yaml (and potentially other playbooks) declare `credentials: {github: github}` on blocks for documentation. Block model had extra='forbid' which rejected these, producing a 422 on create. Changed to extra='ignore' — credentials come from the environment, not the YAML.