### PR TITLE
fix: resolve embedding API key from workspace environment credentials

### DIFF
--- a/apps/api/app/runtime/embedding_client.py
+++ b/apps/api/app/runtime/embedding_client.py
@@ -84,14 +84,23 @@ class VoyageEmbeddingClient:
         return [item["embedding"] for item in sorted(data, key=lambda x: x["index"])]
 
 
-def create_embedding_client() -> EmbeddingClient | None:
-    """Return the best available embedding client based on configured keys."""
+def create_embedding_client(
+    openai_api_key: str | None = None,
+    voyage_api_key: str | None = None,
+) -> EmbeddingClient | None:
+    """Return the best available embedding client.
+
+    Caller should pass workspace-scoped keys resolved from the environment
+    credentials store. Falls back to server-level settings when not provided.
+    """
     from app.core.config import settings
-    if settings.openai_api_key:
+    _openai = openai_api_key or settings.openai_api_key
+    _voyage = voyage_api_key or settings.voyage_api_key
+    if _openai:
         log.debug("embedding.provider", provider="openai")
-        return OpenAIEmbeddingClient(settings.openai_api_key)
-    if settings.voyage_api_key:
+        return OpenAIEmbeddingClient(_openai)
+    if _voyage:
         log.debug("embedding.provider", provider="voyage")
-        return VoyageEmbeddingClient(settings.voyage_api_key)
-    log.warning("embedding.no_provider", msg="Set OPENAI_API_KEY or VOYAGE_API_KEY to enable memory block")
+        return VoyageEmbeddingClient(_voyage)
+    log.warning("embedding.no_provider", msg="Set OPENAI_API_KEY or VOYAGE_API_KEY in workspace environment to enable memory block")
     return None

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -1266,7 +1266,7 @@ def _execute_approval(block: dict, state: dict, credentials: dict, run_id: str) 
 
 # ── main executor ─────────────────────────────────────────────────────────────
 
-def _execute_memory(block: dict, state: dict, db, run_id: str, workspace_id: str, playbook_slug: str) -> dict:
+def _execute_memory(block: dict, state: dict, db, run_id: str, workspace_id: str, playbook_slug: str, credentials: dict | None = None) -> dict:
     """
     Read or write agent memory with vector similarity search.
 
@@ -1283,7 +1283,11 @@ def _execute_memory(block: dict, state: dict, db, run_id: str, workspace_id: str
     action = config.get("action", "read")
     scope = config.get("scope", "repo")
     key = _resolve_refs(config.get("key", ""), state)
-    client = create_embedding_client()
+    creds = credentials or {}
+    client = create_embedding_client(
+        openai_api_key=creds.get("openai", {}).get("api_key") or creds.get("OPENAI_API_KEY"),
+        voyage_api_key=creds.get("voyage", {}).get("api_key") or creds.get("VOYAGE_API_KEY"),
+    )
 
     if action == "read":
         limit = int(config.get("limit", 5))
@@ -1527,6 +1531,7 @@ def execute_run(run_id: str):
                         block, state, db, run_id,
                         str(workspace_id_str),
                         version.workflow.playbook_slug or "",
+                        credentials=credentials,
                     )
 
                 else:


### PR DESCRIPTION
## Summary
- `create_embedding_client()` now accepts `openai_api_key` / `voyage_api_key` as explicit args
- `_execute_memory()` extracts the key from the workspace `credentials` dict (same pattern as `anthropic` / `github`)
- Falls back to `settings.openai_api_key` / `settings.voyage_api_key` when not in workspace credentials
- Users add `OPENAI_API_KEY` as a credential in their workspace environment — no Render env var needed

## Test plan
- [ ] Add `openai` integration with `api_key` to a workspace environment
- [ ] Run a playbook with a `memory` block — embeddings should use workspace key
- [ ] Remove from environment, set `OPENAI_API_KEY` on server — fallback path still works
- [ ] Neither configured — memory block skips embeddings gracefully (recency fallback)