### PR TITLE
fix: preserve trace URL through sign-in redirect

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -8,7 +8,9 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
 
   const { userId } = await auth()
   if (!userId) {
-    return NextResponse.redirect(new URL("/", req.url))
+    const signIn = new URL("/sign-in", req.url)
+    signIn.searchParams.set("redirect_url", req.url)
+    return NextResponse.redirect(signIn)
   }
 })
 


### PR DESCRIPTION
## Summary
- When an unauthenticated user clicks a Slack trace URL (e.g. from a run notification), the middleware was redirecting them to `/` (landing page) — losing the original URL
- After signing in, they'd land on the dashboard, not the trace they wanted
- Fix: redirect to `/sign-in?redirect_url=<original>` so Clerk returns them to the trace page after sign-in

## Test plan
- [ ] Log out of conductai.ai
- [ ] Click a Slack trace URL (`/workflows/{id}/runs/{run_id}`)
- [ ] Should land on sign-in page, not landing page
- [ ] After signing in, should redirect back to the trace URL