### PR TITLE
fix: auto-populate memory Key field from scope

### DIFF
--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -1100,9 +1100,17 @@ export default function BlockEditor({
       {blockType === "memory" && (() => {
         const action = (getNestedValue(blockData, "config.action") as string) || "read"
         const scope  = (getNestedValue(blockData, "config.scope")  as string) || "repo"
-        const key    = (getNestedValue(blockData, "config.key")    as string) || ""
         const limit  = (getNestedValue(blockData, "config.limit")  as string) || "5"
         const summary = (getNestedValue(blockData, "config.summary") as string) || ""
+
+        // Auto-derive key from scope — populate on first render if not set
+        const autoKey = scope === "repo" ? "{{_trigger.repo_name}}" : "{{_trigger.workspace_id}}"
+        const currentKey = (getNestedValue(blockData, "config.key") as string) || ""
+        if (!currentKey) {
+          // Seed default key without blocking render
+          setTimeout(() => handleFieldChange("config.key", autoKey), 0)
+        }
+
         return (
           <>
             <div className={section}>
@@ -1126,7 +1134,13 @@ export default function BlockEditor({
               <span className={sectionLabel}>Scope</span>
               <select
                 value={scope}
-                onChange={e => handleFieldChange("config.scope", e.target.value)}
+                onChange={e => {
+                  const newScope = e.target.value
+                  const newKey = newScope === "repo" ? "{{_trigger.repo_name}}" : "{{_trigger.workspace_id}}"
+                  let updated = setNestedValue({ ...blockData }, "config.scope", newScope)
+                  updated = setNestedValue(updated, "config.key", newKey)
+                  onChange(blockId, updated)
+                }}
                 className={inputBase}
               >
                 <option value="repo">Repo — per repository</option>
@@ -1136,15 +1150,13 @@ export default function BlockEditor({
 
             <div className={section}>
               <span className={sectionLabel}>Key</span>
-              <input
-                type="text"
-                value={key}
-                onChange={e => handleFieldChange("config.key", e.target.value)}
-                placeholder="e.g. {{_trigger.repo_name}}"
-                className={inputBase}
-              />
+              <div className="flex items-center gap-1.5 px-2.5 py-1.5 bg-stone-50 border border-stone-200 rounded-lg">
+                <span className="inline-flex items-center rounded px-1.5 py-0.5 text-[11px] font-mono font-medium bg-violet-100 text-violet-700 border border-violet-200">
+                  {currentKey || autoKey}
+                </span>
+              </div>
               <p className="text-[10px] text-stone-400 mt-1">
-                Groups memories together. Use a template ref to make it dynamic.
+                Auto-set from scope — groups memories by {scope === "repo" ? "repository" : "workspace"}.
               </p>
             </div>
 


### PR DESCRIPTION
Key is now auto-derived from scope (repo → `{{_trigger.repo_name}}`, workspace → `{{_trigger.workspace_id}}`) and shown as a read-only violet chip. Changing scope updates the key automatically. Eliminates manual typing and typo risk.