### PR TITLE
feat: observability phase 2 — watchdog daemon + Slack alerts + SSE live feed

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -70,6 +70,14 @@ class Settings(BaseSettings):
     # Fixture promotion — fallback repo if not derivable from the run's workflow
     github_promotion_repo: str = ""
 
+    # Watchdog — Slack alerts for stale workers and approval timeouts
+    # Leave blank to disable Slack alerting from the watchdog.
+    watchdog_slack_token: str = ""
+    watchdog_slack_channel: str = ""
+    watchdog_stale_minutes: int = 15        # flag run as stale after this many minutes
+    watchdog_approval_timeout_minutes: int = 120  # flag approval as timed-out after this many minutes
+    watchdog_interval_seconds: int = 60     # how often the watchdog scans
+
     # Sentry — leave blank to disable
     sentry_dsn: str = ""
     app_version: str = "1.0.0"

--- a/apps/api/app/routers/observability.py
+++ b/apps/api/app/routers/observability.py
@@ -1,18 +1,24 @@
 """
-GET /observability/summary  — workspace health strip (active runs, stale workers, approvals, error rate)
+GET /observability/summary  — workspace health strip
 GET /observability/agents   — per-agent status grid
+GET /observability/stream   — SSE push of summary snapshots every 10 s
 """
+import asyncio
+import json
 from datetime import datetime, timedelta, timezone
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Request
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
-from sqlalchemy import func, case
+from sqlalchemy import func
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_workspace_id, require_workspace_role
-from app.core.database import get_db
+from app.core.config import settings
+from app.core.database import SessionLocal, get_db
 from app.models.run import Run
 from app.models.watchdog_event import WatchdogEvent
+from app.routers.runs import get_workspace_id_sse, require_workspace_role_sse
 from app.models.workflow import Workflow, WorkflowVersion
 
 router = APIRouter(prefix="/observability", tags=["observability"])
@@ -219,3 +225,97 @@ def get_agents(
         ))
 
     return result
