### PR TITLE
Fix autopilot-quick test trigger and CLI poll timeout/paused handling

### DIFF
--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -131,23 +131,22 @@ test_trigger:
     label:
       name: "[TEST] autopilot ready"
     issue:
-      number: 9999
-      title: "[TEST] Create conductai_test.py"
+      number: 16
+      title: "[TEST] fix: address critical security findings on PR #12"
       body: |
-        Create a file `conductai_test.py` in the repo root that prints:
-        print("Hello, Conduct AI!")
         This is a test run — prefix the branch and PR with [TEST].
-      html_url: "https://github.com/sseshachala/conductai/issues/9999"
+        Review the security scan findings on PR #12 and implement fixes for any critical issues found.
+      html_url: "https://github.com/sseshachala/conductai-testbed-node/issues/16"
       user:
         login: conductai-test-bot
       labels:
         - name: "[TEST] autopilot ready"
     repository:
-      full_name: sseshachala/conductai
-      name: conductai
+      full_name: sseshachala/conductai-testbed-node
+      name: conductai-testbed-node
       owner:
         login: sseshachala
       default_branch: main
-      clone_url: "https://github.com/sseshachala/conductai.git"
+      clone_url: "https://github.com/sseshachala/conductai-testbed-node.git"
     sender:
       login: conductai-test-bot

--- a/packages/conduct-cli/src/conduct_cli/main.py
+++ b/packages/conduct-cli/src/conduct_cli/main.py
@@ -102,14 +102,21 @@ def _stream_run(server: str, workflow_id: str, run_id: str, workspace_id: str, t
 
 
 def _poll_run(server: str, workflow_id: str, run_id: str, hdrs: dict) -> bool:
-    """Poll run status until terminal — fallback when SSE stream unavailable."""
+    """Poll run status until terminal — fallback when SSE stream unavailable.
+
+    'paused' is treated as pass: the run reached a human-approval step, which
+    is correct behaviour for approval-gated agents.
+    """
     terminal = {"succeeded", "failed", "cancelled"}
-    for _ in range(120):  # max 10 min
+    for _ in range(240):  # max 20 min — agentic coding agents can take 15+ min
         time.sleep(5)
         try:
             run = api.req("GET", f"{server}/runs/{run_id}", hdrs)
             status = run.get("status", "")
             print(f"{GRAY}    status: {status}{RESET}", end="\r")
+            if status == "paused":
+                print(f"\n{GRAY}    (paused — awaiting approval){RESET}")
+                return True
             if status in terminal:
                 print()
                 return status == "succeeded"


### PR DESCRIPTION
## Summary

Two related reliability fixes for the autopilot-quick path and the CLI poll fallback:

- **`autopilot-quick.yaml` test trigger** now points at a real, open issue in a dedicated testbed repo (`sseshachala/conductai-testbed-node#16`) instead of the placeholder issue `#9999` in the main repo. The dummy issue didn't exist, so test runs couldn't exercise the real clone → fix → PR flow.
- **CLI `_poll_run`** (the fallback used when the SSE stream is unavailable):
  - Treats `paused` as a successful terminal state — an approval-gated agent reaching a human-approval step is correct behaviour, not a hang. Previously the poll would spin until timeout on these runs.
  - Raises the poll ceiling from 10 min (120 × 5s) to 20 min (240 × 5s), since agentic coding runs routinely take 15+ minutes.

## Why this is a separate PR

This commit landed on the `marketing/playbook-count-sync` branch (PR #385) but is unrelated to that marketing-copy change. Split out here so each PR stays single-purpose; #385 is now marketing-only again.

## Test plan

- [ ] Trigger the autopilot-quick test path and confirm it clones the testbed repo and opens a `[TEST]` PR
- [ ] Run an approval-gated agent via the CLI with SSE disabled; confirm the poll exits cleanly on `paused` with "awaiting approval"
- [ ] Confirm a long (>10 min) run no longer times out at the old 10-minute ceiling