### PR TITLE
security: patch next (CVE-2026-44578, high) — multiple CVEs fixed

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "next": "14.2.35",
+    "next": "15.5.18",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "@clerk/nextjs": "^5.7.5",
@@ -35,7 +35,7 @@
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",
     "eslint": "^8",
-    "eslint-config-next": "14.2.35",
+    "eslint-config-next": "15.5.18",
     "postcss": "^8.4.47",
     "tailwindcss": "^3.4.14",
     "typescript": "^5"


### PR DESCRIPTION
## Security Patch

**Package:** `next` (Next.js)
**Primary CVE:** CVE-2026-44578
**Severity:** HIGH
**Patched to:** 15.5.18

### Vulnerability Summary

The currently installed version `14.2.35` is affected by multiple security vulnerabilities. No patch exists in the 14.x line — upgrading to 15.5.18 (the official backport security release) is required.

### CVEs Addressed

| CVE | Severity | Description |
|-----|----------|-------------|
| CVE-2026-44578 | **HIGH** | SSRF via WebSocket upgrade requests — attacker can proxy requests to arbitrary internal/external destinations |
| CVE-2026-44573 | **HIGH** | Middleware/Proxy bypass in Pages Router via i18n routes |
| CVE-2026-44572 | LOW | Cache poisoning via Middleware/Proxy redirect responses |
| CVE-2026-44580 | MEDIUM | XSS in `beforeInteractive` scripts with untrusted input |
| CVE-2026-44581 | MEDIUM | XSS in App Router apps using CSP nonces |
| CVE-2026-44576 | MEDIUM | Cache poisoning in React Server Component responses |

### Changes
- `apps/web/package.json`: `next` 14.2.35 → 15.5.18
- `apps/web/package.json`: `eslint-config-next` 14.2.35 → 15.5.18

### Migration Notes
- Next.js 15 introduced some breaking changes from 14. Please review the [Next.js 15 upgrade guide](https://nextjs.org/docs/app/building-your-application/upgrading/version-15) before merging.
- Run `npm install` in `apps/web/` after merging to update `package-lock.json`.
- Test your application thoroughly as Next.js 15 has async request APIs and other changes.

---
*Automated security patch by Conduct AI. Review the diff and merge when CI is green.*