### PR TITLE
fix: webhook URL, remove test_repo, read-only secret, cleaner dry-run modal

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -22,6 +22,7 @@ interface BlockEditorProps {
   onChange: (blockId: string, changes: Record<string, unknown>) => void
   getToken?: (() => Promise<string | null>) | null
   selectedEnvId?: string
+  githubHookRepo?: string | null  // set when workflow has a GitHub webhook registered
 }
 
 // ── Webhook registration ──────────────────────────────────────────────────────
@@ -397,6 +398,7 @@ export default function BlockEditor({
   onChange,
   getToken,
   selectedEnvId,
+  githubHookRepo,
 }: BlockEditorProps) {
   const [promptOpen, setPromptOpen] = useState(false)
   const [streamedPrompt, setStreamedPrompt] = useState<string>("")
@@ -418,8 +420,10 @@ export default function BlockEditor({
     ? allStaticFields.filter(f => {
         if (f.key === "config.labels" || f.key === "config.repo_allowlist")
           return triggerEventType === "github_issue_labeled"
-        if (f.key === "config.webhook_secret" || f.key === "config.test_repo" || f.key === "config.test_pr_number")
+        if (f.key === "config.webhook_secret" || f.key === "config.test_pr_number")
           return triggerEventType === "webhook"
+        if (f.key === "config.test_repo")
+          return false  // redundant — repo is known from github_hook_repo
         return true
       })
     : blockType === "output"
@@ -760,21 +764,35 @@ export default function BlockEditor({
                   </div>
                   {rendered}
                   {/* Inbound webhook URL panel */}
-                  {blockType === "trigger" && field.key === "config.event_type" && triggerEventType === "webhook" && (
-                    <div className="rounded-lg border border-violet-100 bg-violet-50 px-3 py-2.5 text-xs text-violet-800 mt-2 space-y-1.5">
-                      <p className="font-semibold text-[10px] uppercase tracking-wide text-violet-500">Webhook URL</p>
-                      <p className="font-mono break-all select-all text-violet-700 text-[11px]">
-                        {(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/inbound/{workflowId}
-                      </p>
-                      <p className="text-violet-500 text-[10px]">POST any JSON to this URL — payload available as <span className="font-mono">{"{{_trigger.*}}"}</span></p>
-                      <div className="border-t border-violet-100 pt-1.5 space-y-0.5">
-                        <p className="font-semibold text-[10px] uppercase tracking-wide text-violet-400">GitHub setup</p>
-                        <p className="text-[10px] text-violet-500">Repo → Settings → Webhooks → Add webhook</p>
-                        <p className="text-[10px] text-violet-500">Content type: <span className="font-mono">application/json</span></p>
-                        <p className="text-[10px] text-violet-500">Events: choose individual → <span className="font-mono">Pull requests</span></p>
+                  {blockType === "trigger" && field.key === "config.event_type" && triggerEventType === "webhook" && (() => {
+                    const ws = typeof document !== "undefined"
+                      ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
+                    const githubUrl = ws
+                      ? `${(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/github?workspace_id=${ws}`
+                      : null
+                    const inboundUrl = `${(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/inbound/${workflowId}`
+                    const webhookUrl = githubHookRepo ? githubUrl : inboundUrl
+                    return (
+                      <div className="rounded-lg border border-violet-100 bg-violet-50 px-3 py-2.5 text-xs text-violet-800 mt-2 space-y-1.5">
+                        <p className="font-semibold text-[10px] uppercase tracking-wide text-violet-500">Webhook URL</p>
+                        <p className="font-mono break-all select-all text-violet-700 text-[11px]">
+                          {webhookUrl ?? inboundUrl}
+                        </p>
+                        {githubHookRepo
+                          ? <p className="text-violet-500 text-[10px]">Registered on <span className="font-mono">{githubHookRepo}</span> — GitHub sends PR events here automatically.</p>
+                          : <>
+                              <p className="text-violet-500 text-[10px]">POST any JSON to this URL — payload available as <span className="font-mono">{"{{_trigger.*}}"}</span></p>
+                              <div className="border-t border-violet-100 pt-1.5 space-y-0.5">
+                                <p className="font-semibold text-[10px] uppercase tracking-wide text-violet-400">GitHub setup</p>
+                                <p className="text-[10px] text-violet-500">Repo → Settings → Webhooks → Add webhook</p>
+                                <p className="text-[10px] text-violet-500">Content type: <span className="font-mono">application/json</span></p>
+                                <p className="text-[10px] text-violet-500">Events: choose individual → <span className="font-mono">Pull requests</span></p>
+                              </div>
+                            </>
+                        }
                       </div>
-                    </div>
-                  )}
+                    )
+                  })()}
                   {/* Vercel deployment trigger URL + auto-register panel */}
                   {blockType === "trigger" && field.key === "config.event_type" && isVercelTrigger && (() => {
                     const ws = typeof document !== "undefined"

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -125,6 +125,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([])
   const [selectedNode, setSelectedNode] = useState<Node | null>(null)
   const [workflowName, setWorkflowName] = useState("Untitled agent")
+  const [githubHookRepo, setGithubHookRepo] = useState<string | null>(null)
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstLoad = useRef(true)
@@ -242,6 +243,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
       .then((data) => {
         setWorkflowName(data.name)
         setSelectedEnvId(data.environment_id ?? "")
+        setGithubHookRepo(data.github_hook_repo ?? null)
         const graph = data.current_version?.graph
         if (graph?.nodes && graph?.edges) {
           // Run auto-layout when:
@@ -453,9 +455,8 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
       })
       if (webhookTriggerNode && !triggerNode) {
         const cfg = (webhookTriggerNode.data as BlockNodeData).config as Record<string, unknown>
-        // Pre-fill from test_repo, or fall back to first repo in repo_allowlist
-        const repoAllowlistFallback = ((cfg.repo_allowlist as string) || "").split(",")[0].trim()
-        setWebhookRepo((cfg.test_repo as string) || repoAllowlistFallback || "")
+        // Use github_hook_repo (authoritative) — test_repo is removed
+        setWebhookRepo(githubHookRepo || "")
         setWebhookPrNumber((cfg.test_pr_number as string) || "")
         setRunning("idle")
         setWebhookModal({ dryRun })
@@ -906,6 +907,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
                       blockData={selectedNode.data as Record<string, unknown>}
                       onChange={handleBlockChange}
                       getToken={getToken}
+                      githubHookRepo={githubHookRepo}
                     />
                   </div>
                 ) : (
@@ -1050,23 +1052,29 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
           <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
             <div>
               <h2 className="text-sm font-semibold text-stone-900">Test with a pull request</h2>
-              <p className="text-xs text-stone-400 mt-1">Provide a real PR to review. The workflow will fetch the diff and post a review comment.</p>
+              <p className="text-xs text-stone-400 mt-1">
+                {webhookRepo ? <>Repo: <span className="font-mono text-stone-600">{webhookRepo}</span></> : "Provide a PR to review."}
+              </p>
             </div>
-            <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-stone-500">GitHub repo</label>
-              <input
-                placeholder="owner/repo"
-                value={webhookRepo}
-                onChange={e => setWebhookRepo(e.target.value)}
-                className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-xs text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400"
-              />
-            </div>
+            {!webhookRepo && (
+              <div className="flex flex-col gap-1.5">
+                <label className="text-xs font-medium text-stone-500">GitHub repo</label>
+                <input
+                  placeholder="owner/repo"
+                  value={webhookRepo}
+                  onChange={e => setWebhookRepo(e.target.value)}
+                  className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-xs text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400"
+                />
+              </div>
+            )}
             <div className="flex flex-col gap-1.5">
               <label className="text-xs font-medium text-stone-500">PR number <span className="font-normal text-stone-400">(from the PR URL — e.g. /pull/42)</span></label>
               <input
+                autoFocus
                 placeholder="42"
                 value={webhookPrNumber}
                 onChange={e => setWebhookPrNumber(e.target.value)}
+                onKeyDown={e => e.key === "Enter" && webhookRepo && webhookPrNumber && startWebhookRun(webhookModal.dryRun, webhookRepo, webhookPrNumber)}
                 className="w-full rounded-lg border border-stone-200 bg-white px-3 py-2 text-xs text-stone-900 focus:outline-none focus:ring-2 focus:ring-stone-400"
               />
             </div>

--- a/apps/web/src/lib/config-schemas.ts
+++ b/apps/web/src/lib/config-schemas.ts
@@ -289,16 +289,9 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       label: "Webhook secret",
       type: "text",
       required: false,
-      placeholder: "optional — verify HMAC-SHA256 signature",
+      placeholder: "auto-generated on install",
       hint: "If set, callers must send X-Webhook-Signature: sha256=<hmac> header",
-    },
-    {
-      key: "config.test_repo",
-      label: "Test repo",
-      type: "text",
-      required: false,
-      placeholder: "owner/repo",
-      hint: "Used when manually triggering — pre-fills the run dialog",
+      readOnly: true,
     },
     {
       key: "config.test_pr_number",
@@ -306,7 +299,7 @@ export const BLOCK_CONFIG_SCHEMAS: Partial<Record<BlockType, ConfigField[]>> = {
       type: "text",
       required: false,
       placeholder: "42",
-      hint: "PR number to review when triggering manually",
+      hint: "PR number from the URL — e.g. /pull/42 — used when triggering manually",
     },
   ],
   output: [


### PR DESCRIPTION
- Webhook URL panel now shows /webhooks/github?workspace_id=... when github_hook_repo is set, /webhooks/inbound/{id} for generic triggers
- test_repo field removed — repo is known from github_hook_repo
- webhook_secret is now read-only (auto-generated on install)
- Dry run modal shows repo as text when known, hides repo input, autofocuses PR number, Enter submits