### PR TITLE
fix: github_webhook flag — hide register button for non-webhook playbooks, remove toolbar banner

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -158,6 +158,13 @@ _GITHUB_WEBHOOK_EVENTS: dict[str, list[str]] = {
 }
 
 
+def _stamp(workflow) -> None:
+    """Set transient fields required by WorkflowDetailOut before returning."""
+    if not hasattr(workflow, "webhook_error") or workflow.webhook_error is None:  # type: ignore[attr-defined]
+        workflow.webhook_error = None  # type: ignore[attr-defined]
+    workflow.github_webhook = (workflow.playbook_slug or "") in _GITHUB_WEBHOOK_EVENTS  # type: ignore[attr-defined]
+
+
 def _register_git_webhook(
     token: str,
     repo: str,
@@ -515,7 +522,7 @@ def create_workflow(body: WorkflowCreate, db: Session = Depends(get_db), workspa
         db.commit()
 
     db.refresh(workflow)
-    workflow.webhook_error = None  # type: ignore[attr-defined]
+    _stamp(workflow)
     return workflow
 
 
@@ -527,6 +534,7 @@ def get_workflow(workflow_id: UUID, db: Session = Depends(get_db), workspace_id:
     ).first()
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
+    _stamp(workflow)
     return workflow
 
 
@@ -569,6 +577,7 @@ def update_workflow(
 
         # Compile in background — doesn't block the save response
         background_tasks.add_task(_run_compiler, version.id, graph_dict)
+        _stamp(workflow)
         return workflow
 
     db.commit()
@@ -576,6 +585,7 @@ def update_workflow(
     audit(db, workspace_id, "workflow.created",
           resource_type="workflow", resource_id=str(workflow.id),
           metadata={"name": workflow.name, "template": body.template})
+    _stamp(workflow)
     return workflow
 
 
@@ -694,7 +704,7 @@ def register_workflow_webhook(
     audit(db, workspace_id, "workflow.webhook_registered",
           resource_type="workflow", resource_id=str(workflow_id),
           metadata={"repo": workflow.github_hook_repo})
-    workflow.webhook_error = None  # type: ignore[attr-defined]
+    _stamp(workflow)
     return workflow
 
 
@@ -1173,6 +1183,7 @@ def compile_workflow_now(
     version.compiled_artifacts = artifacts
     db.commit()
     db.refresh(workflow)
+    _stamp(workflow)
     return workflow
 
 

--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -60,4 +60,5 @@ class WorkflowDetailOut(WorkflowOut):
     github_hook_id: Optional[str] = None
     github_hook_repo: Optional[str] = None
     playbook_slug: Optional[str] = None
+    github_webhook: bool = False  # True when playbook requires GitHub webhook registration
     webhook_error: Optional[str] = None  # set when webhook registration failed on install

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -24,6 +24,7 @@ interface BlockEditorProps {
   selectedEnvId?: string
   githubHookRepo?: string | null
   githubHookId?: string | null
+  githubWebhook?: boolean
   playbookSlug?: string | null
   onWebhookChange?: (hookId: string | null, hookRepo: string | null) => void
 }
@@ -597,6 +598,7 @@ export default function BlockEditor({
   selectedEnvId,
   githubHookRepo,
   githubHookId,
+  githubWebhook,
   playbookSlug,
   onWebhookChange,
 }: BlockEditorProps) {
@@ -1012,7 +1014,7 @@ export default function BlockEditor({
                         <p className="font-mono break-all text-violet-700 text-[11px]">
                           {displayUrl}
                         </p>
-                        {githubHookRepo
+                        {githubHookRepo && githubWebhook
                           ? <GitHubWebhookStatusPanel
                               workflowId={workflowId}
                               hookId={githubHookId ?? null}

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -128,6 +128,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const [workflowName, setWorkflowName] = useState("Untitled agent")
   const [githubHookRepo, setGithubHookRepo] = useState<string | null>(null)
   const [githubHookId, setGithubHookId] = useState<string | null>(null)
+  const [githubWebhook, setGithubWebhook] = useState<boolean>(false)
   const [saveStatus, setSaveStatus] = useState<SaveStatus>("idle")
   const autosaveTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const isFirstLoad = useRef(true)
@@ -286,6 +287,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
         setSelectedEnvId(data.environment_id ?? "")
         setGithubHookRepo(data.github_hook_repo ?? null)
         setGithubHookId(data.github_hook_id ?? null)
+        setGithubWebhook(data.github_webhook ?? false)
         setPlaybookSlug(data.playbook_slug ?? null)
         const graph = data.current_version?.graph
         if (graph?.nodes && graph?.edges) {
@@ -858,12 +860,6 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
           >
             ⊡ Fit
           </button>
-          {/* Webhook warning — shown when this is a GitHub-event workflow but webhook isn't registered */}
-          {!githubHookId && githubHookRepo && (
-            <span className="rounded-md border border-amber-200 bg-amber-50 px-2 py-1 text-[10px] font-medium text-amber-700">
-              ⚠ Webhook not registered — open trigger config to register
-            </span>
-          )}
           {!isViewer && (
             <>
               {prefs.show_test_trigger && playbookSlug && (
@@ -1032,6 +1028,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
                       getToken={getToken}
                       githubHookRepo={githubHookRepo}
                       githubHookId={githubHookId}
+                      githubWebhook={githubWebhook}
                       playbookSlug={playbookSlug}
                       onWebhookChange={(id, repo) => { setGithubHookId(id); setGithubHookRepo(repo) }}
                     />


### PR DESCRIPTION
## Summary
- Adds `github_webhook: bool` to `WorkflowDetailOut` (derived from `playbook_slug in _GITHUB_WEBHOOK_EVENTS`)
- Register button in inbound webhook panel now only shows when `githubWebhook === true` — hides for dependency_updater, incident_responder, postmortem_drafter
- Removes amber toolbar banner ("Webhook not registered — open trigger config to register") — status lives in the right panel only
- Adds `_stamp()` helper in workflows.py to consistently set transient fields (webhook_error, github_webhook) on all return paths