### PR TITLE
Sync playbook count to 18 and derive it from the registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,67 @@ Every step is visible. Every run is logged. Nothing merges without a human in th
 
 ---
 
-## 9 ready-made playbooks
+## 18 ready-made playbooks
 
-Install any of these in one click, configure credentials, and run.
+Install any of these in one click, configure credentials, and run. Grouped by the 10 categories you'll see in the Marketplace.
 
+### Issue → PR
 | Playbook | Trigger | What it does |
 |----------|---------|-------------|
-| **Autopilot Git → Slack** | GitHub issue label | Implements fix, opens PR, posts to Slack |
-| **Dependency Updater** | Weekly cron | Bumps patch/minor deps, opens PR |
-| **Incident Responder** | PagerDuty / OpsGenie webhook | Correlates commits, posts hypothesis to Slack |
-| **Release Notes** | Git tag | Reads merged PRs, writes CHANGELOG, posts to #releases |
-| **Issue Triage** | GitHub issue opened | Labels, prioritises, posts clarifying comment |
-| **Deploy Monitor** | Vercel / Railway webhook | Monitors deployment, alerts on failure |
-| **PR Review** | GitHub PR opened | Reviews diff, posts structured feedback |
-| **Scheduled Report** | Daily cron | Aggregates Linear issues, emails summary |
-| **Custom Agent** | Any trigger | Build from scratch on the canvas |
+| **Autopilot Quick** | GitHub issue labeled | Implements fix, opens PR immediately (CI runs tests on the PR) |
+| **Autopilot Full** | GitHub issue labeled | Implements fix, runs tests with retry, opens PR |
+| **Autopilot + Approval** | GitHub issue labeled | Implements fix, runs tests, human approves in Slack, then opens PR |
+
+### Code Review
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **PR Reviewer** | PR opened | Reviews the diff for bugs, security, and style; posts a review |
+| **Copilot / AI PR Reviewer** | PR opened by Copilot/Cursor/Claude Code | Extra scrutiny for hallucinated APIs and missing tests; human approves before merge |
+| **Security Scanner** | PR opened | Scans for OWASP Top 10, hardcoded secrets, auth bypasses; posts report, files fix issue for criticals |
+
+### Issue Triage
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Issue Triage** | GitHub issue opened | Classifies type and priority, adds labels, posts a clarifying comment if vague |
+
+### CI/CD
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **CI Failure Alert** | CI build fails | Diagnoses the failed step, posts root cause and suggested fix to Slack |
+| **Flaky Test Detective** | Repeated CI failures | Identifies flaky tests, finds the offending commit, posts a fix recommendation |
+
+### Release Management
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Release Readiness Reviewer** | Release branch cut | Checks open blockers, failed CI, pending reviews; posts a go/no-go summary |
+| **Release Notes Drafter** | Git tag pushed | Reads merged PRs, groups by type, writes CHANGELOG, posts to Slack |
+
+### Incidents & Ops
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Incident Responder** | PagerDuty / OpsGenie webhook | Correlates recent commits and deploys, posts root cause hypothesis to Slack |
+| **Postmortem Drafter** | Incident resolved | Reads timeline, alerts, and commits; drafts a structured postmortem |
+
+### Security
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Dependency Updater** | Weekly cron | Bumps patch/minor deps, opens a single clean PR |
+| **Security Patch Updater** | Dependabot alert | Applies the security patch, runs tests, opens a PR with CVE reference |
+
+### Docs
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Docs Drift Detector** | PR merged | Checks if related docs/README/runbooks went stale; opens a docs PR or files an issue |
+
+### Platform & Infra
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Terraform Plan Reviewer** | Terraform plan PR opened | Reviews for security misconfigs, cost anomalies, and drift; posts findings |
+
+### Testing
+| Playbook | Trigger | What it does |
+|----------|---------|-------------|
+| **Smoke Test** | Manual / CI | Minimal 1-step pipeline ping for CI gating and worker health checks |
 
 ---
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { useEffect, useState } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth, SignInButton } from "@clerk/nextjs"
 import BlogSection from "@/components/BlogSection"
