### PR TITLE
fix: rebrand Delegator → Conduct AI in all user-facing text

### DIFF
--- a/apps/api/app/compiler/stream.py
+++ b/apps/api/app/compiler/stream.py
@@ -12,7 +12,7 @@ from app.core.config import settings
 
 log = structlog.get_logger(__name__)
 
-COMPILER_SYSTEM = """You are a system prompt compiler for an AI workflow platform called Delegator.
+COMPILER_SYSTEM = """You are a system prompt compiler for an AI workflow platform called Conduct AI.
 
 Given a plain-English block description, generate a precise, well-structured system prompt.
 The prompt should:

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -26,7 +26,7 @@ class Settings(BaseSettings):
     clerk_audience: str = ""      # set to the expected aud claim to enable audience verification
     # Email — system-level default; can also be added per-workspace in Settings
     resend_api_key: str = ""
-    email_from: str = "Delegator <notifications@delegator.dev>"
+    email_from: str = "Conduct AI <notifications@conductai.ai>"
     # Webhook secrets
     vercel_webhook_secret: str = ""
     github_webhook_secret: str = ""

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -930,7 +930,7 @@ def _fill_template(template: str, state: dict, workflow_name: str = "Agent", tra
 
     # Split subject line if present (first line starting with "Subject:")
     lines = template.strip().splitlines()
-    subject = f"Delegator: {workflow_name} completed"
+    subject = f"Conduct AI: {workflow_name} completed"
     body_lines = lines
     if lines and lines[0].lower().startswith("subject:"):
         subject = lines[0][8:].strip()
@@ -943,7 +943,7 @@ def _fill_template(template: str, state: dict, workflow_name: str = "Agent", tra
         "{duration}": "—",
         "{triggered_by}": triggered_by,
         "{run_summary}": run_summary,
-        "{trace_url}": trace_url or "(see Delegator dashboard)",
+        "{trace_url}": trace_url or "(see Conduct AI dashboard)",
     }
     for k, v in replacements.items():
         subject = subject.replace(k, v)
@@ -1015,10 +1015,10 @@ def _execute_output(block: dict, state: dict, credentials: dict, workflow_name: 
             "trace_url": trace_url,
             "state": {k: v for k, v in state.items() if not k.startswith("__")},
         }, default=str).encode()
-        headers = {"Content-Type": "application/json", "User-Agent": "Delegator/1.0"}
+        headers = {"Content-Type": "application/json", "User-Agent": "ConductAI/1.0"}
         if webhook_secret:
             sig = hmac_lib.new(webhook_secret.encode(), payload, hashlib.sha256).hexdigest()
-            headers["X-Delegator-Signature"] = f"sha256={sig}"
+            headers["X-ConductAI-Signature"] = f"sha256={sig}"
         try:
             req = urllib.request.Request(webhook_url, data=payload, headers=headers, method="POST")
             with urllib.request.urlopen(req, timeout=15) as resp:

--- a/apps/api/app/runtime/integrations/email.py
+++ b/apps/api/app/runtime/integrations/email.py
@@ -5,7 +5,7 @@ Actions: send_email.
 import httpx
 
 
