### PR TITLE
fix: webhook trigger matching — no repo_allowlist should allow all re…

### DIFF
--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -494,7 +494,11 @@ def _repo_matches(config: dict[str, Any], incoming_repo: str, strict: bool) -> b
     # default: allowlist
     allowlist = _parse_repo_allowlist(config.get("repo_allowlist") or config.get("repos"))
     if not allowlist:
-        return not strict
+        # No allowlist configured — pass through. The webhook secret + workspace_id
+        # URL scoping already constrain which events reach this handler. Requiring
+        # an allowlist when none is set would silently block all YAML-installed
+        # workflows that don't have repo_allowlist set in their trigger block.
+        return True
     return incoming_repo in allowlist
 
 

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -834,6 +834,7 @@ def register_workflow_webhook(
             if node.get("data", {}).get("type") == "trigger":
                 node["data"].setdefault("config", {})["webhook_secret"] = encrypted_secret
                 node["data"]["config"]["git_provider"] = provider
+                node["data"]["config"]["repo_allowlist"] = repo
         version.graph = graph
         flag_modified(version, "graph")
 


### PR DESCRIPTION
…pos, not block

Root cause: _repo_matches with enforcement=strict (default) returned False when no repo_allowlist was configured. YAML-installed workflows have no repo_allowlist in their trigger config so they NEVER triggered, regardless of label match.

Fix 1: _repo_matches returns True when no allowlist is configured. Webhook secret
+ workspace_id URL scoping already constrain which events reach the handler.

Fix 2: webhook registration now writes repo_allowlist = repo into the trigger node config so future checks are explicit and matchable.