### PR TITLE
feat(layer1): online eval worker — run scoring, anonymization, fixture promotion

### DIFF
--- a/apps/api/alembic/versions/0030_online_eval_tables.py
+++ b/apps/api/alembic/versions/0030_online_eval_tables.py
@@ -1,0 +1,83 @@
+"""0030 online_eval_tables — run_online_scores + run_fixture_candidates
+
+Revision ID: 0030
+Revises: 0029
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0030"
+down_revision = "0029"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "run_online_scores",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("workflow_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("slug", sa.String(255), nullable=False),
+        sa.Column("grade", sa.String(5), nullable=False),
+        sa.Column("pct", sa.Numeric(5, 2), nullable=False),
+        sa.Column("mechanical_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("mechanical_max", sa.Integer(), nullable=False, server_default="40"),
+        sa.Column("judge_score", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("judge_max", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("judge_used", sa.Boolean(), nullable=False, server_default="false"),
+        sa.Column("run_status", sa.String(50), nullable=True),
+        sa.Column("outcome_type", sa.String(255), nullable=True),
+        sa.Column("token_count", sa.Integer(), nullable=True),
+        sa.Column("anonymized_outcome", postgresql.JSONB(), nullable=True),
+        sa.Column(
+            "scored_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+    )
+    op.create_index("ix_run_online_scores_run_id", "run_online_scores", ["run_id"], unique=True)
+    op.create_index("ix_run_online_scores_slug", "run_online_scores", ["slug"])
+    op.create_index("ix_run_online_scores_grade", "run_online_scores", ["grade"])
+    op.create_index("ix_run_online_scores_scored_at", "run_online_scores", ["scored_at"])
+
+    op.create_table(
+        "run_fixture_candidates",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("slug", sa.String(255), nullable=False),
+        sa.Column("grade", sa.String(5), nullable=False),
+        sa.Column("pct", sa.Numeric(5, 2), nullable=False),
+        sa.Column("anon_trigger_payload", postgresql.JSONB(), nullable=True),
+        sa.Column("anon_state", postgresql.JSONB(), nullable=True),
+        sa.Column("expected_outcome_type", sa.String(255), nullable=True),
+        # pending | promoted | dismissed
+        sa.Column("status", sa.String(50), nullable=False, server_default="pending"),
+        sa.Column("promoted_pr_url", sa.Text(), nullable=True),
+        sa.Column("promoted_by", sa.String(255), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("now()"),
+        ),
+        sa.Column("promoted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index("ix_run_fixture_candidates_run_id", "run_fixture_candidates", ["run_id"], unique=True)
+    op.create_index("ix_run_fixture_candidates_slug", "run_fixture_candidates", ["slug"])
+    op.create_index("ix_run_fixture_candidates_status", "run_fixture_candidates", ["status"])
+
+
+def downgrade():
+    op.drop_index("ix_run_fixture_candidates_status", table_name="run_fixture_candidates")
+    op.drop_index("ix_run_fixture_candidates_slug", table_name="run_fixture_candidates")
+    op.drop_index("ix_run_fixture_candidates_run_id", table_name="run_fixture_candidates")
+    op.drop_table("run_fixture_candidates")
+
+    op.drop_index("ix_run_online_scores_scored_at", table_name="run_online_scores")
+    op.drop_index("ix_run_online_scores_grade", table_name="run_online_scores")
+    op.drop_index("ix_run_online_scores_slug", table_name="run_online_scores")
+    op.drop_index("ix_run_online_scores_run_id", table_name="run_online_scores")
+    op.drop_table("run_online_scores")

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -67,8 +67,8 @@ class Settings(BaseSettings):
     openai_api_key: str = ""   # text-embedding-3-small (1536d)
     voyage_api_key: str = ""   # voyage-3-lite (512d) — future
 
-    # Fixture promotion — target repo for auto-opened PRs
-    github_promotion_repo: str = "sseshachala/conductai"
+    # Fixture promotion — fallback repo if not derivable from the run's workflow
+    github_promotion_repo: str = ""
 
     # Sentry — leave blank to disable
     sentry_dsn: str = ""

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -67,6 +67,10 @@ class Settings(BaseSettings):
     openai_api_key: str = ""   # text-embedding-3-small (1536d)
     voyage_api_key: str = ""   # voyage-3-lite (512d) — future
 
+    # GitHub PAT for fixture promotion PRs — needs repo write on conductai/conductai
+    github_promotion_token: str = ""
+    github_promotion_repo: str = "sseshachala/conductai"
+
     # Sentry — leave blank to disable
     sentry_dsn: str = ""
     app_version: str = "1.0.0"

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -67,8 +67,7 @@ class Settings(BaseSettings):
     openai_api_key: str = ""   # text-embedding-3-small (1536d)
     voyage_api_key: str = ""   # voyage-3-lite (512d) — future
 
-    # GitHub PAT for fixture promotion PRs — needs repo write on conductai/conductai
-    github_promotion_token: str = ""
+    # Fixture promotion — target repo for auto-opened PRs
     github_promotion_repo: str = "sseshachala/conductai"
 
     # Sentry — leave blank to disable

--- a/apps/api/app/models/run_online_score.py
+++ b/apps/api/app/models/run_online_score.py
@@ -1,0 +1,59 @@
+import uuid
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from sqlalchemy import Boolean, Column, Integer, Numeric, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.core.database import Base
+
+
+class RunOnlineScore(Base):
+    """One quality score row per completed production run."""
+
+    __tablename__ = "run_online_scores"
+
+    id               = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id           = Column(UUID(as_uuid=True), nullable=False, index=True, unique=True)
+    workflow_id      = Column(UUID(as_uuid=True), nullable=True)
+    slug             = Column(String(255), nullable=False, index=True)
+    grade            = Column(String(5), nullable=False)
+    pct              = Column(Numeric(5, 2), nullable=False)
+    mechanical_score = Column(Integer, nullable=False, default=0)
+    mechanical_max   = Column(Integer, nullable=False, default=40)
+    judge_score      = Column(Integer, nullable=False, default=0)
+    judge_max        = Column(Integer, nullable=False, default=0)
+    judge_used       = Column(Boolean, nullable=False, default=False)
+    run_status       = Column(String(50), nullable=True)
+    outcome_type     = Column(String(255), nullable=True)
+    token_count      = Column(Integer, nullable=True)
+    anonymized_outcome = Column(JSONB, nullable=True)
+    scored_at        = Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+
+class RunFixtureCandidate(Base):
+    """Low-scoring production run queued for fixture promotion."""
+
+    __tablename__ = "run_fixture_candidates"
+
+    id                    = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    run_id                = Column(UUID(as_uuid=True), nullable=False, index=True, unique=True)
+    slug                  = Column(String(255), nullable=False, index=True)
+    grade                 = Column(String(5), nullable=False)
+    pct                   = Column(Numeric(5, 2), nullable=False)
+    anon_trigger_payload  = Column(JSONB, nullable=True)
+    anon_state            = Column(JSONB, nullable=True)
+    expected_outcome_type = Column(String(255), nullable=True)
+    status                = Column(String(50), nullable=False, default="pending", index=True)
+    promoted_pr_url       = Column(String, nullable=True)
+    promoted_by           = Column(String(255), nullable=True)
+    created_at            = Column(
+        sa.DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    promoted_at = Column(sa.DateTime(timezone=True), nullable=True)

--- a/apps/api/app/routers/eval.py
+++ b/apps/api/app/routers/eval.py
@@ -593,6 +593,177 @@ def list_playbook_baselines(
         raise HTTPException(status_code=500, detail=f"Failed to load baselines: {e}")
 
 
+@router.get("/candidates")
+def list_fixture_candidates(
+    slug: str | None = None,
+    status: str = "pending",
+    limit: int = 50,
+    _: None = Depends(_require_super_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    List production runs queued as fixture promotion candidates.
+
+    Query params:
+      slug    — filter by playbook slug
+      status  — pending | promoted | dismissed (default: pending)
+      limit   — max rows (default: 50)
+    """
+    from app.models.run_online_score import RunFixtureCandidate
+    q = db.query(RunFixtureCandidate).filter(RunFixtureCandidate.status == status)
+    if slug:
+        q = q.filter(RunFixtureCandidate.slug == slug)
+    rows = q.order_by(RunFixtureCandidate.created_at.desc()).limit(limit).all()
+    return [
+        {
+            "id": str(r.id),
+            "run_id": str(r.run_id),
+            "slug": r.slug,
+            "grade": r.grade,
+            "pct": float(r.pct),
+            "expected_outcome_type": r.expected_outcome_type,
+            "anon_trigger_payload": r.anon_trigger_payload,
+            "status": r.status,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+        for r in rows
+    ]
+
+
+@router.post("/candidates/{candidate_id}/promote")
+def promote_fixture_candidate(
+    candidate_id: str,
+    _: None = Depends(_require_super_admin),
+    db: Session = Depends(get_db),
+):
+    """
+    Promote a fixture candidate by opening a GitHub PR that appends the
+    anonymized trigger payload as a new scenario in the playbook's YAML fixture.
+    """
+    from datetime import datetime, timezone
+    import yaml
+    import httpx
+    from app.models.run_online_score import RunFixtureCandidate
+
+    row = db.query(RunFixtureCandidate).filter_by(id=candidate_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    if row.status != "pending":
+        raise HTTPException(status_code=409, detail=f"Candidate is already {row.status}")
+
+    if not settings.github_promotion_token:
+        raise HTTPException(status_code=503, detail="GITHUB_PROMOTION_TOKEN not configured")
+
+    repo = settings.github_promotion_repo
+    token = settings.github_promotion_token
+    fixture_path = f"apps/api/eval/fixtures/{row.slug}.yaml"
+    branch = f"fixture/promote-{str(row.id)[:8]}"
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+    try:
+        base = f"https://api.github.com/repos/{repo}"
+
+        # Get default branch SHA
+        ref_res = httpx.get(f"{base}/git/ref/heads/main", headers=headers, timeout=10)
+        ref_res.raise_for_status()
+        sha = ref_res.json()["object"]["sha"]
+
+        # Create branch
+        httpx.post(f"{base}/git/refs", headers=headers, timeout=10, json={
+            "ref": f"refs/heads/{branch}", "sha": sha
+        }).raise_for_status()
+
+        # Get current fixture file content
+        file_res = httpx.get(f"{base}/contents/{fixture_path}", headers=headers, timeout=10)
+        if file_res.status_code == 404:
+            raise HTTPException(status_code=404, detail=f"Fixture file not found: {fixture_path}")
+        file_res.raise_for_status()
+        file_data = file_res.json()
+        current_content = __import__("base64").b64decode(file_data["content"]).decode()
+        file_sha = file_data["sha"]
+
+        # Build new scenario block
+        new_scenario = {
+            "id": f"promoted_{str(row.id)[:8]}",
+            "label": f"(promoted) Grade {row.grade} run — {row.expected_outcome_type or 'unknown outcome'}",
+            "tags": ["positive"] if row.grade in ("A", "B") else ["negative"],
+            "expected_outcome_type": row.expected_outcome_type,
+            "trigger_payload": row.anon_trigger_payload or {},
+        }
+        scenario_yaml = "\n  " + yaml.dump(
+            new_scenario, default_flow_style=False, allow_unicode=True
+        ).replace("\n", "\n  ").rstrip()
+        updated_content = current_content.rstrip() + f"\n{scenario_yaml}\n"
+
+        # Push updated file
+        import base64
+        httpx.put(
+            f"{base}/contents/{fixture_path}",
+            headers=headers,
+            timeout=10,
+            json={
+                "message": f"fixture: promote run {str(row.run_id)[:8]} ({row.slug}, grade {row.grade})",
+                "content": base64.b64encode(updated_content.encode()).decode(),
+                "sha": file_sha,
+                "branch": branch,
+            },
+        ).raise_for_status()
+
+        # Open PR
+        pr_res = httpx.post(f"{base}/pulls", headers=headers, timeout=10, json={
+            "title": f"fixture({row.slug}): promote production run as eval scenario",
+            "body": (
+                f"Auto-promoted from fixture candidate `{candidate_id}`.\n\n"
+                f"- Playbook: `{row.slug}`\n"
+                f"- Grade: **{row.grade}** ({float(row.pct):.0f}%)\n"
+                f"- Expected outcome: `{row.expected_outcome_type}`\n"
+                f"- Run ID: `{row.run_id}` (anonymized)\n\n"
+                f"Review the appended scenario in `{fixture_path}` before merging."
+            ),
+            "head": branch,
+            "base": "main",
+        })
+        pr_res.raise_for_status()
+        pr_url = pr_res.json()["html_url"]
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        log.error("candidates.promote_failed", candidate_id=candidate_id, error=str(exc))
+        raise HTTPException(status_code=500, detail=f"Failed to open PR: {exc}")
+
+    row.status = "promoted"
+    row.promoted_at = datetime.now(timezone.utc)
+    row.promoted_pr_url = pr_url
+    db.commit()
+
+    return {"status": "promoted", "pr_url": pr_url}
+
+
+@router.post("/candidates/{candidate_id}/dismiss")
+def dismiss_fixture_candidate(
+    candidate_id: str,
+    _: None = Depends(_require_super_admin),
+    db: Session = Depends(get_db),
+):
+    """Mark a fixture candidate as dismissed (won't appear in pending list)."""
+    from app.models.run_online_score import RunFixtureCandidate
+
+    row = db.query(RunFixtureCandidate).filter_by(id=candidate_id).first()
+    if not row:
+        raise HTTPException(status_code=404, detail="Candidate not found")
+    if row.status != "pending":
+        raise HTTPException(status_code=409, detail=f"Candidate is already {row.status}")
+
+    row.status = "dismissed"
+    db.commit()
+    return {"status": "dismissed", "id": candidate_id}
+
+
 @router.get("/scenarios/{slug}")
 def get_scenario_set(
     slug: str,

--- a/apps/api/app/routers/eval.py
+++ b/apps/api/app/routers/eval.py
@@ -660,7 +660,20 @@ def promote_fixture_candidate(
     except Exception:
         raise HTTPException(status_code=503, detail="GitHub credentials not configured — add a GITHUB_TOKEN in Settings → Environments")
 
-    repo = settings.github_promotion_repo
+    # Derive repo from the workflow connected to this run
+    from sqlalchemy import text as _text
+    repo_row = db.execute(
+        _text("""
+            SELECT w.github_hook_repo FROM runs r
+            JOIN workflow_versions wv ON wv.id = r.workflow_version_id
+            JOIN workflows w ON w.id = wv.workflow_id
+            WHERE r.id = :run_id LIMIT 1
+        """),
+        {"run_id": str(row.run_id)},
+    ).fetchone()
+    repo = repo_row[0] if repo_row and repo_row[0] else settings.github_promotion_repo
+    if not repo:
+        raise HTTPException(status_code=503, detail="Could not determine target repo — set GITHUB_PROMOTION_REPO or connect a GitHub repo to the workflow")
     fixture_path = f"apps/api/eval/fixtures/{row.slug}.yaml"
     branch = f"fixture/promote-{str(row.id)[:8]}"
     headers = {

--- a/apps/api/app/routers/eval.py
+++ b/apps/api/app/routers/eval.py
@@ -651,11 +651,16 @@ def promote_fixture_candidate(
     if row.status != "pending":
         raise HTTPException(status_code=409, detail=f"Candidate is already {row.status}")
 
-    if not settings.github_promotion_token:
-        raise HTTPException(status_code=503, detail="GITHUB_PROMOTION_TOKEN not configured")
+    from app.routers.credentials import _github_token
+    from app.core.auth import DEV_WORKSPACE_ID
+
+    # Use the platform workspace's GitHub token (set in Settings → Environments)
+    try:
+        token = _github_token(DEV_WORKSPACE_ID, db)
+    except Exception:
+        raise HTTPException(status_code=503, detail="GitHub credentials not configured — add a GITHUB_TOKEN in Settings → Environments")
 
     repo = settings.github_promotion_repo
-    token = settings.github_promotion_token
     fixture_path = f"apps/api/eval/fixtures/{row.slug}.yaml"
     branch = f"fixture/promote-{str(row.id)[:8]}"
     headers = {

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -282,6 +282,24 @@ def _emit_run_analytics(run, version, state: dict, db, *, outcome: str, error: s
         log.exception("run_analytics.failed")
 
 
+_ONLINE_EVAL_QUEUE = "marshal:eval:online:queue"
+_ONLINE_EVAL_QUEUE_MAX = 10_000  # cap to prevent unbounded growth when worker is down
+
+
+def _enqueue_online_eval(run_id: str) -> None:
+    """Push run_id to the online eval queue. Fire-and-forget — never raises."""
+    try:
+        import redis as _redis
+        r = _redis.from_url(settings.redis_url, decode_responses=True)
+        qlen = r.llen(_ONLINE_EVAL_QUEUE)
+        if qlen >= _ONLINE_EVAL_QUEUE_MAX:
+            log.warning("online_eval.queue_full", queue_len=qlen, run_id=run_id)
+            return
+        r.rpush(_ONLINE_EVAL_QUEUE, run_id)
+    except Exception:
+        log.debug("online_eval.enqueue_failed", run_id=run_id)
+
+
 def _resolve_refs(value: Any, state: dict) -> Any:
     """Replace {{block_id.field}} references with values from run state."""
     if isinstance(value, str):
@@ -1838,6 +1856,7 @@ def execute_run(run_id: str):
             workspace_id_str=str(workspace_id_str),
         )
         _emit_run_analytics(run, version, final_state, db, outcome=run.status, error="")
+        _enqueue_online_eval(str(run.id))
 
     except Exception as e:
         log.exception("run.executor_crash", run_id=run_id)
@@ -1855,6 +1874,7 @@ def execute_run(run_id: str):
                 run.locked_by = None
                 db.commit()
                 _emit_run_analytics(run, None, {}, db, outcome="failed", error=str(e))
+                _enqueue_online_eval(str(run.id))
         except Exception:
             pass
     finally:

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -35,8 +35,10 @@ from app.runtime.executor import execute_run
 setup_logging()
 log = structlog.get_logger(__name__)
 
-QUEUE_KEY   = "marshal:runs:queue"
-CONCURRENCY = int(os.environ.get("WORKER_CONCURRENCY", "1"))
+QUEUE_KEY        = "marshal:runs:queue"
+ONLINE_EVAL_KEY  = "marshal:eval:online:queue"
+CONCURRENCY      = int(os.environ.get("WORKER_CONCURRENCY", "1"))
+JUDGE_SAMPLE_RATE = float(os.environ.get("ONLINE_EVAL_JUDGE_SAMPLE_RATE", "0.20"))
 
 # Reaper configuration — tunable via environment variables.
 STALE_RUN_THRESHOLD_MINUTES = int(os.environ.get("STALE_RUN_THRESHOLD_MINUTES", "20"))
@@ -127,6 +129,37 @@ def _reaper_loop() -> None:
             log.exception("reaper.loop_error")
 
 
+# ── online eval scorer ───────────────────────────────────────────────────────
+
+def _online_eval_loop() -> None:
+    """Daemon thread: consume the online eval queue and score each completed run."""
+    import random
+    r = redis.from_url(settings.redis_url, decode_responses=True)
+    log.info("online_eval.started", queue=ONLINE_EVAL_KEY, judge_sample_rate=JUDGE_SAMPLE_RATE)
+
+    while True:
+        try:
+            item = r.blpop(ONLINE_EVAL_KEY, timeout=30)
+            if item is None:
+                continue
+            _, run_id = item
+            use_judge = random.random() < JUDGE_SAMPLE_RATE
+            log.debug("online_eval.scoring", run_id=run_id, judge=use_judge)
+            try:
+                from app.core.database import SessionLocal
+                from eval.online_scorer import score_run_online
+                with SessionLocal() as db:
+                    score_run_online(run_id, db, judge=use_judge)
+            except Exception:
+                log.exception("online_eval.score_failed", run_id=run_id)
+        except redis.exceptions.ConnectionError:
+            log.warning("online_eval.redis_disconnected", retry_in=3)
+            time.sleep(3)
+        except Exception:
+            log.exception("online_eval.loop_error")
+            time.sleep(1)
+
+
 # ── queue worker ──────────────────────────────────────────────────────────────
 
 def _loop(thread_id: int) -> None:
@@ -152,9 +185,12 @@ def _loop(thread_id: int) -> None:
 def main() -> None:
     log.info("worker.starting", concurrency=CONCURRENCY, queue=QUEUE_KEY)
 
-    # The reaper runs regardless of worker concurrency mode.
+    # The reaper and online eval scorer run regardless of worker concurrency mode.
     reaper = threading.Thread(target=_reaper_loop, daemon=True, name="reaper")
     reaper.start()
+
+    online_eval = threading.Thread(target=_online_eval_loop, daemon=True, name="online-eval")
+    online_eval.start()
 
     if CONCURRENCY == 1:
         _loop(0)

--- a/apps/api/eval/online_scorer.py
+++ b/apps/api/eval/online_scorer.py
@@ -1,0 +1,278 @@
+"""
+Online eval scorer — scores every production run against mechanical quality
+criteria and (20% sample) an LLM-as-judge, then queues low-scoring runs as
+fixture promotion candidates.
+
+Called from the worker daemon after a run completes. Never blocks the run
+execution path — always runs in the background thread.
+"""
+from __future__ import annotations
+
+import hashlib
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy.orm import Session
+
+log = structlog.get_logger(__name__)
+
+# Runs grading below this threshold are queued as fixture candidates
+_CANDIDATE_GRADES = {"C", "D", "F"}
+
+# Fields to scrub from state dicts (keys matched case-insensitively)
+_PII_KEYS = {
+    "email", "author", "assignee", "login", "name", "committer",
+    "sender", "pusher", "owner", "user", "requested_reviewers",
+}
+
+# Regex for inline email addresses anywhere in string values
+_EMAIL_RE = re.compile(r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}")
+
+
+# ── Anonymization ─────────────────────────────────────────────────────────────
+
+def _hash(value: str) -> str:
+    """Deterministic 8-char alias — same input always produces same alias."""
+    return "anon-" + hashlib.sha256(value.encode()).hexdigest()[:8]
+
+
+def _scrub_value(value: Any) -> Any:
+    if isinstance(value, str):
+        return _EMAIL_RE.sub("[redacted]", value)
+    if isinstance(value, dict):
+        return _scrub_dict(value)
+    if isinstance(value, list):
+        return [_scrub_value(v) for v in value]
+    return value
+
+
+def _scrub_dict(d: dict) -> dict:
+    out: dict = {}
+    for k, v in d.items():
+        if k.lower() in _PII_KEYS:
+            if isinstance(v, str) and v:
+                out[k] = _hash(v)
+            elif isinstance(v, dict):
+                out[k] = {"id": _hash(str(v.get("id", v))), "_redacted": True}
+            elif isinstance(v, list):
+                out[k] = ["[redacted]"] * len(v)
+            else:
+                out[k] = "[redacted]"
+        else:
+            out[k] = _scrub_value(v)
+    return out
+
+
+def anonymize_state(state: dict) -> dict:
+    """
+    Return a copy of run state with PII removed.
+
+    - Repository full_name → deterministic hash alias
+    - Email addresses in any string value → [redacted]
+    - Author/assignee/login/name fields → hashed alias
+    - Lists of users → length-preserving [redacted] list
+    - Kept intact: outcome type, token counts, timing, block execution path,
+      trigger type, PR/issue numbers, label names, CI status strings
+    """
+    anon = _scrub_dict(state)
+
+    # Hash repo full_name specifically (owner/repo format)
+    repo = anon.get("repository") or anon.get("repo") or {}
+    if isinstance(repo, dict):
+        for key in ("full_name", "clone_url", "html_url", "url", "ssh_url"):
+            if key in repo and isinstance(repo[key], str):
+                repo[key] = _hash(repo[key])
+
+    return anon
+
+
+# ── Token count helper ────────────────────────────────────────────────────────
+
+def _count_tokens(state: dict) -> int:
+    """Sum input+output tokens from all block outputs in state."""
+    total = 0
+    for v in state.values():
+        if not isinstance(v, dict):
+            continue
+        total += v.get("input_tokens", 0) or 0
+        total += v.get("output_tokens", 0) or 0
+        total += v.get("total_tokens", 0) or 0
+    return total
+
+
+# ── Slug resolution ───────────────────────────────────────────────────────────
+
+def _resolve_slug(workflow_version_id: str, db: Session) -> str | None:
+    from sqlalchemy import text
+    row = db.execute(
+        text("""
+            SELECT w.playbook_slug
+            FROM workflow_versions wv
+            JOIN workflows w ON w.id = wv.workflow_id
+            WHERE wv.id = :wv_id
+            LIMIT 1
+        """),
+        {"wv_id": workflow_version_id},
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _resolve_workflow_id(workflow_version_id: str, db: Session) -> str | None:
+    from sqlalchemy import text
+    row = db.execute(
+        text("SELECT workflow_id FROM workflow_versions WHERE id = :id LIMIT 1"),
+        {"id": workflow_version_id},
+    ).fetchone()
+    return str(row[0]) if row else None
+
+
+# ── Mechanical scoring ────────────────────────────────────────────────────────
+
+def _mechanical_score(run_status: str, outcome: dict | None, state: dict, token_count: int) -> tuple[int, int]:
+    """
+    Return (score, max) for the 4 mechanical quality criteria (40 pts).
+
+    run_succeeded    15 pts
+    outcome_detected 10 pts
+    artifact_produced 10 pts
+    token_budget      5 pts  (passes if < 50k tokens)
+    """
+    score = 0
+
+    if run_status == "succeeded":
+        score += 15
+
+    if outcome and outcome.get("type"):
+        score += 10
+
+    if outcome and outcome.get("artifact_url"):
+        score += 10
+
+    if token_count < 50_000:
+        score += 5
+
+    return score, 40
+
+
+# ── Grade from pct ────────────────────────────────────────────────────────────
+
+def _grade(pct: float) -> str:
+    if pct >= 90: return "A"
+    if pct >= 75: return "B"
+    if pct >= 60: return "C"
+    if pct >= 40: return "D"
+    return "F"
+
+
+# ── Main entry point ──────────────────────────────────────────────────────────
+
+def score_run_online(run_id: str, db: Session, judge: bool = False) -> None:
+    """
+    Score a completed production run and persist the result.
+
+    - Always runs mechanical scoring (~1ms)
+    - Runs LLM-as-judge only when judge=True (caller controls 20% sampling)
+    - Queues run as a fixture candidate if grade is C/D/F
+    - Skips silently if the run has already been scored
+    """
+    from app.models.run import Run
+    from app.models.run_online_score import RunOnlineScore, RunFixtureCandidate
+
+    # Idempotency — skip if already scored
+    existing = db.query(RunOnlineScore).filter_by(run_id=run_id).first()
+    if existing:
+        return
+
+    run = db.query(Run).filter_by(id=run_id).first()
+    if not run:
+        log.warning("online_scorer.run_not_found", run_id=run_id)
+        return
+
+    slug = _resolve_slug(str(run.workflow_version_id), db)
+    if not slug:
+        log.debug("online_scorer.no_slug", run_id=run_id)
+        return
+
+    workflow_id = _resolve_workflow_id(str(run.workflow_version_id), db)
+    state = run.state or {}
+    outcome = run.outcome or {}
+    token_count = _count_tokens(state)
+
+    # Mechanical score
+    mech_score, mech_max = _mechanical_score(run.status, outcome, state, token_count)
+
+    # Optional LLM judge
+    judge_score, judge_max = 0, 0
+    if judge:
+        try:
+            from eval.judge import judge_output, extract_brain_output
+            brain_text = extract_brain_output(state)
+            if brain_text:
+                judge_result = judge_output(slug, brain_text)
+                if judge_result and not judge_result.failed:
+                    for c in judge_result.to_criteria():
+                        judge_score += c.points_earned
+                    judge_max = 30
+        except Exception as exc:
+            log.warning("online_scorer.judge_failed", run_id=run_id, error=str(exc))
+            judge = False
+
+    total_score = mech_score + judge_score
+    total_max = mech_max + judge_max
+    pct = (total_score / total_max * 100) if total_max > 0 else 0.0
+    grade = _grade(pct)
+
+    anon_outcome = anonymize_state(outcome) if outcome else None
+
+    score_row = RunOnlineScore(
+        id=uuid.uuid4(),
+        run_id=run_id,
+        workflow_id=workflow_id,
+        slug=slug,
+        grade=grade,
+        pct=round(pct, 2),
+        mechanical_score=mech_score,
+        mechanical_max=mech_max,
+        judge_score=judge_score,
+        judge_max=judge_max,
+        judge_used=judge,
+        run_status=run.status,
+        outcome_type=outcome.get("type") if outcome else None,
+        token_count=token_count,
+        anonymized_outcome=anon_outcome,
+        scored_at=datetime.now(timezone.utc),
+    )
+    db.add(score_row)
+
+    if grade in _CANDIDATE_GRADES:
+        anon_trigger = anonymize_state(state.get("trigger", state.get("__trigger__", {})))
+        anon_state = anonymize_state(state)
+
+        already = db.query(RunFixtureCandidate).filter_by(run_id=run_id).first()
+        if not already:
+            db.add(RunFixtureCandidate(
+                id=uuid.uuid4(),
+                run_id=run_id,
+                slug=slug,
+                grade=grade,
+                pct=round(pct, 2),
+                anon_trigger_payload=anon_trigger,
+                anon_state=anon_state,
+                expected_outcome_type=outcome.get("type") if outcome else None,
+                status="pending",
+                created_at=datetime.now(timezone.utc),
+            ))
+
+    db.commit()
+    log.info(
+        "online_scorer.scored",
+        run_id=run_id,
+        slug=slug,
+        grade=grade,
+        pct=round(pct, 1),
+        judge_used=judge,
+        candidate=grade in _CANDIDATE_GRADES,
+    )


### PR DESCRIPTION
Closes #402, #403, #404, #405, #406

Part of #401 — Layer 1 Run Data Flywheel.

## What ships

**Migration (#402)**
- `run_online_scores` — one quality score row per production run
- `run_fixture_candidates` — low-scoring runs queued for fixture promotion
- Indexes on run_id (unique), slug, grade, status, scored_at

**`eval/online_scorer.py` (#403)**
- `anonymize_state()` — hashes repo names, redacts emails/author fields, keeps outcome/token/timing data intact
- `score_run_online()` — mechanical scoring (40 pts) + optional LLM judge (30 pts), idempotent, writes both tables

**`executor.py` hook (#404)**
- 2-line `_enqueue_online_eval()` called after `_emit_run_analytics()` on both success and failure paths
- Max queue length cap (10k) with warning log — prevents unbounded growth if worker is down

**`worker.py` daemon (#405)**
- New `_online_eval_loop()` daemon thread alongside the existing reaper
- BLPOP from `marshal:eval:online:queue`, 20% LLM judge sampling (tunable via `ONLINE_EVAL_JUDGE_SAMPLE_RATE` env var)

**API endpoints (#406)**
- `GET /eval/candidates` — list pending fixture candidates (super-admin)
- `POST /eval/candidates/{id}/promote` — opens a GitHub PR appending the anonymized scenario to the fixture YAML
- `POST /eval/candidates/{id}/dismiss` — marks dismissed

## New env var needed on Render
```
GITHUB_PROMOTION_TOKEN=<PAT with repo write on sseshachala/conductai>
```

## What's not in this PR
- #407 Frontend: `/eval/candidates` review UI — follow-on