### PR TITLE
feat: authenticated test-trigger endpoint for workflows

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1326,3 +1326,52 @@ def sync_workflow(
             background_tasks.add_task(_run_compiler, version.id, version.graph)
 
     return result
+
+
+@router.post("/{workflow_id}/trigger")
+def test_trigger(
+    workflow_id: UUID,
+    payload: dict = Body(default={}),
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+):
+    """
+    Authenticated test trigger — enqueues a run with the given payload as _trigger.
+    Bypasses webhook HMAC so dev/test callers don't need the raw secret.
+    Scoped to the caller's workspace; 404 if the workflow belongs to another workspace.
+    """
+    import redis as _redis_mod
+    from app.core.config import settings as _settings
+
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
+    if not workflow or not workflow.current_version:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    version = workflow.current_version
+    try:
+        graph = version.graph or {}
+        pf = _estimate_turns_for_graph(graph, payload.get("title", ""), payload.get("body", ""))
+        suggested_turns = pf["suggested_max_turns"]
+    except Exception:
+        suggested_turns = 20
+
+    run = Run(
+        workflow_version_id=version.id,
+        triggered_by="manual:test_trigger",
+        status="pending",
+        state={"_trigger": payload, "__triggered_by": "manual:test_trigger", "__max_turns": suggested_turns},
+        max_turns=suggested_turns,
+    )
+    db.add(run)
+    db.flush()
+    db.commit()
+
+    r = _redis_mod.from_url(_settings.redis_url, decode_responses=True)
+    r.rpush("marshal:runs:queue", str(run.id))
+
+    log.info("workflow.test_triggered", workflow_id=str(workflow_id), run_id=str(run.id))
+    return {"ok": True, "run_id": str(run.id), "max_turns": suggested_turns}

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -305,8 +305,14 @@ function FieldInput({
 
   if (field.readOnly) {
     const [visible, setVisible] = React.useState(false)
+    const [copied, setCopied] = React.useState(false)
     const display = strVal || field.placeholder || ""
     const masked = display.replace(/./g, "•").slice(0, 24)
+    const copy = () => {
+      navigator.clipboard.writeText(display)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
     return (
       <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-stone-50 border border-stone-200 rounded-lg">
         <span className="text-xs font-mono text-stone-500 truncate flex-1">{visible ? display : masked}</span>
@@ -314,6 +320,12 @@ function FieldInput({
           {visible
             ? <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path d="M10 12a2 2 0 100-4 2 2 0 000 4z"/><path fillRule="evenodd" d="M.458 10C1.732 5.943 5.522 3 10 3s8.268 2.943 9.542 7c-1.274 4.057-5.064 7-9.542 7S1.732 14.057.458 10zM14 10a4 4 0 11-8 0 4 4 0 018 0z" clipRule="evenodd"/></svg>
             : <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M3.707 2.293a1 1 0 00-1.414 1.414l14 14a1 1 0 001.414-1.414l-1.473-1.473A10.014 10.014 0 0019.542 10C18.268 5.943 14.478 3 10 3a9.958 9.958 0 00-4.512 1.074l-1.78-1.781zm4.261 4.26l1.514 1.515a2.003 2.003 0 012.45 2.45l1.514 1.514a4 4 0 00-5.478-5.478z" clipRule="evenodd"/><path d="M12.454 16.697L9.75 13.992a4 4 0 01-3.742-3.741L2.335 6.578A9.98 9.98 0 00.458 10c1.274 4.057 5.064 7 9.542 7 .847 0 1.669-.105 2.454-.303z"/></svg>
+          }
+        </button>
+        <button type="button" onClick={copy} className="shrink-0 text-stone-400 hover:text-stone-600" title="Copy">
+          {copied
+            ? <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5 text-green-500" viewBox="0 0 20 20" fill="currentColor"><path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd"/></svg>
+            : <svg xmlns="http://www.w3.org/2000/svg" className="h-3.5 w-3.5" viewBox="0 0 20 20" fill="currentColor"><path d="M8 3a1 1 0 011-1h2a1 1 0 110 2H9a1 1 0 01-1-1z"/><path d="M6 3a2 2 0 00-2 2v11a2 2 0 002 2h8a2 2 0 002-2V5a2 2 0 00-2-2 3 3 0 01-3 3H9a3 3 0 01-3-3z"/></svg>
           }
         </button>
       </div>

--- a/scripts/trigger_security_patch.py
+++ b/scripts/trigger_security_patch.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""
+Trigger the Security Patch Updater workflow with a test Dependabot-style payload.
+
+Uses the authenticated /workflows/{id}/trigger endpoint — no HMAC secret needed.
+
+Usage:
+    python scripts/trigger_security_patch.py \
+        --workflow-id <uuid> \
+        --token <clerk_session_token> \
+        [--api-url https://api.conductai.ai] \
+        [--repo owner/repo] \
+        [--package lodash] \
+        [--cve CVE-2021-23337] \
+        [--severity high]
+
+Get your token: open conductai.ai, open DevTools → Application → Cookies → __session
+"""
+import argparse
+import json
+import sys
+import urllib.request
+
+
+DEFAULT_API = "https://api.conductai.ai"
+
+DEFAULT_PAYLOAD = {
+    "repo": "sseshachala/conductai",
+    "clone_url": "https://github.com/sseshachala/conductai.git",
+    "default_branch": "main",
+    "advisory": {
+        "package": "lodash",
+        "severity": "high",
+        "cve": "CVE-2021-23337",
+        "patched_versions": ">=4.17.21",
+        "description": "Prototype pollution in lodash before 4.17.21 via the set, setWith, pull, update, and updateWith methods.",
+    },
+}
+
+
+def main():
+    p = argparse.ArgumentParser(description="Trigger Security Patch Updater")
+    p.add_argument("--workflow-id", required=True, help="Workflow UUID")
+    p.add_argument("--token", required=True, help="Clerk session token (from __session cookie)")
+    p.add_argument("--api-url", default=DEFAULT_API, help="API base URL")
+    p.add_argument("--repo", help="owner/repo to patch (default: sseshachala/conductai)")
+    p.add_argument("--package", help="Package name (default: lodash)")
+    p.add_argument("--cve", help="CVE identifier (default: CVE-2021-23337)")
+    p.add_argument("--severity", choices=["low", "medium", "high", "critical"], default="high")
+    args = p.parse_args()
+
+    payload = json.loads(json.dumps(DEFAULT_PAYLOAD))  # deep copy
+    if args.repo:
+        payload["repo"] = args.repo
+        payload["clone_url"] = f"https://github.com/{args.repo}.git"
+    if args.package:
+        payload["advisory"]["package"] = args.package
+    if args.cve:
+        payload["advisory"]["cve"] = args.cve
+    payload["advisory"]["severity"] = args.severity
+
+    body = json.dumps(payload).encode()
+    url = f"{args.api_url.rstrip('/')}/workflows/{args.workflow_id}/trigger"
+
+    req = urllib.request.Request(
+        url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {args.token}",
+        },
+        method="POST",
+    )
+
+    print(f"POST {url}")
+    print(f"Payload: {json.dumps(payload, indent=2)}")
+    print()
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            result = json.loads(resp.read())
+            print(f"Response {resp.status}: {json.dumps(result, indent=2)}")
+            if result.get("run_id"):
+                print(f"\nWatch run: https://conductai.ai/runs/{result['run_id']}")
+    except urllib.error.HTTPError as e:
+        body_err = e.read().decode()
+        print(f"Error {e.code}: {body_err}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `POST /workflows/{id}/trigger` — requires Clerk auth, no HMAC secret
- Enqueues a run with the provided JSON body as `_trigger`
- Scoped to caller's workspace (404 if wrong workspace)
- Updates `scripts/trigger_security_patch.py` to use `--token` instead of `--secret`

## Usage
```bash
python scripts/trigger_security_patch.py \
  --workflow-id <uuid> \
  --token <clerk_session_token> \
  --repo sseshachala/conductai
```
Get token: DevTools → Application → Cookies → `__session`

## Test plan
- [ ] Run script with valid token → run appears in dashboard
- [ ] Run script with wrong workspace token → 404