### PR TITLE
feat: observability dashboard phase 1

### DIFF
--- a/apps/api/alembic/versions/0031_watchdog_events.py
+++ b/apps/api/alembic/versions/0031_watchdog_events.py
@@ -1,0 +1,41 @@
+"""0031 watchdog_events — observability event log + heartbeat column
+
+Revision ID: 0031
+Revises: 0030
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "0031"
+down_revision = "0030"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "runs",
+        sa.Column("last_heartbeat_time", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    op.create_table(
+        "watchdog_events",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("workspace_id", sa.String(255), nullable=False),
+        sa.Column("run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("workflow_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("event_type", sa.String(50), nullable=False),
+        sa.Column("severity", sa.String(20), nullable=False, server_default="info"),
+        sa.Column("payload", postgresql.JSONB(), nullable=False, server_default="{}"),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+    )
+    op.create_index("ix_watchdog_events_workspace_id", "watchdog_events", ["workspace_id"])
+    op.create_index("ix_watchdog_events_created_at", "watchdog_events", ["created_at"])
+
+
+def downgrade():
+    op.drop_index("ix_watchdog_events_created_at", table_name="watchdog_events")
+    op.drop_index("ix_watchdog_events_workspace_id", table_name="watchdog_events")
+    op.drop_table("watchdog_events")
+    op.drop_column("runs", "last_heartbeat_time")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -7,6 +7,7 @@ from app.core.logging import setup_logging
 from app.middleware.logging import LoggingMiddleware
 from app.routers import credentials, dashboard, email_templates, environments, playbooks, projects, runs, webhooks, workflows
 from app.routers.eval import router as eval_router
+from app.routers.observability import router as observability_router
 from app.routers.organizations import router as organizations_router
 from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router, project_direct_router
 from app.routers.runs import workspace_runs_router
@@ -71,6 +72,7 @@ app.include_router(environments.router)
 app.include_router(email_templates.router)
 app.include_router(webhooks.router)
 app.include_router(eval_router)
+app.include_router(observability_router)
 
 
 @app.on_event("startup")

--- a/apps/api/app/models/run.py
+++ b/apps/api/app/models/run.py
@@ -24,10 +24,11 @@ class Run(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
     # ── Run leasing / retry tracking (migration 0024) ─────────────────────────
-    attempt_count = Column(sa.Integer, nullable=False, default=0)
-    locked_at     = Column(DateTime(timezone=True), nullable=True)   # when a worker claimed this run
-    locked_by     = Column(String(255), nullable=True)               # worker hostname/pid
-    next_retry_at = Column(DateTime(timezone=True), nullable=True)   # earliest retry time after failure
+    attempt_count        = Column(sa.Integer, nullable=False, default=0)
+    locked_at            = Column(DateTime(timezone=True), nullable=True)
+    locked_by            = Column(String(255), nullable=True)
+    next_retry_at        = Column(DateTime(timezone=True), nullable=True)
+    last_heartbeat_time  = Column(DateTime(timezone=True), nullable=True)
 
     workflow_version = relationship("WorkflowVersion", back_populates="runs")
     events = relationship("RunEvent", back_populates="run", order_by="RunEvent.created_at")

--- a/apps/api/app/models/watchdog_event.py
+++ b/apps/api/app/models/watchdog_event.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime, timezone
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+from app.core.database import Base
+
+
+class WatchdogEvent(Base):
+    __tablename__ = "watchdog_events"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(String(255), nullable=False)
+    run_id = Column(UUID(as_uuid=True), nullable=True)
+    workflow_id = Column(UUID(as_uuid=True), nullable=True)
+    # stale_worker | approval_timeout | run_failed | run_recovered
+    event_type = Column(String(50), nullable=False)
+    # info | warning | error
+    severity = Column(String(20), nullable=False, default="info")
+    payload = Column(JSONB, nullable=False, default=dict)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))

--- a/apps/api/app/routers/observability.py
+++ b/apps/api/app/routers/observability.py
@@ -1,0 +1,221 @@
+"""
+GET /observability/summary  — workspace health strip (active runs, stale workers, approvals, error rate)
+GET /observability/agents   — per-agent status grid
+"""
+from datetime import datetime, timedelta, timezone
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy import func, case
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_workspace_role
+from app.core.database import get_db
+from app.models.run import Run
+from app.models.watchdog_event import WatchdogEvent
+from app.models.workflow import Workflow, WorkflowVersion
+
+router = APIRouter(prefix="/observability", tags=["observability"])
+
+# A running run with no heartbeat update for this long is considered stale
+STALE_THRESHOLD_MINUTES = 15
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stale_cutoff() -> datetime:
+    return _now() - timedelta(minutes=STALE_THRESHOLD_MINUTES)
+
+
+class HealthSummary(BaseModel):
+    active_runs: int
+    pending_approvals: int
+    stale_workers: int
+    succeeded_last_24h: int
+    failed_last_24h: int
+    total_last_24h: int
+    error_rate_24h: float
+
+
+class RecentEvent(BaseModel):
+    id: str
+    event_type: str
+    severity: str
+    run_id: str | None
+    workflow_id: str | None
+    payload: dict
+    created_at: str
+
+
+class ObservabilitySummary(BaseModel):
+    health: HealthSummary
+    recent_events: list[RecentEvent]
+
+
+class AgentStatus(BaseModel):
+    workflow_id: str
+    name: str
+    playbook_slug: str | None
+    health: str  # healthy | degraded | stale | idle
+    active_runs: int
+    pending_approvals: int
+    stale_runs: int
+    success_rate_24h: float
+    succeeded_24h: int
+    failed_24h: int
+    last_run_at: str | None
+    last_run_status: str | None
+
+
+@router.get("/summary", response_model=ObservabilitySummary)
+def get_summary(
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
+):
+    cutoff_24h = _now() - timedelta(hours=24)
+    stale_cutoff = _stale_cutoff()
+
+    # All runs in workspace joined to workflow
+    base_q = (
+        db.query(Run)
+        .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+        .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+        .filter(Workflow.workspace_id == workspace_id)
+    )
+
+    active_runs = base_q.filter(Run.status == "running").count()
+    pending_approvals = base_q.filter(Run.status == "paused").count()
+
+    # Stale: running longer than threshold with no recent heartbeat
+    stale_workers = base_q.filter(
+        Run.status == "running",
+        Run.locked_at < stale_cutoff,
+    ).count()
+
+    last_24h = base_q.filter(Run.created_at >= cutoff_24h).all()
+    succeeded_24h = sum(1 for r in last_24h if r.status == "succeeded")
+    failed_24h = sum(1 for r in last_24h if r.status == "failed")
+    total_24h = len(last_24h)
+    error_rate = round(failed_24h / total_24h, 3) if total_24h else 0.0
+
+    health = HealthSummary(
+        active_runs=active_runs,
+        pending_approvals=pending_approvals,
+        stale_workers=stale_workers,
+        succeeded_last_24h=succeeded_24h,
+        failed_last_24h=failed_24h,
+        total_last_24h=total_24h,
+        error_rate_24h=error_rate,
+    )
+
+    events_rows = (
+        db.query(WatchdogEvent)
+        .filter(WatchdogEvent.workspace_id == workspace_id)
+        .order_by(WatchdogEvent.created_at.desc())
+        .limit(20)
+        .all()
+    )
+    recent_events = [
+        RecentEvent(
+            id=str(e.id),
+            event_type=e.event_type,
+            severity=e.severity,
+            run_id=str(e.run_id) if e.run_id else None,
+            workflow_id=str(e.workflow_id) if e.workflow_id else None,
+            payload=e.payload or {},
+            created_at=e.created_at.isoformat(),
+        )
+        for e in events_rows
+    ]
+
+    return ObservabilitySummary(health=health, recent_events=recent_events)
+
+
+@router.get("/agents", response_model=list[AgentStatus])
+def get_agents(
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _role: str = Depends(require_workspace_role("admin", "editor", "viewer")),
+):
+    cutoff_24h = _now() - timedelta(hours=24)
+    stale_cutoff = _stale_cutoff()
+
+    workflows = (
+        db.query(Workflow)
+        .filter(Workflow.workspace_id == workspace_id)
+        .order_by(Workflow.name)
+        .all()
+    )
+
+    result: list[AgentStatus] = []
+    for wf in workflows:
+        version_ids_sq = (
+            db.query(WorkflowVersion.id)
+            .filter(WorkflowVersion.workflow_id == wf.id)
+            .subquery()
+        )
+
+        runs_24h = (
+            db.query(Run)
+            .filter(
+                Run.workflow_version_id.in_(version_ids_sq),
+                Run.created_at >= cutoff_24h,
+            )
+            .all()
+        )
+
+        succeeded_24h = sum(1 for r in runs_24h if r.status == "succeeded")
+        failed_24h = sum(1 for r in runs_24h if r.status == "failed")
+        total_24h = len(runs_24h)
+        success_rate = round(succeeded_24h / total_24h, 3) if total_24h else 0.0
+
+        active = sum(1 for r in runs_24h if r.status == "running")
+        pending = sum(1 for r in runs_24h if r.status == "paused")
+
+        # Stale: running with locked_at older than threshold
+        stale = (
+            db.query(func.count(Run.id))
+            .filter(
+                Run.workflow_version_id.in_(version_ids_sq),
+                Run.status == "running",
+                Run.locked_at < stale_cutoff,
+            )
+            .scalar()
+        ) or 0
+
+        last_run = (
+            db.query(Run)
+            .filter(Run.workflow_version_id.in_(version_ids_sq))
+            .order_by(Run.created_at.desc())
+            .first()
+        )
+
+        # Health classification
+        if stale > 0:
+            health = "stale"
+        elif total_24h == 0:
+            health = "idle"
+        elif success_rate < 0.8 or (last_run and last_run.status == "failed"):
+            health = "degraded"
+        else:
+            health = "healthy"
+
+        result.append(AgentStatus(
+            workflow_id=str(wf.id),
+            name=wf.name,
+            playbook_slug=wf.playbook_slug,
+            health=health,
+            active_runs=active,
+            pending_approvals=pending,
+            stale_runs=stale,
+            success_rate_24h=success_rate,
+            succeeded_24h=succeeded_24h,
+            failed_24h=failed_24h,
+            last_run_at=last_run.created_at.isoformat() if last_run else None,
+            last_run_status=last_run.status if last_run else None,
+        ))
+
+    return result

--- a/apps/web/src/app/observability/page.tsx
+++ b/apps/web/src/app/observability/page.tsx
@@ -1,0 +1,300 @@
+"use client"
+
+import { useEffect, useState, useCallback } from "react"
+import Link from "next/link"
+import { useAuth } from "@clerk/nextjs"
+import AppShell from "@/components/AppShell"
+import { timeAgo } from "@/lib/runUtils"
+
+function getCookie(name: string): string | null {
+  if (typeof document === "undefined") return null
+  const m = document.cookie.match(new RegExp(`(?:^|; )${name}=([^;]*)`))
+  return m ? decodeURIComponent(m[1]) : null
+}
+
+interface HealthSummary {
+  active_runs: number
+  pending_approvals: number
+  stale_workers: number
+  succeeded_last_24h: number
+  failed_last_24h: number
+  total_last_24h: number
+  error_rate_24h: number
+}
+
+interface RecentEvent {
+  id: string
+  event_type: string
+  severity: string
+  run_id: string | null
+  workflow_id: string | null
+  payload: Record<string, unknown>
+  created_at: string
+}
+
+interface ObservabilitySummary {
+  health: HealthSummary
+  recent_events: RecentEvent[]
+}
+
+interface AgentStatus {
+  workflow_id: string
+  name: string
+  playbook_slug: string | null
+  health: "healthy" | "degraded" | "stale" | "idle"
+  active_runs: number
+  pending_approvals: number
+  stale_runs: number
+  success_rate_24h: number
+  succeeded_24h: number
+  failed_24h: number
+  last_run_at: string | null
+  last_run_status: string | null
+}
+
+const HEALTH_STYLES: Record<string, { label: string; dot: string; text: string; bg: string; border: string }> = {
+  healthy:  { label: "Healthy",  dot: "bg-green-400", text: "text-green-700", bg: "bg-green-50",  border: "border-green-200" },
+  degraded: { label: "Degraded", dot: "bg-amber-400", text: "text-amber-700", bg: "bg-amber-50",  border: "border-amber-200" },
+  stale:    { label: "Stale",    dot: "bg-red-400",   text: "text-red-700",   bg: "bg-red-50",    border: "border-red-200"   },
+  idle:     { label: "Idle",     dot: "bg-stone-300", text: "text-stone-500", bg: "bg-stone-100", border: "border-stone-200" },
+}
+
+const SEVERITY_STYLES: Record<string, string> = {
+  info:    "text-blue-700 bg-blue-50",
+  warning: "text-amber-700 bg-amber-50",
+  error:   "text-red-700 bg-red-50",
+}
+
+const EVENT_LABELS: Record<string, string> = {
+  stale_worker:       "Stale worker detected",
+  approval_timeout:   "Approval timeout",
+  run_failed:         "Run failed",
+  run_recovered:      "Run recovered",
+}
+
+function HealthBadge({ health }: { health: string }) {
+  const s = HEALTH_STYLES[health] ?? HEALTH_STYLES.idle
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-xs font-medium px-2 py-0.5 rounded-full ${s.bg} ${s.text} border ${s.border}`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${s.dot}`} />
+      {s.label}
+    </span>
+  )
+}
+
+function StatCard({ label, value, sub, accent }: { label: string; value: number | string; sub?: string; accent?: string }) {
+  return (
+    <div className="bg-white rounded-xl border border-stone-200 px-5 py-4 flex flex-col gap-1">
+      <div className={`text-2xl font-bold ${accent ?? "text-stone-900"}`}>{value}</div>
+      <div className="text-xs font-medium text-stone-500 uppercase tracking-wide">{label}</div>
+      {sub && <div className="text-xs text-stone-400">{sub}</div>}
+    </div>
+  )
+}
+
+export default function ObservabilityPage() {
+  const { getToken } = useAuth()
+  const [summary, setSummary] = useState<ObservabilitySummary | null>(null)
+  const [agents, setAgents] = useState<AgentStatus[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const load = useCallback(async () => {
+    const token = await getToken()
+    const workspaceId = getCookie("workspaceId") ?? ""
+    const headers: Record<string, string> = { "Content-Type": "application/json" }
+    if (token) headers["Authorization"] = `Bearer ${token}`
+    if (workspaceId) headers["x-workspace-id"] = workspaceId
+
+    const base = process.env.NEXT_PUBLIC_API_URL ?? ""
+    try {
+      const [sumRes, agentsRes] = await Promise.all([
+        fetch(`${base}/observability/summary`, { headers }),
+        fetch(`${base}/observability/agents`, { headers }),
+      ])
+      if (!sumRes.ok || !agentsRes.ok) throw new Error("Failed to load observability data")
+      const [sumData, agentsData] = await Promise.all([sumRes.json(), agentsRes.json()])
+      setSummary(sumData)
+      setAgents(agentsData)
+      setError(null)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Unknown error")
+    } finally {
+      setLoading(false)
+    }
+  }, [getToken])
+
+  useEffect(() => {
+    load()
+    const interval = setInterval(load, 30_000)
+    return () => clearInterval(interval)
+  }, [load])
+
+  const h = summary?.health
+
+  return (
+    <AppShell>
+      <div className="max-w-6xl mx-auto px-6 py-8 space-y-8">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-xl font-semibold text-stone-900">Observability</h1>
+            <p className="text-sm text-stone-500 mt-1">Live health of all agents and runs in this workspace.</p>
+          </div>
+          <button
+            onClick={load}
+            className="text-xs text-stone-500 hover:text-stone-700 border border-stone-200 rounded-lg px-3 py-1.5 hover:bg-stone-50 transition-colors"
+          >
+            Refresh
+          </button>
+        </div>
+
+        {error && (
+          <div className="rounded-lg bg-red-50 border border-red-200 px-4 py-3 text-sm text-red-700">{error}</div>
+        )}
+
+        {/* Health strip */}
+        {loading ? (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 animate-pulse">
+            {[...Array(4)].map((_, i) => (
+              <div key={i} className="bg-stone-100 rounded-xl h-24" />
+            ))}
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            <StatCard
+              label="Active runs"
+              value={h?.active_runs ?? 0}
+              accent={h && h.active_runs > 0 ? "text-blue-700" : undefined}
+            />
+            <StatCard
+              label="Pending approval"
+              value={h?.pending_approvals ?? 0}
+              accent={h && h.pending_approvals > 0 ? "text-amber-600" : undefined}
+            />
+            <StatCard
+              label="Stale workers"
+              value={h?.stale_workers ?? 0}
+              sub="Running >15 min without heartbeat"
+              accent={h && h.stale_workers > 0 ? "text-red-600" : undefined}
+            />
+            <StatCard
+              label="Error rate (24h)"
+              value={h ? `${Math.round(h.error_rate_24h * 100)}%` : "—"}
+              sub={h ? `${h.failed_last_24h} failed / ${h.total_last_24h} total` : undefined}
+              accent={h && h.error_rate_24h > 0.2 ? "text-red-600" : h && h.error_rate_24h > 0.1 ? "text-amber-600" : undefined}
+            />
+          </div>
+        )}
+
+        {/* Agent status grid */}
+        <div>
+          <h2 className="text-sm font-semibold text-stone-700 mb-3">Agent Status</h2>
+          {loading ? (
+            <div className="space-y-2 animate-pulse">
+              {[...Array(4)].map((_, i) => <div key={i} className="bg-stone-100 rounded-xl h-14" />)}
+            </div>
+          ) : agents.length === 0 ? (
+            <div className="rounded-xl border border-stone-200 bg-white px-6 py-10 text-center text-sm text-stone-400">
+              No agents configured yet.{" "}
+              <Link href="/workflows" className="text-indigo-600 hover:underline">Create a workflow</Link> to get started.
+            </div>
+          ) : (
+            <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-stone-100 text-xs text-stone-400 uppercase tracking-wide">
+                    <th className="px-4 py-3 text-left font-medium">Agent</th>
+                    <th className="px-4 py-3 text-left font-medium">Status</th>
+                    <th className="px-4 py-3 text-right font-medium">Active</th>
+                    <th className="px-4 py-3 text-right font-medium">Approvals</th>
+                    <th className="px-4 py-3 text-right font-medium">Success 24h</th>
+                    <th className="px-4 py-3 text-left font-medium">Last run</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {agents.map((a) => (
+                    <tr
+                      key={a.workflow_id}
+                      className="border-b border-stone-100 last:border-0 hover:bg-stone-50 transition-colors cursor-pointer"
+                      onClick={() => window.location.href = `/workflows/${a.workflow_id}`}
+                    >
+                      <td className="px-4 py-3">
+                        <div className="font-medium text-stone-900">{a.name}</div>
+                        {a.playbook_slug && (
+                          <div className="text-[11px] text-stone-400 mt-0.5">{a.playbook_slug}</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <HealthBadge health={a.health} />
+                        {a.stale_runs > 0 && (
+                          <div className="text-[11px] text-red-500 mt-0.5">{a.stale_runs} stale</div>
+                        )}
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={a.active_runs > 0 ? "text-blue-700 font-medium" : "text-stone-400"}>
+                          {a.active_runs}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        <span className={a.pending_approvals > 0 ? "text-amber-600 font-medium" : "text-stone-400"}>
+                          {a.pending_approvals}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-right">
+                        {a.succeeded_24h + a.failed_24h === 0 ? (
+                          <span className="text-stone-300">—</span>
+                        ) : (
+                          <span className={a.success_rate_24h >= 0.8 ? "text-green-700" : "text-red-600"}>
+                            {Math.round(a.success_rate_24h * 100)}%
+                            <span className="text-stone-400 font-normal"> ({a.succeeded_24h}/{a.succeeded_24h + a.failed_24h})</span>
+                          </span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        {a.last_run_at ? (
+                          <div>
+                            <span className="text-stone-600">{timeAgo(a.last_run_at)}</span>
+                            {a.last_run_status && (
+                              <span className={`ml-2 text-[11px] ${a.last_run_status === "succeeded" ? "text-green-600" : a.last_run_status === "failed" ? "text-red-500" : "text-stone-400"}`}>
+                                {a.last_run_status}
+                              </span>
+                            )}
+                          </div>
+                        ) : (
+                          <span className="text-stone-300">Never</span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        {/* Watchdog events */}
+        {summary && summary.recent_events.length > 0 && (
+          <div>
+            <h2 className="text-sm font-semibold text-stone-700 mb-3">Recent Events</h2>
+            <div className="bg-white rounded-xl border border-stone-200 overflow-hidden">
+              {summary.recent_events.map((ev) => (
+                <div key={ev.id} className="flex items-start gap-3 px-4 py-3 border-b border-stone-100 last:border-0">
+                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full shrink-0 mt-0.5 ${SEVERITY_STYLES[ev.severity] ?? "text-stone-500 bg-stone-100"}`}>
+                    {ev.severity}
+                  </span>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-sm text-stone-800">{EVENT_LABELS[ev.event_type] ?? ev.event_type}</div>
+                    {ev.run_id && (
+                      <div className="text-[11px] text-stone-400 mt-0.5 font-mono truncate">run {ev.run_id}</div>
+                    )}
+                  </div>
+                  <div className="text-xs text-stone-400 shrink-0">{timeAgo(ev.created_at)}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -429,6 +429,7 @@ function AppShellInner({ children, noPadding }: { children: React.ReactNode; noP
 
           <div className="pt-2 border-t border-stone-100 mt-2 space-y-0.5">
             <NavItem href="/runs" icon="▶" label="Runs" collapsed={collapsed} pathname={pathname} />
+            <NavItem href="/observability" icon="◉" label="Observability" collapsed={collapsed} pathname={pathname} />
             <NavItem href="/audit" icon="📋" label="Audit Log" collapsed={collapsed} pathname={pathname} />
             <NavItem href="/settings" icon="⚙" label="Settings" collapsed={collapsed} pathname={pathname} />
           </div>


### PR DESCRIPTION
## Summary
- **Migration 0031**: adds `watchdog_events` table and `last_heartbeat_time` column on `runs`
- **API**: two new endpoints under `/observability` — `GET /summary` (health strip) and `GET /agents` (per-agent grid)
- **UI**: new `/observability` page in AppShell with 4-stat health strip + agent status table, auto-refreshes every 30s

## What ships
- Health strip: Active Runs, Pending Approvals, Stale Workers (>15 min locked with no heartbeat), Error Rate 24h
- Agent grid: health badge (healthy / degraded / stale / idle), active/pending counts, 24h success rate, last run
- Watchdog events feed: shows events from the `watchdog_events` table (empty until Phase 2 daemon writes to it)
- "Observability" nav item added between Runs and Audit Log in sidebar

## What's NOT in this PR (Phase 2)
- SSE live-push updates (static poll only for now)
- Watchdog daemon that writes stale/timeout events to `watchdog_events`
- Slack alerts from watchdog

## Test plan
- [ ] Run `alembic upgrade head` — migration applies cleanly
- [ ] `GET /observability/summary` returns health counts
- [ ] `GET /observability/agents` returns list with correct health classification
- [ ] `/observability` page loads, health strip shows correct counts, agent table rows link to workflow
- [ ] Existing runs/dashboard/audit pages unaffected