-def send_via_resend(api_key: str, to: str, subject: str, body: str, from_address: str = "Delegator <notifications@delegator.dev>") -> dict:
+def send_via_resend(api_key: str, to: str, subject: str, body: str, from_address: str = "Conduct AI <notifications@conductai.ai>") -> dict:
     r = httpx.post(
         "https://api.resend.com/emails",
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
@@ -17,7 +17,7 @@ def send_via_resend(api_key: str, to: str, subject: str, body: str, from_address
     return {"sent": True, "provider": "resend", "id": d.get("id"), "to": to, "subject": subject}
 
 
-def send_via_sendgrid(api_key: str, to: str, subject: str, body: str, from_address: str = "notifications@delegator.dev") -> dict:
+def send_via_sendgrid(api_key: str, to: str, subject: str, body: str, from_address: str = "notifications@conductai.ai") -> dict:
     r = httpx.post(
         "https://api.sendgrid.com/v3/mail/send",
         headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},

--- a/apps/api/app/templates/email_output.txt
+++ b/apps/api/app/templates/email_output.txt
@@ -1,8 +1,8 @@
-Subject: Delegator: {workflow_name} completed ✓
+Subject: Conduct AI: {workflow_name} completed ✓
 
 Hi,
 
-Your Delegator agent "{workflow_name}" finished running.
+Your Conduct AI agent "{workflow_name}" finished running.
 
 Status: {status}
 Duration: {duration}
@@ -18,4 +18,4 @@ View the full trace here:
 {trace_url}
 
 —
-Delegator · AI agent orchestration
+Conduct AI · AI agent orchestration

--- a/apps/api/app/templates/slack_output.txt
+++ b/apps/api/app/templates/slack_output.txt
@@ -1,4 +1,4 @@
-*Delegator agent run complete* ✓
+*Conduct AI* — agent run complete ✓
 
 *Agent:* {workflow_name}
 *Status:* {status}

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -92,7 +92,7 @@ blocks:
       region: "{{params.droplet_region}}"
       size: "{{params.droplet_size}}"
       image: ubuntu-22-04-x64
-      tags: ["delegator", "ai-ready"]
+      tags: ["conduct-ai", "ai-ready"]
       ssh_keys:
         - "{{credentials.digitalocean.ssh_key_fingerprint}}"
     next: wait_droplet

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -171,7 +171,7 @@ blocks:
            {"title": "fix: {{fetch_issue.title}} (closes #{{fetch_issue.issue_number}})",
             "head":  "ai-ready/issue-{{fetch_issue.issue_number}}",
             "base":  "<default branch>",
-            "body":  "Automated fix by Delegator. Closes #{{fetch_issue.issue_number}}.",
+            "body":  "Automated fix by Conduct AI. Closes #{{fetch_issue.issue_number}}.",
             "draft": true}
 
       10. Output as the FINAL line of your response, JSON only:

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -77,7 +77,7 @@ blocks:
       6. Stage and commit: git add -A && git commit -m 'fix: <short description> (closes #{{fetch_issue.issue_number}})'
       7. Set remote with credentials and push:
          git remote set-url origin https://<github_token>@github.com/{{_trigger.repo_full_name}}.git
-         (retrieve the GitHub token from the Delegator credentials vault)
+         (retrieve the GitHub token from the Conduct AI credentials vault)
          git push origin autopilot/issue-{{fetch_issue.issue_number}}
 
       Output ONLY the following JSON on the last line of your response:
@@ -99,7 +99,7 @@ blocks:
       Steps:
       1. Clone the repo with the pushed branch:
          git clone --branch {{implement_fix.branch_name}} https://<github_token>@github.com/{{_trigger.repo_full_name}}.git /tmp/repo
-         (retrieve the GitHub token from the Delegator credentials vault)
+         (retrieve the GitHub token from the Conduct AI credentials vault)
       2. cd /tmp/repo
       3. Detect the test runner by reading package.json or requirements.txt
       4. Run the tests
@@ -151,7 +151,7 @@ blocks:
       Branch: {{implement_fix.branch_name}}
       Base: {{_trigger.default_branch}}
 
-      1. Retrieve the GitHub token from the Delegator credentials vault
+      1. Retrieve the GitHub token from the Conduct AI credentials vault
       2. Open a PR via the GitHub API:
          POST https://api.github.com/repos/{{_trigger.repo_full_name}}/pulls
          Headers: Authorization: token <github_token>, Content-Type: application/json

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -158,7 +158,7 @@ blocks:
          Body: {"title": "fix: {{fetch_issue.title}} (closes #{{fetch_issue.issue_number}})",
                 "head":  "{{implement_fix.branch_name}}",
                 "base":  "{{_trigger.default_branch}}",
-                "body":  "Automated fix by Delegator.\n\nCloses #{{fetch_issue.issue_number}}"}
+                "body":  "Automated fix by Conduct AI.\n\nCloses #{{fetch_issue.issue_number}}"}
 
       Output ONLY the following JSON on the last line:
         {"pr_url": "<full PR URL>"}

--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -76,7 +76,7 @@ blocks:
          {"title": "fix: {{fetch_issue.title}} (closes #{{fetch_issue.issue_number}})",
           "head":  "autopilot/issue-{{fetch_issue.issue_number}}",
           "base":  "{{_trigger.default_branch}}",
-          "body":  "Automated fix by Delegator.\n\nCloses #{{fetch_issue.issue_number}}"}
+          "body":  "Automated fix by Conduct AI.\n\nCloses #{{fetch_issue.issue_number}}"}
 
       Output ONLY the following JSON on the last line of your response:
         {"pr_url": "<full PR URL>"}

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -152,7 +152,7 @@ blocks:
          Body: {"title": "fix: {{fetch_issue.title}} (closes #{{fetch_issue.issue_number}})",
                 "head":  "{{implement_fix.branch_name}}",
                 "base":  "{{_trigger.default_branch}}",
-                "body":  "Automated fix by Delegator.\n\nCloses #{{fetch_issue.issue_number}}"}
+                "body":  "Automated fix by Conduct AI.\n\nCloses #{{fetch_issue.issue_number}}"}
 
       Output ONLY the following JSON on the last line of your response:
         {"pr_url": "<full PR URL>"}

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -87,7 +87,7 @@ blocks:
       6. Stage and commit: git add -A && git commit -m 'fix: <short description> (closes #{{fetch_issue.issue_number}})'
       7. Set remote with credentials and push:
          git remote set-url origin https://<github_token>@github.com/{{_trigger.repo_full_name}}.git
