### PR TITLE
feat: Test Run button + workspace preferences

### DIFF
--- a/apps/api/alembic/versions/0020_playbook_slug_and_workspace_preferences.py
+++ b/apps/api/alembic/versions/0020_playbook_slug_and_workspace_preferences.py
@@ -1,0 +1,24 @@
+"""add playbook_slug to workflows and preferences to workspaces
+
+Revision ID: 0020
+Revises: 0019
+Create Date: 2026-05-25
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0020"
+down_revision = "0019"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column("workflows", sa.Column("playbook_slug", sa.String(100), nullable=True))
+    op.add_column("workspaces", sa.Column("preferences", JSONB, nullable=True))
+
+
+def downgrade():
+    op.drop_column("workflows", "playbook_slug")
+    op.drop_column("workspaces", "preferences")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,7 +7,7 @@ from app.core.logging import setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.routers import credentials, dashboard, email_templates, environments, projects, runs, webhooks, workflows
 from app.routers.organizations import router as organizations_router
-from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router
+from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router
 from app.routers.runs import workspace_runs_router
 
 setup_logging()
@@ -54,6 +54,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 app.include_router(organizations_router)
 app.include_router(workspace_projects_router)
 app.include_router(audit_log_router)
+app.include_router(workspace_preferences_router)
 app.include_router(projects.router)
 app.include_router(dashboard.router)
 app.include_router(workflows.router)

--- a/apps/api/app/models/workflow.py
+++ b/apps/api/app/models/workflow.py
@@ -30,6 +30,7 @@ class Workflow(Base):
     # Auto-registered GitHub webhook — stored so we can deregister on delete
     github_hook_id = Column(String(255), nullable=True)
     github_hook_repo = Column(String(255), nullable=True)  # owner/repo format
+    playbook_slug = Column(String(100), nullable=True)
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))

--- a/apps/api/app/models/workspace.py
+++ b/apps/api/app/models/workspace.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 import sqlalchemy as sa
 from sqlalchemy import Column, String, DateTime, ForeignKey
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.core.database import Base
 
@@ -16,6 +16,7 @@ class Workspace(Base):
     is_approved = Column(sa.Boolean, nullable=False, default=False)
     plan = Column(String(50), nullable=False, default="free")
     kms_key_id = Column(String(255), nullable=True)
+    preferences = Column(JSONB, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -475,6 +475,7 @@ def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspa
         project_id=project_id,
         name=body.name,
         environment_id=default_env.id,
+        playbook_slug=body.template or None,
     )
     db.add(workflow)
     db.flush()
@@ -1286,6 +1287,67 @@ def update_workflow_source(
     db.commit()
     db.refresh(workflow)
     return workflow
+
+
+@router.post("/{workflow_id}/trigger")
+def test_trigger(
+    workflow_id: UUID,
+    payload: dict = Body(default={}),
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+):
+    """
+    Authenticated test trigger. When payload is empty, uses the playbook's
+    built-in test_trigger.payload (defined in the YAML). Bypasses webhook
+    HMAC — callers authenticate via Clerk JWT instead.
+    """
+    import pathlib, yaml as _yaml
+    import redis as _redis_mod
+    from app.core.config import settings as _settings
+
+    workflow = db.query(Workflow).filter(
+        Workflow.id == workflow_id,
+        Workflow.workspace_id == workspace_id,
+    ).first()
+    if not workflow or not workflow.current_version:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    # If no payload supplied, use the playbook's built-in test_trigger.payload
+    if not payload and workflow.playbook_slug and workflow.playbook_slug in _TEMPLATE_PLAYBOOKS:
+        playbook_file = _TEMPLATE_PLAYBOOKS[workflow.playbook_slug]
+        playbook_path = pathlib.Path(__file__).parent.parent.parent / "playbooks" / playbook_file
+        if playbook_path.exists():
+            raw = _yaml.safe_load(playbook_path.read_text()) or {}
+            payload = raw.get("test_trigger", {}).get("payload", {})
+
+    if not payload:
+        raise HTTPException(status_code=400, detail="No payload provided and no test_trigger defined for this playbook")
+
+    version = workflow.current_version
+    try:
+        graph = version.graph or {}
+        pf = _estimate_turns_for_graph(graph, payload.get("title", ""), payload.get("body", ""))
+        suggested_turns = pf["suggested_max_turns"]
+    except Exception:
+        suggested_turns = 20
+
+    run = Run(
+        workflow_version_id=version.id,
+        triggered_by="manual:test_trigger",
+        status="pending",
+        state={"_trigger": payload, "__triggered_by": "manual:test_trigger", "__max_turns": suggested_turns},
+        max_turns=suggested_turns,
+    )
+    db.add(run)
+    db.flush()
+    db.commit()
+
+    r = _redis_mod.from_url(_settings.redis_url, decode_responses=True)
+    r.rpush("marshal:runs:queue", str(run.id))
+
+    log.info("workflow.test_triggered", workflow_id=str(workflow_id), run_id=str(run.id), playbook_slug=workflow.playbook_slug)
+    return {"ok": True, "run_id": str(run.id), "max_turns": suggested_turns}
 
 
 class SyncRequest(BaseModel):

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -15,6 +15,7 @@ from app.core.auth import get_user_id, get_workspace_id, require_workspace_role,
 from app.core.database import get_db
 
 router = APIRouter(prefix="/workspaces/{workspace_id}/projects", tags=["workspace-projects"])
+preferences_router = APIRouter(prefix="/workspaces/{workspace_id}/preferences", tags=["workspace-preferences"])
 
 
 class ProjectOut(BaseModel):
@@ -178,3 +179,53 @@ def list_audit_log(
         }
         for r in rows
     ]
+
+
+# ── Workspace preferences ─────────────────────────────────────────────────────
+
+_PREFERENCE_DEFAULTS = {
+    "show_dry_run": False,
+    "show_test_trigger": True,
+}
+
+
+class PreferencesUpdate(BaseModel):
+    show_dry_run: bool | None = None
+    show_test_trigger: bool | None = None
+
+
+@preferences_router.get("")
+def get_preferences(
+    workspace_id: str,
+    active_workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
+    db: Session = Depends(get_db),
+):
+    _enforce_workspace(workspace_id, active_workspace_id)
+    from app.models.workspace import Workspace
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    stored = ws.preferences or {}
+    return {**_PREFERENCE_DEFAULTS, **stored}
+
+
+@preferences_router.patch("")
+def update_preferences(
+    workspace_id: str,
+    body: PreferencesUpdate,
+    active_workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+    db: Session = Depends(get_db),
+):
+    _enforce_workspace(workspace_id, active_workspace_id)
+    from app.models.workspace import Workspace
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    if not ws:
+        raise HTTPException(status_code=404, detail="Workspace not found")
+    current = dict(ws.preferences or {})
+    patch = body.model_dump(exclude_none=True)
+    current.update(patch)
+    ws.preferences = current
+    db.commit()
+    return {**_PREFERENCE_DEFAULTS, **current}

--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -58,4 +58,5 @@ class WorkflowDetailOut(WorkflowOut):
     current_version: Optional[WorkflowVersionOut] = None
     github_hook_id: Optional[str] = None
     github_hook_repo: Optional[str] = None
+    playbook_slug: Optional[str] = None
     webhook_error: Optional[str] = None  # set when webhook registration failed on install

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -200,3 +200,30 @@ cleanup:
     action: destroy_droplet
     params:
       droplet_id: "{{create_droplet.droplet_id}}"
+
+test_trigger:
+  payload:
+    action: labeled
+    label:
+      name: "[TEST] autopilot ready"
+    issue:
+      number: 9999
+      title: "[TEST] Create conductai_test.py"
+      body: |
+        Create a file `conductai_test.py` in the repo root that prints:
+        print("Hello, Conduct AI!")
+        This is a test run — prefix the branch and PR with [TEST].
+      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+      user:
+        login: conductai-test-bot
+      labels:
+        - name: "[TEST] autopilot ready"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+      clone_url: "https://github.com/sseshachala/conductai.git"
+    sender:
+      login: conductai-test-bot

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -179,3 +179,30 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: labeled
+    label:
+      name: "[TEST] autopilot ready"
+    issue:
+      number: 9999
+      title: "[TEST] Create conductai_test.py"
+      body: |
+        Create a file `conductai_test.py` in the repo root that prints:
+        print("Hello, Conduct AI!")
+        This is a test run — prefix the branch and PR with [TEST].
+      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+      user:
+        login: conductai-test-bot
+      labels:
+        - name: "[TEST] autopilot ready"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+      clone_url: "https://github.com/sseshachala/conductai.git"
+    sender:
+      login: conductai-test-bot

--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -91,3 +91,30 @@ blocks:
       slack:
         channel: "#general"
         approval: true
+
+test_trigger:
+  payload:
+    action: labeled
+    label:
+      name: "[TEST] autopilot ready"
+    issue:
+      number: 9999
+      title: "[TEST] Create conductai_test.py"
+      body: |
+        Create a file `conductai_test.py` in the repo root that prints:
+        print("Hello, Conduct AI!")
+        This is a test run — prefix the branch and PR with [TEST].
+      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+      user:
+        login: conductai-test-bot
+      labels:
+        - name: "[TEST] autopilot ready"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+      clone_url: "https://github.com/sseshachala/conductai.git"
+    sender:
+      login: conductai-test-bot

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -174,3 +174,32 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: labeled
+    label:
+      name: "[TEST] autopilot ready"
+    issue:
+      number: 9999
+      title: "[TEST] Create conductai_test.py"
+      body: |
+        Create a file `conductai_test.py` in the repo root that prints:
+        ```
+        print("Hello, Conduct AI!")
+        ```
+        This is a test run — prefix the branch and PR with [TEST].
+      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+      user:
+        login: conductai-test-bot
+      labels:
+        - name: "[TEST] autopilot ready"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+      clone_url: "https://github.com/sseshachala/conductai.git"
+    sender:
+      login: conductai-test-bot

--- a/apps/api/playbooks/ci-notify.yaml
+++ b/apps/api/playbooks/ci-notify.yaml
@@ -74,3 +74,20 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: completed
+    workflow_run:
+      id: 9999999
+      name: "[TEST] CI"
+      conclusion: failure
+      html_url: "https://github.com/sseshachala/conductai/actions/runs/9999999"
+      head_branch: main
+      head_sha: "abc1234def5678"
+      logs_url: "https://github.com/sseshachala/conductai/actions/runs/9999999/logs"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -245,3 +245,27 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: opened
+    number: 9999
+    pull_request:
+      number: 9999
+      title: "[TEST] Copilot: add conductai_test.py"
+      body: "Test PR simulating a Copilot-authored PR. Opened by Conduct AI test trigger."
+      html_url: "https://github.com/sseshachala/conductai/pull/9999"
+      head:
+        ref: test/copilot-test-trigger
+        sha: "abc1234def5678"
+      base:
+        ref: main
+      user:
+        login: github-actions[bot]
+      diff_url: "https://github.com/sseshachala/conductai/pull/9999.diff"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      clone_url: "https://github.com/sseshachala/conductai.git"

--- a/apps/api/playbooks/dependency-updater.yaml
+++ b/apps/api/playbooks/dependency-updater.yaml
@@ -120,3 +120,14 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+      clone_url: "https://github.com/sseshachala/conductai.git"
+    trigger: "[TEST] manual dependency scan"

--- a/apps/api/playbooks/incident-responder.yaml
+++ b/apps/api/playbooks/incident-responder.yaml
@@ -105,3 +105,16 @@ blocks:
       via: slack
       slack:
         channel: "#incidents"
+
+test_trigger:
+  payload:
+    alert:
+      id: "test-alert-9999"
+      title: "[TEST] High error rate on /api/workflows"
+      severity: high
+      description: "Error rate spiked to 15% on the workflows endpoint. This is a test alert."
+      started_at: "2026-05-25T20:00:00Z"
+      service: conductai-api
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai

--- a/apps/api/playbooks/issue-triage.yaml
+++ b/apps/api/playbooks/issue-triage.yaml
@@ -112,3 +112,23 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: opened
+    issue:
+      number: 9999
+      title: "[TEST] Button does not respond on mobile"
+      body: |
+        [TEST] When tapping the submit button on iOS Safari, nothing happens.
+        Steps to reproduce: open the app on iPhone, go to the form, tap Submit.
+        Expected: form submits. Actual: nothing.
+      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+      user:
+        login: conductai-test-bot
+      labels: []
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala

--- a/apps/api/playbooks/pr-reviewer.yaml
+++ b/apps/api/playbooks/pr-reviewer.yaml
@@ -183,3 +183,27 @@ blocks:
       via: slack
       slack:
         channel: "#engineering"
+
+test_trigger:
+  payload:
+    action: opened
+    number: 9999
+    pull_request:
+      number: 9999
+      title: "[TEST] Add conductai_test.py"
+      body: "Test PR opened by Conduct AI test trigger."
+      html_url: "https://github.com/sseshachala/conductai/pull/9999"
+      head:
+        ref: test/conductai-test-trigger
+        sha: "abc1234def5678"
+      base:
+        ref: main
+      user:
+        login: conductai-test-bot
+      diff_url: "https://github.com/sseshachala/conductai/pull/9999.diff"
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      clone_url: "https://github.com/sseshachala/conductai.git"

--- a/apps/api/playbooks/release-notes.yaml
+++ b/apps/api/playbooks/release-notes.yaml
@@ -105,3 +105,16 @@ blocks:
       via: slack
       slack:
         channel: "#releases"
+
+test_trigger:
+  payload:
+    ref: "[TEST] v0.0.0-test"
+    ref_type: tag
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      default_branch: main
+    sender:
+      login: conductai-test-bot

--- a/apps/api/playbooks/security-patch-updater.yaml
+++ b/apps/api/playbooks/security-patch-updater.yaml
@@ -119,3 +119,15 @@ blocks:
       slack:
         channel: "#security"
         approval: true
+
+test_trigger:
+  payload:
+    repo: sseshachala/conductai
+    clone_url: "https://github.com/sseshachala/conductai.git"
+    default_branch: main
+    advisory:
+      package: lodash
+      severity: high
+      cve: CVE-2021-23337
+      patched_versions: ">=4.17.21"
+      description: "[TEST] Prototype pollution in lodash before 4.17.21. This is a test run — prefix branch and PR with [TEST]."

--- a/apps/api/playbooks/security-scanner.yaml
+++ b/apps/api/playbooks/security-scanner.yaml
@@ -292,3 +292,28 @@ blocks:
       via: slack
       slack:
         channel: "#security"
+
+test_trigger:
+  payload:
+    action: opened
+    number: 9999
+    pull_request:
+      number: 9999
+      title: "[TEST] Security scan — sample vulnerable code"
+      body: |
+        [TEST] This PR contains intentionally weak code for security scanner validation.
+        Do not merge.
+      html_url: "https://github.com/sseshachala/conductai/pull/9999"
+      head:
+        ref: test/security-scanner-trigger
+        sha: "abc1234def5678"
+      base:
+        ref: main
+      user:
+        login: conductai-test-bot
+    repository:
+      full_name: sseshachala/conductai
+      name: conductai
+      owner:
+        login: sseshachala
+      clone_url: "https://github.com/sseshachala/conductai.git"

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -6,9 +6,10 @@ import AppShell from "@/components/AppShell"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
 import AuditLog from "@/components/settings/AuditLog"
+import PreferencesPanel from "@/components/settings/PreferencesPanel"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 
-type Tab = "environments" | "members" | "audit"
+type Tab = "environments" | "members" | "audit" | "preferences"
 
 export default function SettingsPage() {
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
@@ -44,7 +45,7 @@ function SettingsPageWithAuth() {
 }
 
 function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
-  const tabs = (["environments", ...(isAdmin ? ["members", "audit"] : [])] as Tab[])
+  const tabs = (["environments", "preferences", ...(isAdmin ? ["members", "audit"] : [])] as Tab[])
   const [activeTab, setActiveTab] = useState<Tab>("environments")
   const [showTip, setShowTip] = useState(true)
 
@@ -89,6 +90,7 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
         </div>
 
         {activeTab === "environments" && <EnvironmentsManager isAdmin={isAdmin} />}
+        {activeTab === "preferences" && <PreferencesPanel />}
         {activeTab === "members" && isAdmin && <MembersManager />}
         {activeTab === "audit" && isAdmin && <AuditLog workspaceId={workspaceId} getToken={getToken} />}
       </div>

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -6,6 +6,7 @@ import { usePathname, useRouter } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
 import AuthButton from "@/components/AuthButton"
 import { WorkspaceProvider, useWorkspace } from "@/lib/WorkspaceContext"
+import { PreferencesProvider } from "@/lib/PreferencesContext"
 
 interface Project { id: string; name: string; agent_count: number }
 interface Org { id: string; name: string; slug: string }
@@ -201,6 +202,7 @@ function AppShellInner({ children, noPadding }: { children: React.ReactNode; noP
   const activeProjectId = pathname.match(/\/projects\/([^/]+)/)?.[1]
 
   return (
+    <PreferencesProvider workspaceId={activeWorkspace?.id ?? ""} getToken={getToken}>
     <div className="flex h-screen bg-stone-50">
       <aside className={`relative shrink-0 bg-white border-r border-stone-200 flex flex-col transition-all duration-200 ${collapsed ? "w-14" : "w-52"}`}>
 
@@ -495,6 +497,7 @@ function AppShellInner({ children, noPadding }: { children: React.ReactNode; noP
 
       <main className={`flex-1 min-h-0 ${noPadding ? "overflow-hidden flex flex-col" : "overflow-auto"}`}>{children}</main>
     </div>
+    </PreferencesProvider>
   )
 }
 

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -158,10 +158,12 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const [testTriggerModal, setTestTriggerModal] = useState(false)
   const [testRunning, setTestRunning] = useState(false)
   const [testRunId, setTestRunId] = useState<string | null>(null)
+  const [testRunStatus, setTestRunStatus] = useState<string | null>(null)
   const { prefs } = usePreferences()
   const [playbookSlug, setPlaybookSlug] = useState<string | null>(null)
 
   const STORAGE_KEY = `marshal:active-run:${workflowId}`
+  const TEST_RUN_KEY = `marshal:test-run:${workflowId}`
 
   // On mount, check if there's an in-progress run we navigated away from.
   useEffect(() => {
@@ -189,6 +191,37 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
     )
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowId])
+
+  // Restore test run banner on mount + poll status until terminal
+  useEffect(() => {
+    const stored = localStorage.getItem(TEST_RUN_KEY)
+    if (!stored) return
+    const { runId } = JSON.parse(stored)
+    setTestRunId(runId)
+    setTestRunStatus("pending")
+  }, [workflowId])
+
+  useEffect(() => {
+    if (!testRunId) return
+    const terminal = new Set(["succeeded", "failed", "cancelled"])
+    if (testRunStatus && terminal.has(testRunStatus)) return
+
+    const poll = async () => {
+      try {
+        const headers = await authHeaders(getToken)
+        const r = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/runs/${testRunId}`, { headers })
+        if (!r.ok) return
+        const run = await r.json()
+        setTestRunStatus(run.status)
+        if (terminal.has(run.status)) localStorage.removeItem(TEST_RUN_KEY)
+      } catch {}
+    }
+
+    poll()
+    const interval = setInterval(poll, 4000)
+    return () => clearInterval(interval)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [testRunId, testRunStatus])
 
   // Load available environments for the environment picker
   useEffect(() => {
@@ -684,13 +717,15 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
       )
       if (!res.ok) throw new Error("Failed to start test run")
       const data = await res.json()
-      setTestRunId(data.run_id) // banner appears, user can navigate when ready
+      localStorage.setItem(TEST_RUN_KEY, JSON.stringify({ runId: data.run_id, startedAt: Date.now() }))
+      setTestRunId(data.run_id)
+      setTestRunStatus("pending")
     } catch (e) {
       console.error(e)
     } finally {
       setTestRunning(false)
     }
-  }, [workflowId, getToken])
+  }, [workflowId, getToken, TEST_RUN_KEY])
 
   const handleBlockStatus = useCallback((blockId: string, status: "running" | "completed" | "failed" | "skipped") => {
     setNodes(nds => nds.map(n =>
@@ -1131,22 +1166,38 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
         </div>
       )}
 
-      {testRunId && (
-        <div className="fixed bottom-6 right-6 z-50 flex items-center gap-3 bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3 shadow-lg max-w-sm">
-          <span className="text-emerald-500 text-base shrink-0">⚗</span>
-          <div className="flex-1 min-w-0">
-            <p className="text-xs font-semibold text-emerald-800">Test run queued</p>
-            <p className="text-xs text-emerald-600 truncate font-mono">{testRunId}</p>
+      {testRunId && (() => {
+        const failed = testRunStatus === "failed" || testRunStatus === "cancelled"
+        const done = testRunStatus === "succeeded"
+        const active = testRunStatus === "pending" || testRunStatus === "running"
+        const color = failed ? "red" : done ? "emerald" : "indigo"
+        const statusLabel = testRunStatus === "pending" ? "Queued…"
+          : testRunStatus === "running" ? "Running…"
+          : testRunStatus === "succeeded" ? "Succeeded"
+          : testRunStatus === "failed" ? "Failed"
+          : testRunStatus ?? "Starting…"
+        return (
+          <div className={`fixed bottom-6 right-6 z-50 flex items-center gap-3 bg-${color}-50 border border-${color}-200 rounded-xl px-4 py-3 shadow-lg max-w-sm`}>
+            <span className="text-base shrink-0">
+              {active ? <span className="inline-block animate-spin">⚙</span> : done ? "✓" : "✕"}
+            </span>
+            <div className="flex-1 min-w-0">
+              <p className={`text-xs font-semibold text-${color}-800`}>⚗ Test run · {statusLabel}</p>
+              <p className={`text-xs text-${color}-600 truncate font-mono`}>{testRunId.slice(0, 8)}…</p>
+            </div>
+            <a
+              href={`/workflows/${workflowId}/runs/${testRunId}`}
+              className={`shrink-0 text-xs font-medium text-${color}-700 hover:text-${color}-900 underline underline-offset-2`}
+            >
+              View →
+            </a>
+            <button
+              onClick={() => { localStorage.removeItem(TEST_RUN_KEY); setTestRunId(null); setTestRunStatus(null) }}
+              className={`shrink-0 text-${color}-400 hover:text-${color}-700 text-sm`}
+            >✕</button>
           </div>
-          <a
-            href={`/workflows/${workflowId}/runs/${testRunId}`}
-            className="shrink-0 text-xs font-medium text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
-          >
-            View run →
-          </a>
-          <button onClick={() => setTestRunId(null)} className="shrink-0 text-emerald-400 hover:text-emerald-700 text-sm">✕</button>
-        </div>
-      )}
+        )
+      })()}
 
       {testTriggerModal && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -31,6 +31,7 @@ import CostEstimate from "./CostEstimate"
 import YamlPanel from "./YamlPanel"
 import { autoLayout } from "@/lib/auto-layout"
 import { type BlockType } from "@/lib/block-types"
+import { usePreferences } from "@/lib/PreferencesContext"
 
 const nodeTypes = { block: BlockNode }
 
@@ -154,6 +155,11 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const [webhookModal, setWebhookModal] = useState<{ dryRun: boolean } | null>(null)
   const [webhookRepo, setWebhookRepo] = useState("")
   const [webhookPrNumber, setWebhookPrNumber] = useState("")
+  const [testTriggerModal, setTestTriggerModal] = useState(false)
+  const [testRunning, setTestRunning] = useState(false)
+  const [testRunId, setTestRunId] = useState<string | null>(null)
+  const { prefs } = usePreferences()
+  const [playbookSlug, setPlaybookSlug] = useState<string | null>(null)
 
   const STORAGE_KEY = `marshal:active-run:${workflowId}`
 
@@ -244,6 +250,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
         setWorkflowName(data.name)
         setSelectedEnvId(data.environment_id ?? "")
         setGithubHookRepo(data.github_hook_repo ?? null)
+        setPlaybookSlug(data.playbook_slug ?? null)
         const graph = data.current_version?.graph
         if (graph?.nodes && graph?.edges) {
           // Run auto-layout when:
@@ -665,6 +672,26 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
     }
   }, [workflowId, router, STORAGE_KEY])
 
+  const startTestTrigger = useCallback(async () => {
+    setTestTriggerModal(false)
+    setTestRunning(true)
+    try {
+      const headers = await authHeaders(getToken)
+      const res = await fetch(
+        `${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/trigger`,
+        { method: "POST", headers, body: JSON.stringify({}) }
+      )
+      if (!res.ok) throw new Error("Failed to start test run")
+      const data = await res.json()
+      setTestRunId(data.run_id)
+      router.push(`/workflows/${workflowId}/runs/${data.run_id}`)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setTestRunning(false)
+    }
+  }, [workflowId, getToken, router])
+
   const handleBlockStatus = useCallback((blockId: string, status: "running" | "completed" | "failed" | "skipped") => {
     setNodes(nds => nds.map(n =>
       n.id === blockId ? { ...n, data: { ...n.data, runStatus: status } } : n
@@ -780,13 +807,24 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
           </button>
           {!isViewer && (
             <>
-              <button
-                onClick={() => startRun(true)}
-                disabled={running !== "idle"}
-                className="rounded-lg border border-stone-200 px-3 py-1.5 text-xs font-medium text-stone-500 hover:bg-stone-50 transition-colors disabled:opacity-50"
-              >
-                {running === "dry" ? "Simulating…" : "Dry run"}
-              </button>
+              {prefs.show_test_trigger && playbookSlug && (
+                <button
+                  onClick={() => setTestTriggerModal(true)}
+                  disabled={running !== "idle" || testRunning}
+                  className="rounded-lg border border-emerald-200 px-3 py-1.5 text-xs font-medium text-emerald-600 hover:bg-emerald-50 transition-colors disabled:opacity-50"
+                >
+                  {testRunning ? "Starting…" : "⚗ Test Run"}
+                </button>
+              )}
+              {prefs.show_dry_run && (
+                <button
+                  onClick={() => startRun(true)}
+                  disabled={running !== "idle"}
+                  className="rounded-lg border border-stone-200 px-3 py-1.5 text-xs font-medium text-stone-500 hover:bg-stone-50 transition-colors disabled:opacity-50"
+                >
+                  {running === "dry" ? "Simulating…" : "Dry run"}
+                </button>
+              )}
               <button
                 onClick={() => activeRunId ? setDrawerVisible(true) : startRun(false)}
                 disabled={running === "live" || running === "dry"}
@@ -1088,6 +1126,32 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
                 disabled={!webhookRepo.includes("/") || !webhookPrNumber}
                 className="px-4 py-2 text-xs font-medium bg-stone-900 text-white rounded-lg hover:bg-stone-700 disabled:opacity-40 transition-colors"
               >Run review</button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {testTriggerModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+          <div className="bg-white rounded-xl shadow-xl w-full max-w-sm mx-4 p-6 flex flex-col gap-4">
+            <div>
+              <h2 className="text-sm font-semibold text-stone-900">⚗ Test Run</h2>
+              <p className="text-xs text-stone-500 mt-1">
+                This fires a real run using a built-in dummy payload. All artifacts (branches, PRs, files) are prefixed with <span className="font-mono font-medium text-stone-700">[TEST]</span> — safe to close without merging.
+              </p>
+            </div>
+            <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2.5 text-xs text-amber-800">
+              The agent will execute against your connected repo using your environment credentials.
+            </div>
+            <div className="flex gap-2 justify-end">
+              <button
+                onClick={() => setTestTriggerModal(false)}
+                className="px-4 py-2 text-xs text-stone-500 hover:text-stone-700 rounded-lg hover:bg-stone-100 transition-colors"
+              >Cancel</button>
+              <button
+                onClick={startTestTrigger}
+                className="px-4 py-2 text-xs font-medium bg-emerald-600 text-white rounded-lg hover:bg-emerald-700 transition-colors"
+              >Fire test run</button>
             </div>
           </div>
         </div>

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -675,6 +675,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const startTestTrigger = useCallback(async () => {
     setTestTriggerModal(false)
     setTestRunning(true)
+    setTestRunId(null)
     try {
       const headers = await authHeaders(getToken)
       const res = await fetch(
@@ -683,14 +684,13 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
       )
       if (!res.ok) throw new Error("Failed to start test run")
       const data = await res.json()
-      setTestRunId(data.run_id)
-      router.push(`/workflows/${workflowId}/runs/${data.run_id}`)
+      setTestRunId(data.run_id) // banner appears, user can navigate when ready
     } catch (e) {
       console.error(e)
     } finally {
       setTestRunning(false)
     }
-  }, [workflowId, getToken, router])
+  }, [workflowId, getToken])
 
   const handleBlockStatus = useCallback((blockId: string, status: "running" | "completed" | "failed" | "skipped") => {
     setNodes(nds => nds.map(n =>
@@ -1128,6 +1128,23 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
               >Run review</button>
             </div>
           </div>
+        </div>
+      )}
+
+      {testRunId && (
+        <div className="fixed bottom-6 right-6 z-50 flex items-center gap-3 bg-emerald-50 border border-emerald-200 rounded-xl px-4 py-3 shadow-lg max-w-sm">
+          <span className="text-emerald-500 text-base shrink-0">⚗</span>
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-semibold text-emerald-800">Test run queued</p>
+            <p className="text-xs text-emerald-600 truncate font-mono">{testRunId}</p>
+          </div>
+          <a
+            href={`/workflows/${workflowId}/runs/${testRunId}`}
+            className="shrink-0 text-xs font-medium text-emerald-700 hover:text-emerald-900 underline underline-offset-2"
+          >
+            View run →
+          </a>
+          <button onClick={() => setTestRunId(null)} className="shrink-0 text-emerald-400 hover:text-emerald-700 text-sm">✕</button>
         </div>
       )}
 

--- a/apps/web/src/components/settings/PreferencesPanel.tsx
+++ b/apps/web/src/components/settings/PreferencesPanel.tsx
@@ -1,0 +1,64 @@
+"use client"
+
+import { usePreferences } from "@/lib/PreferencesContext"
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <div className="flex items-start justify-between gap-6 py-4 border-b border-stone-100 last:border-0">
+      <div className="flex-1">
+        <p className="text-sm font-medium text-stone-900">{label}</p>
+        <p className="text-xs text-stone-500 mt-0.5">{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors mt-0.5 ${
+          checked ? "bg-indigo-500" : "bg-stone-200"
+        }`}
+      >
+        <span
+          className={`inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform ${
+            checked ? "translate-x-4.5" : "translate-x-0.5"
+          }`}
+        />
+      </button>
+    </div>
+  )
+}
+
+export default function PreferencesPanel() {
+  const { prefs, loading, update } = usePreferences()
+
+  if (loading) {
+    return <div className="text-sm text-stone-400 py-4">Loading preferences…</div>
+  }
+
+  return (
+    <div className="bg-white rounded-xl border border-stone-200 divide-y divide-stone-100 px-5">
+      <ToggleRow
+        label="Show Test Trigger button"
+        description="Adds a 'Test Run' button to the canvas toolbar — fires a real run with a safe dummy payload."
+        checked={prefs.show_test_trigger}
+        onChange={v => update({ show_test_trigger: v })}
+      />
+      <ToggleRow
+        label="Show Dry Run button"
+        description="Adds a 'Dry Run' button to the canvas toolbar — simulates the workflow without calling any external APIs."
+        checked={prefs.show_dry_run}
+        onChange={v => update({ show_dry_run: v })}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/lib/PreferencesContext.tsx
+++ b/apps/web/src/lib/PreferencesContext.tsx
@@ -1,0 +1,84 @@
+"use client"
+
+import React, { createContext, useContext, useEffect, useState, useCallback } from "react"
+
+interface Preferences {
+  show_dry_run: boolean
+  show_test_trigger: boolean
+}
+
+const DEFAULTS: Preferences = {
+  show_dry_run: false,
+  show_test_trigger: true,
+}
+
+interface PreferencesContextValue {
+  prefs: Preferences
+  loading: boolean
+  update: (patch: Partial<Preferences>) => Promise<void>
+}
+
+const PreferencesContext = createContext<PreferencesContextValue>({
+  prefs: DEFAULTS,
+  loading: false,
+  update: async () => {},
+})
+
+export function PreferencesProvider({
+  children,
+  workspaceId,
+  getToken,
+}: {
+  children: React.ReactNode
+  workspaceId: string
+  getToken: (() => Promise<string | null>) | null
+}) {
+  const [prefs, setPrefs] = useState<Preferences>(DEFAULTS)
+  const [loading, setLoading] = useState(true)
+
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+  const headers = useCallback(async (): Promise<Record<string, string>> => {
+    const h: Record<string, string> = { "Content-Type": "application/json" }
+    if (getToken) { const t = await getToken(); if (t) h["Authorization"] = `Bearer ${t}` }
+    if (workspaceId) h["X-Workspace-Id"] = workspaceId
+    return h
+  }, [getToken, workspaceId])
+
+  useEffect(() => {
+    if (!workspaceId || !apiUrl) { setLoading(false); return }
+    ;(async () => {
+      try {
+        const h = await headers()
+        const r = await fetch(`${apiUrl}/workspaces/${workspaceId}/preferences`, { headers: h })
+        if (r.ok) setPrefs(await r.json())
+      } catch {}
+      setLoading(false)
+    })()
+  }, [workspaceId, apiUrl])
+
+  const update = useCallback(async (patch: Partial<Preferences>) => {
+    const optimistic = { ...prefs, ...patch }
+    setPrefs(optimistic)
+    try {
+      const h = await headers()
+      await fetch(`${apiUrl}/workspaces/${workspaceId}/preferences`, {
+        method: "PATCH",
+        headers: h,
+        body: JSON.stringify(patch),
+      })
+    } catch {
+      setPrefs(prefs) // rollback on error
+    }
+  }, [prefs, headers, apiUrl, workspaceId])
+
+  return (
+    <PreferencesContext.Provider value={{ prefs, loading, update }}>
+      {children}
+    </PreferencesContext.Provider>
+  )
+}
+
+export function usePreferences() {
+  return useContext(PreferencesContext)
+}


### PR DESCRIPTION
## Summary
- **Test Run button** on canvas toolbar — fires a real run with a safe `[TEST]`-prefixed dummy payload
- **Dry Run button** now toggleable via preferences (hidden by default)
- **Workspace preferences** — `GET/PATCH /workspaces/{id}/preferences`, Settings → Preferences tab
- **All 13 playbooks** get a `test_trigger.payload` block — safe, realistic, `[TEST]`-prefixed
- **`POST /workflows/{id}/trigger`** — authenticated endpoint, reads playbook YAML for test payload when body empty
- **Migration 0020** — `playbook_slug` on workflows, `preferences` JSONB on workspaces

## Behaviour
- Test Run button only shows when: preferences `show_test_trigger=true` AND workflow has a `playbook_slug`
- Dry Run button only shows when: preferences `show_dry_run=true`
- Confirmation modal warns user it's a real run, explains `[TEST]` prefix, then redirects to run page

## Test plan
- [ ] Settings → Preferences tab shows two toggles with correct defaults
- [ ] Toggle Test Trigger off → button disappears from canvas
- [ ] Toggle Dry Run on → button appears on canvas
- [ ] Click Test Run on any playbook → confirmation modal → fires run → redirects to run page
- [ ] Run appears in dashboard with `triggered_by: manual:test_trigger`