### PR TITLE
fix: add eslintrc + fix lint errors to unblock CI

### DIFF
--- a/apps/web/.eslintrc.json
+++ b/apps/web/.eslintrc.json
@@ -1,0 +1,9 @@
+{
+  "extends": "next",
+  "rules": {
+    "react/no-unescaped-entities": "warn",
+    "react-hooks/exhaustive-deps": "warn",
+    "react-hooks/rules-of-hooks": "error",
+    "@next/next/no-img-element": "warn"
+  }
+}

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -300,11 +300,11 @@ function FieldInput({
 }) {
   const strVal = value === undefined || value === null ? (field.defaultValue !== undefined ? String(field.defaultValue) : "") : String(value)
   const boolVal = value === undefined ? (field.defaultValue as boolean ?? false) : Boolean(value)
+  const [visible, setVisible] = React.useState(false)
 
   const base = "w-full border border-stone-200 rounded-lg px-2.5 py-1.5 text-sm text-stone-900 focus:outline-none focus:ring-2 focus:ring-indigo-200 bg-white"
 
   if (field.readOnly) {
-    const [visible, setVisible] = React.useState(false)
     const display = strVal || field.placeholder || ""
     const masked = display.replace(/./g, "•").slice(0, 24)
     return (

--- a/apps/web/src/components/settings/ApiKeysManager.tsx
+++ b/apps/web/src/components/settings/ApiKeysManager.tsx
@@ -94,7 +94,7 @@ export default function ApiKeysManager() {
       {/* New key — shown once after creation */}
       {newKey && (
         <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 space-y-3">
-          <p className="text-sm font-semibold text-amber-800">Copy your API key — it won't be shown again.</p>
+          <p className="text-sm font-semibold text-amber-800">Copy your API key — it won&apos;t be shown again.</p>
           <div className="flex items-center gap-2">
             <code className="flex-1 bg-white border border-amber-200 rounded px-3 py-2 text-xs font-mono text-stone-800 break-all select-all">
               {newKey}
@@ -118,7 +118,7 @@ export default function ApiKeysManager() {
             onClick={() => setNewKey(null)}
             className="text-xs text-amber-500 hover:text-amber-700 underline"
           >
-            I've saved it, dismiss
+            I&apos;ve saved it, dismiss
           </button>
         </div>
       )}


### PR DESCRIPTION
- Added .eslintrc.json (was missing, causing next lint to prompt interactively in CI)
- Moved React.useState out of conditional branch in BlockEditor (rules-of-hooks)
- Escaped apostrophes in ApiKeysManager