### PR TITLE
fix: marketplace installed count by playbook_slug

### DIFF
--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -49,6 +49,7 @@ class WorkflowOut(BaseModel):
     last_run_status: Optional[str] = None
     last_run_at: Optional[datetime] = None
     environment_id: Optional[UUID] = None
+    playbook_slug: Optional[str] = None
 
     class Config:
         from_attributes = True

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -134,11 +134,12 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
       if (pbRes.ok) setPlaybooks(await pbRes.json())
 
       if (wfRes.ok) {
-        const workflows: { id: string; name: string; workspace_id: string }[] = await wfRes.json()
+        const workflows: { id: string; name: string; playbook_slug?: string }[] = await wfRes.json()
         const counts = new Map<string, number>()
-        for (const [slug, friendlyName] of Object.entries(FRIENDLY_NAMES)) {
-          const n = workflows.filter(w => w.name === friendlyName).length
-          if (n > 0) counts.set(slug, n)
+        for (const wf of workflows) {
+          if (wf.playbook_slug) {
+            counts.set(wf.playbook_slug, (counts.get(wf.playbook_slug) ?? 0) + 1)
+          }
         }
         setInstalledCount(counts)
       }


### PR DESCRIPTION
Name-based matching was wrong for half the playbooks. playbook_slug is now in WorkflowOut and used directly.