### PR TITLE
feat: manual webhook registration (#334)

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -509,55 +509,13 @@ def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspa
     workflow.current_version_id = version.id
     db.commit()
 
-    # Always store the repo when provided (used by BlockEditor to show which repo is targeted)
-    webhook_error: str | None = None
+    # Store the repo — webhook registration is now explicit via POST /{id}/webhook
     if body.repo and not workflow.github_hook_repo:
         workflow.github_hook_repo = body.repo
         db.commit()
 
-    # Auto-register git webhook if template needs one and repo was provided
-    if body.repo and body.template in _GITHUB_WEBHOOK_EVENTS:
-        try:
-            import secrets as _secrets
-            import re as _re
-            from app.routers.credentials import _git_token
-            token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
-            project_slug: str | None = None
-            if workflow.project_id:
-                from app.models.project import Project as _Project
-                proj = db.query(_Project).filter(_Project.id == workflow.project_id).first()
-                if proj:
-                    project_slug = _re.sub(r"[^a-z0-9]+", "-", proj.name.lower()).strip("-")
-            webhook_secret = _secrets.token_hex(32)
-            hook_id, webhook_error = _register_git_webhook(
-                token, body.repo, str(workflow.id), _GITHUB_WEBHOOK_EVENTS[body.template],
-                provider=provider,
-                project_slug=project_slug,
-                secret=webhook_secret,
-                workspace_id=str(workspace_id),
-            )
-            if hook_id:
-                workflow.github_hook_id = hook_id
-                workflow.github_hook_repo = body.repo
-                # Store secret + provider encrypted in trigger node config
-                from app.core.crypto import encrypt as _encrypt
-                encrypted_secret = _encrypt({"secret": webhook_secret})
-                graph = version.graph
-                for node in graph.get("nodes", []):
-                    if node.get("data", {}).get("type") == "trigger":
-                        node["data"].setdefault("config", {})["webhook_secret"] = encrypted_secret
-                        node["data"]["config"]["git_provider"] = provider
-                version.graph = graph
-                from sqlalchemy.orm.attributes import flag_modified
-                flag_modified(version, "graph")
-                db.commit()
-        except Exception as e:
-            webhook_error = str(e)
-            log.warning("Webhook auto-registration skipped: %s", e)
-
     db.refresh(workflow)
-    # Attach webhook_error as a transient attribute so the schema can include it
-    workflow.webhook_error = webhook_error  # type: ignore[attr-defined]
+    workflow.webhook_error = None  # type: ignore[attr-defined]
     return workflow
 
 
@@ -657,6 +615,115 @@ def delete_workflow(
     db.commit()
     audit(db, workspace_id, "workflow.deleted",
           resource_type="workflow", resource_id=str(workflow_id))
+
+
+# ── Manual webhook registration ───────────────────────────────────────────────
+
+@router.post("/{workflow_id}/webhook", response_model=WorkflowDetailOut)
+def register_workflow_webhook(
+    workflow_id: UUID,
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+):
+    """Explicitly register (or re-register) the GitHub webhook for this workflow."""
+    workflow = db.query(Workflow).filter(Workflow.id == workflow_id, Workflow.workspace_id == workspace_id).first()
+    if not workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    if not workflow.github_hook_repo:
+        raise HTTPException(status_code=400, detail="No repository configured — set repo_allowlist in the trigger block first")
+    if not workflow.current_version_id:
+        raise HTTPException(status_code=400, detail="Workflow has no version — save the canvas first")
+
+    playbook_slug = workflow.playbook_slug or ""
+    if playbook_slug not in _GITHUB_WEBHOOK_EVENTS:
+        raise HTTPException(status_code=400, detail="This workflow type does not use GitHub webhooks")
+
+    import secrets as _secrets
+    import re as _re
+    from app.routers.credentials import _git_token
+    from app.core.crypto import encrypt as _encrypt
+    from sqlalchemy.orm.attributes import flag_modified
+
+    # Deregister stale hook first if one exists
+    if workflow.github_hook_id:
+        try:
+            token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
+            _deregister_git_webhook(token, workflow.github_hook_repo, workflow.github_hook_id, provider=provider)
+        except Exception as e:
+            log.warning("Stale webhook deregistration skipped: %s", e)
+        workflow.github_hook_id = None
+        db.commit()
+
+    token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
+    project_slug: str | None = None
+    if workflow.project_id:
+        from app.models.project import Project as _Project
+        proj = db.query(_Project).filter(_Project.id == workflow.project_id).first()
+        if proj:
+            project_slug = _re.sub(r"[^a-z0-9]+", "-", proj.name.lower()).strip("-")
+
+    webhook_secret = _secrets.token_hex(32)
+    hook_id, error = _register_git_webhook(
+        token, workflow.github_hook_repo, str(workflow.id),
+        _GITHUB_WEBHOOK_EVENTS[playbook_slug],
+        provider=provider,
+        project_slug=project_slug,
+        secret=webhook_secret,
+        workspace_id=str(workspace_id),
+    )
+    if not hook_id:
+        raise HTTPException(status_code=502, detail=error or "Webhook registration failed")
+
+    workflow.github_hook_id = hook_id
+
+    # Store encrypted secret + provider in trigger node of current version
+    version = db.query(WorkflowVersion).filter(WorkflowVersion.id == workflow.current_version_id).first()
+    if version:
+        encrypted_secret = _encrypt({"secret": webhook_secret})
+        graph = version.graph
+        for node in graph.get("nodes", []):
+            if node.get("data", {}).get("type") == "trigger":
+                node["data"].setdefault("config", {})["webhook_secret"] = encrypted_secret
+                node["data"]["config"]["git_provider"] = provider
+        version.graph = graph
+        flag_modified(version, "graph")
+
+    db.commit()
+    db.refresh(workflow)
+    audit(db, workspace_id, "workflow.webhook_registered",
+          resource_type="workflow", resource_id=str(workflow_id),
+          metadata={"repo": workflow.github_hook_repo})
+    workflow.webhook_error = None  # type: ignore[attr-defined]
+    return workflow
+
+
+@router.delete("/{workflow_id}/webhook", status_code=204)
+def deregister_workflow_webhook(
+    workflow_id: UUID,
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+    _role: str = Depends(require_workspace_role("admin", "editor")),
+):
+    """Deregister the GitHub webhook for this workflow."""
+    workflow = db.query(Workflow).filter(Workflow.id == workflow_id, Workflow.workspace_id == workspace_id).first()
+    if not workflow:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+    if not workflow.github_hook_id:
+        raise HTTPException(status_code=400, detail="No webhook registered")
+
+    try:
+        from app.routers.credentials import _git_token
+        token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
+        _deregister_git_webhook(token, workflow.github_hook_repo or "", workflow.github_hook_id, provider=provider)
+    except Exception as e:
+        log.warning("Webhook deregistration error: %s", e)
+
+    workflow.github_hook_id = None
+    db.commit()
+    audit(db, workspace_id, "workflow.webhook_deregistered",
+          resource_type="workflow", resource_id=str(workflow_id),
+          metadata={"repo": workflow.github_hook_repo})
 
 
 class BlockCompileRequest(BaseModel):

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -25,6 +25,7 @@ interface BlockEditorProps {
   githubHookRepo?: string | null
   githubHookId?: string | null
   playbookSlug?: string | null
+  onWebhookChange?: (hookId: string | null, hookRepo: string | null) => void
 }
 
 // ── Client-side model router preview (mirrors model_router.py) ────────────────
@@ -65,6 +66,103 @@ function previewModel(playbookSlug: string | null | undefined, pref: string): [s
   const category = SLUG_CATEGORY[playbookSlug ?? ""] ?? ""
   const [model, reason] = (category ? POLICY[category]?.[p] : null) ?? PREF_DEFAULTS[p] ?? ["claude-sonnet-4-6", "default"]
   return [MODEL_LABELS[model] ?? model, reason]
+}
+
+// ── GitHub webhook status panel ───────────────────────────────────────────────
+
+function GitHubWebhookStatusPanel({
+  workflowId, hookId, hookRepo, getToken, onWebhookChange,
+}: {
+  workflowId: string
+  hookId: string | null
+  hookRepo: string | null
+  getToken?: (() => Promise<string | null>) | null
+  onWebhookChange?: (hookId: string | null, hookRepo: string | null) => void
+}) {
+  const [busy, setBusy] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+
+  async function authHeaders() {
+    const h: Record<string, string> = { "Content-Type": "application/json" }
+    if (getToken) { const t = await getToken(); if (t) h["Authorization"] = `Bearer ${t}` }
+    const ws = typeof document !== "undefined"
+      ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
+    if (ws) h["X-Workspace-Id"] = ws
+    return h
+  }
+
+  async function register() {
+    setBusy(true); setErr(null)
+    try {
+      const r = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/webhook`, {
+        method: "POST", headers: await authHeaders(),
+      })
+      const data = await r.json()
+      if (!r.ok) { setErr(data.detail || `HTTP ${r.status}`); return }
+      onWebhookChange?.(data.github_hook_id, data.github_hook_repo)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Network error")
+    } finally { setBusy(false) }
+  }
+
+  async function deregister() {
+    setBusy(true); setErr(null)
+    try {
+      const r = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/webhook`, {
+        method: "DELETE", headers: await authHeaders(),
+      })
+      if (!r.ok && r.status !== 204) {
+        const data = await r.json().catch(() => ({}))
+        setErr(data.detail || `HTTP ${r.status}`); return
+      }
+      onWebhookChange?.(null, hookRepo)
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : "Network error")
+    } finally { setBusy(false) }
+  }
+
+  const registered = !!hookId
+
+  return (
+    <div className={`rounded-lg border px-3 py-2.5 text-xs mt-2 ${registered ? "border-emerald-200 bg-emerald-50" : "border-amber-200 bg-amber-50"}`}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <p className={`font-semibold ${registered ? "text-emerald-800" : "text-amber-800"}`}>
+            {registered ? `✓ Webhook registered` : "Webhook not registered"}
+          </p>
+          <p className={`mt-0.5 ${registered ? "text-emerald-700" : "text-amber-700"}`}>
+            {registered
+              ? <span>on <span className="font-mono">{hookRepo}</span> — GitHub sends events here automatically</span>
+              : hookRepo
+              ? <span>Configure once you're ready — real GitHub events won't arrive until registered</span>
+              : <span>Set a repository in the trigger config first</span>
+            }
+          </p>
+          {err && <p className="text-red-600 mt-1">{err}</p>}
+        </div>
+        <div className="flex flex-col gap-1 shrink-0">
+          {!registered && hookRepo && (
+            <button onClick={register} disabled={busy}
+              className="rounded-md bg-amber-600 text-white px-3 py-1.5 font-medium hover:bg-amber-700 disabled:opacity-50 transition-colors text-xs">
+              {busy ? "Registering…" : "Register Webhook"}
+            </button>
+          )}
+          {registered && (
+            <>
+              <button onClick={register} disabled={busy}
+                className="rounded-md bg-emerald-600 text-white px-3 py-1.5 font-medium hover:bg-emerald-700 disabled:opacity-50 transition-colors text-xs">
+                {busy ? "Updating…" : "Update"}
+              </button>
+              <button onClick={deregister} disabled={busy}
+                className="rounded-md border border-stone-300 text-stone-600 px-3 py-1.5 font-medium hover:bg-stone-100 disabled:opacity-50 transition-colors text-xs">
+                Unregister
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }
 
 // ── Webhook registration ──────────────────────────────────────────────────────
@@ -472,6 +570,7 @@ export default function BlockEditor({
   githubHookRepo,
   githubHookId,
   playbookSlug,
+  onWebhookChange,
 }: BlockEditorProps) {
   const [promptOpen, setPromptOpen] = useState(false)
   const [streamedPrompt, setStreamedPrompt] = useState<string>("")
@@ -815,18 +914,16 @@ export default function BlockEditor({
             </div>
           )}
 
-          {/* GitHub trigger — auto-register info */}
-          {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (() => {
-            const repoAllowlist = (getNestedValue(blockData, "config.repo_allowlist") as string) || ""
-            const firstRepo = repoAllowlist.split(",")[0].trim()
-            const [owner, repo] = firstRepo.includes("/") ? firstRepo.split("/") : ["", ""]
-            if (!owner || !repo) return null
-            return (
-              <div className="rounded-lg border border-indigo-100 bg-indigo-50 px-3 py-2 text-xs text-indigo-700 mt-2">
-                Webhook on <span className="font-mono font-medium">{owner}/{repo}</span> will be registered automatically when you run.
-              </div>
-            )
-          })()}
+          {/* GitHub trigger — webhook status panel */}
+          {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (
+            <GitHubWebhookStatusPanel
+              workflowId={workflowId}
+              hookId={githubHookId ?? null}
+              hookRepo={githubHookRepo ?? null}
+              getToken={getToken}
+              onWebhookChange={onWebhookChange}
+            />
+          )}
 
 
           {/* Secret warning */}

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -858,6 +858,12 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
           >
             ⊡ Fit
           </button>
+          {/* Webhook warning — shown when this is a GitHub-event workflow but webhook isn't registered */}
+          {!githubHookId && githubHookRepo && (
+            <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] font-medium text-amber-700">
+              ⚠ Webhook not registered — open trigger config to register
+            </span>
+          )}
           {!isViewer && (
             <>
               {prefs.show_test_trigger && playbookSlug && (
@@ -1027,6 +1033,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
                       githubHookRepo={githubHookRepo}
                       githubHookId={githubHookId}
                       playbookSlug={playbookSlug}
+                      onWebhookChange={(id, repo) => { setGithubHookId(id); setGithubHookRepo(repo) }}
                     />
                   </div>
                 ) : (


### PR DESCRIPTION
## Summary
- Removes auto-register webhook on playbook install — webhook registration is now an explicit user action
- Adds `POST /workflows/{id}/webhook` — registers (or re-registers) the GitHub webhook using the configured `github_hook_repo`
- Adds `DELETE /workflows/{id}/webhook` — deregisters and clears `github_hook_id`
- Adds `GitHubWebhookStatusPanel` in BlockEditor: amber when unregistered, green when registered, with Register / Update / Unregister buttons
- Adds amber warning badge in CanvasEditor toolbar when repo is configured but webhook isn't registered
- TypeScript: clean

## Behaviour
- Install a playbook → repo stored, no webhook yet
- Open trigger config → see amber panel "Webhook not registered" + Register button
- Click Register → `POST /workflows/{id}/webhook` → panel turns green with repo name
- Change repo in allowlist → panel stays green but Update button appears to re-register on new repo
- Unregister → panel returns to amber
- Test run → always allowed; toolbar shows amber badge if webhook missing

## Files changed
| File | Change |
|---|---|
| `apps/api/app/routers/workflows.py` | Remove auto-register block; add POST + DELETE `/webhook` endpoints |
| `apps/web/src/components/canvas/BlockEditor.tsx` | Add `GitHubWebhookStatusPanel`, `onWebhookChange` prop |
| `apps/web/src/components/canvas/CanvasEditor.tsx` | Pass `onWebhookChange` callback; add toolbar warning badge |

Closes #334