-         (retrieve the GitHub token from the Delegator credentials vault)
+         (retrieve the GitHub token from the Conduct AI credentials vault)
          git push origin autopilot/issue-{{fetch_issue.issue_number}}
 
       Output ONLY the following JSON on the last line of your response:
@@ -109,7 +109,7 @@ blocks:
       Steps:
       1. Clone the repo with the pushed branch:
          git clone --branch {{implement_fix.branch_name}} https://<github_token>@github.com/{{_trigger.repo_full_name}}.git /tmp/repo
-         (retrieve the GitHub token from the Delegator credentials vault)
+         (retrieve the GitHub token from the Conduct AI credentials vault)
       2. cd /tmp/repo
       3. Detect the test runner by reading package.json or requirements.txt
       4. Run the tests
@@ -145,7 +145,7 @@ blocks:
       Branch: {{implement_fix.branch_name}}
       Base: {{_trigger.default_branch}}
 
-      1. Retrieve the GitHub token from the Delegator credentials vault
+      1. Retrieve the GitHub token from the Conduct AI credentials vault
       2. Open a PR via the GitHub API:
          POST https://api.github.com/repos/{{_trigger.repo_full_name}}/pulls
          Headers: Authorization: token <github_token>, Content-Type: application/json

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -123,7 +123,7 @@ blocks:
       PR number: {{_trigger.number}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Search GitHub for existing open issues:
          GET https://api.github.com/search/issues?q=repo:{{_trigger.repository.full_name}}+is:issue+is:open+"PR+%23{{_trigger.number}}"+in:title
          Headers: Authorization: token <github_token>
@@ -158,7 +158,7 @@ blocks:
       Critical issues: {{review_pr.critical}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Append a comment to the existing issue:
          POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues/{{check_existing_issue.issue_number}}/comments
          Headers: Authorization: token <github_token>, Content-Type: application/json
@@ -192,7 +192,7 @@ blocks:
       is added to an existing issue — not when an issue is created with labels attached.
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Create the issue (no labels):
          POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues
          Headers: Authorization: token <github_token>, Content-Type: application/json

--- a/apps/api/playbooks/dependency-updater.yaml
+++ b/apps/api/playbooks/dependency-updater.yaml
@@ -101,7 +101,7 @@ blocks:
            "title": "chore: auto-update patch/minor dependencies",
            "head": "deps/auto-update-<date>",
            "base": "{{_trigger.default_branch}}",
-           "body": "Automated dependency update by Delegator.\n\n**Patch and minor bumps only — no breaking changes.**\n\nMerge when CI passes."
+           "body": "Automated dependency update by Conduct AI.\n\n**Patch and minor bumps only — no breaking changes.**\n\nMerge when CI passes."
          }
          Header: Authorization: token <github_token>
 

--- a/apps/api/playbooks/pr-reviewer.yaml
+++ b/apps/api/playbooks/pr-reviewer.yaml
@@ -87,7 +87,7 @@ blocks:
       PR number: {{_trigger.number}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Search GitHub for existing open issues:
          GET https://api.github.com/search/issues?q=repo:{{_trigger.repository.full_name}}+is:issue+is:open+"PR+%23{{_trigger.number}}"+in:title
          Headers: Authorization: token <github_token>
@@ -122,7 +122,7 @@ blocks:
       Critical issues: {{review_pr.critical}}
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Append a comment to the existing issue:
          POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues/{{check_existing_issue.issue_number}}/comments
          Headers: Authorization: token <github_token>, Content-Type: application/json
@@ -156,7 +156,7 @@ blocks:
       is added to an existing issue — not when an issue is created with labels attached.
 
       Steps:
-      1. Retrieve the GitHub token from the Delegator credentials vault.
+      1. Retrieve the GitHub token from the Conduct AI credentials vault.
       2. Create the issue (no labels):
          POST https://api.github.com/repos/{{_trigger.repository.full_name}}/issues
          Headers: Authorization: token <github_token>, Content-Type: application/json


### PR DESCRIPTION
## Summary
- Slack notification: `Delegator agent run complete ✓` → `Conduct AI — agent run complete ✓`
- Email template subject and body updated to Conduct AI
- PR body in playbooks: `Automated fix by Delegator` → `Automated fix by Conduct AI`
- Compiler system prompt updated
- Email from-address defaults updated to `notifications@conductai.ai`
- Webhook signature header: `X-Delegator-Signature` → `X-ConductAI-Signature`
- User-Agent: `Delegator/1.0` → `ConductAI/1.0`

## Test plan
- [ ] Trigger a test run (Autopilot Quick) and verify Slack message shows "Conduct AI — agent run complete ✓"
- [ ] Verify PR body says "Automated fix by Conduct AI."