### PR TITLE
feat: token usage section on dashboard

### DIFF
--- a/apps/api/app/routers/dashboard.py
+++ b/apps/api/app/routers/dashboard.py
@@ -16,8 +16,13 @@ from sqlalchemy.orm import Session
 from app.core.auth import get_workspace_id, require_workspace_role
 from app.core.database import get_db
 from app.models.run import Run
+from app.models.run_trace import RunTrace
 from app.models.workflow import Workflow, WorkflowVersion
 from app.schemas.run import _extract_trigger_summary
+
+# Sonnet pricing (per 1M tokens) used for cost estimates — approximate
+_INPUT_COST_PER_M  = 3.0
+_OUTPUT_COST_PER_M = 15.0
 
 router = APIRouter(prefix="/dashboard", tags=["dashboard"])
 
@@ -102,11 +107,29 @@ class RecentRun(BaseModel):
     created_at: str
 
 
+class AgentTokenUsage(BaseModel):
+    workflow_id: str
+    name: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+
+
+class TokenUsage(BaseModel):
+    total_input_tokens: int
+    total_output_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float
+    by_agent: list[AgentTokenUsage]
+
+
 class DashboardOut(BaseModel):
     outcomes: OutcomeStats
     needs_attention: list[AttentionRun]
     agent_health: list[AgentHealth]
     recent_activity: list[RecentRun]
+    token_usage: TokenUsage
 
 
 @router.get("", response_model=DashboardOut)
@@ -266,9 +289,51 @@ def get_dashboard(
         for run, wf_id, wf_name in recent_rows
     ]
 
+    # ── Token usage — all-time, aggregated from run_traces ───────────────────
+    token_rows = (
+        db.query(
+            Workflow.id.label("wf_id"),
+            Workflow.name.label("wf_name"),
+            func.coalesce(func.sum(RunTrace.input_tokens), 0).label("input_tokens"),
+            func.coalesce(func.sum(RunTrace.output_tokens), 0).label("output_tokens"),
+        )
+        .join(WorkflowVersion, WorkflowVersion.workflow_id == Workflow.id)
+        .join(Run, Run.workflow_version_id == WorkflowVersion.id)
+        .join(RunTrace, RunTrace.run_id == Run.id)
+        .filter(Workflow.workspace_id == workspace_id)
+        .group_by(Workflow.id, Workflow.name)
+        .order_by(func.sum(RunTrace.input_tokens + RunTrace.output_tokens).desc().nullslast())
+        .all()
+    )
+
+    def _cost(inp: int, out: int) -> float:
+        return round((inp * _INPUT_COST_PER_M + out * _OUTPUT_COST_PER_M) / 1_000_000, 4)
+
+    by_agent = [
+        AgentTokenUsage(
+            workflow_id=str(row.wf_id),
+            name=row.wf_name,
+            input_tokens=row.input_tokens,
+            output_tokens=row.output_tokens,
+            total_tokens=row.input_tokens + row.output_tokens,
+            estimated_cost_usd=_cost(row.input_tokens, row.output_tokens),
+        )
+        for row in token_rows
+    ]
+    total_input  = sum(a.input_tokens for a in by_agent)
+    total_output = sum(a.output_tokens for a in by_agent)
+    token_usage = TokenUsage(
+        total_input_tokens=total_input,
+        total_output_tokens=total_output,
+        total_tokens=total_input + total_output,
+        estimated_cost_usd=_cost(total_input, total_output),
+        by_agent=by_agent,
+    )
+
     return DashboardOut(
         outcomes=outcomes,
         needs_attention=needs_attention,
         agent_health=agent_health,
         recent_activity=recent_activity,
+        token_usage=token_usage,
     )

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -48,11 +48,35 @@ interface RecentRun {
   created_at: string
 }
 
