### PR TITLE
feat: add recall+record memory blocks to all 15 playbooks + fix test trigger normalization

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1604,11 +1604,38 @@ def test_trigger(
     except Exception:
         suggested_turns = 20
 
+    # Normalize GitHub issue payloads to match the real webhook path so that
+    # {{_trigger.issue_number}}, {{_trigger.repo_full_name}}, etc. resolve in
+    # the same way whether this is a real webhook or a test trigger.
+    _issue = payload.get("issue") or {}
+    _repo = payload.get("repository") or {}
+    _label = (payload.get("label") or {}).get("name", "")
+    _initial_state: dict = {"__triggered_by": "manual:test_trigger", "__max_turns": suggested_turns}
+    if _issue:
+        _initial_state["github_issue"] = {
+            "issue_number": _issue.get("number"),
+            "title": _issue.get("title"),
+            "body": _issue.get("body") or "",
+            "url": _issue.get("html_url", ""),
+            "author": (_issue.get("user") or {}).get("login", ""),
+            "labels": [l.get("name", "") for l in (_issue.get("labels") or [])],
+            "label_added": _label,
+            "repo_full_name": _repo.get("full_name", ""),
+            "repo_name": _repo.get("name", ""),
+            "repo_owner": (_repo.get("owner") or {}).get("login", ""),
+            "default_branch": _repo.get("default_branch", "main"),
+            "clone_url": _repo.get("clone_url", ""),
+        }
+        _initial_state["github_trigger"] = payload
+    else:
+        # Non-GitHub trigger — keep raw payload as _trigger
+        _initial_state["_trigger"] = payload
+
     run = Run(
         workflow_version_id=version.id,
         triggered_by="manual:test_trigger",
         status="pending",
-        state={"_trigger": payload, "__triggered_by": "manual:test_trigger", "__max_turns": suggested_turns},
+        state=_initial_state,
         max_turns=suggested_turns,
     )
     db.add(run)

--- a/apps/api/playbooks/ai_ready.yaml
+++ b/apps/api/playbooks/ai_ready.yaml
@@ -70,9 +70,18 @@ on:
       - "{{inputs.trigger_label}}"
       - ai-ready
     label_mode: one_of
-    next: fetch_issue
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repo_full_name}}"
+    limit: 5
+    next: fetch_issue
+
   fetch_issue:
     type: tool
     integration: github
@@ -174,6 +183,13 @@ blocks:
             "body":  "Automated fix by Conduct AI. Closes #{{fetch_issue.issue_number}}.",
             "draft": true}
 
+      {% if recall_context.entries %}
+      Prior runs on this repo (use to avoid re-exploring known structure):
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       10. Output as the FINAL line of your response, JSON only:
            {"pr_url": "<full PR URL>",
             "stack":   "<node|python|go|ruby>",
@@ -182,6 +198,19 @@ blocks:
 
       If anything blocks you (missing token, unrecognised stack, repeated
       test failures), stop and report — do not push speculative changes.
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repo_full_name}}"
+    summary: |
+      Repo: {{_trigger.repo_full_name}}
+      PR: {{implement.pr_url}}
+      Stack: {{implement.stack}} · Tests: {{implement.tests}}
+      Summary: {{implement.summary}}
     next: notify
 
   notify:

--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -185,7 +185,7 @@ blocks:
     scope: repo
     key: "{{_trigger.repo_full_name}}"
     summary: |
-      Issue #{{fetch_issue.issue_number}}: {{fetch_issue.title}}
+      Issue #{{_trigger.issue_number}}: {{_trigger.title}}
       Fix: {{implement_fix.summary}}
       PR: {{push_pr.pr_url}}
     next: notify_success

--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -109,7 +109,7 @@ blocks:
     scope: repo
     key: "{{_trigger.repo_full_name}}"
     summary: |
-      Issue #{{fetch_issue.issue_number}}: {{fetch_issue.title}}
+      Issue #{{_trigger.issue_number}}: {{_trigger.title}}
       Fix: {{implement_fix.approach}}
       Files: {{implement_fix.files_changed}}
       PR: {{implement_fix.pr_url}}

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -179,7 +179,7 @@ blocks:
     scope: repo
     key: "{{_trigger.repo_full_name}}"
     summary: |
-      Issue #{{fetch_issue.issue_number}}: {{fetch_issue.title}}
+      Issue #{{_trigger.issue_number}}: {{_trigger.title}}
       Fix: {{implement_fix.summary}}
       PR: {{push_pr.pr_url}}
     next: notify_success

--- a/apps/api/playbooks/copilot-reviewer.yaml
+++ b/apps/api/playbooks/copilot-reviewer.yaml
@@ -26,9 +26,18 @@ inputs:
 
 on:
   webhook:
-    next: check_author
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: check_author
+
   check_author:
     type: logic
     label: Is AI-authored PR?
