### PR TITLE
fix: handle empty 204 body in api.req

### DIFF
--- a/packages/conduct-cli/src/conduct_cli/api.py
+++ b/packages/conduct-cli/src/conduct_cli/api.py
@@ -22,7 +22,8 @@ def req(method: str, url: str, hdrs: dict, body=None) -> dict:
     r = urllib.request.Request(url, data=data, headers=hdrs, method=method)
     try:
         with urllib.request.urlopen(r) as resp:
-            return json.loads(resp.read())
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as e:
         raw = e.read().decode()
         try:
@@ -37,7 +38,8 @@ def req_text(method: str, url: str, hdrs: dict, body_text: str) -> dict:
     r = urllib.request.Request(url, data=body_text.encode(), headers=hdrs, method=method)
     try:
         with urllib.request.urlopen(r) as resp:
-            return json.loads(resp.read())
+            raw = resp.read()
+            return json.loads(raw) if raw else {}
     except urllib.error.HTTPError as e:
         raw = e.read().decode()
         try:


### PR DESCRIPTION
DELETE returns 204 No Content — json.loads on empty string raises JSONDecodeError. Now returns {} for empty responses.