### PR TITLE
fix: SSE live streaming + trace URL to conductai.ai + logic route label

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -18,6 +18,8 @@ class Settings(BaseSettings):
     debug: bool = True
     # Base URL for callbacks (approval webhooks, etc.)
     api_base_url: str = "http://localhost:8000"
+    # Frontend URL — used for trace links in Slack/email notifications
+    app_url: str = "https://conductai.ai"
     # Slack signing secret for verifying interactive component payloads
     slack_signing_secret: str = ""
     # Clerk (optional — if unset, all requests use the dev workspace)

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -33,10 +33,11 @@ def get_workspace_id_sse(
     request: Request,
     workspace_id: str | None = Depends(lambda: None),
 ) -> str:
-    """Auth dependency for SSE endpoints — accepts token via Authorization header.
-    EventSource cannot set custom headers so workspace_id comes from x-workspace-id header."""
+    """Auth dependency for SSE endpoints.
+    EventSource cannot set custom headers, so token and workspace_id come via query params."""
+    # Accept token from Authorization header OR ?token= query param (EventSource workaround)
     auth_header = request.headers.get("Authorization", "")
-    x_ws = request.headers.get("x-workspace-id")
+    x_ws = request.headers.get("x-workspace-id") or request.query_params.get("workspace_id")
 
     if not _clerk_enabled():
         return x_ws or DEV_WORKSPACE_ID
@@ -53,6 +54,8 @@ def get_workspace_id_sse(
     raw_token = None
     if auth_header.startswith("Bearer "):
         raw_token = auth_header.removeprefix("Bearer ")
+    elif request.query_params.get("token"):
+        raw_token = request.query_params.get("token")
 
     if not raw_token:
         raise HTTPException(status_code=401, detail="Authorization required")
@@ -68,13 +71,18 @@ def get_workspace_id_sse(
 
 
 def _get_user_id_from_request(request: Request) -> str:
-    """Extract Clerk user_id from the Authorization header for SSE endpoints."""
+    """Extract Clerk user_id from Authorization header or ?token= query param for SSE endpoints."""
     if not _clerk_enabled():
         return DEV_USER_ID
     auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
+    raw_token = None
+    if auth_header.startswith("Bearer "):
+        raw_token = auth_header.removeprefix("Bearer ")
+    elif request.query_params.get("token"):
+        raw_token = request.query_params.get("token")
+    if not raw_token:
         raise HTTPException(status_code=401, detail="Authorization required")
-    claims = _verify_clerk_token(auth_header.removeprefix("Bearer "))
+    claims = _verify_clerk_token(raw_token)
     if not claims:
         raise HTTPException(status_code=401, detail="Invalid or expired token")
     user_id = claims.get("sub")

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -905,7 +905,8 @@ def _build_run_summary(state: dict) -> str:
         elif val.get("triggered") and val.get("service_id"):
             summary = f"Railway service {val['service_id']} redeployed"
         elif val.get("route"):
-            summary = f"Logic route: {val['route']}"
+            route = val["route"]
+            summary = f"→ {route}" if route in ("pass", "fail") else f"Logic route: {route}"
         elif isinstance(val.get("output"), str):
             summary = val["output"][:120]
         if summary:
@@ -1305,7 +1306,7 @@ def execute_run(run_id: str):
 
                 elif block_type == "output":
                     wf_name = version.workflow.name if version.workflow else "Agent"
-                    trace_url = f"{settings.api_base_url.rstrip('/')}/workflows/{version.workflow.id}/runs/{run_id}" if version.workflow else ""
+                    trace_url = f"{settings.app_url.rstrip('/')}/workflows/{version.workflow.id}/runs/{run_id}" if version.workflow else ""
                     try:
                         result = _execute_output(block, state, credentials, workflow_name=wf_name, trace_url=trace_url, run_id=run_id)
                     except Exception as out_err:


### PR DESCRIPTION
## Summary
- **SSE auth fixed**: EventSource cannot set headers — token and workspace_id were being sent as query params but server only read headers. Both `get_workspace_id_sse` and `_get_user_id_from_request` now fall back to `?token=` and `?workspace_id=` query params. This was why live streaming showed nothing during a run.
- **Trace URL**: Slack/email notifications now link to `conductai.ai/workflows/.../runs/...` (frontend) instead of `delegator-api.onrender.com` (API backend). Added `app_url` config setting (default: `https://conductai.ai`).
- **Logic route label**: `"Logic route: fail"` → `"→ fail"` in Slack summaries.

## Env var needed
Set `APP_URL=https://conductai.ai` on the API + worker Render services.

## Test plan
- [ ] Trigger a test run and watch the Timeline tab stream events live
- [ ] Check Slack notification trace link points to conductai.ai