### PR TITLE
ux: friendly webhook error messages

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -199,8 +199,15 @@ def _register_github_webhook(token: str, repo: str, webhook_url: str, events: li
         )
         if r.status_code == 201:
             return str(r.json()["id"]), None
-        err = f"GitHub returned {r.status_code}: {r.text[:300]}"
-        log.warning("GitHub webhook registration failed: %s", err)
+        log.warning("GitHub webhook registration failed: %s %s", r.status_code, r.text[:300])
+        if r.status_code == 403:
+            err = "GitHub rejected the request — your token is missing the Administration (read & write) permission. Go to Settings → Environments, update your GitHub token, and reinstall the agent."
+        elif r.status_code == 404:
+            err = f"Repository '{repo}' not found or your token doesn't have access to it. Check the repo name and token scopes in Settings → Environments."
+        elif r.status_code == 422:
+            err = "Webhook already exists on this repo for this URL. You may already have this agent installed — check your agents list."
+        else:
+            err = f"GitHub returned an unexpected error (HTTP {r.status_code}). Check your token permissions in Settings → Environments."
         return None, err
     except Exception as e:
         log.warning("GitHub webhook registration exception: %s", e)

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -480,9 +480,9 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
 
             {webhookError && (
               <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-3">
-                <p className="text-xs font-semibold text-red-700 mb-1">Webhook registration failed</p>
+                <p className="text-xs font-semibold text-red-700 mb-1">Webhook not registered</p>
                 <p className="text-xs text-red-600 leading-relaxed">{webhookError}</p>
-                <p className="text-xs text-red-500 mt-2">Agent was installed. Add <strong>Administration (read &amp; write)</strong> permission to your GitHub PAT in Settings → Environments, then reinstall.</p>
+                <p className="text-xs text-stone-400 mt-2">The agent was installed — the webhook can be added once the token is updated.</p>
                 <button onClick={() => { closeInstallModal(); router.push(`/workflows/${lastInstalledId ?? ""}`) }}
                   className="mt-2 text-xs underline text-red-700">Open agent anyway →</button>
               </div>

--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -424,9 +424,9 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
 
               {webhookError && (
                 <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-3">
-                  <p className="text-xs font-semibold text-red-700 mb-1">Webhook registration failed</p>
+                  <p className="text-xs font-semibold text-red-700 mb-1">Webhook not registered</p>
                   <p className="text-xs text-red-600 leading-relaxed">{webhookError}</p>
-                  <p className="text-xs text-red-500 mt-1">Agent was created. Add <strong>Administration (read &amp; write)</strong> to your GitHub PAT then reinstall.</p>
+                  <p className="text-xs text-stone-400 mt-2">The agent was installed — the webhook can be added once the token is updated.</p>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- Backend: detect GitHub 403/404/422 status codes and return actionable error strings (no raw JSON)
- Frontend (marketplace + workflows/new): replace "Webhook registration failed" title with "Webhook not registered", remove the raw error dump, add neutral footer noting the agent was installed and the webhook can be fixed later

## Test plan
- [ ] Install a playbook with a token missing Admin permission — should see "GitHub rejected the request — your token is missing the Administration (read & write) permission"
- [ ] Install with wrong repo — should see clean "Repository not found" message
- [ ] Successful install — no error shown