@@ -99,8 +108,27 @@ blocks:
 
       If there are no critical issues, say so clearly.
 
+      {% if recall_context.entries %}
+      Prior reviews on this repo (recurring patterns to watch for):
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"review_url": "<PR URL>", "critical": <count>, "warnings": <count>, "findings": <total count>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}} PR #{{_trigger.number}}
+      AI review: {{review_pr.critical}} critical, {{review_pr.warnings}} warnings
+      URL: {{review_pr.review_url}}
     next: gate_merge
 
   has_critical:

--- a/apps/api/playbooks/dependency-updater.yaml
+++ b/apps/api/playbooks/dependency-updater.yaml
@@ -36,9 +36,18 @@ inputs:
 
 on:
   webhook:
-    next: scan_and_update
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: scan_and_update
+
   scan_and_update:
     type: brain
     mode: agentic
@@ -109,11 +118,30 @@ blocks:
          }
          Header: Authorization: token $GIT_TOKEN
 
+      {% if recall_context.entries %}
+      Prior context for this repo:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"pr_url": "<full PR URL>", "updated": <number of packages bumped>, "message": null}
 
       On any failure output:
         {"pr_url": null, "updated": 0, "message": "<error description>"}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}}
+      Updated {{scan_and_update.updated}} dependencies
+      PR: {{scan_and_update.pr_url}}
     next: notify_update
 
   notify_update:

--- a/apps/api/playbooks/docs-drift-detector.yaml
+++ b/apps/api/playbooks/docs-drift-detector.yaml
@@ -26,9 +26,18 @@ inputs:
 
 on:
   webhook:
-    next: check_merged
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: check_merged
+
   check_merged:
     type: logic
     label: Was PR actually merged?
@@ -77,6 +86,13 @@ blocks:
 
       4. If docs need updating, draft the specific changes needed.
 
+      {% if recall_context.entries %}
+      Prior doc drift detected on this repo:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {
           "needs_update": true/false,
@@ -119,6 +135,18 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<url>", "issue_number": <number>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}} PR #{{_trigger.number}}
+      Stale docs: {{analyze_drift.stale_docs}}
+      Issue: {{create_docs_issue.issue_url}}
     next: notify_drift
 
   notify_drift:
@@ -138,7 +166,9 @@ blocks:
     label: No docs update needed
     description: "PR #{{_trigger.number}} merged — docs are up to date."
     output:
-      via: log
+      via: slack
+      slack:
+        channel: "{{inputs.slack_channel}}"
 
 test_trigger:
   payload:

--- a/apps/api/playbooks/flaky-test-detective.yaml
+++ b/apps/api/playbooks/flaky-test-detective.yaml
@@ -22,9 +22,18 @@ inputs:
 
 on:
   webhook:
-    next: investigate_failures
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: investigate_failures
+
   investigate_failures:
     type: brain
     mode: agentic
@@ -65,6 +74,13 @@ blocks:
       5. Search for the offending commit:
          GET https://api.github.com/repos/{{_trigger.repository.full_name}}/commits?sha={{_trigger.workflow_run.head_branch}}&per_page=5
          Headers: Authorization: token $GIT_TOKEN
+
+      {% if recall_context.entries %}
+      Prior flaky test reports on this repo:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
 
       Output ONLY the following JSON on the last line:
         {
@@ -112,6 +128,19 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<url>", "issue_number": <number>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}}
+      Flaky tests: {{investigate_failures.failing_tests}}
+      Failure rate: {{investigate_failures.failure_rate}}
+      Issue: {{create_flaky_issue.issue_url}}
     next: notify_flaky
 
   notify_flaky:

--- a/apps/api/playbooks/incident-responder.yaml
+++ b/apps/api/playbooks/incident-responder.yaml
@@ -25,9 +25,18 @@ inputs:
 
 on:
   webhook:
-    next: investigate
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: investigate
+
   investigate:
     type: brain
     mode: agentic
@@ -90,12 +99,31 @@ blocks:
         2. If commit is the culprit: revert `<sha>` or roll back the deploy
         3. Page <author> if confirmation needed
 
+      {% if recall_context.entries %}
+      Prior incidents on this repo/service:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"hypothesis": "<one sentence>", "suspect_commit": "<sha or null>", "message": "<slack message>"}
 
       If the payload is not a real alert (e.g. a test ping), output:
         {"hypothesis": null, "suspect_commit": null, "message": null}
       And stop — do not post to Slack.
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}}
+      Hypothesis: {{investigate.hypothesis}}
+      Suspect commit: {{investigate.suspect_commit}}
     next: notify_incident
 
   notify_incident:

--- a/apps/api/playbooks/issue-triage.yaml
+++ b/apps/api/playbooks/issue-triage.yaml
@@ -22,9 +22,18 @@ inputs:
 
 on:
   webhook:
