### PR TITLE
ux: block type icons on canvas nodes

### DIFF
--- a/apps/web/src/components/canvas/BlockNode.tsx
+++ b/apps/web/src/components/canvas/BlockNode.tsx
@@ -43,6 +43,23 @@ function GitHubMark({ className }: { className?: string }) {
   )
 }
 
+// Block type icons — Lucide-style 24px viewBox, rendered at 9px
+function BlockIcon({ type, className }: { type: string; className?: string }) {
+  const cls = className ?? "w-[9px] h-[9px]"
+  const props = { viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2.5, strokeLinecap: "round" as const, strokeLinejoin: "round" as const, className: cls }
+  switch (type) {
+    case "trigger":  return <svg {...props}><path d="M13 2L3 14h9l-1 8 10-12h-9l1-8z"/></svg>
+    case "brain":    return <svg {...props}><path d="M12 2a4 4 0 014 4c0 .34-.04.67-.1 1H17a3 3 0 010 6h-.5M12 2a4 4 0 00-4 4c0 .34.04.67.1 1H7a3 3 0 000 6h.5"/><path d="M12 2v18M8.5 13h7"/></svg>
+    case "tool":     return <svg {...props}><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+    case "logic":    return <svg {...props}><path d="M16 3h5v5M4 20L21 3"/><path d="M21 16v5h-5M15 15l6 6M4 4l5 5"/></svg>
+    case "memory":   return <svg {...props}><ellipse cx="12" cy="5" rx="9" ry="3"/><path d="M3 5v14a9 3 0 0018 0V5"/><path d="M3 12a9 3 0 0018 0"/></svg>
+    case "approval": return <svg {...props}><path d="M22 11.08V12a10 10 0 11-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>
+    case "output":   return <svg {...props}><line x1="22" y1="2" x2="11" y2="13"/><polygon points="22 2 15 22 11 13 2 9 22 2"/></svg>
+    case "cleanup":  return <svg {...props}><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14H6L5 6"/><path d="M10 11v6M14 11v6"/><path d="M9 6V4h6v2"/></svg>
+    default:         return null
+  }
+}
+
 function handleClass(color: string) {
   return `!w-3 !h-3 !border-0 !bg-transparent !shadow-none !opacity-0 !transition-none ${color}`
 }
@@ -127,7 +144,8 @@ function BlockNode({ data, selected }: NodeProps) {
 
       {/* Type badge row */}
       <div className="flex items-center gap-1.5 mb-1.5">
-        <span className={cn("text-[8px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded", style.label)}>
+        <span className={cn("inline-flex items-center gap-1 text-[8px] font-bold tracking-widest uppercase px-1.5 py-0.5 rounded", style.label)}>
+          <BlockIcon type={nodeData.type} />
           {style.labelText}
         </span>
         {nodeData.isAgentic && (


### PR DESCRIPTION
## Summary

Closes #383. Each block badge on the canvas now shows a small matching icon left of the type label — makes the workflow scannable at a glance without reading the text.

| Block type | Icon |
|---|---|
| Trigger | ⚡ lightning bolt |
| Agent Step | 🧠 neural/brain |
| Action | 🔧 wrench |
| Condition | ↗ git-branch fork |
| Memory | 🗄 database cylinders |
| Approval | ✓ check circle |
| Notify | ➤ send arrow |
| Cleanup | 🗑 trash can |

## Implementation

- Added `BlockIcon` component in `BlockNode.tsx` — one inline SVG path per block type (Lucide-style, 9px rendered)
- Badge updated to `inline-flex items-center gap-1` so icon sits flush left of the label text
- No layout change to the node card itself — icon fits within existing badge padding

🤖 Generated with [Claude Code](https://claude.com/claude-code)