### PR TITLE
fix: Register webhook panel never rendered for trigger blocks

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -948,18 +948,6 @@ export default function BlockEditor({
             </div>
           )}
 
-          {/* GitHub trigger — webhook status panel */}
-          {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (
-            <GitHubWebhookStatusPanel
-              workflowId={workflowId}
-              hookId={githubHookId ?? null}
-              hookRepo={githubHookRepo ?? null}
-              getToken={getToken}
-              onWebhookChange={onWebhookChange}
-            />
-          )}
-
-
           {/* Secret warning */}
           {(() => {
             const leaked = findHardcodedSecrets(getNestedValue(blockData, "config.params"))
@@ -1068,6 +1056,19 @@ export default function BlockEditor({
               )
             })}
           </div>
+        </div>
+      )}
+
+      {/* GitHub issue-labeled trigger — webhook register panel (below config fields) */}
+      {blockType === "trigger" && triggerEventType === "github_issue_labeled" && (
+        <div className="px-4 pb-3">
+          <GitHubWebhookStatusPanel
+            workflowId={workflowId}
+            hookId={githubHookId ?? null}
+            hookRepo={githubHookRepo ?? null}
+            getToken={getToken}
+            onWebhookChange={onWebhookChange}
+          />
         </div>
       )}
 


### PR DESCRIPTION
## Bug

The `GitHubWebhookStatusPanel` for `github_issue_labeled` triggers was placed inside the `{isToolLike && (...)}` block. `isToolLike` is only true for `tool` and `cleanup` blocks — never for `trigger`. So the Register button never appeared.

## Fix

Moved the panel outside `isToolLike`, into its own top-level conditional block that renders below the Configuration section (TRIGGER TYPE / LABELS / REPO ALLOWLIST), with correct `px-4 pb-3` padding to match the rest of the panel.

## Test plan
- [ ] Open Autopilot Quick trigger block in canvas — Register Webhook panel appears below config fields
- [ ] Register button works as expected
🤖 Generated with [Claude Code](https://claude.com/claude-code)