### PR TITLE
feat: project slugs, slug-addressed webhooks, breadcrumbs

### DIFF
--- a/apps/api/alembic/versions/0027_project_slug.py
+++ b/apps/api/alembic/versions/0027_project_slug.py
@@ -1,0 +1,50 @@
+"""0027 project_slug — add slug column to projects, backfill from name
+
+Revision ID: 0027
+Revises: 0026
+"""
+import re
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0027"
+down_revision = "0026"
+branch_labels = None
+depends_on = None
+
+
+def _slugify(name: str) -> str:
+    s = name.lower().strip()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-")
+
+
+def upgrade():
+    op.add_column("projects", sa.Column("slug", sa.String(100), nullable=True))
+
+    # Backfill slugs from existing names, de-duplicating with a numeric suffix
+    conn = op.get_bind()
+    rows = conn.execute(sa.text("SELECT id, name FROM projects ORDER BY created_at")).fetchall()
+    seen: dict[str, int] = {}
+    for row in rows:
+        base = _slugify(row.name) or "project"
+        if base not in seen:
+            slug = base
+        else:
+            seen[base] += 1
+            slug = f"{base}-{seen[base]}"
+        seen.setdefault(base, 0)
+        conn.execute(
+            sa.text("UPDATE projects SET slug = :slug WHERE id = :id"),
+            {"slug": slug, "id": str(row.id)},
+        )
+
+    op.alter_column("projects", "slug", nullable=False)
+    op.create_unique_constraint("uq_projects_slug_workspace", "projects", ["workspace_id", "slug"])
+
+
+def downgrade():
+    op.drop_constraint("uq_projects_slug_workspace", "projects", type_="unique")
+    op.drop_column("projects", "slug")

--- a/apps/api/alembic/versions/0027_project_slug.py
+++ b/apps/api/alembic/versions/0027_project_slug.py
@@ -30,12 +30,9 @@ def upgrade():
     seen: dict[str, int] = {}
     for row in rows:
         base = _slugify(row.name) or "project"
-        if base not in seen:
-            slug = base
-        else:
-            seen[base] += 1
-            slug = f"{base}-{seen[base]}"
-        seen.setdefault(base, 0)
+        n = seen.get(base, 0)
+        slug = base if n == 0 else f"{base}-{n}"
+        seen[base] = n + 1
         conn.execute(
             sa.text("UPDATE projects SET slug = :slug WHERE id = :id"),
             {"slug": slug, "id": str(row.id)},

--- a/apps/api/app/models/project.py
+++ b/apps/api/app/models/project.py
@@ -12,6 +12,7 @@ class Project(Base):
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), nullable=False)
     name = Column(String(255), nullable=False)
