### PR TITLE
[TEST] security: patch lodash (CVE-2021-23337, high)

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -20,6 +20,7 @@
         "@xyflow/react": "^12.3.2",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "lodash": "4.17.21",
         "lucide-react": "^0.460.0",
         "next": "14.2.35",
         "react": "^18.3.1",
@@ -503,9 +504,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -521,9 +519,6 @@
       "integrity": "sha512-k5xf/tg1FBv/M4CMd8S+JL3uV9BnnRmoe7F+GWC3DxkTCD9aewFRH1s5rJ1zkzDa+Do4zyN8qD0N8c84Hu96FQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -541,9 +536,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -559,9 +551,6 @@
       "integrity": "sha512-PZ5YE9ouy/IdO7QVJeIcyLn/Rc4ml9M2G4y3kCM9MNf1YKvFY4heg3pVa/jQbMro+tP6yc4G2o9LjAz1zxD7tQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2064,9 +2053,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2081,9 +2067,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2098,9 +2081,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2115,9 +2095,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2132,9 +2109,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2149,9 +2123,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2166,9 +2137,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2183,9 +2151,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2200,9 +2165,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2217,9 +2179,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5316,6 +5275,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,7 +27,8 @@
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-tabs": "^1.1.1",
-    "@radix-ui/react-tooltip": "^1.1.4"
+    "@radix-ui/react-tooltip": "^1.1.4",
+    "lodash": "4.17.21"
   },
   "devDependencies": {
     "@types/node": "^20",


### PR DESCRIPTION
## [TEST] Security Patch

**Package:** lodash
**CVE:** CVE-2021-23337
**Severity:** high
**Patched to:** 4.17.21

### Vulnerability summary
[TEST] Prototype pollution in lodash before 4.17.21. This is a test run — prefix branch and PR with [TEST].

Lodash versions prior to 4.17.21 are vulnerable to prototype pollution via the `template` and `bindAll` functions, which can allow attackers to execute arbitrary code or escalate privileges by manipulating object prototypes.

### Changes
- Added `lodash` to `apps/web/package.json` dependencies
- Version pinned to `4.17.21` (patched version)
- `package-lock.json` updated accordingly

---
*Automated security patch by Conduct AI. Review the diff and merge when CI is green.*