### PR TITLE
fix: remove stale setConflictWarning call in workflows/new page

### DIFF
--- a/apps/web/src/app/workflows/new/page.tsx
+++ b/apps/web/src/app/workflows/new/page.tsx
@@ -152,7 +152,6 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
     async function loadTemplate(slug: string) {
       const headers = await buildHeaders()
       setAgentName(FRIENDLY_NAMES[slug] ?? slug)
-      setConflictWarning(null)
       setWebhookError(null)
 
       const pbPromise = fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/playbooks/${slug}`).then(async res => {


### PR DESCRIPTION
Missed call site when removing conflictWarning state in #348. Build error: Cannot find name 'setConflictWarning' at line 155.