+interface AgentTokenUsage {
+  workflow_id: string
+  name: string
+  input_tokens: number
+  output_tokens: number
+  total_tokens: number
+  estimated_cost_usd: number
+}
+
+interface TokenUsage {
+  total_input_tokens: number
+  total_output_tokens: number
+  total_tokens: number
+  estimated_cost_usd: number
+  by_agent: AgentTokenUsage[]
+}
+
 interface DashboardData {
   outcomes: OutcomeStats
   needs_attention: AttentionRun[]
   agent_health: AgentHealth[]
   recent_activity: RecentRun[]
+  token_usage: TokenUsage
+}
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(n)
 }
 
 function timeAgo(ts: string): string {
@@ -220,7 +244,59 @@ function DashboardContent({ getToken }: { getToken: (() => Promise<string | null
               )}
             </section>
 
-            {/* 4 — Recent Activity */}
+            {/* 4 — Token Usage */}
+            {data.token_usage.total_tokens > 0 && (
+              <section>
+                <SectionHeader label="Token Usage" sub="All time" />
+                <div className="grid grid-cols-3 gap-3 mb-3">
+                  <div className="rounded-xl border border-stone-200 bg-white px-4 py-4">
+                    <p className="text-xs text-stone-400 mb-1.5">Total tokens</p>
+                    <p className="text-2xl font-bold text-stone-900">{fmtTokens(data.token_usage.total_tokens)}</p>
+                    <p className="text-xs text-stone-400 mt-1">{fmtTokens(data.token_usage.total_input_tokens)} in · {fmtTokens(data.token_usage.total_output_tokens)} out</p>
+                  </div>
+                  <div className="rounded-xl border border-stone-200 bg-white px-4 py-4">
+                    <p className="text-xs text-stone-400 mb-1.5">Est. cost</p>
+                    <p className="text-2xl font-bold text-stone-900">${data.token_usage.estimated_cost_usd.toFixed(2)}</p>
+                    <p className="text-xs text-stone-400 mt-1">Sonnet pricing · approximate</p>
+                  </div>
+                  <div className="rounded-xl border border-stone-200 bg-white px-4 py-4">
+                    <p className="text-xs text-stone-400 mb-1.5">Output ratio</p>
+                    <p className="text-2xl font-bold text-stone-900">
+                      {data.token_usage.total_tokens > 0
+                        ? `${Math.round((data.token_usage.total_output_tokens / data.token_usage.total_tokens) * 100)}%`
+                        : "—"}
+                    </p>
+                    <p className="text-xs text-stone-400 mt-1">of total are output tokens</p>
+                  </div>
+                </div>
+                <div className="rounded-xl border border-stone-200 bg-white overflow-hidden">
+                  <table className="w-full text-xs">
+                    <thead>
+                      <tr className="border-b border-stone-100">
+                        <th className="text-left px-4 py-2.5 text-stone-400 font-medium">Agent</th>
+                        <th className="text-right px-4 py-2.5 text-stone-400 font-medium">Input</th>
+                        <th className="text-right px-4 py-2.5 text-stone-400 font-medium">Output</th>
+                        <th className="text-right px-4 py-2.5 text-stone-400 font-medium">Total</th>
+                        <th className="text-right px-4 py-2.5 text-stone-400 font-medium">Est. cost</th>
+                      </tr>
+                    </thead>
+                    <tbody className="divide-y divide-stone-100">
+                      {data.token_usage.by_agent.map(agent => (
+                        <tr key={agent.workflow_id} className="hover:bg-stone-50 transition-colors">
+                          <td className="px-4 py-2.5 font-medium text-stone-900">{agent.name}</td>
+                          <td className="px-4 py-2.5 text-right text-stone-500">{fmtTokens(agent.input_tokens)}</td>
+                          <td className="px-4 py-2.5 text-right text-stone-500">{fmtTokens(agent.output_tokens)}</td>
+                          <td className="px-4 py-2.5 text-right text-stone-700 font-medium">{fmtTokens(agent.total_tokens)}</td>
+                          <td className="px-4 py-2.5 text-right text-stone-500">${agent.estimated_cost_usd.toFixed(3)}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            )}
+
+            {/* 5 — Recent Activity */}
             <section>
               <SectionHeader label="Recent Activity" href="/runs" linkLabel="View all runs →" />
               {data.recent_activity.length === 0 ? (


### PR DESCRIPTION
## Summary

- **New dashboard section: Token Usage** — shown below Agent Health, hidden when no data
- Three summary cards: total tokens (with input/output split), estimated cost (USD), output ratio
- Per-agent table: Input · Output · Total · Est. cost, sorted by highest usage
- `fmtTokens` helper formats large numbers as `2.6M`, `404.8k` etc.

## Backend

- `GET /dashboard` now returns `token_usage` — aggregated from `run_traces.input_tokens/output_tokens` joined through `workflow_versions → workflows`
- Pricing: Sonnet rates ($3/M input, $15/M output) — approximate, labelled as such
- Zero tokens → section is hidden on frontend

## Test plan
- [ ] Open dashboard — Token Usage section appears with correct totals
- [ ] Per-agent row counts match `run_traces` aggregation in DB
- [ ] Workspace with no runs → section hidden (no empty table)

🤖 Generated with [Claude Code](https://claude.com/claude-code)