+    slug = Column(String(100), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
     workspace = relationship("Workspace", back_populates="projects")

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -571,6 +571,118 @@ def _trigger_github_workflows(
     return queued
 
 
+@router.post("/github/{project_slug}/{workflow_slug}")
+async def github_webhook_by_slug(
+    project_slug: str,
+    workflow_slug: str,
+    request: Request,
+    db: Session = Depends(get_db),
+):
+    """
+    Slug-addressed GitHub webhook — one URL per agent, human-readable.
+
+    URL: /webhooks/github/{project-slug}/{workflow-slug}
+    e.g. /webhooks/github/devops/autopilot-quick
+
+    Auth: HMAC-SHA256 via X-Hub-Signature-256 header (webhook secret stored
+    on the workflow's trigger node). No workspace_id cookie needed.
+    """
+    from app.models.project import Project
+    from app.models.workflow import Workflow, WorkflowVersion
+    import hashlib, hmac as _hmac
+    from app.core.crypto import decrypt as _decrypt
+
+    body = await request.body()
+
+    # Resolve project → workflow by slugs
+    project = db.query(Project).filter(Project.slug == project_slug).first()
+    if not project:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    workflow = (
+        db.query(Workflow)
+        .filter(
+            Workflow.project_id == project.id,
+            Workflow.playbook_slug == workflow_slug,
+        )
+        .first()
+    )
+    if not workflow or not workflow.current_version:
+        raise HTTPException(status_code=404, detail="Workflow not found")
+
+    version = workflow.current_version
+    nodes = version.graph.get("nodes", [])
+    trigger_node = next(
+        (n for n in nodes if n.get("data", {}).get("type") == "trigger"), None
+    )
+    if not trigger_node:
+        raise HTTPException(status_code=400, detail="Workflow has no trigger node")
+
+    trigger_config = trigger_node.get("data", {}).get("config", {})
+    raw_secret = trigger_config.get("webhook_secret", "")
+    if not raw_secret:
+        raise HTTPException(status_code=401, detail="Workflow has no webhook secret configured")
+
+    try:
+        webhook_secret = _decrypt(raw_secret)["secret"]
+    except Exception:
+        webhook_secret = raw_secret
+
+    sig_header = request.headers.get("X-Hub-Signature-256", "")
+    expected = "sha256=" + _hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()  # type: ignore[attr-defined]
+    if not sig_header or not _hmac.compare_digest(expected, sig_header):
+        raise HTTPException(status_code=401, detail="Invalid webhook signature")
+
+    event = request.headers.get("X-GitHub-Event", "unknown")
+    try:
+        payload = json.loads(body)
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=400, detail="Invalid JSON")
+
+    if event != "issues" or payload.get("action") != "labeled":
+        return {"ok": True, "queued": 0, "reason": f"event {event}/{payload.get('action')} not handled"}
+
+    normalized = _normalize_github_issue_labeled_payload(payload)
+    initial_state = {
+        "github_issue": {
+            "issue_number": normalized["issue"]["number"],
+            "title": normalized["issue"]["title"],
+            "body": normalized["issue"]["body"],
+            "url": normalized["issue"]["url"],
+            "author": normalized["issue"]["author"],
+            "labels": normalized["issue"]["labels"],
+            "label_added": normalized["label"],
+            "repo_full_name": normalized["repo"]["full_name"],
+            "repo_name": normalized["repo"]["name"],
+            "repo_owner": normalized["repo"]["owner"],
+            "default_branch": normalized["repo"]["default_branch"],
+            "clone_url": normalized["repo"]["clone_url"],
+        },
+        "github_trigger": normalized,
+    }
+
+    from app.routers.workflows import _estimate_turns_for_graph
+    try:
+        pf = _estimate_turns_for_graph(version.graph or {}, normalized["issue"]["title"], normalized["issue"]["body"] or "")
+        suggested_turns = pf["suggested_max_turns"]
+    except Exception:
+        suggested_turns = 20
+
+    run = Run(
+        workflow_version_id=version.id,
+        triggered_by=f"github:github_issue:{normalized['label']}",
+        status="pending",
+        state={**initial_state, "__triggered_by": "github:github_issue", "__max_turns": suggested_turns},
+        max_turns=suggested_turns,
+    )
+    db.add(run)
+    db.flush()
+    db.commit()
+    _redis().rpush(QUEUE_KEY, str(run.id))
+    log.info("github.slug_triggered", project_slug=project_slug, workflow_slug=workflow_slug, run_id=str(run.id))
+    return {"ok": True, "queued": 1, "run_ids": [str(run.id)], "label": normalized["label"], "repo": normalized["repo"]["full_name"]}
+
+
 @router.post("/github")
 async def github_webhook(
     request: Request,

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -21,6 +21,7 @@ from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from app.core.config import settings
 from app.core.database import get_db
+from app.models.project import Project
 from app.models.run import Run, RunEvent
 from app.models.workflow import Workflow, WorkflowVersion
 
@@ -587,9 +588,6 @@ async def github_webhook_by_slug(
     Auth: HMAC-SHA256 via X-Hub-Signature-256 header (webhook secret stored
     on the workflow's trigger node). No workspace_id cookie needed.
     """
-    from app.models.project import Project
-    from app.models.workflow import Workflow, WorkflowVersion
-    import hashlib, hmac as _hmac
     from app.core.crypto import decrypt as _decrypt
 
     body = await request.body()
@@ -629,8 +627,8 @@ async def github_webhook_by_slug(
         webhook_secret = raw_secret
 
     sig_header = request.headers.get("X-Hub-Signature-256", "")
-    expected = "sha256=" + _hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()  # type: ignore[attr-defined]
-    if not sig_header or not _hmac.compare_digest(expected, sig_header):
+    expected = "sha256=" + hmac.new(webhook_secret.encode(), body, hashlib.sha256).hexdigest()  # type: ignore[attr-defined]
+    if not sig_header or not hmac.compare_digest(expected, sig_header):
         raise HTTPException(status_code=401, detail="Invalid webhook signature")
 
     event = request.headers.get("X-GitHub-Event", "unknown")

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -200,6 +200,7 @@ def _register_git_webhook(
     events: list[str],
     provider: str = "github",
     project_slug: str | None = None,
+    workflow_slug: str | None = None,
     secret: str | None = None,
     workspace_id: str | None = None,
 ) -> tuple[str | None, str | None]:
@@ -207,10 +208,11 @@ def _register_git_webhook(
     import httpx
     from app.core.config import settings
 
-    # GitHub issue-based triggers must use /webhooks/github so label filtering
-    # (ai-ready, etc.) is enforced. The generic /webhooks/inbound endpoint has
-    # no label awareness and fires on every issues event.
-    if provider == "github" and "issues" in events and workspace_id:
+    # Prefer slug-addressed URL when both project and workflow slugs are available.
+    # Falls back to workspace-scoped URL (legacy) or inbound URL.
+    if provider == "github" and "issues" in events and project_slug and workflow_slug:
+        webhook_url = f"{settings.api_base_url}/webhooks/github/{project_slug}/{workflow_slug}"
+    elif provider == "github" and "issues" in events and workspace_id:
         webhook_url = f"{settings.api_base_url}/webhooks/github?workspace_id={workspace_id}"
     else:
         slug_segment = f"{project_slug}/" if project_slug else ""
@@ -578,6 +580,12 @@ def get_workflow(workflow_id: UUID, db: Session = Depends(get_db), workspace_id:
     if not workflow:
         raise HTTPException(status_code=404, detail="Workflow not found")
     _stamp(workflow)
+    if workflow.project_id:
+        from app.models.project import Project as _Proj
+        proj = db.query(_Proj).filter(_Proj.id == workflow.project_id).first()
+        if proj:
+            workflow.project_slug = proj.slug  # type: ignore[attr-defined]
+            workflow.project_name = proj.name  # type: ignore[attr-defined]
     return workflow
 
 
@@ -817,6 +825,7 @@ def register_workflow_webhook(
         _GITHUB_WEBHOOK_EVENTS[playbook_slug],
         provider=provider,
         project_slug=project_slug,
+        workflow_slug=workflow.playbook_slug,
         secret=webhook_secret,
         workspace_id=str(workspace_id),
     )

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -808,12 +808,18 @@ def register_workflow_webhook(
         from app.models.project import Project as _Project
         proj = db.query(_Project).filter(_Project.id == workflow.project_id).first()
         if proj:
-            project_slug = _re.sub(r"[^a-z0-9]+", "-", proj.name.lower()).strip("-")
+            project_slug = proj.slug  # use the stored slug, not a runtime derivation
 
-    # Workspace-scoped hooks (/webhooks/github) are verified using the global
-    # GITHUB_WEBHOOK_SECRET env var. Per-workflow inbound hooks use a random secret
-    # stored encrypted in the trigger node config.
-    uses_workspace_url = (provider == "github" and "issues" in _GITHUB_WEBHOOK_EVENTS.get(playbook_slug, []))
+    # Slug-addressed webhooks use a per-workflow random secret (verified in
+    # github_webhook_by_slug). Legacy workspace-scoped URL falls back to the
+    # global GITHUB_WEBHOOK_SECRET. If we have both slugs we always prefer the
+    # slug URL so always generate a per-workflow secret.
+    uses_slug_url = bool(project_slug and workflow.playbook_slug)
+    uses_workspace_url = (
+        not uses_slug_url and
+        provider == "github" and
+        "issues" in _GITHUB_WEBHOOK_EVENTS.get(playbook_slug, [])
+    )
     if uses_workspace_url:
         from app.core.config import settings as _settings
         webhook_secret = _settings.github_webhook_secret or _secrets.token_hex(32)

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -41,9 +41,9 @@ def _slugify(name: str) -> str:
 
 
 def _unique_slug(base: str, workspace_id: str, db: Session, exclude_id: str | None = None) -> str:
-    slug = base
-    n = 1
+    n = 0
     while True:
+        slug = base if n == 0 else f"{base}-{n}"
         q = "SELECT 1 FROM projects WHERE workspace_id = :ws AND slug = :slug"
         params: dict = {"ws": workspace_id, "slug": slug}
         if exclude_id:
@@ -52,7 +52,6 @@ def _unique_slug(base: str, workspace_id: str, db: Session, exclude_id: str | No
         if not db.execute(text(q), params).fetchone():
             return slug
         n += 1
-        slug = f"{base}-{n}"
 
 
 def _enforce_workspace(path_id: str, active_id: str) -> None:

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -2,6 +2,7 @@
 Projects — logical grouping of resources within a workspace/team.
 Routes: /workspaces/{workspace_id}/projects
 """
+import re
 import uuid
 from datetime import datetime, timezone
 from typing import Annotated
@@ -22,12 +23,36 @@ class ProjectOut(BaseModel):
     id: str
     workspace_id: str
     name: str
+    slug: str = ""
     created_at: datetime
     agent_count: int = 0
 
 
 class ProjectCreate(BaseModel):
     name: str
+
+
+def _slugify(name: str) -> str:
+    s = name.lower().strip()
+    s = re.sub(r"[^\w\s-]", "", s)
+    s = re.sub(r"[\s_]+", "-", s)
+    s = re.sub(r"-+", "-", s)
+    return s.strip("-") or "project"
+
+
+def _unique_slug(base: str, workspace_id: str, db: Session, exclude_id: str | None = None) -> str:
+    slug = base
+    n = 1
+    while True:
+        q = "SELECT 1 FROM projects WHERE workspace_id = :ws AND slug = :slug"
+        params: dict = {"ws": workspace_id, "slug": slug}
+        if exclude_id:
+            q += " AND id != :eid"
+            params["eid"] = exclude_id
+        if not db.execute(text(q), params).fetchone():
+            return slug
+        n += 1
+        slug = f"{base}-{n}"
 
 
 def _enforce_workspace(path_id: str, active_id: str) -> None:
@@ -45,7 +70,7 @@ def list_projects(
 ):
     _enforce_workspace(workspace_id, active_workspace_id)
     rows = db.execute(text("""
-        SELECT p.id, p.workspace_id, p.name, p.created_at,
+        SELECT p.id, p.workspace_id, p.name, p.slug, p.created_at,
                COUNT(w.id) AS agent_count
         FROM projects p
         LEFT JOIN workflows w ON w.project_id = p.id
@@ -54,7 +79,7 @@ def list_projects(
         ORDER BY p.created_at ASC
     """), {"ws": workspace_id}).fetchall()
     return [ProjectOut(id=str(r.id), workspace_id=str(r.workspace_id), name=r.name,
-                       created_at=r.created_at, agent_count=r.agent_count or 0)
+                       slug=r.slug or "", created_at=r.created_at, agent_count=r.agent_count or 0)
             for r in rows]
 
 
@@ -73,13 +98,15 @@ def create_project(
 
     project_id = uuid.uuid4()
     now = datetime.now(timezone.utc)
+    name = body.name.strip()
+    slug = _unique_slug(_slugify(name), workspace_id, db)
     db.execute(text("""
-        INSERT INTO projects (id, workspace_id, name, created_at)
-        VALUES (:id, :ws, :name, :now)
-    """), {"id": str(project_id), "ws": workspace_id, "name": body.name.strip(), "now": now})
+        INSERT INTO projects (id, workspace_id, name, slug, created_at)
+        VALUES (:id, :ws, :name, :slug, :now)
+    """), {"id": str(project_id), "ws": workspace_id, "name": name, "slug": slug, "now": now})
     db.commit()
     return ProjectOut(id=str(project_id), workspace_id=workspace_id,
-                      name=body.name.strip(), created_at=now)
+                      name=name, slug=slug, created_at=now)
 
 
 @router.patch("/{project_id}", response_model=ProjectOut)
@@ -95,22 +122,23 @@ def rename_project(
     name = (body.get("name") or "").strip()
     if not name:
         raise HTTPException(status_code=422, detail="Name cannot be empty")
+    slug = _unique_slug(_slugify(name), workspace_id, db, exclude_id=project_id)
     result = db.execute(text("""
-        UPDATE projects SET name = :name
+        UPDATE projects SET name = :name, slug = :slug
         WHERE id = :id AND workspace_id = :ws
         RETURNING id
-    """), {"name": name, "id": project_id, "ws": workspace_id})
+    """), {"name": name, "slug": slug, "id": project_id, "ws": workspace_id})
     if not result.fetchone():
         raise HTTPException(status_code=404, detail="Project not found")
     db.commit()
 
     row = db.execute(text("""
-        SELECT p.id, p.workspace_id, p.name, p.created_at, COUNT(w.id) AS agent_count
+        SELECT p.id, p.workspace_id, p.name, p.slug, p.created_at, COUNT(w.id) AS agent_count
         FROM projects p LEFT JOIN workflows w ON w.project_id = p.id
         WHERE p.id = :id GROUP BY p.id
     """), {"id": project_id}).fetchone()
     return ProjectOut(id=str(row.id), workspace_id=str(row.workspace_id), name=row.name,
-                      created_at=row.created_at, agent_count=row.agent_count or 0)
+                      slug=row.slug or "", created_at=row.created_at, agent_count=row.agent_count or 0)
 
 
 @router.delete("/{project_id}", status_code=204)
@@ -150,7 +178,7 @@ def get_project(
     no X-Workspace-ID cookie required. Used by the project page to work correctly
     regardless of which workspace the browser cookie currently points to."""
     row = db.execute(text("""
-        SELECT p.id, p.workspace_id, p.name, p.created_at, COUNT(w.id) AS agent_count
+        SELECT p.id, p.workspace_id, p.name, p.slug, p.created_at, COUNT(w.id) AS agent_count
         FROM projects p
         LEFT JOIN workflows w ON w.project_id = p.id
         WHERE p.id = :pid
@@ -169,7 +197,7 @@ def get_project(
         raise HTTPException(status_code=403, detail="Not a member of this workspace")
 
     return ProjectOut(id=str(row.id), workspace_id=proj_ws, name=row.name,
-                      created_at=row.created_at, agent_count=row.agent_count or 0)
+                      slug=row.slug or "", created_at=row.created_at, agent_count=row.agent_count or 0)
 
 
 # ── Audit log endpoint ────────────────────────────────────────────────────────

--- a/apps/api/app/schemas/workflow.py
+++ b/apps/api/app/schemas/workflow.py
@@ -63,3 +63,5 @@ class WorkflowDetailOut(WorkflowOut):
     playbook_slug: Optional[str] = None
     github_webhook: bool = False  # True when playbook requires GitHub webhook registration
     webhook_error: Optional[str] = None  # set when webhook registration failed on install
+    project_slug: Optional[str] = None
+    project_name: Optional[str] = None

--- a/apps/web/src/app/projects/[id]/page.tsx
+++ b/apps/web/src/app/projects/[id]/page.tsx
@@ -171,10 +171,15 @@ function ProjectContent({ getToken, currentUserId }: {
   return (
     <AppShell>
       <div className="mx-auto max-w-3xl px-6 py-10">
+        {/* Breadcrumb */}
+        <nav className="flex items-center gap-1.5 text-xs text-stone-400 mb-4">
+          <Link href="/projects" className="hover:text-stone-600 transition-colors">Projects</Link>
+          <span>/</span>
+          <span className="text-stone-600 font-medium">{project?.name ?? "…"}</span>
+        </nav>
         {/* Header */}
         <div className="flex items-center justify-between mb-6">
           <div>
-            <p className="text-xs text-stone-400 mb-1">Project</p>
             <h1 className="text-xl font-semibold text-stone-900">
               {project?.name ?? "Loading..."}
             </h1>

--- a/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/workflows/[id]/runs/[run_id]/page.tsx
@@ -43,6 +43,7 @@ export default function RunDetailPage() {
   const [run, setRun] = useState<RunMeta | null>(null)
   const [workflowName, setWorkflowName] = useState<string | null>(null)
   const [projectName, setProjectName] = useState<string | null>(null)
+  const [projectId, setProjectId] = useState<string | null>(null)
   const [agentModel, setAgentModel] = useState<string | null>(null)
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
@@ -100,6 +101,7 @@ export default function RunDetailPage() {
         const wf = await wfRes.json()
         setWorkflowName(wf.name ?? null)
         setProjectName(wf.project_name ?? null)
+        setProjectId(wf.project_id ?? null)
         const nodes: {data?: {type?: string; model?: string}}[] = wf.graph?.nodes ?? []
         const brainNode = nodes.find(n => n.data?.type === "brain")
         if (brainNode?.data?.model) setAgentModel(brainNode.data.model)
@@ -138,13 +140,14 @@ export default function RunDetailPage() {
     <AppShell>
       <div className="mx-auto max-w-4xl px-6 py-8">
         {/* Breadcrumb */}
-        <div className="flex items-center gap-1.5 text-xs text-stone-400 mb-5">
-          <Link href="/runs" className="hover:text-stone-600">Runs</Link>
+        <nav className="flex items-center gap-1.5 text-xs text-stone-400 mb-5">
+          <Link href="/projects" className="hover:text-stone-600">Projects</Link>
+          {projectId && projectName && (<><span>/</span><Link href={`/projects/${projectId}`} className="hover:text-stone-600 max-w-[100px] truncate">{projectName}</Link></>)}
           <span>/</span>
-          <Link href={`/workflows/${workflowId}`} className="hover:text-stone-600">{workflowName ?? workflowId.slice(0,8)}</Link>
+          <Link href={`/workflows/${workflowId}`} className="hover:text-stone-600 max-w-[120px] truncate">{workflowName ?? workflowId.slice(0,8)}</Link>
           <span>/</span>
           <span className="font-mono text-stone-500">{run.id.slice(0,8)}…</span>
-        </div>
+        </nav>
 
         {/* Header */}
         <div className="mb-6 flex items-start justify-between gap-4">

--- a/apps/web/src/components/canvas/BlockEditor.tsx
+++ b/apps/web/src/components/canvas/BlockEditor.tsx
@@ -26,6 +26,7 @@ interface BlockEditorProps {
   githubHookId?: string | null
   githubWebhook?: boolean
   playbookSlug?: string | null
+  projectSlug?: string | null
   onWebhookChange?: (hookId: string | null, hookRepo: string | null) => void
 }
 
@@ -604,6 +605,7 @@ export default function BlockEditor({
   githubHookId,
   githubWebhook,
   playbookSlug,
+  projectSlug,
   onWebhookChange,
 }: BlockEditorProps) {
   const [promptOpen, setPromptOpen] = useState(false)
@@ -979,11 +981,14 @@ export default function BlockEditor({
                   {rendered}
                   {/* GitHub issue-labeled — webhook URL card + compact register panel */}
                   {blockType === "trigger" && field.key === "config.event_type" && triggerEventType === "github_issue_labeled" && (() => {
-                    const ws = typeof document !== "undefined"
-                      ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
-                    const webhookUrl = ws
-                      ? `${(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/github?workspace_id=${ws}`
-                      : null
+                    const base = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")
+                    const webhookUrl = projectSlug && playbookSlug
+                      ? `${base}/webhooks/github/${projectSlug}/${playbookSlug}`
+                      : (() => {
+                          const ws = typeof document !== "undefined"
+                            ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
+                          return ws ? `${base}/webhooks/github?workspace_id=${ws}` : null
+                        })()
                     return (
                       <div className="rounded-lg border border-violet-100 bg-violet-50 px-3 py-2.5 text-xs text-violet-800 mt-2 space-y-1.5">
                         <div className="flex items-center justify-between">
@@ -1016,11 +1021,14 @@ export default function BlockEditor({
 
                   {/* Inbound webhook URL panel */}
                   {blockType === "trigger" && field.key === "config.event_type" && triggerEventType === "webhook" && (() => {
-                    const ws = typeof document !== "undefined"
-                      ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
-                    const githubUrl = ws
-                      ? `${(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/github?workspace_id=${ws}`
-                      : null
+                    const base = (process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")
+                    const githubUrl = projectSlug && playbookSlug
+                      ? `${base}/webhooks/github/${projectSlug}/${playbookSlug}`
+                      : (() => {
+                          const ws = typeof document !== "undefined"
+                            ? document.cookie.match(/(?:^|;\s*)delegator_project_id=([^;]+)/)?.[1] : null
+                          return ws ? `${base}/webhooks/github?workspace_id=${ws}` : null
+                        })()
                     const inboundUrl = `${(process.env.NEXT_PUBLIC_API_URL || "").replace(/\/$/, "")}/webhooks/inbound/${workflowId}`
                     const webhookUrl = githubHookRepo ? githubUrl : inboundUrl
                     const displayUrl = webhookUrl ?? inboundUrl

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -164,6 +164,8 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
   const [testPrNumber, setTestPrNumber] = useState("")
   const { prefs } = usePreferences()
   const [playbookSlug, setPlaybookSlug] = useState<string | null>(null)
+  const [projectSlug, setProjectSlug] = useState<string | null>(null)
+  const [projectName, setProjectName] = useState<string | null>(null)
 
   const STORAGE_KEY = `marshal:active-run:${workflowId}`
   const TEST_RUN_KEY = `marshal:test-run:${workflowId}`
@@ -289,6 +291,8 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
         setGithubHookId(data.github_hook_id ?? null)
         setGithubWebhook(data.github_webhook ?? false)
         setPlaybookSlug(data.playbook_slug ?? null)
+        setProjectSlug(data.project_slug ?? null)
+        setProjectName(data.project_name ?? null)
         const graph = data.current_version?.graph
         if (graph?.nodes && graph?.edges) {
           // Run auto-layout when:
@@ -783,6 +787,16 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
     <div className="flex flex-col h-full bg-stone-50">
       {/* Top bar */}
       <header className="flex items-center justify-between px-5 py-3 bg-white border-b border-stone-200 shrink-0">
+        <div className="flex flex-col gap-0.5">
+          {projectName && (
+            <nav className="flex items-center gap-1 text-[10px] text-stone-400">
+              <button onClick={() => router.push("/projects")} className="hover:text-stone-600 transition-colors">Projects</button>
+              <span>/</span>
+              <button onClick={() => router.back()} className="hover:text-stone-600 transition-colors max-w-[120px] truncate">{projectName}</button>
+              <span>/</span>
+              <span className="text-stone-500 font-medium max-w-[140px] truncate">{workflowName}</span>
+            </nav>
+          )}
         <div className="flex items-center gap-3">
           <input
             value={workflowName}
@@ -835,6 +849,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
               Runs
             </button>
           </div>
+        </div>
         </div>
         <div className="flex items-center gap-3">
           {/* Autosave status */}
@@ -1030,6 +1045,7 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false }: CanvasEdi
                       githubHookId={githubHookId}
                       githubWebhook={githubWebhook}
                       playbookSlug={playbookSlug}
+                      projectSlug={projectSlug}
                       onWebhookChange={(id, repo) => { setGithubHookId(id); setGithubHookRepo(repo) }}
                     />
                   </div>


### PR DESCRIPTION
## Summary

- **Migration 0027**: adds `slug` column to `projects`, backfills from name, unique per workspace
- **Slug-addressed webhooks**: new `POST /webhooks/github/{project_slug}/{workflow_slug}` — fires exactly one workflow, no cross-workflow fan-out, human-readable URL (e.g. `/webhooks/github/devops/autopilot-quick`)
- **Webhook registration**: prefers slug URL when both slugs are available; falls back to legacy `?workspace_id=` for existing installs
- **WorkflowDetailOut**: adds `project_slug` and `project_name` fields
- **BlockEditor**: webhook URL displayed to user now shows slug form instead of UUID workspace URL
- **Breadcrumbs**: `Projects > Project > Agent` in canvas header; full trail in run detail page

## Test plan

- [ ] Create a new project — verify slug is auto-generated (e.g. "DevOps" → `devops`)
- [ ] Rename project — verify slug updates and stays unique
- [ ] Register webhook on a workflow inside a project — URL shows `/webhooks/github/devops/autopilot-quick`
- [ ] Label a GitHub issue — only the targeted workflow fires, not all workspace workflows
- [ ] Navigate canvas → breadcrumb shows project name and links back to project page
- [ ] Run detail page → breadcrumb shows Projects > Project > Workflow > Run

## Migration note

Run `alembic upgrade head` on deploy. Backfill is idempotent — existing projects get slugs derived from their names.