### PR TITLE
fix: wire API key bypass into get_user_id + Python 3.9 CLI compat

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -135,10 +135,26 @@ def get_clerk_user_email(user_id: str) -> str | None:
 
 def get_user_id(
     credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
+    x_api_key: Annotated[str | None, Header()] = None,
+    db: Session = Depends(get_db),
 ) -> str:
     """Returns the Clerk user_id (sub claim), or 'dev' in local dev mode."""
     if not _clerk_enabled():
         return DEV_USER_ID
+
+    # Master API key — return synthetic user ID scoped to the CLI workspace
+    if x_api_key and settings.cli_api_key and x_api_key == settings.cli_api_key:
+        return f"api-key:{settings.cli_workspace_id}"
+
+    # Per-user cond_live_ key — return the stored user_id
+    if x_api_key and x_api_key.startswith("cond_live_"):
+        import hashlib
+        from app.models.conduct_api_key import ConductApiKey
+        key_hash = hashlib.sha256(x_api_key.encode()).hexdigest()
+        row = db.query(ConductApiKey).filter(ConductApiKey.key_hash == key_hash).first()
+        if row:
+            return row.user_id
+        raise HTTPException(status_code=401, detail="Invalid API key")
 
     if not credentials:
         raise HTTPException(status_code=401, detail="Authorization header required")

--- a/packages/conduct-cli/src/conduct_cli/api.py
+++ b/packages/conduct-cli/src/conduct_cli/api.py
@@ -48,7 +48,7 @@ def req_text(method: str, url: str, hdrs: dict, body_text: str) -> dict:
         sys.exit(1)
 
 
-def stream(url: str, hdrs: dict | None = None):
+def stream(url: str, hdrs=None):
     """Yield parsed SSE data dicts."""
     r = urllib.request.Request(url, headers=hdrs or {})
     try:

--- a/packages/conduct-cli/src/conduct_cli/main.py
+++ b/packages/conduct-cli/src/conduct_cli/main.py
@@ -34,7 +34,7 @@ def _save_config(data: dict):
     CONFIG_PATH.write_text(json.dumps(data, indent=2))
 
 
-def _resolve(args, key: str, config_key: str | None = None):
+def _resolve(args, key: str, config_key=None):
     """Return value from CLI args first, then config file."""
     val = getattr(args, key.replace("-", "_"), None)
     if val:
@@ -43,7 +43,7 @@ def _resolve(args, key: str, config_key: str | None = None):
     return cfg.get(config_key or key)
 
 
-def _require_auth(args) -> tuple[str, str, str | None, str | None]:
+def _require_auth(args):
     """Return (server, workspace_id, api_key, token) — exit if not configured."""
     server     = _resolve(args, "server")
     workspace  = _resolve(args, "workspace")


### PR DESCRIPTION
get_user_id only had Clerk JWT handling — any request using it (including GET /workflows) would 401 even with a valid cond_live_ key. Both master key and cond_live_ now handled in get_user_id.