### PR TITLE
fix: trailing underscore in Slack trace URL

### DIFF
--- a/apps/api/app/templates/slack_output.txt
+++ b/apps/api/app/templates/slack_output.txt
@@ -6,4 +6,4 @@
 
 {run_summary}
 
-_View full trace → {trace_url}_
+<{trace_url}|View full trace →>


### PR DESCRIPTION
## Summary
- Slack message used `_View full trace → {trace_url}_` (italic mrkdwn)
- Slack's link parser included the closing `_` as part of the URL, producing `…run_id_` which fails UUID parsing → "Run not found."
- Fix: use Slack's native hyperlink syntax `<url|text>` which is unambiguous and never bleeds into the URL

## Test plan
- [ ] Trigger a run via webhook
- [ ] Click trace URL in Slack — should open the run page correctly
- [ ] URL in browser bar should end with the run UUID, no trailing `_`