+
+
+# ── SSE live stream ───────────────────────────────────────────────────────────
+
+def _build_summary_payload(workspace_id: str) -> str:
+    """Build a fresh summary snapshot using a short-lived DB session."""
+    db = SessionLocal()
+    try:
+        now = datetime.now(timezone.utc)
+        cutoff_24h = now - timedelta(hours=24)
+        stale_cutoff = now - timedelta(minutes=STALE_THRESHOLD_MINUTES)
+
+        base_q = (
+            db.query(Run)
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+            .filter(Workflow.workspace_id == workspace_id)
+        )
+
+        active_runs = base_q.filter(Run.status == "running").count()
+        pending_approvals = base_q.filter(Run.status == "paused").count()
+        stale_workers = base_q.filter(Run.status == "running", Run.locked_at < stale_cutoff).count()
+
+        last_24h = base_q.filter(Run.created_at >= cutoff_24h).all()
+        succeeded_24h = sum(1 for r in last_24h if r.status == "succeeded")
+        failed_24h = sum(1 for r in last_24h if r.status == "failed")
+        total_24h = len(last_24h)
+
+        events_rows = (
+            db.query(WatchdogEvent)
+            .filter(WatchdogEvent.workspace_id == workspace_id)
+            .order_by(WatchdogEvent.created_at.desc())
+            .limit(20)
+            .all()
+        )
+
+        payload = {
+            "health": {
+                "active_runs": active_runs,
+                "pending_approvals": pending_approvals,
+                "stale_workers": stale_workers,
+                "succeeded_last_24h": succeeded_24h,
+                "failed_last_24h": failed_24h,
+                "total_last_24h": total_24h,
+                "error_rate_24h": round(failed_24h / total_24h, 3) if total_24h else 0.0,
+            },
+            "recent_events": [
+                {
+                    "id": str(e.id),
+                    "event_type": e.event_type,
+                    "severity": e.severity,
+                    "run_id": str(e.run_id) if e.run_id else None,
+                    "workflow_id": str(e.workflow_id) if e.workflow_id else None,
+                    "payload": e.payload or {},
+                    "created_at": e.created_at.isoformat(),
+                }
+                for e in events_rows
+            ],
+        }
+        return json.dumps(payload)
+    finally:
+        db.close()
+
+
+@router.get("/stream")
+async def stream_summary(
+    request: Request,
+    workspace_id: str = Depends(get_workspace_id_sse),
+    _role: str = Depends(require_workspace_role_sse("admin", "editor", "viewer")),
+):
+    """SSE endpoint — pushes a fresh summary snapshot every 10 seconds."""
+    PUSH_INTERVAL = 10  # seconds
+    MAX_DURATION  = 300  # reconnect after 5 min to avoid stale connections
+
+    async def event_generator():
+        deadline = asyncio.get_event_loop().time() + MAX_DURATION
+        while asyncio.get_event_loop().time() < deadline:
+            if await request.is_disconnected():
+                break
+            try:
+                payload = await asyncio.get_event_loop().run_in_executor(
+                    None, _build_summary_payload, workspace_id
+                )
+                yield f"data: {payload}\n\n"
+            except Exception:
+                yield "data: {\"error\": true}\n\n"
+            await asyncio.sleep(PUSH_INTERVAL)
+        yield "data: {\"kind\": \"stream_timeout\"}\n\n"
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/apps/api/app/watchdog.py
+++ b/apps/api/app/watchdog.py
@@ -1,0 +1,213 @@
+"""
+Watchdog daemon — scans for stale workers and approval timeouts, writes
+WatchdogEvent records, and sends Slack alerts when configured.
+
+Runs as a background daemon thread inside the worker process (alongside the
+existing stale-run reaper). The reaper marks runs as failed after 20 min;
+the watchdog flags them as stale at 15 min so the observability dashboard
+shows issues before the reaper hard-kills them.
+
+Slack alerting is opt-in: set WATCHDOG_SLACK_TOKEN + WATCHDOG_SLACK_CHANNEL
+env vars. Both must be set for alerts to fire.
+"""
+import time
+from datetime import datetime, timedelta, timezone
+
+import structlog
+
+from app.core.config import settings
+
+log = structlog.get_logger(__name__)
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _slack_enabled() -> bool:
+    return bool(settings.watchdog_slack_token and settings.watchdog_slack_channel)
+
+
+def _send_slack_alert(event_type: str, run_id: str, workflow_name: str, workspace_id: str, detail: str) -> None:
+    from app.runtime.integrations.slack import post_message
+
+    run_url = f"{settings.app_url}/workflows/{workspace_id}/runs/{run_id}"
+    text = f":warning: *Conduct Watchdog* — {event_type.replace('_', ' ').title()}"
+    blocks = [
+        {
+            "type": "section",
+            "text": {
+                "type": "mrkdwn",
+                "text": (
+                    f":warning: *Watchdog alert: {event_type.replace('_', ' ')}*\n"
+                    f"*Agent:* {workflow_name}\n"
+                    f"{detail}\n"
+                    f"<{run_url}|View run>"
+                ),
+            },
+        }
+    ]
+    try:
+        post_message(
+            token=settings.watchdog_slack_token,
+            channel=settings.watchdog_slack_channel,
+            text=text,
+            blocks=blocks,
+        )
+        log.info("watchdog.slack_sent", event_type=event_type, run_id=run_id)
+    except Exception:
+        log.exception("watchdog.slack_failed", event_type=event_type, run_id=run_id)
+
+
+def _already_emitted(db, run_id, event_type: str, dedup_window_hours: int = 2) -> bool:
+    """Return True if we already wrote this event for this run within the dedup window."""
+    from app.models.watchdog_event import WatchdogEvent
+    from sqlalchemy import and_
+
+    cutoff = _now() - timedelta(hours=dedup_window_hours)
+    return (
+        db.query(WatchdogEvent)
+        .filter(
+            WatchdogEvent.run_id == run_id,
+            WatchdogEvent.event_type == event_type,
+            WatchdogEvent.created_at >= cutoff,
+        )
+        .first()
+    ) is not None
+
+
+def scan(db) -> dict:
+    """
+    Scan the DB for stale workers and approval timeouts.
+    Writes WatchdogEvent rows and sends Slack alerts.
+    Returns counts for logging.
+    """
+    from app.models.run import Run
+    from app.models.watchdog_event import WatchdogEvent
+    from app.models.workflow import Workflow, WorkflowVersion
+
+    now = _now()
+    stale_cutoff = now - timedelta(minutes=settings.watchdog_stale_minutes)
+    approval_cutoff = now - timedelta(minutes=settings.watchdog_approval_timeout_minutes)
+
+    stale_flagged = 0
+    approval_flagged = 0
+
+    # ── Stale workers ──────────────────────────────────────────────────────────
+    stale_runs = (
+        db.query(Run, Workflow.id.label("wf_id"), Workflow.name.label("wf_name"), Workflow.workspace_id.label("ws_id"))
+        .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+        .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+        .filter(
+            Run.status == "running",
+            Run.locked_at.isnot(None),
+            Run.locked_at < stale_cutoff,
+        )
+        .all()
+    )
+
+    for run, wf_id, wf_name, ws_id in stale_runs:
+        if _already_emitted(db, run.id, "stale_worker"):
+            continue
+
+        minutes_stale = int((now - run.locked_at).total_seconds() / 60)
+        event = WatchdogEvent(
+            workspace_id=str(ws_id),
+            run_id=run.id,
+            workflow_id=wf_id,
+            event_type="stale_worker",
+            severity="warning",
+            payload={
+                "minutes_stale": minutes_stale,
+                "locked_by": run.locked_by,
+                "workflow_name": wf_name,
+            },
+        )
+        db.add(event)
+        stale_flagged += 1
+
+        if _slack_enabled():
+            _send_slack_alert(
+                event_type="stale_worker",
+                run_id=str(run.id),
+                workflow_name=wf_name,
+                workspace_id=str(ws_id),
+                detail=f"Run has been stuck for *{minutes_stale} minutes* (worker: {run.locked_by or 'unknown'}).",
+            )
+
+    # ── Approval timeouts ─────────────────────────────────────────────────────
+    approval_runs = (
+        db.query(Run, Workflow.id.label("wf_id"), Workflow.name.label("wf_name"), Workflow.workspace_id.label("ws_id"))
+        .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+        .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+        .filter(
+            Run.status == "paused",
+            Run.paused_at.isnot(None),
+            Run.paused_at < approval_cutoff,
+        )
+        .all()
+    )
+
+    for run, wf_id, wf_name, ws_id in approval_runs:
+        if _already_emitted(db, run.id, "approval_timeout"):
+            continue
+
+        minutes_waiting = int((now - run.paused_at).total_seconds() / 60)
+        event = WatchdogEvent(
+            workspace_id=str(ws_id),
+            run_id=run.id,
+            workflow_id=wf_id,
+            event_type="approval_timeout",
+            severity="warning",
+            payload={
+                "minutes_waiting": minutes_waiting,
+                "workflow_name": wf_name,
+            },
+        )
+        db.add(event)
+        approval_flagged += 1
+
+        if _slack_enabled():
+            _send_slack_alert(
+                event_type="approval_timeout",
+                run_id=str(run.id),
+                workflow_name=wf_name,
+                workspace_id=str(ws_id),
+                detail=f"Approval has been pending for *{minutes_waiting} minutes*.",
+            )
+
+    db.commit()
+    return {"stale_flagged": stale_flagged, "approval_flagged": approval_flagged}
+
+
+def watchdog_loop() -> None:
+    """Daemon thread entry point — runs scan() on a fixed interval."""
+    log.info(
+        "watchdog.started",
+        stale_minutes=settings.watchdog_stale_minutes,
+        approval_timeout_minutes=settings.watchdog_approval_timeout_minutes,
+        interval_seconds=settings.watchdog_interval_seconds,
+        slack_enabled=_slack_enabled(),
+    )
+
+    while True:
+        time.sleep(settings.watchdog_interval_seconds)
+        try:
+            from app.core.database import SessionLocal
+            db = SessionLocal()
+            try:
+                counts = scan(db)
+                if counts["stale_flagged"] or counts["approval_flagged"]:
+                    log.warning("watchdog.issues_detected", **counts)
+                else:
+                    log.debug("watchdog.cycle_clean")
+            except Exception:
+                log.exception("watchdog.scan_error")
+                try:
+                    db.rollback()
+                except Exception:
+                    pass
+            finally:
+                db.close()
+        except Exception:
+            log.exception("watchdog.loop_error")

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -185,9 +185,13 @@ def _loop(thread_id: int) -> None:
 def main() -> None:
     log.info("worker.starting", concurrency=CONCURRENCY, queue=QUEUE_KEY)
 
