### PR TITLE
fix: restore webhook_secret field for webhook triggers

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -626,9 +626,7 @@ export default function BlockEditor({
     ? allStaticFields.filter(f => {
         if (f.key === "config.labels" || f.key === "config.repo_allowlist")
           return triggerEventType === "github_issue_labeled"
-        if (f.key === "config.webhook_secret")
-          return false  // auto-generated — never shown to users
-        if (f.key === "config.test_pr_number")
+        if (f.key === "config.webhook_secret" || f.key === "config.test_pr_number")
           return triggerEventType === "webhook"
         if (f.key === "config.test_repo")
           return false  // redundant — repo is known from github_hook_repo


### PR DESCRIPTION
Reverts unasked change — webhook_secret field shown for webhook trigger type as before.