### PR TITLE
fix: fail-fast token pre-flight check in autopilot brain blocks

### DIFF
--- a/apps/api/playbooks/autopilot-approved.yaml
+++ b/apps/api/playbooks/autopilot-approved.yaml
@@ -85,6 +85,17 @@ blocks:
       SINGLE run_shell call. Do NOT split across multiple calls — /tmp is gone after each call.
       You MUST push the branch to the remote before this block finishes.
 
+      BEFORE ANYTHING ELSE — verify token write access in one shell call:
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X GET \
+          -H "Authorization: token $GIT_TOKEN" \
+          https://api.github.com/repos/{{_trigger.repo_full_name}})
+        if [ "$STATUS" != "200" ]; then
+          echo '{"pr_url": null, "approach": null, "files_changed": null, "error": "GIT_TOKEN cannot access repo — HTTP '$STATUS'"}'
+          exit 0
+        fi
+      If the above check fails OR if any subsequent git push / API call returns 403,
+      output the failure JSON immediately and stop — do NOT retry with alternate auth formats.
+
       Do ALL of the following in ONE run_shell call:
       - rm -rf /tmp/repo
       - git clone --depth {{inputs.clone_depth}} https://$GIT_TOKEN@github.com/{{_trigger.repo_full_name}}.git /tmp/repo

--- a/apps/api/playbooks/autopilot-quick.yaml
+++ b/apps/api/playbooks/autopilot-quick.yaml
@@ -84,6 +84,17 @@ blocks:
       CRITICAL: Each run_shell call gets a FRESH container — do ALL git work in a
       SINGLE run_shell call. Use read_file for exploration, then ONE run_shell for all git ops.
 
+      BEFORE ANYTHING ELSE — verify token write access in one shell call:
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X GET \
+          -H "Authorization: token $GIT_TOKEN" \
+          https://api.github.com/repos/{{_trigger.repo_full_name}})
+        if [ "$STATUS" != "200" ]; then
+          echo '{"pr_url": null, "approach": null, "files_changed": null, "error": "GIT_TOKEN cannot access repo — HTTP '$STATUS'"}'
+          exit 0
+        fi
+      If the above check fails OR if any subsequent git push / API call returns 403,
+      output the failure JSON immediately and stop — do NOT retry with alternate auth formats.
+
       Do ALL of the following in ONE run_shell call:
       - rm -rf /tmp/autopilot_repo
       - git clone --depth {{inputs.clone_depth}} https://$GIT_TOKEN@github.com/{{_trigger.repo_full_name}}.git /tmp/autopilot_repo

--- a/apps/api/playbooks/autopilot.yaml
+++ b/apps/api/playbooks/autopilot.yaml
@@ -95,6 +95,17 @@ blocks:
       SINGLE run_shell call. Do NOT split across multiple calls — /tmp is gone after each call.
       You MUST push the branch to the remote before this block finishes.
 
+      BEFORE ANYTHING ELSE — verify token write access in one shell call:
+        STATUS=$(curl -s -o /dev/null -w "%{http_code}" -X GET \
+          -H "Authorization: token $GIT_TOKEN" \
+          https://api.github.com/repos/{{_trigger.repo_full_name}})
+        if [ "$STATUS" != "200" ]; then
+          echo '{"pr_url": null, "approach": null, "files_changed": null, "error": "GIT_TOKEN cannot access repo — HTTP '$STATUS'"}'
+          exit 0
+        fi
+      If the above check fails OR if any subsequent git push / API call returns 403,
+      output the failure JSON immediately and stop — do NOT retry with alternate auth formats.
+
       Do ALL of the following in ONE run_shell call:
       - rm -rf /tmp/repo
       - git clone --depth {{inputs.clone_depth}} https://$GIT_TOKEN@github.com/{{_trigger.repo_full_name}}.git /tmp/repo


### PR DESCRIPTION
## Summary
- Adds a token write-access pre-flight check as the first action in all three autopilot `implement_fix` brain blocks (quick, full, approved)
- If `GIT_TOKEN` returns non-200 on the repo, outputs failure JSON and exits immediately
- If any subsequent git push / API call returns 403, instructs the agent to fail fast — no retrying alternate auth formats

## Why
Autopilot Quick/Full/Approval were exhausting their 20-turn budget retrying 15+ different git push auth formats after getting a 403. This caps that waste at 1 turn.

## Part of
Closes Layer 1 of #394 (turn budget strategy)