### PR TITLE
fix: webhook 403 error — remove 'reinstall the agent'

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -215,7 +215,7 @@ def _register_github_webhook(token: str, repo: str, webhook_url: str, events: li
             return str(r.json()["id"]), None
         log.warning("GitHub webhook registration failed: %s %s", r.status_code, r.text[:300])
         if r.status_code == 403:
-            err = "GitHub rejected the request — your token is missing the Administration (read & write) permission. Go to Settings → Environments, update your GitHub token, and reinstall the agent."
+            err = "GitHub rejected the request — your token needs the Administration (read & write) permission. Update your GitHub token in Settings → Environments, then click Register again."
         elif r.status_code == 404:
             err = f"Repository '{repo}' not found or your token doesn't have access to it. Check the repo name and token scopes in Settings → Environments."
         elif r.status_code == 422:


### PR DESCRIPTION
Replaces wrong instruction with correct one: update the token in Settings → Environments, then click Register again. No reinstall needed.