### PR TITLE
fix: memory block DSL schema + canvas READ/WRITE badge

### DIFF
--- a/apps/api/app/dsl/loader.py
+++ b/apps/api/app/dsl/loader.py
@@ -394,6 +394,18 @@ def _block_to_node(block_id: str, block: Block, col: int) -> dict[str, Any]:
             if block.runs_on.port:
                 config["remote_host"]["port"] = block.runs_on.port
 
+    elif block.type == "memory":
+        if block.action:
+            config["action"] = block.action
+        if block.scope:
+            config["scope"] = block.scope
+        if block.key:
+            config["key"] = block.key
+        if block.limit is not None:
+            config["limit"] = str(block.limit)
+        if block.summary:
+            config["summary"] = block.summary
+
     elif block.type == "logic":
         config["condition"] = block.condition
 

--- a/apps/api/app/dsl/schema.py
+++ b/apps/api/app/dsl/schema.py
@@ -28,6 +28,7 @@ SUPPORTED_BLOCK_TYPES = {
     "brain",
     "logic",
     "approval",
+    "memory",
     "output",
     # `trigger` and `cleanup` are special: triggers live under top-level
     # ``on:`` and cleanups under top-level ``cleanup:`` — they do not appear
@@ -114,7 +115,7 @@ class OutputConfig(BaseModel):
 # don't have to context-switch between subclasses while authoring YAML.
 # ---------------------------------------------------------------------------
 class Block(BaseModel):
-    type: Literal["tool", "brain", "logic", "approval", "output"]
+    type: Literal["tool", "brain", "logic", "approval", "memory", "output"]
     label: str | None = None
     description: str | None = None
 
@@ -138,6 +139,12 @@ class Block(BaseModel):
     slack_user: str | None = None
     approval_email: str | None = None  # email address to send approve/reject link
     message: str | None = None
+
+    # — memory blocks —
+    scope: Literal["repo", "workspace"] | None = None
+    key: str | None = None
+    limit: int | None = None
+    summary: str | None = None
 
     # — output blocks —
     output: OutputConfig | None = None
@@ -178,6 +185,11 @@ class Block(BaseModel):
                 raise ValueError("approval blocks with via=email/both require `approval_email`")
             if not has_slack and not has_email:
                 raise ValueError("approval blocks require at least one of: `channel`, `slack_user`, or `approval_email`")
+        elif t == "memory":
+            if not self.action or self.action not in ("read", "write"):
+                raise ValueError("memory blocks require `action: read` or `action: write`")
+            if self.action == "write" and not self.summary:
+                raise ValueError("memory write blocks require a `summary:` template")
         elif t == "output":
             if not self.output:
                 raise ValueError("output blocks require an `output:` section")

--- a/apps/web/src/components/canvas/BlockNode.tsx
+++ b/apps/web/src/components/canvas/BlockNode.tsx
@@ -80,6 +80,8 @@ function BlockNode({ data, selected }: NodeProps) {
   const isTrigger  = nodeData.type === "trigger"
   const isBrain    = nodeData.type === "brain"
   const isOutput   = nodeData.type === "output"
+  const isMemory   = nodeData.type === "memory"
+  const memoryAction = isMemory ? ((nodeData.config as Record<string, string>)?.action || "read") : null
 
   const missingCondition = isLogic && !(nodeData.config as Record<string, unknown>)?.condition
 
@@ -137,6 +139,20 @@ function BlockNode({ data, selected }: NodeProps) {
       <p className="text-xs font-semibold text-stone-800 leading-tight truncate">
         {primaryLabel}
       </p>
+
+      {/* Memory READ/WRITE badge */}
+      {isMemory && (
+        <div className="flex items-center gap-1 mt-1.5">
+          <span className={cn(
+            "text-[9px] font-bold px-1.5 py-0.5 rounded uppercase tracking-wide",
+            memoryAction === "write"
+              ? "bg-amber-600 text-white"
+              : "bg-amber-100 text-amber-800"
+          )}>
+            {memoryAction === "write" ? "WRITE" : "READ"}
+          </span>
+        </div>
+      )}
 
       {/* Provider badge — only badge, no redundant action text */}
       {integrationLabel && !isTrigger && (


### PR DESCRIPTION
## Summary
- **Critical bug fix**: `memory` was missing from `Block.type` Literal — `autopilot-quick.yaml` could not be installed or re-saved (schema validation error at install time)
- Added `scope`, `key`, `limit`, `summary` fields to `Block` model
- `_block_to_node` now propagates all memory config to canvas nodes — summary template no longer shows placeholder on existing workflows
- Canvas memory nodes now show an amber **READ** or **WRITE** badge for instant clarity

## Test plan
- [ ] Install autopilot-quick — should succeed without schema validation error
- [ ] Open autopilot-quick on canvas, click the write Memory block — summary template should show the actual YAML value
- [ ] Canvas memory nodes should show READ (amber-100) and WRITE (amber-600) badges
- [ ] `pytest tests/test_dsl_loader.py tests/test_dsl_graph_to_workflow.py` passes