### PR TITLE
fix: auth UUID guard + watchdog per-workspace Slack config

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -206,6 +206,9 @@ def get_user_id(
 
 def _assert_workspace_member(db: Session, workspace_id: str, user_id: str) -> None:
     """Raises 403 if user is not a member of the workspace (checks both join table and legacy owner_id)."""
+    import re as _re
+    if not _re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", workspace_id, _re.I):
+        raise HTTPException(status_code=403, detail="Invalid workspace ID — please select a workspace")
     from sqlalchemy import text
     row = db.execute(
         text("""
@@ -278,9 +281,9 @@ def get_workspace_id(
         _assert_workspace_member(db, x_workspace_id, user_id)
         return x_workspace_id
 
-    workspace_id = claims.get("org_id") or claims.get("sub")
+    workspace_id = claims.get("org_id")
     if not workspace_id:
-        raise HTTPException(status_code=401, detail="No workspace in token claims")
+        raise HTTPException(status_code=403, detail="No organization selected — please join or create a workspace")
 
     return workspace_id
 
@@ -296,6 +299,13 @@ def get_user_workspace_role(
     """
     if not _clerk_enabled():
         return "admin"
+
+    # workspace_id must be a valid UUID — Clerk user_ids (user_xxx) are not.
+    # This happens when the client cookie holds a personal Clerk ID instead of an org UUID.
+    import re as _re
+    _UUID_RE = _re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", _re.I)
+    if not _UUID_RE.match(workspace_id):
+        raise HTTPException(status_code=403, detail="Invalid workspace ID — please select a workspace")
 
     from sqlalchemy import text
     row = db.execute(

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -70,13 +70,12 @@ class Settings(BaseSettings):
     # Fixture promotion — fallback repo if not derivable from the run's workflow
     github_promotion_repo: str = ""
 
-    # Watchdog — Slack alerts for stale workers and approval timeouts
-    # Leave blank to disable Slack alerting from the watchdog.
-    watchdog_slack_token: str = ""
-    watchdog_slack_channel: str = ""
-    watchdog_stale_minutes: int = 15        # flag run as stale after this many minutes
-    watchdog_approval_timeout_minutes: int = 120  # flag approval as timed-out after this many minutes
-    watchdog_interval_seconds: int = 60     # how often the watchdog scans
+    # Watchdog — tunable thresholds
+    # Slack alerts are per-workspace: token from the workspace's Slack integration,
+    # channel from workspace.preferences["watchdog_channel"].
+    watchdog_stale_minutes: int = 15
+    watchdog_approval_timeout_minutes: int = 120
+    watchdog_interval_seconds: int = 60
 
     # Sentry — leave blank to disable
     sentry_dsn: str = ""

--- a/apps/api/app/routers/workspace_projects.py
+++ b/apps/api/app/routers/workspace_projects.py
@@ -250,12 +250,14 @@ def list_audit_log(
 _PREFERENCE_DEFAULTS = {
     "show_dry_run": False,
     "show_test_trigger": True,
+    "watchdog_channel": "",
 }
 
 
 class PreferencesUpdate(BaseModel):
     show_dry_run: bool | None = None
     show_test_trigger: bool | None = None
+    watchdog_channel: str | None = None  # Slack channel for watchdog alerts (e.g. #ops-alerts)
 
 
 @preferences_router.get("")

--- a/apps/api/app/watchdog.py
+++ b/apps/api/app/watchdog.py
@@ -2,13 +2,12 @@
 Watchdog daemon — scans for stale workers and approval timeouts, writes
 WatchdogEvent records, and sends Slack alerts when configured.
 
-Runs as a background daemon thread inside the worker process (alongside the
-existing stale-run reaper). The reaper marks runs as failed after 20 min;
-the watchdog flags them as stale at 15 min so the observability dashboard
-shows issues before the reaper hard-kills them.
+Slack config is per-workspace:
+  - Token:   the workspace's Slack integration (handle='slack', service='slack')
+             decrypted via app.core.crypto.decrypt
+  - Channel: workspace.preferences["watchdog_channel"]
 
-Slack alerting is opt-in: set WATCHDOG_SLACK_TOKEN + WATCHDOG_SLACK_CHANNEL
-env vars. Both must be set for alerts to fire.
+Both must be present for a workspace to receive Slack alerts.
 """
 import time
 from datetime import datetime, timedelta, timezone
@@ -24,15 +23,49 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _slack_enabled() -> bool:
-    return bool(settings.watchdog_slack_token and settings.watchdog_slack_channel)
+def _get_slack_config(db, workspace_id: str) -> tuple[str, str] | None:
+    """
+    Return (token, channel) for the workspace's Slack integration, or None
+    if either the integration or the watchdog_channel preference is missing.
+    """
+    from app.core.crypto import decrypt
+    from app.models.integration import Integration
+    from app.models.workspace import Workspace
+
+    row = (
+        db.query(Integration)
+        .filter(
+            Integration.workspace_id == workspace_id,
+            Integration.service == "slack",
+            Integration.encrypted_credentials.isnot(None),
+        )
+        .first()
+    )
+    if not row:
+        return None
+
+    try:
+        creds = decrypt(row.encrypted_credentials)
+    except Exception:
+        return None
+
+    token = creds.get("token") or creds.get("bot_token") or ""
+    if not token:
+        return None
+
+    ws = db.query(Workspace).filter(Workspace.id == workspace_id).first()
+    channel = (ws.preferences or {}).get("watchdog_channel", "") if ws else ""
+    if not channel:
+        return None
+
+    return token, channel
 
 
-def _send_slack_alert(event_type: str, run_id: str, workflow_name: str, workspace_id: str, detail: str) -> None:
+def _send_slack_alert(token: str, channel: str, event_type: str, run_id: str, workflow_name: str, workspace_id: str, detail: str) -> None:
     from app.runtime.integrations.slack import post_message
 
     run_url = f"{settings.app_url}/workflows/{workspace_id}/runs/{run_id}"
-    text = f":warning: *Conduct Watchdog* — {event_type.replace('_', ' ').title()}"
+    text = f":warning: Conduct Watchdog — {event_type.replace('_', ' ').title()}"
     blocks = [
         {
             "type": "section",
@@ -48,21 +81,14 @@ def _send_slack_alert(event_type: str, run_id: str, workflow_name: str, workspac
         }
     ]
     try:
-        post_message(
-            token=settings.watchdog_slack_token,
-            channel=settings.watchdog_slack_channel,
-            text=text,
-            blocks=blocks,
-        )
+        post_message(token=token, channel=channel, text=text, blocks=blocks)
         log.info("watchdog.slack_sent", event_type=event_type, run_id=run_id)
     except Exception:
         log.exception("watchdog.slack_failed", event_type=event_type, run_id=run_id)
 
 
 def _already_emitted(db, run_id, event_type: str, dedup_window_hours: int = 2) -> bool:
-    """Return True if we already wrote this event for this run within the dedup window."""
     from app.models.watchdog_event import WatchdogEvent
-    from sqlalchemy import and_
 
     cutoff = _now() - timedelta(hours=dedup_window_hours)
     return (
@@ -79,7 +105,7 @@ def _already_emitted(db, run_id, event_type: str, dedup_window_hours: int = 2) -
 def scan(db) -> dict:
     """
     Scan the DB for stale workers and approval timeouts.
-    Writes WatchdogEvent rows and sends Slack alerts.
+    Writes WatchdogEvent rows and sends per-workspace Slack alerts.
     Returns counts for logging.
     """
     from app.models.run import Run
@@ -89,6 +115,14 @@ def scan(db) -> dict:
     now = _now()
     stale_cutoff = now - timedelta(minutes=settings.watchdog_stale_minutes)
     approval_cutoff = now - timedelta(minutes=settings.watchdog_approval_timeout_minutes)
+
+    # Cache per-workspace Slack config so we only decrypt once per scan cycle
+    _slack_cache: dict[str, tuple[str, str] | None] = {}
+
+    def slack_for(workspace_id: str) -> tuple[str, str] | None:
+        if workspace_id not in _slack_cache:
+            _slack_cache[workspace_id] = _get_slack_config(db, workspace_id)
+        return _slack_cache[workspace_id]
 
     stale_flagged = 0
     approval_flagged = 0
@@ -111,27 +145,22 @@ def scan(db) -> dict:
             continue
 
         minutes_stale = int((now - run.locked_at).total_seconds() / 60)
-        event = WatchdogEvent(
+        db.add(WatchdogEvent(
             workspace_id=str(ws_id),
             run_id=run.id,
             workflow_id=wf_id,
             event_type="stale_worker",
             severity="warning",
-            payload={
-                "minutes_stale": minutes_stale,
-                "locked_by": run.locked_by,
-                "workflow_name": wf_name,
-            },
-        )
-        db.add(event)
+            payload={"minutes_stale": minutes_stale, "locked_by": run.locked_by, "workflow_name": wf_name},
+        ))
         stale_flagged += 1
 
-        if _slack_enabled():
+        slack = slack_for(str(ws_id))
+        if slack:
             _send_slack_alert(
-                event_type="stale_worker",
-                run_id=str(run.id),
-                workflow_name=wf_name,
-                workspace_id=str(ws_id),
+                token=slack[0], channel=slack[1],
+                event_type="stale_worker", run_id=str(run.id),
+                workflow_name=wf_name, workspace_id=str(ws_id),
                 detail=f"Run has been stuck for *{minutes_stale} minutes* (worker: {run.locked_by or 'unknown'}).",
             )
 
@@ -153,26 +182,22 @@ def scan(db) -> dict:
             continue
 
         minutes_waiting = int((now - run.paused_at).total_seconds() / 60)
-        event = WatchdogEvent(
+        db.add(WatchdogEvent(
             workspace_id=str(ws_id),
             run_id=run.id,
             workflow_id=wf_id,
             event_type="approval_timeout",
             severity="warning",
-            payload={
-                "minutes_waiting": minutes_waiting,
-                "workflow_name": wf_name,
-            },
-        )
-        db.add(event)
+            payload={"minutes_waiting": minutes_waiting, "workflow_name": wf_name},
+        ))
         approval_flagged += 1
 
-        if _slack_enabled():
+        slack = slack_for(str(ws_id))
+        if slack:
             _send_slack_alert(
-                event_type="approval_timeout",
-                run_id=str(run.id),
-                workflow_name=wf_name,
-                workspace_id=str(ws_id),
+                token=slack[0], channel=slack[1],
+                event_type="approval_timeout", run_id=str(run.id),
+                workflow_name=wf_name, workspace_id=str(ws_id),
                 detail=f"Approval has been pending for *{minutes_waiting} minutes*.",
             )
 
@@ -181,13 +206,11 @@ def scan(db) -> dict:
 
 
 def watchdog_loop() -> None:
-    """Daemon thread entry point — runs scan() on a fixed interval."""
     log.info(
         "watchdog.started",
         stale_minutes=settings.watchdog_stale_minutes,
         approval_timeout_minutes=settings.watchdog_approval_timeout_minutes,
         interval_seconds=settings.watchdog_interval_seconds,
-        slack_enabled=_slack_enabled(),
     )
 
     while True:


### PR DESCRIPTION
## Summary
- **Auth 500 fix**: `workspace_id` from cookie was a Clerk user_id string (`user_xxx`) instead of a UUID, causing `DataError: invalid input syntax for type uuid` in three places. Now all three auth functions reject non-UUID workspace IDs with a clean 403 before hitting PostgreSQL
- **Watchdog Slack config**: moved from server-level env vars (`WATCHDOG_SLACK_TOKEN` / `WATCHDOG_SLACK_CHANNEL`) to per-workspace: token from the workspace's existing Slack integration, channel from `workspace.preferences["watchdog_channel"]`

## Root cause (production 500s on /observability/\*)
Users without a Clerk org have `workspaceId` cookie set to their personal Clerk user_id. Frontend sends this as `x-workspace-id` header. PostgreSQL rejects it when cast to UUID.

Fix: UUID regex check in `_assert_workspace_member`, `get_workspace_id`, and `get_user_workspace_role` — returns 403 instead of 500.

## Test plan
- [ ] User with no org gets 403 "Invalid workspace ID" (not 500) on any authenticated endpoint
- [ ] Observability page loads correctly for users with a valid workspace UUID
- [ ] Watchdog Slack alerts fire when workspace has Slack integration + `watchdog_channel` preference set