### PR TITLE
fix: remove install-time conflict warning; shared webhook reuse at Register

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1,6 +1,7 @@
 import structlog
 from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, BackgroundTasks
+from fastapi.responses import JSONResponse
 from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import text
@@ -655,17 +656,55 @@ def register_workflow_webhook(
     from app.core.crypto import encrypt as _encrypt
     from sqlalchemy.orm.attributes import flag_modified
 
-    # Deregister stale hook first if one exists
+    token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
+
+    repo = workflow.github_hook_repo
+
+    # Check for a sibling workflow that already has an active hook on this repo.
+    # If found, reuse its hook_id instead of registering a new one on GitHub —
+    # this prevents duplicate hooks and avoids the orphan-deregister bug.
+    sibling = db.query(Workflow).filter(
+        Workflow.workspace_id == workspace_id,
+        Workflow.github_hook_repo == repo,
+        Workflow.github_hook_id.isnot(None),
+        Workflow.id != workflow_id,
+    ).first()
+
+    if sibling:
+        # Deregister any stale hook this workflow previously owned (best-effort)
+        if workflow.github_hook_id and workflow.github_hook_id != sibling.github_hook_id:
+            try:
+                _deregister_git_webhook(token, repo, workflow.github_hook_id, provider=provider)
+            except Exception as e:
+                log.warning("Stale webhook deregistration skipped: %s", e)
+
+        workflow.github_hook_id = sibling.github_hook_id
+        db.commit()
+        db.refresh(workflow)
+        audit(db, workspace_id, "workflow.webhook_shared",
+              resource_type="workflow", resource_id=str(workflow_id),
+              metadata={"repo": repo, "shared_with": str(sibling.id)})
+        _stamp(workflow)
+        wf_out = WorkflowDetailOut.model_validate(workflow)
+        wf_out.github_hook_id = workflow.github_hook_id
+        wf_out.github_hook_repo = repo
+        wf_out.github_webhook = True
+        wf_out.webhook_error = None
+        return JSONResponse(content={
+            **wf_out.model_dump(mode="json"),
+            "shared": True,
+            "shared_with_name": sibling.name,
+        })
+
+    # No sibling — deregister any stale hook first, then register fresh
     if workflow.github_hook_id:
         try:
-            token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
-            _deregister_git_webhook(token, workflow.github_hook_repo, workflow.github_hook_id, provider=provider)
+            _deregister_git_webhook(token, repo, workflow.github_hook_id, provider=provider)
         except Exception as e:
             log.warning("Stale webhook deregistration skipped: %s", e)
         workflow.github_hook_id = None
         db.commit()
 
-    token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
     project_slug: str | None = None
     if workflow.project_id:
         from app.models.project import Project as _Project
@@ -675,7 +714,7 @@ def register_workflow_webhook(
 
     webhook_secret = _secrets.token_hex(32)
     hook_id, error = _register_git_webhook(
-        token, workflow.github_hook_repo, str(workflow.id),
+        token, repo, str(workflow.id),
         _GITHUB_WEBHOOK_EVENTS[playbook_slug],
         provider=provider,
         project_slug=project_slug,
@@ -703,7 +742,7 @@ def register_workflow_webhook(
     db.refresh(workflow)
     audit(db, workspace_id, "workflow.webhook_registered",
           resource_type="workflow", resource_id=str(workflow_id),
-          metadata={"repo": workflow.github_hook_repo})
+          metadata={"repo": repo})
     _stamp(workflow)
     return workflow
 
@@ -725,7 +764,19 @@ def deregister_workflow_webhook(
     try:
         from app.routers.credentials import _git_token
         token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
-        _deregister_git_webhook(token, workflow.github_hook_repo or "", workflow.github_hook_id, provider=provider)
+
+        # Only delete from GitHub if no other workflow in this workspace shares the hook
+        siblings = db.query(Workflow).filter(
+            Workflow.workspace_id == workspace_id,
+            Workflow.github_hook_repo == workflow.github_hook_repo,
+            Workflow.github_hook_id == workflow.github_hook_id,
+            Workflow.id != workflow_id,
+        ).count()
+
+        if siblings == 0:
+            _deregister_git_webhook(token, workflow.github_hook_repo or "", workflow.github_hook_id, provider=provider)
+        else:
+            log.info("webhook.deregister_skipped_shared", workflow_id=str(workflow_id), siblings=siblings)
     except Exception as e:
         log.warning("Webhook deregistration error: %s", e)
 

--- a/apps/web/src/app/marketplace/page.tsx
+++ b/apps/web/src/app/marketplace/page.tsx
@@ -126,7 +126,6 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
   const [reposLoading, setReposLoading] = useState(false)
   const [webhookError, setWebhookError] = useState<string | null>(null)
   const [lastInstalledId, setLastInstalledId] = useState<string | null>(null)
-  const [conflictWarning, setConflictWarning] = useState<string | null>(null)
   const [agentName, setAgentName] = useState<string>("")
 
   async function authHeaders(): Promise<Record<string, string>> {
@@ -232,33 +231,10 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
     setRepos([])
     setSelectedRepo("")
     setWebhookError(null)
-    setConflictWarning(null)
   }
 
   useEffect(() => {
-    if (!pendingSlug || !selectedRepo) { setConflictWarning(null); return }
-    const triggerLabel = inputValues["trigger_label"] ?? ""
-    authHeaders().then(async headers => {
-      const workspaceId = getWorkspaceId()
-      if (workspaceId) headers["X-Workspace-Id"] = workspaceId
-      const params = new URLSearchParams({ template: pendingSlug, repo: selectedRepo })
-      if (triggerLabel) params.set("trigger_label", triggerLabel)
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/workflows/conflict-check?${params}`,
-        { headers }
-      )
-      if (res.ok) {
-        const data = await res.json()
-        if (data.conflicts.length > 0) {
-          const msg = data.conflict_type === "label"
-            ? `An agent is already watching the "${triggerLabel}" label on ${selectedRepo}. Select a different trigger label above — you can have up to 3 agents on the same repo using different labels.`
-            : `This playbook is already installed on ${selectedRepo}. Installing again will run two independent agents on the same events.`
-          setConflictWarning(msg)
-        } else {
-          setConflictWarning(null)
-        }
-      }
-    })
+    if (!pendingSlug || !selectedRepo) { return }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedRepo, pendingSlug, inputValues["trigger_label"]])
 
@@ -531,12 +507,7 @@ function MarketplaceContent({ getToken }: { getToken: (() => Promise<string | nu
               </div>
             )}
 
-            {conflictWarning && (
-              <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-3 flex gap-2">
-                <span className="text-amber-500 text-sm">⚠️</span>
-                <p className="text-xs text-amber-700 leading-relaxed">{conflictWarning}</p>
-              </div>
-            )}
+
 
             {webhookError && (
               <div className="bg-red-50 border border-red-200 rounded-lg px-3 py-3">

--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -95,7 +95,6 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
   const [reposLoading, setReposLoading]   = useState(false)
   const [loading, setLoading]             = useState(false)
   const [bootstrapping, setBootstrapping] = useState(true)
-  const [conflictWarning, setConflictWarning] = useState<string | null>(null)
   const [webhookError, setWebhookError]   = useState<string | null>(null)
   const [error, setError]                 = useState<string | null>(null)
 
@@ -187,25 +186,6 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [template])
 
-  // Conflict check when repo or trigger_label changes
-  useEffect(() => {
-    if (!selectedRepo) { setConflictWarning(null); return }
-    const triggerLabel = inputValues["trigger_label"] ?? ""
-    buildHeaders().then(async headers => {
-      const params = new URLSearchParams({ template, repo: selectedRepo })
-      if (triggerLabel) params.set("trigger_label", triggerLabel)
-      const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/conflict-check?${params}`, { headers })
-      if (res.ok) {
-        const data = await res.json()
-        setConflictWarning(data.conflicts.length > 0
-          ? data.conflict_type === "label"
-            ? `An agent is already watching "${triggerLabel}" on ${selectedRepo}. Choose a different trigger label.`
-            : `This playbook is already installed on ${selectedRepo}. Installing again runs two independent agents.`
-          : null)
-      }
-    })
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedRepo, template, inputValues["trigger_label"]])
 
   async function handleCreate() {
     setLoading(true)
@@ -412,13 +392,6 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
                     After creating, copy the webhook URL from agent settings and paste it into your{" "}
                     {template === "incident_responder" ? "PagerDuty or OpsGenie" : "GitHub Actions"} configuration.
                   </p>
-                </div>
-              )}
-
-              {conflictWarning && (
-                <div className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-3 flex gap-2">
-                  <span className="text-amber-500">⚠</span>
-                  <p className="text-xs text-amber-700 leading-relaxed">{conflictWarning}</p>
                 </div>
               )}
 

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -83,6 +83,7 @@ function GitHubWebhookStatusPanel({
 }) {
   const [busy, setBusy] = useState(false)
   const [err, setErr] = useState<string | null>(null)
+  const [sharedWith, setSharedWith] = useState<string | null>(null)
 
   async function authHeaders() {
     const h: Record<string, string> = { "Content-Type": "application/json" }
@@ -94,13 +95,14 @@ function GitHubWebhookStatusPanel({
   }
 
   async function register() {
-    setBusy(true); setErr(null)
+    setBusy(true); setErr(null); setSharedWith(null)
     try {
       const r = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${workflowId}/webhook`, {
         method: "POST", headers: await authHeaders(),
       })
       const data = await r.json()
       if (!r.ok) { setErr(data.detail || `HTTP ${r.status}`); return }
+      if (data.shared) setSharedWith(data.shared_with_name ?? "another agent")
       onWebhookChange?.(data.github_hook_id, data.github_hook_repo)
     } catch (e) {
       setErr(e instanceof Error ? e.message : "Network error")
@@ -132,6 +134,7 @@ function GitHubWebhookStatusPanel({
           <p className={`font-semibold ${registered ? "text-emerald-700" : "text-amber-700"}`}>
             {registered ? `✓ Registered on ${hookRepo}` : "Not registered — GitHub won't send events"}
           </p>
+          {sharedWith && <p className="text-stone-500 mt-0.5">Shared with &ldquo;{sharedWith}&rdquo;</p>}
           {err && <p className="text-red-600 mt-0.5">{err}</p>}
         </div>
         <div className="flex gap-1 shrink-0">
@@ -167,6 +170,7 @@ function GitHubWebhookStatusPanel({
               : <span>Set a repository in the trigger config first</span>
             }
           </p>
+          {sharedWith && <p className="text-stone-500 mt-1">Webhook shared with &ldquo;{sharedWith}&rdquo; — no duplicate hook created on GitHub.</p>}
           {err && <p className="text-red-600 mt-1">{err}</p>}
         </div>
         <div className="flex flex-col gap-1 shrink-0">


### PR DESCRIPTION
## Summary

- Remove stale amber conflict warning from install pages — it was tied to auto-registration on install, which no longer happens
- `POST /workflows/{id}/webhook`: detect sibling agent on same repo, reuse their `hook_id` instead of creating a duplicate GitHub hook
- `DELETE /workflows/{id}/webhook`: only delete from GitHub if no sibling shares the hook (fixes #347)
- `BlockEditor`: shows "Shared with [agent name]" note when register returns `shared: true`

## Behaviour

**Before:** Two agents on same repo → two GitHub hooks → deleting one silently kills the other  
**After:** Two agents on same repo → one GitHub hook shared → deleting one leaves hook alive for the other

## Test plan

- [ ] Install two autopilot_quick agents on same repo — second Register shows "Shared with…" note
- [ ] Delete first agent — verify webhook still active on GitHub for second agent
- [ ] Install page no longer shows amber conflict warning
- [ ] Single agent Register/Unregister still works as before

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)