### PR TITLE
feat: publish conduct-cli to PyPI

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,32 @@
+name: Publish conduct-cli to PyPI
+
+on:
+  push:
+    tags:
+      - "cli/v*"   # trigger on tags like cli/v0.2.0
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write   # required for trusted publishing (no API token needed)
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        working-directory: packages/conduct-cli
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: packages/conduct-cli/dist/

--- a/packages/conduct-cli/README.md
+++ b/packages/conduct-cli/README.md
@@ -1,0 +1,84 @@
+# conduct-cli
+
+Official CLI for [Conduct AI](https://conductai.ai) — install AI agents, manage projects, and run end-to-end tests from the terminal.
+
+## Install
+
+```bash
+pip install conduct-cli
+```
+
+## Quick start
+
+```bash
+# Authenticate (one-time)
+conduct login \
+  --server https://api.conductai.ai \
+  --api-key cond_live_xxx \
+  --workspace <workspace-id>
+
+# Browse available agents
+conduct playbooks
+
+# Create a project and install all agents in one shot
+conduct install-all --project DevOps --repo owner/repo
+
+# List installed agents
+conduct agents
+
+# Run a test trigger on any agent
+conduct test "PR Reviewer"
+conduct test --all
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `conduct login` | Save connection config to `~/.conduct/config.json` |
+| `conduct projects` | List all projects |
+| `conduct create project <name>` | Create a project |
+| `conduct delete project <name>` | Delete a project and all its agents |
+| `conduct reset project <name>` | Delete all agents in a project (clean slate) |
+| `conduct playbooks` | Browse available playbooks |
+| `conduct playbooks <slug>` | Show required inputs for a playbook |
+| `conduct install <slug>` | Install one agent from a playbook |
+| `conduct install-all` | Install all 12 playbooks into a project |
+| `conduct agents` | List all installed agents |
+| `conduct test <name>` | Fire test trigger on an agent and stream results |
+| `conduct test --all` | Test every playbook-based agent |
+
+## Authentication
+
+Generate an API key from **Settings → API Keys** in the Conduct AI dashboard. Keys start with `cond_live_` and are stored as SHA-256 hashes — the plaintext is shown only once.
+
+```bash
+conduct login --server https://api.conductai.ai --api-key cond_live_xxx --workspace <id>
+```
+
+## Install all agents
+
+```bash
+# Installs all 12 playbooks into a project, pointed at your GitHub repo
+conduct install-all --project DevOps --repo myorg/myrepo
+```
+
+If the project doesn't exist it's created automatically. Use `--input key=value` to override any playbook input.
+
+## Test agents
+
+```bash
+# Test a single agent (fires synthetic test payload, streams run events)
+conduct test "Autopilot Quick"
+
+# Test all playbook-based agents in sequence
+conduct test --all
+```
+
+Exit code is `0` if all pass, `1` if any fail — works in CI.
+
+## Links
+
+- Dashboard: [conductai.ai](https://conductai.ai)
+- Docs: [conductai.ai/docs](https://conductai.ai/docs)
+- Issues: [github.com/sseshachala/conductai/issues](https://github.com/sseshachala/conductai/issues)

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -4,10 +4,31 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-cli"
-version = "0.1.0"
-description = "Conduct workflow CLI"
+version = "0.2.0"
+description = "CLI for Conduct AI — install agents, manage projects, run tests"
+readme = "README.md"
+license = { text = "MIT" }
 requires-python = ">=3.9"
+authors = [{ name = "Conduct AI", email = "hello@conductai.ai" }]
+keywords = ["ai", "agents", "automation", "devops", "cli"]
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: MIT License",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development :: Libraries :: Application Frameworks",
+]
 dependencies = ["pyyaml>=6.0"]
+
+[project.urls]
+Homepage    = "https://conductai.ai"
+Repository  = "https://github.com/sseshachala/conductai"
+"Bug Tracker" = "https://github.com/sseshachala/conductai/issues"
 
 [project.scripts]
 conduct = "conduct_cli.main:main"


### PR DESCRIPTION
## Summary
- `pyproject.toml` updated with author, classifiers, URLs, keywords, version `0.2.0`
- `README.md` written for PyPI package page — full command reference
- GitHub Actions workflow `publish-cli.yml` triggers on `cli/v*` tags using PyPI trusted publishing (OIDC — no secret needed)

## Setup required (one-time on PyPI)
1. Create account at pypi.org
2. Create project `conduct-cli`
3. Go to project → Publishing → Add trusted publisher:
   - Owner: `sseshachala`
   - Repo: `conductai`
   - Workflow: `publish-cli.yml`
   - Environment: `pypi`
4. Create `pypi` environment in GitHub repo settings

## To publish
```bash
git tag cli/v0.2.0
git push origin cli/v0.2.0
```

Users can then install with:
```bash
pip install conduct-cli
```