-    next: triage_issue
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: triage_issue
+
   triage_issue:
     type: brain
     mode: agentic
@@ -100,8 +109,27 @@ blocks:
         If the issue is clear and well-described, post a brief acknowledgment:
         "Thanks @<author> — triaged as <type>, <priority>. We'll review shortly."
 
+      {% if recall_context.entries %}
+      Prior context for this repo (use to recognize recurring issue patterns):
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Step 7 — Output ONLY the following JSON on the last line:
         {"issue_number": <number>, "type": "<classification>", "priority": "<P1-P4>", "clarification_requested": <true|false>, "skipped": false}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}} Issue #{{triage_issue.issue_number}}
+      Type: {{triage_issue.type}} / {{triage_issue.priority}}
+      Clarification requested: {{triage_issue.clarification_requested}}
     next: notify_triage
 
   notify_triage:

--- a/apps/api/playbooks/postmortem-drafter.yaml
+++ b/apps/api/playbooks/postmortem-drafter.yaml
@@ -24,9 +24,18 @@ inputs:
 
 on:
   webhook:
-    next: gather_context
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: gather_context
+
   gather_context:
     type: brain
     mode: agentic
@@ -62,6 +71,13 @@ blocks:
          - **What went well**: detection, response, comms
          - **Action items**: specific tasks with owners (leave TBD if unknown)
 
+      {% if recall_context.entries %}
+      Prior incidents on this repo/service:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {
           "title": "Postmortem: <incident title>",
@@ -76,6 +92,8 @@ blocks:
   human_review:
     type: approval
     label: Review postmortem draft
+    via: slack
+    channel: "{{inputs.slack_channel}}"
     description: |
       AI has drafted a postmortem for: {{_trigger.title}}
 
@@ -113,6 +131,19 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<url>", "issue_number": <number>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Incident: {{_trigger.title}}
+      Root cause: {{gather_context.root_cause}}
+      Duration: {{gather_context.duration_minutes}} min
+      Issue: {{publish_postmortem.issue_url}}
     next: notify_published
 
   notify_published:

--- a/apps/api/playbooks/pr-reviewer.yaml
+++ b/apps/api/playbooks/pr-reviewer.yaml
@@ -21,9 +21,18 @@ inputs:
 
 on:
   webhook:
-    next: review_pr
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: review_pr
+
   review_pr:
     type: brain
     mode: agentic
@@ -63,6 +72,13 @@ blocks:
       Be concise. Group findings by severity (critical / warning / suggestion).
       If the PR looks clean, say so clearly.
 
+      {% if recall_context.entries %}
+      Prior reviews on this repo (use to spot recurring issues):
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"review_url": "<PR URL>", "findings": <number of issues found>, "critical": <number of critical issues>}
     next: has_critical
@@ -73,7 +89,7 @@ blocks:
     condition: "{{review_pr.critical}} > 0"
     next:
       pass: check_existing_issue
-      fail: notify_review
+      fail: record_outcome
 
   check_existing_issue:
     type: brain
@@ -137,7 +153,7 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "{{check_existing_issue.issue_url}}", "issue_number": {{check_existing_issue.issue_number}}}
-    next: notify_review
+    next: record_outcome
 
   create_fix_issue:
     type: brain
@@ -173,6 +189,18 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<created issue URL>", "issue_number": <number>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}} PR #{{_trigger.number}}
+      Findings: {{review_pr.findings}} ({{review_pr.critical}} critical)
+      URL: {{review_pr.review_url}}
     next: notify_review
 
   notify_review:

--- a/apps/api/playbooks/release-notes.yaml
+++ b/apps/api/playbooks/release-notes.yaml
@@ -22,9 +22,18 @@ inputs:
 
 on:
   webhook:
-    next: draft_release_notes
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: draft_release_notes
+
   draft_release_notes:
     type: brain
     mode: agentic
@@ -93,8 +102,26 @@ blocks:
 
         Full changelog: https://github.com/{{_trigger.repository.full_name}}/releases/tag/<tag>
 
+      {% if recall_context.entries %}
+      Prior releases on this repo:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"tag": "<tag name>", "pr_count": <number>, "changelog": "<markdown entry>", "slack_message": "<slack message>", "skipped": false}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}}
+      Tag: {{draft_release_notes.tag}} · {{draft_release_notes.pr_count}} PRs shipped
     next: notify_release
 
   notify_release:

--- a/apps/api/playbooks/security-patch-updater.yaml
+++ b/apps/api/playbooks/security-patch-updater.yaml
@@ -35,9 +35,18 @@ inputs:
 
 on:
   webhook:
-    next: assess_and_patch
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: assess_and_patch
+
   assess_and_patch:
     type: brain
     mode: agentic