-    # The reaper and online eval scorer run regardless of worker concurrency mode.
+    # The reaper, watchdog, and online eval scorer run regardless of concurrency.
     reaper = threading.Thread(target=_reaper_loop, daemon=True, name="reaper")
     reaper.start()
+
+    from app.watchdog import watchdog_loop
+    watchdog = threading.Thread(target=watchdog_loop, daemon=True, name="watchdog")
+    watchdog.start()
 
     online_eval = threading.Thread(target=_online_eval_loop, daemon=True, name="online-eval")
     online_eval.start()

--- a/apps/web/src/app/observability/page.tsx
+++ b/apps/web/src/app/observability/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState, useCallback } from "react"
+import { useEffect, useRef, useState, useCallback } from "react"
 import Link from "next/link"
 import { useAuth } from "@clerk/nextjs"
 import AppShell from "@/components/AppShell"
@@ -98,37 +98,76 @@ export default function ObservabilityPage() {
   const [agents, setAgents] = useState<AgentStatus[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [live, setLive] = useState(false)
+  const esRef = useRef<EventSource | null>(null)
 
-  const load = useCallback(async () => {
+  const loadAgents = useCallback(async () => {
     const token = await getToken()
     const workspaceId = getCookie("workspaceId") ?? ""
     const headers: Record<string, string> = { "Content-Type": "application/json" }
     if (token) headers["Authorization"] = `Bearer ${token}`
     if (workspaceId) headers["x-workspace-id"] = workspaceId
-
     const base = process.env.NEXT_PUBLIC_API_URL ?? ""
     try {
-      const [sumRes, agentsRes] = await Promise.all([
-        fetch(`${base}/observability/summary`, { headers }),
-        fetch(`${base}/observability/agents`, { headers }),
-      ])
-      if (!sumRes.ok || !agentsRes.ok) throw new Error("Failed to load observability data")
-      const [sumData, agentsData] = await Promise.all([sumRes.json(), agentsRes.json()])
-      setSummary(sumData)
-      setAgents(agentsData)
-      setError(null)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Unknown error")
-    } finally {
-      setLoading(false)
+      const res = await fetch(`${base}/observability/agents`, { headers })
+      if (!res.ok) throw new Error("Failed to load agent data")
+      setAgents(await res.json())
+    } catch {
+      // non-fatal — agents grid keeps last known state
+    }
+  }, [getToken])
+
+  const connectSSE = useCallback(async () => {
+    const token = await getToken()
+    const workspaceId = getCookie("workspaceId") ?? ""
+    const base = process.env.NEXT_PUBLIC_API_URL ?? ""
+    const params = new URLSearchParams()
+    if (token) params.set("token", token)
+    if (workspaceId) params.set("workspace_id", workspaceId)
+    const url = `${base}/observability/stream?${params.toString()}`
+
+    if (esRef.current) esRef.current.close()
+    const es = new EventSource(url)
+    esRef.current = es
+
+    es.onopen = () => setLive(true)
+    es.onerror = () => {
+      setLive(false)
+      // EventSource auto-reconnects; nothing extra needed
+    }
+    es.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data)
+        if (data.kind === "stream_timeout") {
+          // Server closed — EventSource will reconnect
+          return
+        }
+        if (data.health) {
+          setSummary(data as ObservabilitySummary)
+          setLoading(false)
+          setError(null)
+        }
+      } catch {
+        // malformed frame — ignore
+      }
     }
   }, [getToken])
 
   useEffect(() => {
-    load()
-    const interval = setInterval(load, 30_000)
-    return () => clearInterval(interval)
-  }, [load])
+    connectSSE()
+    loadAgents()
+    // Refresh agent grid every 30s (agents endpoint is not streamed)
+    const agentInterval = setInterval(loadAgents, 30_000)
+    return () => {
+      agentInterval && clearInterval(agentInterval)
+      esRef.current?.close()
+    }
+  }, [connectSSE, loadAgents])
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    await Promise.all([connectSSE(), loadAgents()])
+  }, [connectSSE, loadAgents])
 
   const h = summary?.health
 
