### PR TITLE
fix: correct Base and get_db imports in api_keys router

### DIFF
--- a/apps/api/app/models/conduct_api_key.py
+++ b/apps/api/app/models/conduct_api_key.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 from sqlalchemy import Column, String, DateTime
-from app.db.base import Base
+from app.core.database import Base
 
 
 class ConductApiKey(Base):

--- a/apps/api/app/routers/api_keys.py
+++ b/apps/api/app/routers/api_keys.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_user_id, get_workspace_id, require_workspace_role
-from app.db.session import get_db
+from app.core.database import get_db
 from app.models.conduct_api_key import ConductApiKey
 
 router = APIRouter(prefix="/workspaces/{workspace_id}/api-keys", tags=["api-keys"])


### PR DESCRIPTION
Wrong import paths caused startup crash — routes never registered, hence 404. Fixed app.db.base → app.core.database and app.db.session → app.core.database.