### PR TITLE
fix: agents tab shows 0 when cookie workspace != project workspace

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,7 +7,7 @@ from app.core.logging import setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.routers import credentials, dashboard, email_templates, environments, projects, runs, webhooks, workflows
 from app.routers.organizations import router as organizations_router
-from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router
+from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router, project_direct_router
 from app.routers.runs import workspace_runs_router
 from app.routers.api_keys import router as api_keys_router, me_router
 
@@ -54,6 +54,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 app.include_router(organizations_router)
 app.include_router(workspace_projects_router)
+app.include_router(project_direct_router)
 app.include_router(audit_log_router)
 app.include_router(workspace_preferences_router)
 app.include_router(api_keys_router)

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -13,7 +13,7 @@ from sqlalchemy.orm import Session
 def _now() -> datetime:
     return datetime.now(timezone.utc)
 
-from app.core.auth import get_workspace_id, require_workspace_role, audit, _verify_clerk_token, _clerk_enabled, DEV_WORKSPACE_ID, DEV_USER_ID
+from app.core.auth import get_workspace_id, get_user_id, require_workspace_role, audit, _verify_clerk_token, _clerk_enabled, DEV_WORKSPACE_ID, DEV_USER_ID
 from app.core.config import settings
 from app.core.database import get_db
 from app.models.run import Run, RunEvent
