### PR TITLE
fix: Workflow DSL schema extra=ignore to allow test_trigger field

### DIFF
--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -239,7 +239,7 @@ class Workflow(BaseModel):
     blocks: dict[str, Block]
     cleanup: dict[str, CleanupBlock] = Field(default_factory=dict)
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     # ----- structural validation -------------------------------------------
     @field_validator("name")


### PR DESCRIPTION
extra=forbid was rejecting playbook YAMLs that contain test_trigger — changed to ignore so test_trigger and any future annotation fields pass through.