@@ -23,6 +24,19 @@ function LandingPageWithAuth() {
 function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isLoaded: boolean }) {
   const router = useRouter()
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+
+  // Single source of truth for the playbook count — fetched from the same
+  // endpoint the Marketplace uses, so marketing copy never drifts from the
+  // registry. Falls back to the default if the API is unreachable.
+  const [playbookCount, setPlaybookCount] = useState(18)
+  useEffect(() => {
+    fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/playbooks`)
+      .then(r => (r.ok ? r.json() : []))
+      .then((pbs: unknown[]) => {
+        if (Array.isArray(pbs) && pbs.length > 0) setPlaybookCount(pbs.length)
+      })
+      .catch(() => {})
+  }, [])
 
   return (
     <div className="min-h-screen bg-white flex flex-col">
@@ -213,7 +227,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
       {/* Trust strip */}
       <div className="border-y border-stone-100 bg-stone-50 py-4 px-6">
         <div className="max-w-4xl mx-auto flex flex-wrap items-center justify-center gap-6 text-xs font-medium text-stone-500">
-          <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block"/>11 ready-made agents</span>
+          <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block"/>{playbookCount} ready-made agents</span>
           <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block"/>Zero prompt engineering</span>
           <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block"/>Human approval on every merge</span>
           <span className="flex items-center gap-1.5"><span className="w-1.5 h-1.5 rounded-full bg-emerald-400 inline-block"/>RBAC — admin, editor, viewer</span>
@@ -247,7 +261,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
             One click to install.<br />Running in minutes.
           </h2>
           <p className="text-center text-stone-500 text-sm max-w-xl mx-auto mb-12">
-            12 pre-built agent playbooks — browse, install, configure your credentials, and run. Already installed playbooks are tracked so you never duplicate. No blank canvas required.
+            {playbookCount} pre-built agent playbooks across 10 categories — browse, install, configure your credentials, and run. Already installed playbooks are tracked so you never duplicate. No blank canvas required.
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5 mb-8">
             {TEMPLATES.map(t => (
@@ -271,7 +285,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
               href="/marketplace"
               className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-medium text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all"
             >
-              📦 Browse all 12 playbooks in the Marketplace →
+              📦 Browse all {playbookCount} playbooks in the Marketplace →
             </a>
           </div>
         </div>
@@ -285,7 +299,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
             {[
               { step: "1", icon: "🔗", title: "Connect your repo", body: "Link GitHub, GitLab, or Bitbucket. Add Slack, Linear, and your API keys. No migration, no new tooling — Conduct wraps around what you already use." },
-              { step: "2", icon: "📦", title: "Install from the Marketplace", body: "Browse 12 pre-built playbooks, click Install — canvas is pre-wired. Add credentials and the agent is ready to run." },
+              { step: "2", icon: "📦", title: "Install from the Marketplace", body: `Browse ${playbookCount} pre-built playbooks, click Install — canvas is pre-wired. Add credentials and the agent is ready to run.` },
               { step: "3", icon: "✅", title: "Get output in Slack", body: "PRs, diagnoses, triage comments, changelogs — delivered to Slack. Approve or reject with one click." },
             ].map(s => (
               <div key={s.step} className="bg-white rounded-2xl border border-stone-200 p-6 text-center">
@@ -359,7 +373,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
             Not just another AI tool.<br />An AI teammate you can trust.
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-5">
-            {WHY_DELEGATOR.map(f => (
+            {WHY_DELEGATOR(playbookCount).map(f => (
               <div key={f.title} className="bg-white rounded-2xl border border-stone-200 p-6">
                 <div className="text-2xl mb-3">{f.icon}</div>
                 <p className="font-semibold text-stone-900 mb-1.5">{f.title}</p>
@@ -574,7 +588,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
           <p className="text-xs font-semibold text-stone-400 uppercase tracking-widest mb-3">FAQ</p>
           <h2 className="text-2xl font-bold text-stone-900 mb-8">Common questions</h2>
           <div className="space-y-6">
-            {FAQ.map(({ q, a }) => (
+            {FAQ(playbookCount).map(({ q, a }) => (
               <div key={q} className="border-b border-stone-100 pb-6 last:border-0">
                 <p className="font-semibold text-stone-900 mb-2">{q}</p>
                 <p className="text-sm text-stone-500 leading-relaxed">{a}</p>
@@ -613,7 +627,7 @@ function LandingPageContent({ isSignedIn, isLoaded }: { isSignedIn: boolean; isL
         dangerouslySetInnerHTML={{ __html: JSON.stringify({
           "@context": "https://schema.org",
           "@type": "FAQPage",
-          "mainEntity": FAQ.map(({ q, a }) => ({
+          "mainEntity": FAQ(playbookCount).map(({ q, a }) => ({
             "@type": "Question",
             "name": q,
             "acceptedAnswer": { "@type": "Answer", "text": a },
@@ -709,10 +723,45 @@ const TEMPLATES = [
     what: "Dependabot alert fires → AI confirms the vulnerable package is present → applies the patched version → runs tests → opens a PR with full CVE reference. No waiting for the weekly cron.",
     scenario: "A critical CVE lands at 2am. By the time the team wakes up, a PR with the patch is already open, tests ran, and #security has a notification with the CVE number and severity.",
   },
+  {
+    icon: "🔬",
+    name: "Flaky Test Detective",
+    trigger: "CI webhook",
+    what: "CI run has repeated failures → AI identifies which tests are flaky, traces the offending commit, and posts a fix recommendation to Slack.",
+    scenario: "A test fails 1-in-5 runs and everyone keeps hitting retry. Conduct names the flaky test, points at the commit that introduced it, and suggests the fix — no more guessing.",
+  },
+  {
+    icon: "✅",
+    name: "Release Readiness Reviewer",
+    trigger: "Release branch cut",
+    what: "Release branch created → AI checks open blockers, failed CI, pending reviews, and unresolved incidents → posts a go/no-go summary before you ship.",
+    scenario: "Release manager cuts release/2.0 on Friday. Within a minute Slack has a go/no-go: 2 open blockers, 1 failing check, 3 PRs still awaiting review — decision made in seconds.",
+  },
+  {
+    icon: "📋",
+    name: "Postmortem Drafter",
+    trigger: "Incident resolved",
+    what: "Incident closed → AI reads the timeline, alerts, and commits → drafts a structured postmortem with root cause and action items, ready for human edit.",
+    scenario: "An outage resolves at midnight. By morning a draft postmortem is waiting — timeline reconstructed, root cause hypothesized, action items listed. The team edits instead of starting from a blank page.",
+  },
+  {
+    icon: "📖",
+    name: "Docs Drift Detector",
+    trigger: "PR merged",
+    what: "PR merged → AI checks whether related docs, README, or runbooks went stale → opens a follow-up docs PR or files an issue.",
+    scenario: "An engineer renames an env var and merges. Conduct notices the README still references the old name and opens a one-line docs PR before anyone is paged about a broken setup guide.",
+  },
+  {
+    icon: "🏗️",
+    name: "Terraform Plan Reviewer",
+    trigger: "Terraform PR opened",
+    what: "Terraform plan PR opened → AI reviews for security misconfigs, cost anomalies, and drift from approved patterns → posts structured findings as a review.",
+    scenario: "A PR opens a public S3 bucket and bumps an instance to a $2k/mo type. Conduct flags both on the diff before a human reviewer even reads it.",
+  },
 ]
 
 
-const WHY_DELEGATOR = [
+const WHY_DELEGATOR = (count: number) => [
   {
     icon: "🔒",
     title: "Human approval on every merge",
@@ -736,7 +785,7 @@ const WHY_DELEGATOR = [
   {
     icon: "⚡",
     title: "Playbook Marketplace — one click to install",
-    body: "12 pre-built agents in the Marketplace: Autopilot, PR Reviewer, Security Scanner, Security Patch Updater, Issue Triage, Release Notes, CI Failure Alert, Incident Responder, Dependency Updater, and more. Install, configure credentials, run. Already-installed playbooks are tracked so you never duplicate.",
+    body: `${count} pre-built agents in the Marketplace: Autopilot, PR Reviewer, Security Scanner, Security Patch Updater, Issue Triage, Flaky Test Detective, Release Readiness, Release Notes, CI Failure Alert, Incident Responder, Postmortem Drafter, Dependency Updater, Docs Drift Detector, Terraform Reviewer, and more. Install, configure credentials, run. Already-installed playbooks are tracked so you never duplicate.`,
   },
   {
     icon: "🧩",
@@ -874,7 +923,7 @@ const INTEGRATIONS: { name: string; color: string; svg: string }[] = [
 ]
 
 
-const FAQ = [
+const FAQ = (count: number) => [
   {
     q: "What does Conduct actually do?",
     a: "Conduct turns YAML agent recipes into reusable team automations. Your team installs a playbook into a project, configures the environment and credentials, then runs agents for tasks like issue triage, PR review, incident response, release notes, and security scanning.",
@@ -897,7 +946,7 @@ const FAQ = [
   },
   {
     q: "What specific agents come included?",
-    a: "The Playbook Marketplace includes 12 agents: Autopilot, PR Reviewer, Security Scanner, Security Patch Updater, Issue Triage, Release Notes, CI Failure Alert, Incident Responder, Dependency Updater, and more. Each installs in one click — the canvas is pre-wired, just add credentials. Already-installed playbooks are tracked so you never create duplicates.",
+    a: `The Playbook Marketplace includes ${count} agents: Autopilot, PR Reviewer, Security Scanner, Security Patch Updater, Issue Triage, Flaky Test Detective, Release Readiness, Release Notes, CI Failure Alert, Incident Responder, Postmortem Drafter, Dependency Updater, Docs Drift Detector, Terraform Reviewer, and more. Each installs in one click — the canvas is pre-wired, just add credentials. Already-installed playbooks are tracked so you never create duplicates.`,
   },
   {
     q: "How long does it take to get up and running?",


### PR DESCRIPTION
## Summary

Marketing surfaces undercounted the playbook library: the README said "9 ready-made playbooks" and the landing page said "11"/"12" in **seven** different places, while the registry (`_TEMPLATE_PLAYBOOKS` / `_PLAYBOOK_META` in `apps/api/app/routers/workflows.py`) actually ships **18 playbooks across 10 categories**.

This PR fixes the counts and removes the source of future drift.

## What changed

**README.md**
- Replaced the stale 9-row "9 ready-made playbooks" table with all 18 playbooks, grouped by the 10 product categories (Issue → PR, Code Review, Issue Triage, CI/CD, Release Management, Incidents & Ops, Security, Docs, Platform & Infra, Testing) — mirroring the in-app Marketplace grouping.

**apps/web/src/app/page.tsx**
- Fetches `/workflows/playbooks` (the same endpoint the Marketplace uses) once on mount and derives `playbookCount` from `playbooks.length`, with a graceful fallback if the API is unreachable.
- Replaced all seven hardcoded counts with the dynamic value, so the landing page can no longer drift from the registry. This is now the single source of truth for the count, shared with the Marketplace.
- `WHY_DELEGATOR` and `FAQ` became `(count) => [...]` functions so their embedded prose — and the FAQ JSON-LD structured data — stay in sync too.
- Expanded the showcase highlight reel from 12 to 17 cards (added Flaky Test Detective, Release Readiness Reviewer, Postmortem Drafter, Docs Drift Detector, Terraform Plan Reviewer).

## Notes for reviewers

- Count framing is **18** (includes `smoke_test`, matching the registry exactly). `ai_ready.yaml` exists on disk but is intentionally **not** a Marketplace template (it's the worked example cited in `dsl/schema.py` and covered by tests), so it's excluded from the count — no change there.
- Because the landing page is a `"use client"` component, the count resolves after hydration; the `18` fallback shows briefly before the fetch lands. Fine for this Clerk-gated, non-SSR marketing page.
- `tsc --noEmit` passes clean.
- The README table remains static (it carries trigger / "what it does" detail the API doesn't expose), but lives in-repo where a new-playbook PR naturally touches it.

## Test plan

- [ ] `cd apps/web && npx tsc --noEmit` passes
- [ ] Landing page renders the correct count once `/workflows/playbooks` resolves
- [ ] With the API unreachable, the page still renders (fallback count)
- [ ] FAQ JSON-LD reflects the same count as the visible copy