### PR TITLE
ux: eye toggle on read-only fields instead of AUTO badge

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef } from "react"
+import React, { useState, useEffect, useRef } from "react"
 import { BLOCK_STYLES, type BlockType } from "@/lib/block-types"
 import {
   BLOCK_CONFIG_SCHEMAS,
@@ -304,10 +304,18 @@ function FieldInput({
   const base = "w-full border border-stone-200 rounded-lg px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200 bg-white"
 
   if (field.readOnly) {
+    const [visible, setVisible] = React.useState(false)
+    const display = strVal || field.placeholder || ""
+    const masked = display.replace(/./g, "•").slice(0, 24)
     return (
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-stone-50 border border-stone-200 rounded-lg">
-        <span className="text-[10px] font-bold uppercase tracking-wider text-indigo-400 shrink-0">auto</span>
-        <span className="text-xs font-mono text-stone-500 truncate">{strVal || field.placeholder}</span>
+        <span className="text-xs font-mono text-stone-500 truncate flex-1">{visible ? display : masked}</span>
+        <button type="button" onClick={() => setVisible(v => !v)} className="shrink-0 text-stone-400 hover:text-stone-600">
+          {visible
+            ? <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/><path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd"/></svg>
+            : <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clipRule="evenodd"/><path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.064 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/></svg>
+          }
+        </button>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Replaces the `AUTO` chip on read-only fields (webhook secret, etc.) with a masked value + eye icon toggle
- Click eye to reveal full value, click again to hide
- Applies to all `readOnly: true` fields in BlockEditor

## Test plan
- [ ] Open Security Patch Updater canvas → trigger block → Webhook secret shows bullets + eye icon
- [ ] Click eye → full value revealed
- [ ] Click again → masked