### PR TITLE
fix: run detail page — Live stops on completion, hide unknown duration

### DIFF
--- a/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
@@ -67,6 +67,15 @@ export default function RunDetailPage() {
     setRefreshing(false)
   }
 
+  // Stop polling as soon as run reaches a terminal state
+  useEffect(() => {
+    if (run && TERMINAL.has(run.status) && pollRef.current) {
+      clearInterval(pollRef.current)
+      pollRef.current = null
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [run?.status])
+
   useEffect(() => {
     if (!isLoaded) return
     async function load() {
@@ -84,15 +93,10 @@ export default function RunDetailPage() {
       }
       setLoading(false)
 
-      // Auto-poll every 4s while run is non-terminal
       if (runData && !TERMINAL.has(runData.status)) {
         pollRef.current = setInterval(async () => {
           const h = await buildHeaders()
-          const updated = await fetchRun(h)
-          if (updated && TERMINAL.has(updated.status)) {
-            clearInterval(pollRef.current!)
-            pollRef.current = null
-          }
+          await fetchRun(h)
         }, 4000)
       }
     }

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -347,6 +347,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         const run = await res.json()
         setMeta({ triggered_by: run.triggered_by, started_at: run.started_at, completed_at: run.completed_at, paused_at: run.paused_at, current_block_id: run.current_block_id, workflow_version_id: run.workflow_version_id ?? null })
         if (run.status === "paused") { setStatus("paused"); setApprovalPending(true); setApprovalBlockId(run.current_block_id) }
+        else if (["succeeded", "failed", "cancelled"].includes(run.status)) { setStatus(run.status) }
       }
     } catch { /* ignore */ }
   }
@@ -510,10 +511,12 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
 
       {/* Summary stats grid */}
       <div className="grid grid-cols-5 gap-3 rounded-xl border border-stone-100 bg-stone-50 px-4 py-3">
+        {(totalDur || !done) && (
         <div>
           <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-0.5">Duration</p>
-          <p className="text-sm font-semibold text-stone-800">{totalDur ?? (done ? "—" : "…")}</p>
+          <p className="text-sm font-semibold text-stone-800">{totalDur ?? "…"}</p>
         </div>
+        )}
         <div>
           <p className="text-[10px] font-semibold text-stone-400 uppercase tracking-wider mb-0.5">Turns</p>
           <p className="text-sm font-semibold text-stone-800">
@@ -546,7 +549,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         <span className={`text-xs font-medium px-2.5 py-1 rounded-full ${STATUS_COLORS[status] ?? STATUS_COLORS.pending}`}>
           {status}
         </span>
-        {totalDur && <span className="text-xs text-stone-400">{totalDur} total</span>}
+        {totalDur && <span className="text-xs text-stone-400">{totalDur}</span>}
         {!done && (
           <span className="flex items-center gap-1.5 text-xs text-stone-400">
             <span className="inline-block w-1.5 h-1.5 bg-blue-400 rounded-full animate-pulse" />


### PR DESCRIPTION
## Summary
- **Live polling stops correctly**: page now uses a `useEffect` watching `run.status` to clear the interval the moment a terminal status is set — no longer relies solely on the poll callback (which could miss if a fetch failed)
- **RunTrace terminal status synced**: `refreshMeta()` (called on SSE `[DONE]`) now sets `status` to "succeeded"/"failed"/"cancelled" from the API response — previously only checked for "paused", leaving the status badge stuck on "running"
- **Duration hidden when unknown**: grid stat and status bar no longer show "Duration: —" after completion when timestamps aren't available

## Test plan
- [ ] Watch a run complete live — "Live" button should switch to "Refresh" automatically
- [ ] Status badge inside Timeline tab should update to "succeeded" without hard refresh
- [ ] Completed run with no duration timestamps shows no Duration stat