### PR TITLE
feat: promote audit log to top-level nav

### DIFF
--- a/apps/web/src/app/audit/page.tsx
+++ b/apps/web/src/app/audit/page.tsx
@@ -1,0 +1,23 @@
+"use client"
+
+import { useAuth } from "@clerk/nextjs"
+import AppShell from "@/components/AppShell"
+import AuditLog from "@/components/settings/AuditLog"
+
+export default function AuditPage() {
+  const { getToken } = useAuth()
+
+  return (
+    <AppShell>
+      <div className="max-w-5xl mx-auto px-6 py-8 space-y-6">
+        <div>
+          <h1 className="text-xl font-semibold text-stone-900">Audit Log</h1>
+          <p className="text-sm text-stone-500 mt-1">
+            All workspace activity — credential changes, agent runs, and member events.
+          </p>
+        </div>
+        <AuditLog workspaceId="" getToken={getToken} />
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -429,6 +429,7 @@ function AppShellInner({ children, noPadding }: { children: React.ReactNode; noP
 
           <div className="pt-2 border-t border-stone-100 mt-2 space-y-0.5">
             <NavItem href="/runs" icon="▶" label="Runs" collapsed={collapsed} pathname={pathname} />
+            <NavItem href="/audit" icon="📋" label="Audit" collapsed={collapsed} pathname={pathname} />
             <NavItem href="/settings" icon="⚙" label="Settings" collapsed={collapsed} pathname={pathname} />
           </div>
         </nav>


### PR DESCRIPTION
## Summary
- New `/audit` page wrapping the existing `AuditLog` component in `AppShell`
- Adds **Audit** (📋) nav item in the sidebar between Runs and Settings
- No backend changes — uses the existing admin-only `GET /workspaces/{id}/audit-log` endpoint
- Workspace resolves from cookie (same pattern as Settings page)

## Test plan
- [ ] Visit `/audit` as admin — entries load, filter and export work
- [ ] Sidebar shows Audit item, active state highlights correctly
- [ ] Settings → Audit Log tab still works (no regression)