@@ -109,11 +118,30 @@ blocks:
            "body": "## Security Patch\n\n**Package:** <package>\n**CVE:** <cve>\n**Severity:** <severity>\n**Patched to:** <patched_version>\n\n### Vulnerability summary\n<summary>\n\n---\n*Automated security patch by Conduct AI. Review the diff and merge when CI is green.*"
          }
 
+      {% if recall_context.entries %}
+      Prior context for this repo:
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"pr_url": "<full PR URL>", "patched": true, "severity": "<severity>", "cve": "<cve>", "tests_passed": true|false, "message": null}
 
       On any failure:
         {"pr_url": null, "patched": false, "severity": "<severity>", "cve": "<cve>", "tests_passed": false, "message": "<error>"}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}}
+      Patched {{assess_and_patch.cve}} ({{assess_and_patch.severity}})
+      PR: {{assess_and_patch.pr_url}}
     next: notify_security_patch
 
   notify_security_patch:

--- a/apps/api/playbooks/security-scanner.yaml
+++ b/apps/api/playbooks/security-scanner.yaml
@@ -28,9 +28,18 @@ inputs:
 
 on:
   webhook:
-    next: fetch_pr_diff
+    next: recall_context
 
 blocks:
+  recall_context:
+    type: memory
+    label: Recall prior context
+    action: read
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    limit: 5
+    next: fetch_pr_diff
+
   fetch_pr_diff:
     type: brain
     mode: agentic
@@ -171,6 +180,13 @@ blocks:
       - Event: COMMENT
       - Body: <the formatted comment above>
 
+      {% if recall_context.entries %}
+      Prior scans on this repo (known patterns and false positives):
+      {% for entry in recall_context.entries %}
+      - {{entry.summary}}
+      {% endfor %}
+      {% endif %}
+
       Output ONLY the following JSON on the last line:
         {"review_url": "<PR URL>", "critical": <count of 🔴 findings>, "high": <count of 🟠 findings>, "medium": <count of 🟡 findings>, "total": <total findings>}
     next: has_critical
@@ -181,7 +197,7 @@ blocks:
     condition: "{{security_scan.critical}} > 0"
     next:
       pass: check_existing_issue
-      fail: notify_scan
+      fail: record_outcome
 
   check_existing_issue:
     type: brain
@@ -244,7 +260,7 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "{{check_existing_issue.issue_url}}", "issue_number": {{check_existing_issue.issue_number}}}
-    next: notify_scan
+    next: record_outcome
 
   create_security_issue:
     type: brain
@@ -279,6 +295,18 @@ blocks:
 
       Output ONLY the following JSON on the last line:
         {"issue_url": "<url>", "issue_number": <number>}
+    next: record_outcome
+
+  record_outcome:
+    type: memory
+    label: Record outcome
+    action: write
+    scope: repo
+    key: "{{_trigger.repository.full_name}}"
+    summary: |
+      Repo: {{_trigger.repository.full_name}} PR #{{_trigger.number}}
+      Findings: {{security_scan.critical}} critical, {{security_scan.high}} high, {{security_scan.medium}} medium
+      Review: {{security_scan.review_url}}
     next: notify_scan
 
   notify_scan:


### PR DESCRIPTION
## Summary

- Fix `{{fetch_issue.*}}` templates not resolving in memory blocks during test runs
- Add `recall_context` + `record_outcome` memory blocks to all 12 remaining playbooks
- Fix two pre-existing DSL schema bugs in `docs-drift-detector` and `postmortem-drafter`

## Changes

### 1. Test trigger state normalization (`workflows.py`)
Test triggers stored `_trigger: raw_payload` in initial state, causing the trigger block to skip (already in state). `github_issue` fields were never flattened, so `{{fetch_issue.*}}` had nothing to resolve when GitHub credentials were absent in test environments. Fix: normalize test trigger state identically to the real webhook path.

### 2. Memory summary templates (`autopilot*.yaml`)
Switch `{{fetch_issue.issue_number}}` / `{{fetch_issue.title}}` → `{{_trigger.issue_number}}` / `{{_trigger.title}}` — always available from the trigger block regardless of credential availability.

### 3. Memory blocks added to 12 playbooks
dependency-updater, security-patch-updater, security-scanner, copilot-reviewer, pr-reviewer, issue-triage, flaky-test-detective, ai_ready, docs-drift-detector, incident-responder, postmortem-drafter, release-notes

Each now reads prior context at run start and writes a summary at run end, building a per-repo knowledge base.

### 4. Pre-existing schema fixes
- `docs-drift-detector`: `skip` block had `via: log` → `via: slack`
- `postmortem-drafter`: `human_review` approval block missing `channel` field

## Test plan
- [ ] Merge and deploy
- [ ] Run full smoke test suite
- [ ] Verify `agent_memory` rows written with resolved `issue_number` and `title` (no `{{...}}` placeholders)