### PR TITLE
fix: use global GITHUB_WEBHOOK_SECRET for workspace-scoped issue hooks

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -775,7 +775,16 @@ def register_workflow_webhook(
         if proj:
             project_slug = _re.sub(r"[^a-z0-9]+", "-", proj.name.lower()).strip("-")
 
-    webhook_secret = _secrets.token_hex(32)
+    # Workspace-scoped hooks (/webhooks/github) are verified using the global
+    # GITHUB_WEBHOOK_SECRET env var. Per-workflow inbound hooks use a random secret
+    # stored encrypted in the trigger node config.
+    uses_workspace_url = (provider == "github" and "issues" in _GITHUB_WEBHOOK_EVENTS.get(playbook_slug, []))
+    if uses_workspace_url:
+        from app.core.config import settings as _settings
+        webhook_secret = _settings.github_webhook_secret or _secrets.token_hex(32)
+    else:
+        webhook_secret = _secrets.token_hex(32)
+
     hook_id, error = _register_git_webhook(
         token, repo, str(workflow.id),
         _GITHUB_WEBHOOK_EVENTS[playbook_slug],


### PR DESCRIPTION
## Problem
`POST /webhooks/github` verifies HMAC signatures using `settings.github_webhook_secret` (global env var). But `POST /workflows/{id}/webhook` was registering workspace-scoped hooks with a random `token_hex(32)` secret — GitHub signs deliveries with that random secret, handler verifies with the global var → always 401.

## Fix
When registering a workspace-scoped hook (issues events → `/webhooks/github` URL), use `settings.github_webhook_secret` as the hook secret instead of a random value. Per-workflow inbound hooks (`/webhooks/inbound/{id}`) keep their random per-workflow secret stored encrypted in the trigger node config.

## Env var required
`GITHUB_WEBHOOK_SECRET` must be set on Render. If empty, `_verify_github_signature` returns False and all deliveries are rejected.

## Test plan
- [ ] Confirm `GITHUB_WEBHOOK_SECRET` is set on Render
- [ ] Delete + reinstall + register Autopilot Quick on testbed repo
- [ ] Add `autopilot-ready` label to an issue → webhook delivers with 200