### PR TITLE
fix: enforce label uniqueness per repo in webhook registration

### DIFF
--- a/apps/api/alembic/versions/0025_webhook_hook_label.py
+++ b/apps/api/alembic/versions/0025_webhook_hook_label.py
@@ -1,0 +1,35 @@
+"""0025 webhook hook label — track which label each workflow listens for
+
+Adds github_hook_label to workflows so the webhook registration logic can
+enforce: same (repo, event-type, label) = conflict; different labels = share
+the same GitHub hook_id.
+
+Revision ID: 0025
+Revises: 0024
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0025"
+down_revision = "0024"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "workflows",
+        sa.Column("github_hook_label", sa.String(255), nullable=True),
+    )
+    op.create_index(
+        "ix_workflows_hook_label",
+        "workflows",
+        ["github_hook_repo", "github_hook_label"],
+        postgresql_where=sa.text("github_hook_label IS NOT NULL"),
+    )
+
+
+def downgrade():
+    op.drop_index("ix_workflows_hook_label", table_name="workflows")
+    op.drop_column("workflows", "github_hook_label")

--- a/apps/api/app/models/workflow.py
+++ b/apps/api/app/models/workflow.py
@@ -30,6 +30,7 @@ class Workflow(Base):
     # Auto-registered GitHub webhook — stored so we can deregister on delete
     github_hook_id = Column(String(255), nullable=True)
     github_hook_repo = Column(String(255), nullable=True)  # owner/repo format
+    github_hook_label = Column(String(255), nullable=True)  # label filter this workflow watches
     playbook_slug = Column(String(100), nullable=True)
 
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -562,8 +562,7 @@ def update_workflow(
         db.flush()
         workflow.current_version_id = version.id
 
-        # Keep github_hook_repo in sync with config.repo_allowlist (first entry).
-        # Without this, the test trigger and conflict checks keep using the stale install-time repo.
+        # Keep github_hook_repo and github_hook_label in sync with trigger config.
         nodes = graph_dict.get("nodes", [])
         trigger_node = next((n for n in nodes if n.get("data", {}).get("type") == "trigger"), None)
         if trigger_node:
@@ -572,6 +571,11 @@ def update_workflow(
             first_repo = next((r.strip() for r in allowlist_raw.split(",") if r.strip()), None)
             if first_repo and first_repo != workflow.github_hook_repo:
                 workflow.github_hook_repo = first_repo
+            # labels is a list in the graph config (e.g. ["autopilot-ready"])
+            labels_raw = cfg.get("labels") or []
+            label = labels_raw[0].strip() if labels_raw else None
+            if label != workflow.github_hook_label:
+                workflow.github_hook_label = label
 
         db.commit()
         db.refresh(workflow)
@@ -659,15 +663,42 @@ def register_workflow_webhook(
     token, provider = _git_token(str(workspace_id), db, str(workflow.environment_id) if workflow.environment_id else None)
 
     repo = workflow.github_hook_repo
+    current_events = set(_GITHUB_WEBHOOK_EVENTS.get(playbook_slug, []))
+    current_label = workflow.github_hook_label  # may be None for non-label-filtered agents
 
-    # Check for a sibling workflow that already has an active hook on this repo.
-    # If found, reuse its hook_id instead of registering a new one on GitHub —
-    # this prevents duplicate hooks and avoids the orphan-deregister bug.
+    # Conflict check: another workflow on this repo watches the same event type AND the same label.
+    # Same label + same events = would fire on identical payloads — reject.
+    if current_label:
+        label_conflict = db.query(Workflow).filter(
+            Workflow.workspace_id == workspace_id,
+            Workflow.github_hook_repo == repo,
+            Workflow.github_hook_id.isnot(None),
+            Workflow.id != workflow_id,
+            Workflow.github_hook_label == current_label,
+            Workflow.playbook_slug.in_([
+                slug for slug, evts in _GITHUB_WEBHOOK_EVENTS.items()
+                if set(evts) & current_events
+            ]),
+        ).first()
+        if label_conflict:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Label '{current_label}' is already registered on {repo} by '{label_conflict.name}'. "
+                       f"Each agent must watch a unique label on this repo.",
+            )
+
+    # Sibling check: another workflow on this repo uses the same event type.
+    # Share its hook_id — GitHub only needs one inbound webhook per event type per repo.
+    same_event_slugs = [
+        slug for slug, evts in _GITHUB_WEBHOOK_EVENTS.items()
+        if set(evts) & current_events
+    ]
     sibling = db.query(Workflow).filter(
         Workflow.workspace_id == workspace_id,
         Workflow.github_hook_repo == repo,
         Workflow.github_hook_id.isnot(None),
         Workflow.id != workflow_id,
+        Workflow.playbook_slug.in_(same_event_slugs),
     ).first()
 
     if sibling:

--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -59,6 +59,7 @@ class WorkflowDetailOut(WorkflowOut):
     current_version: Optional[WorkflowVersionOut] = None
     github_hook_id: Optional[str] = None
     github_hook_repo: Optional[str] = None
+    github_hook_label: Optional[str] = None
     playbook_slug: Optional[str] = None
     github_webhook: bool = False  # True when playbook requires GitHub webhook registration
     webhook_error: Optional[str] = None  # set when webhook registration failed on install


### PR DESCRIPTION
## Summary
- Migration 0025: adds `github_hook_label` nullable column to `workflows` with index on `(github_hook_repo, github_hook_label)`
- Canvas PUT now syncs `github_hook_label` from trigger node `config.labels[0]` alongside `github_hook_repo`
- `POST /workflows/{id}/webhook` — two-phase check:
  1. **Conflict**: 409 if another agent on same repo + same event-type group already watches the same label
  2. **Sibling share**: share `hook_id` only with agents in the same event-type group (`issues` ↔ `issues`, `pull_request` ↔ `pull_request`) — Release Notes (`create`) no longer falsely matches Autopilot Quick (`issues`)

## Root cause
Sibling query filtered only by `workspace_id + github_hook_repo + hook_id != NULL` — any workflow with an active hook on the same repo matched, regardless of event type. Release Notes (`create` events) was reusing Autopilot Quick's hook_id.

## Test plan
- [ ] Install Autopilot Quick on testbed repo, configure label `autopilot-ready`, register → fresh hook registered
- [ ] Install Autopilot Full on same repo, configure label `autopilot-full`, register → shares Autopilot Quick's hook_id (same `issues` event type, different label)
- [ ] Try registering second Autopilot Quick with same label `autopilot-ready` → 409 conflict error shown in panel
- [ ] Release Notes on same repo → registers its own separate hook (different event type `create`)