@@ -138,10 +177,13 @@ export default function ObservabilityPage() {
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-xl font-semibold text-stone-900">Observability</h1>
-            <p className="text-sm text-stone-500 mt-1">Live health of all agents and runs in this workspace.</p>
+            <p className="text-sm text-stone-500 mt-1">
+              Live health of all agents and runs in this workspace.
+              {live && <span className="ml-2 text-green-600 text-xs">● live</span>}
+            </p>
           </div>
           <button
-            onClick={load}
+            onClick={refresh}
             className="text-xs text-stone-500 hover:text-stone-700 border border-stone-200 rounded-lg px-3 py-1.5 hover:bg-stone-50 transition-colors"
           >
             Refresh


### PR DESCRIPTION
## Summary
- **Watchdog daemon**: new `app/watchdog.py` — scans every 60s for stale workers and approval timeouts, writes `WatchdogEvent` rows with 2h deduplication
- **Slack alerting**: opt-in via `WATCHDOG_SLACK_TOKEN` + `WATCHDOG_SLACK_CHANNEL` env vars; block-kit messages with run link
- **SSE stream**: `GET /observability/stream` pushes fresh summary every 10s; frontend switches from 30s polling to EventSource
- **Worker**: watchdog starts as a daemon thread alongside the existing reaper and online-eval threads

## Config (all optional, tunable via env vars)
| Var | Default | Purpose |
|---|---|---|
| `WATCHDOG_SLACK_TOKEN` | — | Slack bot token for alerts |
| `WATCHDOG_SLACK_CHANNEL` | — | Slack channel (e.g. `#ops-alerts`) |
| `WATCHDOG_STALE_MINUTES` | 15 | Flag run as stale after N minutes |
| `WATCHDOG_APPROVAL_TIMEOUT_MINUTES` | 120 | Flag approval timeout after N minutes |
| `WATCHDOG_INTERVAL_SECONDS` | 60 | Watchdog scan interval |

## What's NOT in this PR (Phase 3 — blocked on #152 + #119)
- Cost panel (blocked on RunTrace schema changes in #152)
- Watchdog YAML playbook (blocked on #119)

## Test plan
- [ ] Worker starts without errors; logs show `watchdog.started`
- [ ] Create a run, set `locked_at` to >15 min ago — watchdog writes a `stale_worker` event on next cycle
- [ ] `GET /observability/stream` returns `text/event-stream` with JSON snapshots every 10s
- [ ] Observability page shows "● live" indicator when SSE connected
- [ ] With WATCHDOG_SLACK_TOKEN + WATCHDOG_SLACK_CHANNEL set, Slack message appears on detection
- [ ] Duplicate events not created if watchdog cycles multiple times for same stale run