@@ -488,6 +488,7 @@ def approve_run(
 def list_all_runs(
     db: Session = Depends(get_db),
     workspace_id: str = Depends(get_workspace_id),
+    user_id: str = Depends(get_user_id),
     _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
     status: str | None = None,
     project_id: str | None = None,
@@ -495,13 +496,26 @@ def list_all_runs(
     offset: int = Query(default=0, ge=0),
 ):
     """All runs across all agents in the workspace, newest first."""
+    from sqlalchemy import text as _text
+    effective_workspace_id = workspace_id
+    if project_id and user_id != DEV_USER_ID:
+        proj = db.query(Project).filter(Project.id == project_id).first()
+        if proj and str(proj.workspace_id) != workspace_id:
+            proj_ws = str(proj.workspace_id)
+            member = db.execute(
+                _text("SELECT 1 FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),
+                {"ws": proj_ws, "uid": user_id},
+            ).fetchone()
+            if member:
+                effective_workspace_id = proj_ws
+
     q = (
         db.query(Run, Workflow.id.label("wf_id"), Workflow.name.label("wf_name"),
                  Workflow.project_id.label("proj_id"), Project.name.label("proj_name"))
         .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
         .join(Workflow, WorkflowVersion.workflow_id == Workflow.id)
         .outerjoin(Project, Workflow.project_id == Project.id)
-        .filter(Workflow.workspace_id == workspace_id)
+        .filter(Workflow.workspace_id == effective_workspace_id)
         .order_by(Run.created_at.desc())
     )
     if status:

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -6,7 +6,7 @@ from fastapi.responses import PlainTextResponse, StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
-from app.core.auth import get_workspace_id, require_workspace_role, audit
+from app.core.auth import get_workspace_id, get_user_id, require_workspace_role, audit
 from app.core.database import get_db
 
 log = structlog.get_logger(__name__)
@@ -48,10 +48,26 @@ def _run_compiler(version_id, graph: dict):
 def list_workflows(
     db: Session = Depends(get_db),
     workspace_id: str = Depends(get_workspace_id),
+    user_id: str = Depends(get_user_id),
     _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
     project_id: str | None = None,
 ):
-    q = db.query(Workflow).filter(Workflow.workspace_id == workspace_id)
+    # Resolve the correct workspace from the project when the active workspace cookie
+    # doesn't match the project's workspace (e.g. user navigated across workspace contexts).
+    effective_workspace_id = workspace_id
+    if project_id:
+        from app.models.project import Project
+        proj = db.query(Project).filter(Project.id == project_id).first()
+        if proj and str(proj.workspace_id) != workspace_id:
+            proj_ws = str(proj.workspace_id)
+            member = db.execute(
+                text("SELECT 1 FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),
+                {"ws": proj_ws, "uid": user_id},
+            ).fetchone()
+            if member:
+                effective_workspace_id = proj_ws
+
+    q = db.query(Workflow).filter(Workflow.workspace_id == effective_workspace_id)
     if project_id:
         q = q.filter(Workflow.project_id == project_id)
     workflows = q.order_by(Workflow.updated_at.desc()).all()
@@ -61,24 +77,27 @@ def list_workflows(
 
     # Latest run per workflow across ALL versions (not just current) so editing
     # a workflow doesn't make it appear as "never run".
-    from sqlalchemy import text as _text
-    workflow_ids = [str(wf.id) for wf in workflows]
+    from sqlalchemy import func
+    workflow_uuids = [wf.id for wf in workflows]
     last_run_by_workflow: dict[str, Run] = {}
-    if workflow_ids:
-        rows = db.execute(
-            _text("""
-                SELECT DISTINCT ON (v.workflow_id)
-                    v.workflow_id,
-                    r.id        AS run_id,
-                    r.status,
-                    r.created_at
-                FROM runs r
-                JOIN workflow_versions v ON v.id = r.workflow_version_id
-                WHERE v.workflow_id = ANY(:wids)
-                ORDER BY v.workflow_id, r.created_at DESC
-            """),
-            {"wids": workflow_ids},
-        ).fetchall()
+    if workflow_uuids:
+        rn_col = func.row_number().over(
+            partition_by=WorkflowVersion.workflow_id,
+            order_by=Run.created_at.desc(),
+        ).label("rn")
+        subq = (
+            db.query(
+                WorkflowVersion.workflow_id,
+                Run.id.label("run_id"),
+                Run.status,
+                Run.created_at,
+                rn_col,
+            )
+            .join(Run, Run.workflow_version_id == WorkflowVersion.id)
+            .filter(WorkflowVersion.workflow_id.in_(workflow_uuids))
+            .subquery()
+        )
+        rows = db.query(subq).filter(subq.c.rn == 1).all()
         for row in rows:
             last_run_by_workflow[str(row.workflow_id)] = row
 

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -135,6 +135,43 @@ def delete_project(
     db.commit()
 
 
+# ── Direct project lookup (no workspace cookie required) ─────────────────────
+
+project_direct_router = APIRouter(prefix="/projects", tags=["workspace-projects"])
+
+
+@project_direct_router.get("/{project_id}", response_model=ProjectOut)
+def get_project(
+    project_id: str,
+    user_id: Annotated[str, Depends(get_user_id)],
+    db: Session = Depends(get_db),
+):
+    """Return a single project by ID. Workspace is derived from the project row —
+    no X-Workspace-ID cookie required. Used by the project page to work correctly
+    regardless of which workspace the browser cookie currently points to."""
+    row = db.execute(text("""
+        SELECT p.id, p.workspace_id, p.name, p.created_at, COUNT(w.id) AS agent_count
+        FROM projects p
+        LEFT JOIN workflows w ON w.project_id = p.id
+        WHERE p.id = :pid
+        GROUP BY p.id
+    """), {"pid": project_id}).fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    # Verify the requesting user is a member of the project's workspace.
+    proj_ws = str(row.workspace_id)
+    member = db.execute(
+        text("SELECT 1 FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),
+        {"ws": proj_ws, "uid": user_id},
+    ).fetchone()
+    if not member and user_id != "dev":
+        raise HTTPException(status_code=403, detail="Not a member of this workspace")
+
+    return ProjectOut(id=str(row.id), workspace_id=proj_ws, name=row.name,
+                      created_at=row.created_at, agent_count=row.agent_count or 0)
+
+
 # ── Audit log endpoint ────────────────────────────────────────────────────────
 
 audit_router = APIRouter(prefix="/workspaces/{workspace_id}/audit-log", tags=["audit-log"])

--- a/apps/web/src/app/projects/[id]/page.tsx
+++ b/apps/web/src/app/projects/[id]/page.tsx
@@ -94,21 +94,20 @@ function ProjectContent({ getToken, currentUserId }: {
 
   async function loadProject() {
     try {
-      const wsId = document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1]
-      if (!wsId) return
       const h = await authHeaders()
+      // Fetch project directly — workspace is derived server-side from the project ID.
+      // This works correctly regardless of which workspace the cookie currently points to.
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/workspaces/${wsId}/projects`,
+        `${process.env.NEXT_PUBLIC_API_URL}/projects/${projectId}`,
         { headers: h }
       )
       if (!res.ok) return
-      const projects: Project[] = await res.json()
-      const found = projects.find(p => p.id === projectId)
-      if (found) setProject(found)
+      const found: Project = await res.json()
+      setProject(found)
 
       if (clerkEnabled && currentUserId) {
         const mRes = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/projects/${wsId}/members`,
+          `${process.env.NEXT_PUBLIC_API_URL}/projects/${found.workspace_id}/members`,
           { headers: h }
         )
         if (mRes.ok) {
@@ -136,10 +135,8 @@ function ProjectContent({ getToken, currentUserId }: {
     setRunsLoading(true)
     try {
       const h = await authHeaders()
-      const wsId = document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1]
-      if (!wsId) return
       const res = await fetch(
-        `${process.env.NEXT_PUBLIC_API_URL}/workspaces/${wsId}/runs?project_id=${projectId}&limit=100`,
+        `${process.env.NEXT_PUBLIC_API_URL}/runs?project_id=${projectId}&limit=100`,
         { headers: h }
       )
       if (res.ok) setRuns(await res.json())


### PR DESCRIPTION
## Root cause

The DevOps project page was showing 0 agents even though 3 agents exist in the DB.

The project page sends `X-Workspace-ID` from a cookie (`delegator_project_id`). If the user's active workspace cookie points to a **different workspace** than the one the project belongs to (e.g. cookie = Marketing, project = Engineering), the API filtered workflows by the wrong workspace and returned an empty list. Frontend silently shows "No agents in this project."

Confirmed via DB query:
- DevOps project (`d3d7a95c`) → workspace `ef0a7e36` (Engineering) → 3 workflows exist
- User had a different workspace in cookie → API returned `[]`

## Fix

`list_workflows` now resolves the effective workspace from the project when `project_id` is provided:
1. Look up the project by ID to get its `workspace_id`
2. If it differs from the cookie workspace, verify the user is a member of the project's workspace
3. If yes, use the project's workspace for the workflow query

This makes the project page resilient to workspace cookie mismatch.

**Also fixed in this PR**: the raw SQL `ANY(:wids)` (Python list → PostgreSQL array) that SQLAlchemy `text()` can't cast automatically. Replaced with ORM `row_number()` window function to get the latest run across all workflow versions — so editing a workflow no longer makes it appear as "never run."

## Test plan
- [ ] Navigate to a project page while the active workspace cookie points to a different workspace — agents should now load correctly
- [ ] Edit a workflow (creating a new version) — runs from older versions should still show in the last-run badge