### PR TITLE
ux: token pill in dashboard header

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -143,9 +143,23 @@ function DashboardContent({ getToken }: { getToken: (() => Promise<string | null
             <h1 className="text-xl font-semibold text-stone-900">Dashboard</h1>
             <p className="text-xs text-stone-400 mt-0.5">Last 7 days</p>
           </div>
-          <Link href="/workflows/new" className="rounded-lg bg-stone-900 px-4 py-2 text-sm font-medium text-white hover:bg-stone-700 transition-colors">
-            + New agent
-          </Link>
+          <div className="flex items-center gap-2">
+            {data && data.token_usage.total_tokens > 0 && (
+              <a
+                href="#token-usage"
+                className="flex items-center gap-1.5 rounded-full border border-amber-200 bg-amber-50 px-3 py-1.5 text-xs font-medium text-amber-700 hover:bg-amber-100 transition-colors"
+                title="Jump to token usage breakdown"
+              >
+                <svg className="w-3 h-3" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M13 10V3L4 14h7v7l9-11h-7z" />
+                </svg>
+                {fmtTokens(data.token_usage.total_tokens)} tokens · ${data.token_usage.estimated_cost_usd.toFixed(2)}
+              </a>
+            )}
+            <Link href="/workflows/new" className="rounded-lg bg-stone-900 px-4 py-2 text-sm font-medium text-white hover:bg-stone-700 transition-colors">
+              + New agent
+            </Link>
+          </div>
         </div>
 
         {loading ? (
@@ -246,7 +260,7 @@ function DashboardContent({ getToken }: { getToken: (() => Promise<string | null
 
             {/* 4 — Token Usage */}
             {data.token_usage.total_tokens > 0 && (
-              <section>
+              <section id="token-usage">
                 <SectionHeader label="Token Usage" sub="All time" />
                 <div className="grid grid-cols-3 gap-3 mb-3">
                   <div className="rounded-xl border border-stone-200 bg-white px-4 py-4">


### PR DESCRIPTION
## Summary

Surfaces token cost immediately at the top of the dashboard — no scrolling needed.

- Amber pill in the header row (between title and "+ New agent") showing `2.6M tokens · $12.67`
- Lightning bolt icon signals it's a cost/energy metric
- Clicking scrolls to the full Token Usage breakdown via `#token-usage` anchor
- Hidden when `total_tokens == 0` (empty workspace, no flicker)

## Why amber

Token cost is a caution signal — amber reads as "worth watching" without being alarming like red. Distinct from the green/red outcome cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)