### PR TITLE
feat: per-user CONDUCT_API_KEY with SHA-256 hash storage

### DIFF
--- a/apps/api/alembic/versions/0021_conduct_api_keys.py
+++ b/apps/api/alembic/versions/0021_conduct_api_keys.py
@@ -1,0 +1,33 @@
+"""0021 conduct api keys
+
+Revision ID: 0021
+Revises: 0020
+Create Date: 2026-05-26
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0021"
+down_revision = "0020"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "conduct_api_keys",
+        sa.Column("id",           sa.String(36),  primary_key=True),
+        sa.Column("workspace_id", sa.String(36),  nullable=False, index=True),
+        sa.Column("user_id",      sa.String(255), nullable=False),
+        sa.Column("name",         sa.String(100), nullable=False),
+        sa.Column("key_prefix",   sa.String(20),  nullable=False),   # first 20 chars — display only
+        sa.Column("key_hash",     sa.String(64),  nullable=False, unique=True),  # SHA-256 hex
+        sa.Column("role",         sa.String(20),  nullable=False, server_default="editor"),
+        sa.Column("created_at",   sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("expires_at",   sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_table("conduct_api_keys")

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -189,11 +189,30 @@ def get_workspace_id(
     if not _clerk_enabled():
         return x_workspace_id or DEV_WORKSPACE_ID
 
-    # CLI / server-to-server API key bypasses Clerk
+    # Master server-to-server key (env var) — unchanged
     if x_api_key and settings.cli_api_key and x_api_key == settings.cli_api_key:
         if not settings.cli_workspace_id:
             raise HTTPException(status_code=500, detail="CLI_WORKSPACE_ID is not configured on the server")
         return settings.cli_workspace_id
+
+    # Per-user CONDUCT_API_KEY (cond_live_...) — verified against DB hash
+    if x_api_key and x_api_key.startswith("cond_live_"):
+        import hashlib
+        from app.models.conduct_api_key import ConductApiKey
+        from datetime import datetime, timezone
+        key_hash = hashlib.sha256(x_api_key.encode()).hexdigest()
+        row = db.query(ConductApiKey).filter(ConductApiKey.key_hash == key_hash).first()
+        if not row:
+            raise HTTPException(status_code=401, detail="Invalid API key")
+        if row.expires_at and row.expires_at < datetime.now(timezone.utc):
+            raise HTTPException(status_code=401, detail="API key expired")
+        # Update last_used_at async-style (best effort, don't block)
+        try:
+            row.last_used_at = datetime.now(timezone.utc)
+            db.commit()
+        except Exception:
+            db.rollback()
+        return row.workspace_id
 
     if not credentials:
         raise HTTPException(status_code=401, detail="Authorization header required")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -9,6 +9,7 @@ from app.routers import credentials, dashboard, email_templates, environments, p
 from app.routers.organizations import router as organizations_router
 from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router
 from app.routers.runs import workspace_runs_router
+from app.routers.api_keys import router as api_keys_router
 
 setup_logging()
 log = structlog.get_logger(__name__)
@@ -55,6 +56,7 @@ app.include_router(organizations_router)
 app.include_router(workspace_projects_router)
 app.include_router(audit_log_router)
 app.include_router(workspace_preferences_router)
+app.include_router(api_keys_router)
 app.include_router(projects.router)
 app.include_router(dashboard.router)
 app.include_router(workflows.router)

--- a/apps/api/app/models/conduct_api_key.py
+++ b/apps/api/app/models/conduct_api_key.py
@@ -1,0 +1,18 @@
+from datetime import datetime
+from sqlalchemy import Column, String, DateTime
+from app.db.base import Base
+
+
+class ConductApiKey(Base):
+    __tablename__ = "conduct_api_keys"
+
+    id           = Column(String(36),  primary_key=True)
+    workspace_id = Column(String(36),  nullable=False, index=True)
+    user_id      = Column(String(255), nullable=False)
+    name         = Column(String(100), nullable=False)
+    key_prefix   = Column(String(20),  nullable=False)
+    key_hash     = Column(String(64),  nullable=False, unique=True)
+    role         = Column(String(20),  nullable=False, default="editor")
+    created_at   = Column(DateTime(timezone=True), nullable=False)
+    last_used_at = Column(DateTime(timezone=True), nullable=True)
+    expires_at   = Column(DateTime(timezone=True), nullable=True)

--- a/apps/api/app/routers/api_keys.py
+++ b/apps/api/app/routers/api_keys.py
@@ -1,0 +1,120 @@
+import hashlib
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Annotated, Optional
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_user_id, get_workspace_id, require_workspace_role
+from app.db.session import get_db
+from app.models.conduct_api_key import ConductApiKey
+
+router = APIRouter(prefix="/workspaces/{workspace_id}/api-keys", tags=["api-keys"])
+
+PREFIX = "cond_live_"
+
+
+def _generate_key() -> tuple[str, str, str]:
+    """Return (plaintext, prefix, sha256_hex)."""
+    raw       = PREFIX + os.urandom(32).hex()
+    prefix    = raw[:20]
+    key_hash  = hashlib.sha256(raw.encode()).hexdigest()
+    return raw, prefix, key_hash
+
+
+def _hash_key(key: str) -> str:
+    return hashlib.sha256(key.encode()).hexdigest()
+
+
+# ── Schemas ───────────────────────────────────────────────────────────────────
+
+class ApiKeyCreate(BaseModel):
+    name: str
+    expires_at: Optional[datetime] = None
+
+
+class ApiKeyOut(BaseModel):
+    id:           str
+    name:         str
+    key_prefix:   str
+    role:         str
+    created_at:   datetime
+    last_used_at: Optional[datetime]
+    expires_at:   Optional[datetime]
+
+
+class ApiKeyCreated(ApiKeyOut):
+    key: str  # plaintext — returned once only
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────────
+
+@router.get("", response_model=list[ApiKeyOut])
+def list_api_keys(
+    workspace_id: str,
+    user_id:      Annotated[str, Depends(get_user_id)],
+    _ws:          str = Depends(get_workspace_id),
+    _role:        str = Depends(require_workspace_role("admin", "editor")),
+    db:           Session = Depends(get_db),
+):
+    rows = db.query(ConductApiKey).filter(
+        ConductApiKey.workspace_id == workspace_id
+    ).order_by(ConductApiKey.created_at.desc()).all()
+    return [ApiKeyOut(
+        id=r.id, name=r.name, key_prefix=r.key_prefix, role=r.role,
+        created_at=r.created_at, last_used_at=r.last_used_at, expires_at=r.expires_at,
+    ) for r in rows]
+
+
+@router.post("", response_model=ApiKeyCreated, status_code=201)
+def create_api_key(
+    workspace_id: str,
+    body:         ApiKeyCreate,
+    user_id:      Annotated[str, Depends(get_user_id)],
+    role:         str = Depends(require_workspace_role("admin")),
+    db:           Session = Depends(get_db),
+):
+    if not body.name.strip():
+        raise HTTPException(status_code=422, detail="Key name cannot be empty")
+
+    plaintext, prefix, key_hash = _generate_key()
+
+    row = ConductApiKey(
+        id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        user_id=user_id,
+        name=body.name.strip(),
+        key_prefix=prefix,
+        key_hash=key_hash,
+        role="admin",
+        created_at=datetime.now(timezone.utc),
+        expires_at=body.expires_at,
+    )
+    db.add(row)
+    db.commit()
+
+    return ApiKeyCreated(
+        id=row.id, name=row.name, key_prefix=row.key_prefix, role=row.role,
+        created_at=row.created_at, last_used_at=None, expires_at=row.expires_at,
+        key=plaintext,
+    )
+
+
+@router.delete("/{key_id}", status_code=204)
+def revoke_api_key(
+    workspace_id: str,
+    key_id:       str,
+    _role:        str = Depends(require_workspace_role("admin")),
+    db:           Session = Depends(get_db),
+):
+    row = db.query(ConductApiKey).filter(
+        ConductApiKey.id == key_id,
+        ConductApiKey.workspace_id == workspace_id,
+    ).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="API key not found")
+    db.delete(row)
+    db.commit()

--- a/apps/web/src/app/settings/page.tsx
+++ b/apps/web/src/app/settings/page.tsx
@@ -7,9 +7,10 @@ import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
 import AuditLog from "@/components/settings/AuditLog"
 import PreferencesPanel from "@/components/settings/PreferencesPanel"
+import ApiKeysManager from "@/components/settings/ApiKeysManager"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 
-type Tab = "environments" | "members" | "audit" | "preferences"
+type Tab = "environments" | "members" | "audit" | "preferences" | "api-keys"
 
 export default function SettingsPage() {
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
@@ -45,7 +46,7 @@ function SettingsPageWithAuth() {
 }
 
 function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
-  const tabs = (["environments", "preferences", ...(isAdmin ? ["members", "audit"] : [])] as Tab[])
+  const tabs = (["environments", "preferences", ...(isAdmin ? ["members", "audit", "api-keys"] : [])] as Tab[])
   const [activeTab, setActiveTab] = useState<Tab>("environments")
   const [showTip, setShowTip] = useState(true)
 
@@ -93,6 +94,7 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
         {activeTab === "preferences" && <PreferencesPanel />}
         {activeTab === "members" && isAdmin && <MembersManager />}
         {activeTab === "audit" && isAdmin && <AuditLog workspaceId={workspaceId} getToken={getToken} />}
+        {activeTab === "api-keys" && isAdmin && <ApiKeysManager />}
       </div>
     </AppShell>
   )

--- a/apps/web/src/components/settings/ApiKeysManager.tsx
+++ b/apps/web/src/components/settings/ApiKeysManager.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { useAuth } from "@clerk/nextjs"
+import { useWorkspace } from "@/lib/WorkspaceContext"
+
+interface ApiKey {
+  id: string
+  name: string
+  key_prefix: string
+  role: string
+  created_at: string
+  last_used_at: string | null
+  expires_at: string | null
+}
+
+export default function ApiKeysManager() {
+  const { getToken } = useAuth()
+  const { activeWorkspace } = useWorkspace()
+  const workspaceId = activeWorkspace?.id ?? ""
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL
+
+  const [keys, setKeys] = useState<ApiKey[]>([])
+  const [loading, setLoading] = useState(true)
+  const [creating, setCreating] = useState(false)
+  const [newName, setNewName] = useState("")
+  const [newKey, setNewKey] = useState<string | null>(null)
+  const [copied, setCopied] = useState(false)
+  const [revoking, setRevoking] = useState<string | null>(null)
+
+  const headers = useCallback(async (): Promise<Record<string, string>> => {
+    const h: Record<string, string> = { "Content-Type": "application/json" }
+    if (getToken) { const t = await getToken(); if (t) h["Authorization"] = `Bearer ${t}` }
+    if (workspaceId) h["X-Workspace-Id"] = workspaceId
+    return h
+  }, [getToken, workspaceId])
+
+  const load = useCallback(async () => {
+    if (!workspaceId || !apiUrl) return
+    try {
+      const h = await headers()
+      const r = await fetch(`${apiUrl}/workspaces/${workspaceId}/api-keys`, { headers: h })
+      if (r.ok) setKeys(await r.json())
+    } catch {}
+    setLoading(false)
+  }, [workspaceId, apiUrl, headers])
+
+  useEffect(() => { load() }, [load])
+
+  async function create() {
+    if (!newName.trim()) return
+    setCreating(true)
+    try {
+      const h = await headers()
+      const r = await fetch(`${apiUrl}/workspaces/${workspaceId}/api-keys`, {
+        method: "POST",
+        headers: h,
+        body: JSON.stringify({ name: newName.trim() }),
+      })
+      if (r.ok) {
+        const data = await r.json()
+        setNewKey(data.key)
+        setNewName("")
+        await load()
+      }
+    } catch {}
+    setCreating(false)
+  }
+
+  async function revoke(id: string) {
+    setRevoking(id)
+    try {
+      const h = await headers()
+      await fetch(`${apiUrl}/workspaces/${workspaceId}/api-keys/${id}`, { method: "DELETE", headers: h })
+      setKeys(k => k.filter(x => x.id !== id))
+    } catch {}
+    setRevoking(null)
+  }
+
+  function copy() {
+    if (!newKey) return
+    navigator.clipboard.writeText(newKey)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  function fmt(dateStr: string | null) {
+    if (!dateStr) return "—"
+    return new Date(dateStr).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* New key — shown once after creation */}
+      {newKey && (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-3">
+          <p className="text-sm font-semibold text-amber-800">Copy your API key — it won't be shown again.</p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 bg-white border border-amber-200 rounded px-3 py-2 text-xs font-mono text-stone-800 break-all select-all">
+              {newKey}
+            </code>
+            <button
+              onClick={copy}
+              className={`shrink-0 px-3 py-2 rounded text-xs font-medium transition-colors ${
+                copied
+                  ? "bg-green-100 text-green-700 border border-green-300"
+                  : "bg-amber-100 text-amber-800 border border-amber-300 hover:bg-amber-200"
+              }`}
+            >
+              {copied ? "Copied!" : "Copy"}
+            </button>
+          </div>
+          <p className="text-xs text-amber-600">
+            Use this key with <code className="bg-amber-100 px-1 rounded">X-Api-Key</code> header or{" "}
+            <code className="bg-amber-100 px-1 rounded">conduct login --api-key</code>.
+          </p>
+          <button
+            onClick={() => setNewKey(null)}
+            className="text-xs text-amber-500 hover:text-amber-700 underline"
+          >
+            I've saved it, dismiss
+          </button>
+        </div>
+      )}
+
+      {/* Create form */}
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+          onKeyDown={e => e.key === "Enter" && create()}
+          placeholder="Key name (e.g. My laptop, CI pipeline)"
+          className="flex-1 border border-stone-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-stone-300"
+        />
+        <button
+          onClick={create}
+          disabled={creating || !newName.trim()}
+          className="px-4 py-2 bg-stone-900 text-white text-sm rounded-lg hover:bg-stone-700 disabled:opacity-40 transition-colors"
+        >
+          {creating ? "Generating…" : "Generate key"}
+        </button>
+      </div>
+
+      {/* Keys table */}
+      {loading ? (
+        <p className="text-sm text-stone-400">Loading…</p>
+      ) : keys.length === 0 ? (
+        <p className="text-sm text-stone-400">No API keys yet. Generate one above.</p>
+      ) : (
+        <div className="border border-stone-200 rounded-lg overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-stone-50 text-stone-500 text-xs">
+              <tr>
+                <th className="text-left px-4 py-2 font-medium">Name</th>
+                <th className="text-left px-4 py-2 font-medium">Prefix</th>
+                <th className="text-left px-4 py-2 font-medium">Created</th>
+                <th className="text-left px-4 py-2 font-medium">Last used</th>
+                <th className="px-4 py-2" />
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-100">
+              {keys.map(k => (
+                <tr key={k.id} className="hover:bg-stone-50">
+                  <td className="px-4 py-3 font-medium text-stone-800">{k.name}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-stone-500">{k.key_prefix}…</td>
+                  <td className="px-4 py-3 text-stone-500">{fmt(k.created_at)}</td>
+                  <td className="px-4 py-3 text-stone-500">{fmt(k.last_used_at)}</td>
+                  <td className="px-4 py-3 text-right">
+                    <button
+                      onClick={() => revoke(k.id)}
+                      disabled={revoking === k.id}
+                      className="text-xs text-red-500 hover:text-red-700 disabled:opacity-40 transition-colors"
+                    >
+                      {revoking === k.id ? "Revoking…" : "Revoke"}
+                    </button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      <p className="text-xs text-stone-400">
+        Keys are stored as SHA-256 hashes — Conduct never sees your key again after generation.
+        Admin only can create or revoke keys.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
GitHub PAT-style API keys for Conduct — plaintext shown once, only hash stored.

**Token format**: `cond_live_<64 hex chars>` — greppable prefix for credential scanners.

**Flow**:
1. Admin goes to Settings → API Keys → types a name → clicks Generate
2. `cond_live_...` key appears with Copy button and amber "won't be shown again" warning
3. SHA-256 hash stored in DB, plaintext discarded
4. User runs `conduct login --api-key cond_live_...` — works immediately
5. Every request: middleware SHA-256s the incoming key, looks up in `conduct_api_keys` table
6. `last_used_at` updated on each auth so admins can see stale keys

**RBAC**: admin only can create/revoke. Existing master `CLI_API_KEY` env var untouched.

## Migration
`0021_conduct_api_keys.py` — new `conduct_api_keys` table

## Test plan
- [ ] Settings → API Keys tab visible for admin, hidden for editor/viewer
- [ ] Generate key → amber banner with copy button appears
- [ ] Key disappears from banner after "I've saved it, dismiss"
- [ ] `conduct login --api-key cond_live_xxx` → connects successfully
- [ ] `conduct agents` works with the new key
- [ ] Expired/revoked key → 401
- [ ] `last_used_at` updates after first use