### PR TITLE
feat: conduct-mcp, Guard tool coverage, run detail polish, UX gap backfill

### DIFF
--- a/apps/api/alembic/versions/0056_guard_developer_tools_table.py
+++ b/apps/api/alembic/versions/0056_guard_developer_tools_table.py
@@ -1,0 +1,36 @@
+"""guard: add guard_developer_tools table for per-developer AI tool coverage tracking
+
+Revision ID: 0056
+Revises: 0055
+Create Date: 2026-06-04
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0056"
+down_revision = "0055"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.execute("""
+        CREATE TABLE IF NOT EXISTS guard_developer_tools (
+            id              SERIAL PRIMARY KEY,
+            workspace_id    TEXT NOT NULL,
+            user_email      TEXT NOT NULL,
+            detected_tools  JSONB NOT NULL DEFAULT '[]',
+            mcp_registered  JSONB NOT NULL DEFAULT '[]',
+            hook_registered JSONB NOT NULL DEFAULT '[]',
+            reported_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            CONSTRAINT uq_guard_dev_tools UNIQUE (workspace_id, user_email)
+        )
+    """)
+    op.execute("""
+        CREATE INDEX IF NOT EXISTS ix_guard_developer_tools_workspace_id
+        ON guard_developer_tools (workspace_id)
+    """)
+
+
+def downgrade():
+    op.execute("ALTER TABLE IF EXISTS guard_developer_tools RENAME TO guard_developer_tools_removed_0056")

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -67,6 +67,18 @@ class Settings(BaseSettings):
     openai_api_key: str = ""   # text-embedding-3-small (1536d)
     voyage_api_key: str = ""   # voyage-3-lite (512d) — future
 
+    # Pricing registry overrides (optional).
+    # MODEL_PRICING_OVERRIDES_JSON format:
+    # {
+    #   "version": "2026-06-10",
+    #   "providers": {
+    #     "anthropic": {"claude-sonnet-4-6": {"input": 3.0, "output": 15.0, "cache_read": 0.3, "cache_write": 3.75}},
+    #     "openai": {"gpt-4.1-mini": {"input": 0.4, "output": 1.6}}
+    #   }
+    # }
+    pricing_registry_version: str = "2026-06-04-default"
+    pricing_overrides_json: str = ""
+
     # Fixture promotion — fallback repo if not derivable from the run's workflow
     github_promotion_repo: str = ""
 

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -15,6 +15,7 @@ from app.modules.guard.routers import policies as guard_policies
 from app.modules.guard.routers import events as guard_events
 from app.modules.guard.routers import spend as guard_spend
 from app.modules.guard.routers import savings as guard_savings
+from app.modules.guard.routers import developer_tools as guard_developer_tools
 from app.routers.organizations import router as organizations_router
 from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router, notifications_router, project_direct_router
 from app.routers.runs import workspace_runs_router
@@ -92,6 +93,7 @@ app.include_router(guard_policies.router)
 app.include_router(guard_events.router)
 app.include_router(guard_spend.router)
 app.include_router(guard_savings.router)
+app.include_router(guard_developer_tools.router)
 app.include_router(rbac_router)
 app.include_router(me_rbac_router)
 app.include_router(mcp_router)

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -1,8 +1,8 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text, func
-from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Integer, String, Text, UniqueConstraint, func
+from sqlalchemy.dialects.postgresql import JSON, UUID
 
 from app.core.database import Base
 
@@ -135,6 +135,23 @@ class GuardSavings(Base):
     period_start = Column(DateTime(timezone=True), nullable=True)
     period_end = Column(DateTime(timezone=True), nullable=False)
     recorded_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+
+class GuardDeveloperTools(Base):
+    """Per-developer AI tool coverage snapshot, pushed by conduct login / guard sync."""
+    __tablename__ = "guard_developer_tools"
+
+    id = Column(Integer, primary_key=True)
+    workspace_id = Column(String, nullable=False, index=True)
+    user_email = Column(String, nullable=False)
+    detected_tools = Column(JSON, nullable=False, default=list)   # ["claude-code", "vscode", ...]
+    mcp_registered = Column(JSON, nullable=False, default=list)   # tools where conduct-mcp is wired
+    hook_registered = Column(JSON, nullable=False, default=list)  # tools where Guard hook is wired
+    reported_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "user_email", name="uq_guard_dev_tools"),
+    )
 
 
 class GuardSpendBudget(Base):

--- a/apps/api/app/modules/guard/routers/developer_tools.py
+++ b/apps/api/app/modules/guard/routers/developer_tools.py
@@ -1,0 +1,91 @@
+"""
+POST /guard/developer-tools  — CLI pushes tool coverage snapshot
+GET  /guard/developer-tools  — dashboard reads per-developer coverage
+"""
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+from app.core.auth import get_guard_org_id
+from app.core.database import get_db
+from app.modules.guard.models import GuardDeveloperTools
+
+router = APIRouter(prefix="/guard/developer-tools", tags=["guard"])
+
+
+class ToolEntry(BaseModel):
+    name: str
+    mcp_registered: bool = False
+    hook_registered: bool = False
+
+
+class DeveloperToolsIn(BaseModel):
+    email: str
+    tools: list[ToolEntry]
+
+
+class DeveloperToolsOut(BaseModel):
+    email: str
+    detected_tools: list[str]
+    mcp_registered: list[str]
+    hook_registered: list[str]
+    reported_at: datetime
+
+
+@router.post("", status_code=204)
+def report_developer_tools(
+    body: DeveloperToolsIn,
+    workspace_id: str = Depends(get_guard_org_id),
+    db: Session = Depends(get_db),
+):
+    """CLI pushes AI tool coverage snapshot for a developer (upsert by workspace + email)."""
+    detected = [t.name for t in body.tools]
+    mcp_reg  = [t.name for t in body.tools if t.mcp_registered]
+    hook_reg = [t.name for t in body.tools if t.hook_registered]
+
+    stmt = pg_insert(GuardDeveloperTools).values(
+        workspace_id=workspace_id,
+        user_email=body.email,
+        detected_tools=detected,
+        mcp_registered=mcp_reg,
+        hook_registered=hook_reg,
+        reported_at=datetime.now(timezone.utc),
+    ).on_conflict_do_update(
+        constraint="uq_guard_dev_tools",
+        set_=dict(
+            detected_tools=detected,
+            mcp_registered=mcp_reg,
+            hook_registered=hook_reg,
+            reported_at=datetime.now(timezone.utc),
+        ),
+    )
+    db.execute(stmt)
+    db.commit()
+
+
+@router.get("", response_model=list[DeveloperToolsOut])
+def get_developer_tools(
+    workspace_id: str = Depends(get_guard_org_id),
+    db: Session = Depends(get_db),
+):
+    """Return the latest tool coverage snapshot for every developer in the workspace."""
+    rows = (
+        db.query(GuardDeveloperTools)
+        .filter(GuardDeveloperTools.workspace_id == workspace_id)
+        .order_by(GuardDeveloperTools.reported_at.desc())
+        .all()
+    )
+    return [
+        DeveloperToolsOut(
+            email=row.user_email,
+            detected_tools=row.detected_tools or [],
+            mcp_registered=row.mcp_registered or [],
+            hook_registered=row.hook_registered or [],
+            reported_at=row.reported_at,
+        )
+        for row in rows
+    ]

--- a/apps/api/app/modules/guard/routers/spend.py
+++ b/apps/api/app/modules/guard/routers/spend.py
@@ -16,7 +16,7 @@ from sqlalchemy.orm import Session
 from fastapi import HTTPException
 from app.core.auth import get_workspace_id
 from app.core.database import get_db
-from app.modules.guard.models import GuardAuditEvent, GuardConfig, GuardSession, GuardSpendBudget
+from app.modules.guard.models import GuardAuditEvent, GuardConfig, GuardDeveloperTools, GuardSession, GuardSpendBudget
 
 router = APIRouter(prefix="/guard/spend", tags=["guard"])
 
@@ -55,6 +55,9 @@ class DeveloperSpend(BaseModel):
     cost_usd: float
     saved_usd: float
     sessions: int
+    detected_tools: list[str] = []
+    mcp_registered: list[str] = []
+    hook_registered: list[str] = []
 
 
 class ToolSpend(BaseModel):
@@ -214,6 +217,16 @@ def _get_spend_summary_inner(db: Session, workspace_id: str, month: str | None) 
         if email:
             session_counts[email] = cnt
 
+    # Tool coverage per developer (latest snapshot, keyed by email)
+    tool_coverage: dict[str, GuardDeveloperTools] = {}
+    coverage_rows = (
+        db.query(GuardDeveloperTools)
+        .filter(GuardDeveloperTools.workspace_id == workspace_id)
+        .all()
+    )
+    for tc in coverage_rows:
+        tool_coverage[tc.user_email] = tc
+
     by_developer = [
         DeveloperSpend(
             email=row.user_email,
@@ -221,6 +234,9 @@ def _get_spend_summary_inner(db: Session, workspace_id: str, month: str | None) 
             cost_usd=round(float(row.cost_usd), 6),
             saved_usd=round(float(row.saved_usd), 6),
             sessions=session_counts.get(row.user_email, 0),
+            detected_tools=tool_coverage[row.user_email].detected_tools or [] if row.user_email in tool_coverage else [],
+            mcp_registered=tool_coverage[row.user_email].mcp_registered or [] if row.user_email in tool_coverage else [],
+            hook_registered=tool_coverage[row.user_email].hook_registered or [] if row.user_email in tool_coverage else [],
         )
         for row in dev_rows
     ]

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -23,6 +23,7 @@ from app.models.run import Run, RunEvent
 from app.models.workflow import Workflow, WorkflowVersion
 from app.models.project import Project
 from app.schemas.run import RunCreate, RunDetailOut, RunOut, RunWithWorkflowOut
+from app.runtime.input_contract import InputContractError, validate_run_start_inputs
 
 router = APIRouter(prefix="/workflows/{workflow_id}/runs", tags=["runs"])
 
@@ -209,6 +210,11 @@ def create_run(
     initial_state = body.initial_state or {}
     if body.dry_run:
         initial_state["__dry_run"] = True
+
+    try:
+        initial_state = validate_run_start_inputs(initial_state)
+    except InputContractError as err:
+        raise HTTPException(status_code=422, detail=str(err))
 
     # If the caller didn't provide an explicit turn budget, estimate it server-side
     # so CLI and API callers get the same guard as the canvas preflight banner.

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -24,6 +24,7 @@ from app.core.database import get_db
 from app.models.project import Project
 from app.models.run import Run, RunEvent
 from app.models.workflow import Workflow, WorkflowVersion
+from app.runtime.input_contract import InputContractError, validate_run_start_inputs
 
 log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/webhooks", tags=["webhooks"])
@@ -328,6 +329,11 @@ async def inbound_webhook(
         "__triggered_by": "webhook:inbound",
         "__max_turns": suggested_turns,
     }
+    try:
+        initial_state = validate_run_start_inputs(initial_state)
+    except InputContractError as err:
+        raise HTTPException(status_code=422, detail=str(err))
+
     run = Run(
         workflow_version_id=version.id,
         triggered_by="webhook:inbound",
@@ -769,11 +775,18 @@ def _trigger_github_workflows(
         if not matched:
             continue
 
+        run_state = {**initial_state, "__triggered_by": f"github:{event_type}"}
+        try:
+            run_state = validate_run_start_inputs(run_state)
+        except InputContractError as err:
+            log.warning("github.input_contract_failed", event_type=event_type, error=str(err))
+            continue
+
         run = Run(
             workflow_version_id=version.id,
             triggered_by=f"github:{event_type}",
             status="pending",
-            state={**initial_state, "__triggered_by": f"github:{event_type}"},
+            state=run_state,
         )
         db.add(run)
         queued_runs.append(run)
@@ -891,11 +904,20 @@ async def github_webhook_by_slug(
     except Exception:
         suggested_turns = 20
 
+    try:
+        run_state = validate_run_start_inputs({
+            **initial_state,
+            "__triggered_by": "github:github_issue",
+            "__max_turns": suggested_turns,
+        })
+    except InputContractError as err:
+        raise HTTPException(status_code=422, detail=str(err))
+
     run = Run(
         workflow_version_id=version.id,
         triggered_by=f"github:github_issue:{normalized['label']}",
         status="pending",
-        state={**initial_state, "__triggered_by": "github:github_issue", "__max_turns": suggested_turns},
+        state=run_state,
         max_turns=suggested_turns,
     )
     db.add(run)

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -27,6 +27,7 @@ from app.compiler.compiler import compile_workflow
 from app.compiler.stream import stream_compile_block
 from app.runtime.model_router import resolve as resolve_model
 from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates, pricing_note
+from app.runtime.input_contract import InputContractError, validate_run_start_inputs
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 
@@ -1744,6 +1745,11 @@ def test_trigger(
     else:
         # Non-GitHub trigger — keep raw payload as _trigger
         _initial_state["_trigger"] = payload
+
+    try:
+        _initial_state = validate_run_start_inputs(_initial_state)
+    except InputContractError as err:
+        raise HTTPException(status_code=422, detail=str(err))
 
     run = Run(
         workflow_version_id=version.id,

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -25,6 +25,8 @@ from app.models.workflow import Workflow, WorkflowVersion
 from app.schemas.workflow import WorkflowCreate, WorkflowUpdate, WorkflowOut, WorkflowDetailOut
 from app.compiler.compiler import compile_workflow
 from app.compiler.stream import stream_compile_block
+from app.runtime.model_router import resolve as resolve_model
+from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates, pricing_note
 
 router = APIRouter(prefix="/workflows", tags=["workflows"])
 
@@ -1172,7 +1174,7 @@ def estimate_workflow_cost(
     Estimate token usage and cost for this workflow.
     Uses actual historical run data when available; falls back to static estimates.
     ?issues=N multiplies cost by number of matching GitHub issues.
-    Pricing: Claude Sonnet 4.6 — $3/1M input, $15/1M output.
+    Pricing is resolved from the runtime pricing registry.
     """
     workflow = db.query(Workflow).filter(
         Workflow.id == workflow_id,
@@ -1191,10 +1193,8 @@ def estimate_workflow_cost(
     artifacts = version.compiled_artifacts or {}
     nodes     = graph.get("nodes", [])
 
-    # Pricing constants (Claude Sonnet 4.6)
-    INPUT_PRICE_PER_TOKEN  = 3.00  / 1_000_000
-    OUTPUT_PRICE_PER_TOKEN = 15.00 / 1_000_000
     CHARS_PER_TOKEN        = 4
+    pricing_snapshot = freeze_pricing_snapshot()
 
     # ── Pull historical actuals from past succeeded runs ──────────────────────
     # RunEvent.payload shape for block_completed:
@@ -1240,6 +1240,8 @@ def estimate_workflow_cost(
     total_input_tokens  = 0
     total_output_tokens = 0
     integrations_used: set[str] = set()
+    llm_models_used: set[str] = set()
+    llm_pricing_note: str | None = None
     has_actuals = False
 
     for node in nodes:
@@ -1301,7 +1303,23 @@ def estimate_workflow_cost(
             output_tokens = 200
             note = ""
 
-        cost = (input_tokens * INPUT_PRICE_PER_TOKEN) + (output_tokens * OUTPUT_PRICE_PER_TOKEN)
+        provider = None
+        model = None
+        rates = None
+        if mode in ("agentic", "brain", "logic"):
+            routing_pref = data.get("routingPreference") or "balanced"
+            explicit_model = data.get("model") or None
+            explicit_provider = data.get("provider") or None
+            provider, model, _ = resolve_model(workflow.playbook_slug, routing_pref, explicit_model, explicit_provider)
+            rates, pricing_version = get_model_rates(provider, model, pricing_snapshot)
+            llm_models_used.add(f"{provider}:{model}")
+            if llm_pricing_note is None:
+                llm_pricing_note = pricing_note(provider, model, rates, pricing_version)
+
+        if rates:
+            cost = (input_tokens * rates["input"] + output_tokens * rates["output"]) / 1_000_000
+        else:
+            cost = 0.0
 
         blocks.append({
             "block_id":      nid,
@@ -1309,6 +1327,8 @@ def estimate_workflow_cost(
             "type":          btype,
             "mode":          mode,
             "integration":   integration,
+            "provider":      provider,
+            "model":         model,
             "input_tokens":  input_tokens,
             "output_tokens": output_tokens,
             "cost_usd":      round(cost, 6),
@@ -1318,7 +1338,8 @@ def estimate_workflow_cost(
         total_input_tokens  += input_tokens
         total_output_tokens += output_tokens
 
-    per_run_cost = (total_input_tokens * INPUT_PRICE_PER_TOKEN) + (total_output_tokens * OUTPUT_PRICE_PER_TOKEN)
+    # Sum from block-level costs so multi-model/provider workflows estimate correctly.
+    per_run_cost = sum(float(b.get("cost_usd", 0.0) or 0.0) for b in blocks)
     issues       = max(1, issues)
     total_cost   = per_run_cost * issues
 
@@ -1333,8 +1354,10 @@ def estimate_workflow_cost(
         "issues_count":         issues,
         "total_cost_usd":       round(total_cost, 4),
         "integrations_used":    sorted(integrations_used),
-        "model":                "claude-sonnet-4-6",
-        "pricing_note":         "$3/1M input · $15/1M output",
+        "model":                sorted(llm_models_used)[0] if llm_models_used else None,
+        "models_used":          sorted(llm_models_used),
+        "pricing_version":      pricing_snapshot.get("version"),
+        "pricing_note":         llm_pricing_note or "No LLM-cost blocks in this workflow",
         "based_on_actuals":     has_actuals,
     }
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -414,6 +414,11 @@ def _classify_failure(exc: Exception, block_id: str | None = None) -> dict[str, 
         category = "reliability"
         stop_reason = "max_turns_reached"
         next_action = "Tighten the task scope or increase the run turn budget for this workflow."
+    elif isinstance(exc, RuntimeError) and "Cost budget exhausted" in msg:
+        code = "COST_BUDGET_EXHAUSTED"
+        category = "reliability"
+        stop_reason = "max_cost_reached"
+        next_action = "Reduce task scope or raise the cost cap for this workflow run."
     elif isinstance(exc, ValueError) and msg.startswith("NEEDS_CLARIFICATION:"):
         code = "INSUFFICIENT_INPUT_CONTEXT"
         category = "input_contract"
@@ -878,10 +883,13 @@ def _execute_brain(
     pricing_rates, pricing_version = get_model_rates(provider, model_id, pricing_snapshot)
 
     if is_agentic:
-        # Bounded agentic loop — max_turns from run state, default 20
+        # Bounded agentic loop — deterministic retry boundaries from run state
         messages: list[dict] = [{"role": "user", "content": user_message}]
         turns = 0
         max_turns = int(state.get("__max_turns", 20))
+        max_turns = max(1, max_turns)
+        max_cost_usd = float(state.get("__max_cost_usd", 5.0) or 5.0)
+        max_cost_usd = max(0.01, max_cost_usd)
         total_input_tokens = 0
         total_output_tokens = 0
         total_cache_read_tokens = 0
@@ -911,6 +919,35 @@ def _execute_brain(
             total_cache_read_tokens  += response.usage.cache_read_tokens
             total_cache_write_tokens += response.usage.cache_write_tokens
             total_cost_usd           += response.cost_usd
+
+            if total_cost_usd >= max_cost_usd:
+                cost_usd = round(total_cost_usd, 6)
+                files_changed, diff_stat = session.capture_artifacts()
+                if db and run_id:
+                    _emit(db, run_id, block_id, "brain_budget_exhausted", {
+                        "reason": "max_cost_reached",
+                        "stop_reason": "max_cost_reached",
+                        "turns": turns,
+                        "max_turns": max_turns,
+                        "max_cost_usd": max_cost_usd,
+                        "input_tokens": total_input_tokens,
+                        "output_tokens": total_output_tokens,
+                        "cache_read_tokens": total_cache_read_tokens,
+                        "cache_write_tokens": total_cache_write_tokens,
+                        "cost_usd": cost_usd,
+                        "files_changed": files_changed,
+                        "diff_stat": diff_stat,
+                        "provider": provider,
+                        "model": model_id,
+                        "pricing_version": pricing_version,
+                        "pricing_rates": pricing_rates,
+                        "next_action": "Reduce scope or raise max_cost_usd before retrying.",
+                    })
+                _close_session()
+                raise RuntimeError(
+                    f"Cost budget exhausted: agent reached ${cost_usd:.4f} with cap ${max_cost_usd:.4f} "
+                    f"after {turns} turns"
+                )
 
             # Collect tool calls from response
             tool_calls  = [b for b in response.content if isinstance(b, LLMToolUseBlock)]
@@ -1034,7 +1071,11 @@ def _execute_brain(
                     "turn": max_turns,
                 })
             _emit(db, run_id, block_id, "brain_budget_exhausted", {
+                "reason": "max_turns_reached",
+                "stop_reason": "max_turns_reached",
                 "turns": max_turns,
+                "max_turns": max_turns,
+                "max_cost_usd": max_cost_usd,
                 "input_tokens": total_input_tokens,
                 "output_tokens": total_output_tokens,
                 "cache_read_tokens": total_cache_read_tokens,
@@ -1046,6 +1087,7 @@ def _execute_brain(
                 "model": model_id,
                 "pricing_version": pricing_version,
                 "pricing_rates": pricing_rates,
+                "next_action": "Reduce scope or increase max_turns before retrying.",
             })
         _close_session()
         raise RuntimeError(

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -395,6 +395,46 @@ class ApprovalRequired(Exception):
         super().__init__(message)
 
 
+def _classify_failure(exc: Exception, block_id: str | None = None) -> dict[str, Any]:
+    """Normalize runtime failures into a structured, user-actionable summary."""
+    msg = str(exc)
+
+    code = "EXECUTION_ERROR"
+    category = "runtime"
+    stop_reason = "exception"
+    next_action = "Inspect the failed block output and rerun after fixing the underlying error."
+
+    if isinstance(exc, PermissionError):
+        code = "EGRESS_POLICY_BLOCKED"
+        category = "governance"
+        stop_reason = "policy_block"
+        next_action = "Update allowed_hosts for this environment or remove the blocked outbound call."
+    elif isinstance(exc, RuntimeError) and "Turn budget exhausted" in msg:
+        code = "RETRY_BUDGET_EXHAUSTED"
+        category = "reliability"
+        stop_reason = "max_turns_reached"
+        next_action = "Tighten the task scope or increase the run turn budget for this workflow."
+    elif isinstance(exc, ValueError) and msg.startswith("NEEDS_CLARIFICATION:"):
+        code = "INSUFFICIENT_INPUT_CONTEXT"
+        category = "input_contract"
+        stop_reason = "missing_context"
+        next_action = "Provide clearer trigger context or required inputs before starting the run."
+    elif "Approval rejected" in msg:
+        code = "APPROVAL_REJECTED"
+        category = "approval"
+        stop_reason = "human_rejected"
+        next_action = "Review rejection feedback, update the plan, and rerun for approval."
+
+    return {
+        "code": code,
+        "category": category,
+        "stop_reason": stop_reason,
+        "message": msg,
+        "block_id": block_id,
+        "next_action": next_action,
+    }
+
+
 # ── tool definitions for Brain agentic mode ───────────────────────────────────
 
 BRAIN_TOOLS = [
@@ -1821,6 +1861,7 @@ def _execute_dag(
 
     failed = False
     fail_error = ""
+    fail_summary: dict[str, Any] | None = None
     logic_routes: dict[str, str] = {}  # block_id → 'pass'|'fail'
 
     # Cache the skip set and only recompute when a new logic route is resolved.
@@ -1973,7 +2014,13 @@ def _execute_dag(
                     sentry_sdk.capture_exception(e)
             failed = True
             fail_error = str(e)
-            _emit(db, run_id, block_id, "block_failed", {"error": str(e)})
+            fail_summary = _classify_failure(e, block_id)
+            _emit(db, run_id, block_id, "block_failed", {
+                "error": str(e),
+                "failure": fail_summary,
+                "reason_code": fail_summary["code"],
+                "next_action": fail_summary["next_action"],
+            })
             break
 
         except Exception as e:
@@ -1987,7 +2034,13 @@ def _execute_dag(
                     sentry_sdk.capture_exception(e)
             failed = True
             fail_error = str(e)
-            _emit(db, run_id, block_id, "block_failed", {"error": str(e)})
+            fail_summary = _classify_failure(e, block_id)
+            _emit(db, run_id, block_id, "block_failed", {
+                "error": str(e),
+                "failure": fail_summary,
+                "reason_code": fail_summary["code"],
+                "next_action": fail_summary["next_action"],
+            })
             break
 
     # Always run cleanup blocks
@@ -1997,7 +2050,13 @@ def _execute_dag(
             result = _execute_tool(block, state, credentials, allowed_hosts=allowed_hosts)
             _emit(db, run_id, block["id"], "block_completed", {"output": result})
         except Exception as e:
-            _emit(db, run_id, block["id"], "block_failed", {"error": str(e)})
+            cleanup_summary = _classify_failure(e, block["id"])
+            _emit(db, run_id, block["id"], "block_failed", {
+                "error": str(e),
+                "failure": cleanup_summary,
+                "reason_code": cleanup_summary["code"],
+                "next_action": cleanup_summary["next_action"],
+            })
 
     run.status = "failed" if failed else "succeeded"
     run.completed_at = _now()
@@ -2013,9 +2072,16 @@ def _execute_dag(
     except Exception:
         pass
 
+    if failed and not fail_summary and fail_error:
+        fail_summary = _classify_failure(RuntimeError(fail_error), None)
+
     _emit(db, run_id, None, "run_completed" if not failed else "run_failed", {
         "status": run.status,
         "error": fail_error,
+        "failure": fail_summary,
+        "reason_code": fail_summary["code"] if fail_summary else None,
+        "next_action": fail_summary["next_action"] if fail_summary else None,
+        "stop_reason": fail_summary["stop_reason"] if fail_summary else None,
     })
     log.info("run.finished", run_id=run_id, status=run.status)
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -22,6 +22,7 @@ from typing import Any
 from app.core.config import settings
 from app.runtime.llm_client import AnthropicClient, OpenAIClient, LLMTextBlock, LLMToolUseBlock
 from app.runtime.model_router import resolve as _router_resolve
+from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates
 from app.core.crypto import decrypt
 from app.core.database import SessionLocal
 from app.models.environment import Environment  # noqa: F401 — used for FK relationship loading
@@ -821,15 +822,20 @@ def _execute_brain(
         or settings.openai_api_key
     )
 
+    pricing_snapshot = freeze_pricing_snapshot()
+
     # Provider fallback keeps existing Anthropic behavior if OpenAI is selected
     # but no key is configured for this workspace/run.
     if provider == "openai" and _openai_key:
-        llm = OpenAIClient(api_key=_openai_key)
+        llm = OpenAIClient(api_key=_openai_key, pricing_snapshot=pricing_snapshot)
     else:
         if provider == "openai" and not _openai_key:
             log.warning("brain.provider_fallback", reason="missing_openai_key", selected_provider=provider, fallback_provider="anthropic")
-            provider = "anthropic"
-        llm = AnthropicClient(api_key=_anthropic_key)
+            provider, model_id, fallback_reason = _router_resolve(playbook_slug, routing_pref, None, "anthropic")
+            routing_reason = f"{routing_reason}; fallback: {fallback_reason}"
+        llm = AnthropicClient(api_key=_anthropic_key, pricing_snapshot=pricing_snapshot)
+
+    pricing_rates, pricing_version = get_model_rates(provider, model_id, pricing_snapshot)
 
     if is_agentic:
         # Bounded agentic loop — max_turns from run state, default 20
@@ -908,6 +914,8 @@ def _execute_brain(
                     "provider": provider,
                     "model": model_id,
                     "routing_reason": routing_reason,
+                    "pricing_version": pricing_version,
+                    "pricing_rates": pricing_rates,
                 }
                 # Extract structured values from the last JSON line of the output
                 # so brain blocks can surface keys like pr_url, passed, etc. as
@@ -994,6 +1002,10 @@ def _execute_brain(
                 "cost_usd": cost_usd,
                 "files_changed": files_changed,
                 "diff_stat": diff_stat,
+                "provider": provider,
+                "model": model_id,
+                "pricing_version": pricing_version,
+                "pricing_rates": pricing_rates,
             })
         _close_session()
         raise RuntimeError(
@@ -1020,6 +1032,8 @@ def _execute_brain(
             "provider": provider,
             "model": model_id,
             "routing_reason": routing_reason,
+            "pricing_version": pricing_version,
+            "pricing_rates": pricing_rates,
         }
         # Extract structured values from the last JSON line of the output
         import json as _json

--- a/apps/api/app/runtime/input_contract.py
+++ b/apps/api/app/runtime/input_contract.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+
+class InputContractError(ValueError):
+    """Raised when run-start inputs do not meet the explicit contract."""
+
+
+def _is_non_empty_dict(value: Any) -> bool:
+    return isinstance(value, dict) and bool(value)
+
+
+def _validate_trigger_shape(trigger: dict[str, Any]) -> None:
+    has_core_signal = any(
+        key in trigger
+        for key in (
+            "event_type",
+            "action",
+            "issue",
+            "pull_request",
+            "repository",
+            "ref",
+        )
+    )
+    if not has_core_signal:
+        raise InputContractError(
+            "`_trigger` is present but missing required signal fields "
+            "(expected one of: event_type, action, issue, pull_request, repository, ref)"
+        )
+
+
+def _validate_github_shape(state: dict[str, Any]) -> None:
+    github_trigger = state.get("github_trigger")
+    github_issue = state.get("github_issue")
+    if not _is_non_empty_dict(github_trigger) or not _is_non_empty_dict(github_issue):
+        raise InputContractError(
+            "GitHub runs must include both non-empty `github_trigger` and `github_issue` objects"
+        )
+
+    has_issue_number = bool(github_issue.get("issue_number") or github_issue.get("number"))
+    has_title = bool(github_issue.get("title"))
+    trigger_repo = (github_trigger or {}).get("repo") or (github_trigger or {}).get("repository") or {}
+    has_repo = bool(
+        github_issue.get("repo_full_name")
+        or github_issue.get("full_name")
+        or trigger_repo.get("full_name")
+    )
+
+    missing: list[str] = []
+    if not has_issue_number:
+        missing.append("issue_number|number")
+    if not has_title:
+        missing.append("title")
+    if not has_repo:
+        missing.append("repo_full_name|full_name")
+
+    if missing:
+        raise InputContractError(
+            "`github_issue` is missing required fields: " + ", ".join(missing)
+        )
+
+
+def validate_run_start_inputs(initial_state: dict[str, Any] | None) -> dict[str, Any]:
+    """
+    Validate and normalize run-start state.
+
+    Contract (phase2.v1):
+    - state must be a non-empty dict
+    - must carry either:
+      1) a non-empty `_trigger` envelope with core signal fields, OR
+      2) GitHub normalized shape: `github_trigger` + `github_issue`
+    """
+    if not _is_non_empty_dict(initial_state):
+        raise InputContractError(
+            "Run start requires explicit inputs. Provide `_trigger` or GitHub normalized input state."
+        )
+
+    state: dict[str, Any] = deepcopy(initial_state)
+    has_trigger = _is_non_empty_dict(state.get("_trigger"))
+    has_github = _is_non_empty_dict(state.get("github_trigger")) or _is_non_empty_dict(state.get("github_issue"))
+
+    if not has_trigger and not has_github:
+        raise InputContractError(
+            "Run start input contract not satisfied. Expected `_trigger` or `github_trigger`/`github_issue`."
+        )
+
+    if has_trigger:
+        _validate_trigger_shape(state["_trigger"])
+        shape = "trigger"
+    else:
+        _validate_github_shape(state)
+        shape = "github"
+
+    state["__input_contract"] = {
+        "version": "phase2.v1",
+        "status": "validated",
+        "shape": shape,
+    }
+    return state

--- a/apps/api/app/runtime/llm_client.py
+++ b/apps/api/app/runtime/llm_client.py
@@ -20,6 +20,8 @@ import json
 from dataclasses import dataclass, field
 from typing import Any, Protocol, runtime_checkable
 
+from app.runtime.pricing import get_model_rates
+
 
 # ── Normalized response types ─────────────────────────────────────────────────
 
@@ -105,37 +107,8 @@ class LLMClient(Protocol):
         ...
 
 
-# ── Anthropic adapter ─────────────────────────────────────────────────────────
-
-# Per-model pricing in USD per 1M tokens.
-# Cache read ≈ 10% of input price; cache write ≈ 125% of input price.
-_ANTHROPIC_PRICING: dict[str, dict[str, float]] = {
-    "claude-sonnet-4-6": {
-        "input":       3.00,
-        "output":     15.00,
-        "cache_read":  0.30,
-        "cache_write": 3.75,
-    },
-    "claude-opus-4-7": {
-        "input":       15.00,
-        "output":      75.00,
-        "cache_read":   1.50,
-        "cache_write": 18.75,
-    },
-    "claude-haiku-4-5-20251001": {
-        "input":       0.80,
-        "output":      4.00,
-        "cache_read":  0.08,
-        "cache_write": 1.00,
-    },
-}
-
-# Fallback: Sonnet rates for any unrecognized model ID
-_ANTHROPIC_PRICING_DEFAULT = _ANTHROPIC_PRICING["claude-sonnet-4-6"]
-
-
-def _anthropic_cost(model: str, usage: LLMUsage) -> float:
-    rates = _ANTHROPIC_PRICING.get(model, _ANTHROPIC_PRICING_DEFAULT)
+def _anthropic_cost(model: str, usage: LLMUsage, pricing_snapshot: dict[str, Any] | None = None) -> float:
+    rates, _ = get_model_rates("anthropic", model, pricing_snapshot)
     return round((
         usage.input_tokens         * rates["input"]
         + usage.output_tokens      * rates["output"]
@@ -156,9 +129,10 @@ class AnthropicClient:
     - Conversation history formatting (Anthropic requires raw content objects for assistant turns)
     """
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, pricing_snapshot: dict[str, Any] | None = None) -> None:
         import anthropic as _anthropic
         self._client = _anthropic.Anthropic(api_key=api_key)
+        self._pricing_snapshot = pricing_snapshot
 
     def create(
         self,
@@ -210,7 +184,7 @@ class AnthropicClient:
             content=content,
             stop_reason=raw.stop_reason or "end_turn",
             usage=usage,
-            cost_usd=_anthropic_cost(model, usage),
+            cost_usd=_anthropic_cost(model, usage, self._pricing_snapshot),
             _raw_content=raw.content,  # preserved for make_assistant_turn
         )
 
@@ -227,25 +201,8 @@ class AnthropicClient:
         ]}]
 
 
-# ── OpenAI adapter ───────────────────────────────────────────────────────────
-
-# Per-model pricing in USD per 1M tokens.
-_OPENAI_PRICING: dict[str, dict[str, float]] = {
-    "gpt-4.1": {
-        "input": 2.00,
-        "output": 8.00,
-    },
-    "gpt-4.1-mini": {
-        "input": 0.40,
-        "output": 1.60,
-    },
-}
-
-_OPENAI_PRICING_DEFAULT = _OPENAI_PRICING["gpt-4.1-mini"]
-
-
-def _openai_cost(model: str, usage: LLMUsage) -> float:
-    rates = _OPENAI_PRICING.get(model, _OPENAI_PRICING_DEFAULT)
+def _openai_cost(model: str, usage: LLMUsage, pricing_snapshot: dict[str, Any] | None = None) -> float:
+    rates, _ = get_model_rates("openai", model, pricing_snapshot)
     return round((
         usage.input_tokens * rates["input"]
         + usage.output_tokens * rates["output"]
@@ -263,8 +220,9 @@ class OpenAIClient:
     - Conversation history formatting for assistant/tool turns
     """
 
-    def __init__(self, api_key: str) -> None:
+    def __init__(self, api_key: str, pricing_snapshot: dict[str, Any] | None = None) -> None:
         self._api_key = api_key
+        self._pricing_snapshot = pricing_snapshot
 
     def create(
         self,
@@ -355,7 +313,7 @@ class OpenAIClient:
             content=content,
             stop_reason=stop_reason,
             usage=usage,
-            cost_usd=_openai_cost(model, usage),
+            cost_usd=_openai_cost(model, usage, self._pricing_snapshot),
             _raw_content=message,
         )
 

--- a/apps/api/app/runtime/pricing.py
+++ b/apps/api/app/runtime/pricing.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import json
+import structlog
+from copy import deepcopy
+from typing import Any
+
+from app.core.config import settings
+
+log = structlog.get_logger(__name__)
+
+_DEFAULT_PRICING: dict[str, dict[str, dict[str, float]]] = {
+    "anthropic": {
+        "claude-sonnet-4-6": {
+            "input": 3.00,
+            "output": 15.00,
+            "cache_read": 0.30,
+            "cache_write": 3.75,
+        },
+        "claude-opus-4-7": {
+            "input": 15.00,
+            "output": 75.00,
+            "cache_read": 1.50,
+            "cache_write": 18.75,
+        },
+        "claude-haiku-4-5-20251001": {
+            "input": 0.80,
+            "output": 4.00,
+            "cache_read": 0.08,
+            "cache_write": 1.00,
+        },
+    },
+    "openai": {
+        "gpt-4.1": {
+            "input": 2.00,
+            "output": 8.00,
+        },
+        "gpt-4.1-mini": {
+            "input": 0.40,
+            "output": 1.60,
+        },
+    },
+}
+
+_DEFAULTS_BY_PROVIDER: dict[str, str] = {
+    "anthropic": "claude-sonnet-4-6",
+    "openai": "gpt-4.1-mini",
+}
+
+
+def _merge_overrides(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    out = deepcopy(base)
+    providers = overrides.get("providers")
+    if not isinstance(providers, dict):
+        return out
+
+    for provider, models in providers.items():
+        if not isinstance(provider, str) or not isinstance(models, dict):
+            continue
+        p = provider.lower().strip()
+        out.setdefault(p, {})
+        for model, rates in models.items():
+            if not isinstance(model, str) or not isinstance(rates, dict):
+                continue
+            clean_rates: dict[str, float] = {}
+            for key in ("input", "output", "cache_read", "cache_write"):
+                if key in rates:
+                    try:
+                        clean_rates[key] = float(rates[key])
+                    except (TypeError, ValueError):
+                        continue
+            if clean_rates:
+                out[p][model] = clean_rates
+    return out
+
+
+def freeze_pricing_snapshot() -> dict[str, Any]:
+    pricing = deepcopy(_DEFAULT_PRICING)
+    version = settings.pricing_registry_version or "unknown"
+
+    raw = (settings.pricing_overrides_json or "").strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, dict):
+                pricing = _merge_overrides(pricing, parsed)
+                parsed_version = parsed.get("version")
+                if isinstance(parsed_version, str) and parsed_version.strip():
+                    version = parsed_version.strip()
+        except Exception as e:
+            log.warning("pricing.override_parse_failed", error=str(e))
+
+    return {
+        "version": version,
+        "providers": pricing,
+    }
+
+
+def get_model_rates(
+    provider: str,
+    model: str,
+    pricing_snapshot: dict[str, Any] | None = None,
+) -> tuple[dict[str, float], str]:
+    snap = pricing_snapshot or freeze_pricing_snapshot()
+    version = str(snap.get("version") or "unknown")
+
+    providers = snap.get("providers") or {}
+    if not isinstance(providers, dict):
+        providers = {}
+
+    p = (provider or "anthropic").lower().strip()
+    provider_map = providers.get(p)
+    if not isinstance(provider_map, dict):
+        provider_map = {}
+
+    rates = provider_map.get(model)
+    if not isinstance(rates, dict):
+        default_model = _DEFAULTS_BY_PROVIDER.get(p)
+        if default_model:
+            rates = provider_map.get(default_model)
+        if not isinstance(rates, dict):
+            fallback_provider = p if p in _DEFAULT_PRICING else "anthropic"
+            fallback_model = _DEFAULTS_BY_PROVIDER.get(fallback_provider, "claude-sonnet-4-6")
+            rates = _DEFAULT_PRICING[fallback_provider][fallback_model]
+
+    out = {
+        "input": float(rates.get("input", 0.0)),
+        "output": float(rates.get("output", 0.0)),
+        "cache_read": float(rates.get("cache_read", 0.0)),
+        "cache_write": float(rates.get("cache_write", 0.0)),
+    }
+    return out, version
+
+
+def pricing_note(provider: str, model: str, rates: dict[str, float], version: str) -> str:
+    p = (provider or "").lower().strip() or "unknown"
+    return (
+        f"{p}/{model} @ v{version} — "
+        f"input ${rates.get('input', 0):.2f}/1M, output ${rates.get('output', 0):.2f}/1M"
+    )

--- a/apps/api/tests/test_input_contract.py
+++ b/apps/api/tests/test_input_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from app.runtime.input_contract import InputContractError, validate_run_start_inputs
+
+
+def test_rejects_empty_initial_state():
+    with pytest.raises(InputContractError):
+        validate_run_start_inputs({})
+
+
+def test_accepts_trigger_shape_and_sets_contract_metadata():
+    state = {"_trigger": {"event_type": "manual", "action": "start"}}
+    out = validate_run_start_inputs(state)
+
+    assert out["__input_contract"]["status"] == "validated"
+    assert out["__input_contract"]["shape"] == "trigger"
+
+
+def test_rejects_trigger_without_core_signal_fields():
+    with pytest.raises(InputContractError):
+        validate_run_start_inputs({"_trigger": {"foo": "bar"}})
+
+
+def test_accepts_github_shape_with_required_fields():
+    state = {
+        "github_trigger": {"event_type": "github_issue_labeled"},
+        "github_issue": {
+            "issue_number": 42,
+            "title": "Fix build",
+            "repo_full_name": "acme/repo",
+        },
+    }
+    out = validate_run_start_inputs(state)
+
+    assert out["__input_contract"]["shape"] == "github"
+
+
+def test_rejects_github_shape_missing_required_fields():
+    state = {
+        "github_trigger": {"event_type": "github_issue_labeled"},
+        "github_issue": {
+            "issue_number": 42,
+            "title": "Fix build",
+        },
+    }
+    with pytest.raises(InputContractError):
+        validate_run_start_inputs(state)

--- a/apps/api/tests/test_pricing_registry.py
+++ b/apps/api/tests/test_pricing_registry.py
@@ -1,0 +1,72 @@
+from app.core.config import settings
+from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates
+
+
+def test_default_rates_lookup():
+    snapshot = freeze_pricing_snapshot()
+    rates, version = get_model_rates("anthropic", "claude-sonnet-4-6", snapshot)
+
+    assert version
+    assert rates["input"] == 3.0
+    assert rates["output"] == 15.0
+    assert rates["cache_read"] == 0.3
+    assert rates["cache_write"] == 3.75
+
+
+def test_override_rates_and_version_applied():
+    prev_json = settings.pricing_overrides_json
+    prev_ver = settings.pricing_registry_version
+    try:
+        settings.pricing_registry_version = "base-version"
+        settings.pricing_overrides_json = (
+            '{"version":"2026-07-01","providers":{"openai":{"gpt-4.1-mini":{"input":0.5,"output":1.7}}}}'
+        )
+
+        snapshot = freeze_pricing_snapshot()
+        rates, version = get_model_rates("openai", "gpt-4.1-mini", snapshot)
+
+        assert version == "2026-07-01"
+        assert rates["input"] == 0.5
+        assert rates["output"] == 1.7
+    finally:
+        settings.pricing_overrides_json = prev_json
+        settings.pricing_registry_version = prev_ver
+
+
+def test_invalid_override_json_falls_back_to_defaults():
+    prev_json = settings.pricing_overrides_json
+    try:
+        settings.pricing_overrides_json = "{not-json}"
+        snapshot = freeze_pricing_snapshot()
+        rates, _ = get_model_rates("openai", "gpt-4.1-mini", snapshot)
+        assert rates["input"] == 0.4
+        assert rates["output"] == 1.6
+    finally:
+        settings.pricing_overrides_json = prev_json
+
+
+def test_snapshot_freezes_rates_even_if_settings_change_later():
+    prev_json = settings.pricing_overrides_json
+    prev_ver = settings.pricing_registry_version
+    try:
+        settings.pricing_registry_version = "v1"
+        settings.pricing_overrides_json = (
+            '{"version":"v1","providers":{"openai":{"gpt-4.1-mini":{"input":0.4,"output":1.6}}}}'
+        )
+        snap_v1 = freeze_pricing_snapshot()
+
+        settings.pricing_registry_version = "v2"
+        settings.pricing_overrides_json = (
+            '{"version":"v2","providers":{"openai":{"gpt-4.1-mini":{"input":0.9,"output":1.9}}}}'
+        )
+
+        rates_v1, ver_v1 = get_model_rates("openai", "gpt-4.1-mini", snap_v1)
+        rates_latest, ver_latest = get_model_rates("openai", "gpt-4.1-mini")
+
+        assert ver_v1 == "v1"
+        assert rates_v1["input"] == 0.4
+        assert ver_latest == "v2"
+        assert rates_latest["input"] == 0.9
+    finally:
+        settings.pricing_overrides_json = prev_json
+        settings.pricing_registry_version = prev_ver

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -390,7 +390,7 @@ jobs:
         <SectionHeading id="cli-mcp">MCP Server</SectionHeading>
         <p className="text-stone-500 text-sm mb-4 leading-relaxed">
           <Code>conduct-mcp</Code> is a zero-dependency MCP server that ships inside <Code>conduct-cli</Code>.
-          It exposes your Conduct workspace as tools that Claude Code, Codex, Cursor, and Windsurf can call directly —
+          It exposes your Conduct workspace as tools that Claude Code, Codex, Cursor, Windsurf, and VS Code (Copilot) can call directly —
           no copy-pasting workflow IDs or run commands.
         </p>
 
@@ -457,10 +457,11 @@ conduct mcp install`}</Pre>
             </thead>
             <tbody className="divide-y divide-stone-100">
               {[
-                ["Claude Code", "conduct login  /  conduct mcp install", "~/.claude/settings.json"],
-                ["Codex CLI",   "conduct login  /  conduct mcp install", "~/.codex/config.toml"],
-                ["Cursor",      "Manual — add conduct-mcp in Cursor MCP settings", "Cursor UI"],
-                ["Windsurf",    "Manual — add conduct-mcp in Windsurf MCP settings", "Windsurf UI"],
+                ["Claude Code",      "conduct login  /  conduct mcp install", "~/.claude/settings.json"],
+                ["Codex CLI",        "conduct login  /  conduct mcp install", "~/.codex/config.toml"],
+                ["Cursor",           "conduct login  /  conduct mcp install", "~/.cursor/mcp.json"],
+                ["Windsurf",         "conduct login  /  conduct mcp install", "~/.codeium/windsurf/mcp_config.json"],
+                ["VS Code (Copilot)","conduct login  /  conduct mcp install", "VS Code settings.json → mcp.servers"],
               ].map(([tool, how, cfg]) => (
                 <tr key={tool}>
                   <td className="px-4 py-3 text-xs font-medium text-stone-800">{tool}</td>

--- a/apps/web/src/app/docs/page.tsx
+++ b/apps/web/src/app/docs/page.tsx
@@ -85,6 +85,7 @@ const TAB_NAV: Record<TabId, { href: string; label: string }[]> = {
     { href: "#cli-auth",     label: "CLI — Authentication" },
     { href: "#cli-commands", label: "CLI — Commands" },
     { href: "#ci",           label: "CI / GitHub Actions" },
+    { href: "#cli-mcp",      label: "MCP Server" },
   ],
   "api": [
     { href: "#api-auth",      label: "Authentication" },
@@ -378,6 +379,93 @@ jobs:
                 <tr key={s}>
                   <td className="px-4 py-3 font-mono text-xs text-stone-800">{s}</td>
                   <td className="px-4 py-3 text-stone-500">{v}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section id="cli-mcp">
+        <SectionHeading id="cli-mcp">MCP Server</SectionHeading>
+        <p className="text-stone-500 text-sm mb-4 leading-relaxed">
+          <Code>conduct-mcp</Code> is a zero-dependency MCP server that ships inside <Code>conduct-cli</Code>.
+          It exposes your Conduct workspace as tools that Claude Code, Codex, Cursor, and Windsurf can call directly —
+          no copy-pasting workflow IDs or run commands.
+        </p>
+
+        <SubHeading>Installation</SubHeading>
+        <p className="text-stone-500 text-sm mb-3">
+          The server binary is installed automatically with the CLI. Register it in your AI tools with one command:
+        </p>
+        <Pre>{`pip install conduct-cli
+conduct login --server https://api.conductai.ai --api-key cond_live_xxxx
+# ↑ login auto-registers conduct-mcp in Claude Code and Codex
+
+# Or register manually at any time:
+conduct mcp install`}</Pre>
+
+        <p className="text-stone-500 text-sm mt-3 mb-4">
+          <Code>conduct mcp install</Code> detects which AI tools are present and registers <Code>conduct-mcp</Code>
+          in each: it runs <Code>claude mcp add conduct conduct-mcp</Code> for Claude Code and writes the
+          <Code>[[mcp_servers]]</Code> block into <Code>~/.codex/config.toml</Code> for Codex.
+          Restart your AI tool once to pick up the server.
+        </p>
+
+        <SubHeading>Available tools</SubHeading>
+        <div className="rounded-xl border border-stone-200 overflow-hidden mb-6">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-stone-50 border-b border-stone-200">
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-stone-500 uppercase tracking-wider w-56">Tool</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-stone-500 uppercase tracking-wider">What it does</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-100">
+              {[
+                ["conduct_list_agents",    "List all installed agents in your workspace (id, name, status)"],
+                ["conduct_list_projects",  "List all projects in your workspace"],
+                ["conduct_list_playbooks", "List available playbook templates"],
+                ["conduct_run_workflow",   "Trigger a workflow run — provide workflow_id and an optional payload"],
+                ["conduct_get_run",        "Fetch the status and result of any run by workflow_id + run_id"],
+                ["conduct_guard_status",   "Show active ConductGuard policy: rule count, team info, policy version"],
+              ].map(([tool, desc]) => (
+                <tr key={tool}>
+                  <td className="px-4 py-3 font-mono text-xs text-stone-800">{tool}</td>
+                  <td className="px-4 py-3 text-xs text-stone-500">{desc}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <SubHeading>Example usage in Claude Code</SubHeading>
+        <Pre>{`# After conduct mcp install + restart, ask Claude:
+"List my Conduct agents"
+"Run the autopilot workflow on myorg/my-repo"
+"What's the status of run abc-123 in workflow xyz-456?"`}</Pre>
+
+        <SubHeading>Tool coverage by AI client</SubHeading>
+        <div className="rounded-xl border border-stone-200 overflow-hidden mb-4">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="bg-stone-50 border-b border-stone-200">
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-stone-500 uppercase tracking-wider">Tool</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-stone-500 uppercase tracking-wider">Registered by</th>
+                <th className="text-left px-4 py-2.5 text-xs font-semibold text-stone-500 uppercase tracking-wider">Config written</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-stone-100">
+              {[
+                ["Claude Code", "conduct login  /  conduct mcp install", "~/.claude/settings.json"],
+                ["Codex CLI",   "conduct login  /  conduct mcp install", "~/.codex/config.toml"],
+                ["Cursor",      "Manual — add conduct-mcp in Cursor MCP settings", "Cursor UI"],
+                ["Windsurf",    "Manual — add conduct-mcp in Windsurf MCP settings", "Windsurf UI"],
+              ].map(([tool, how, cfg]) => (
+                <tr key={tool}>
+                  <td className="px-4 py-3 text-xs font-medium text-stone-800">{tool}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-stone-500">{how}</td>
+                  <td className="px-4 py-3 font-mono text-xs text-stone-500">{cfg}</td>
                 </tr>
               ))}
             </tbody>

--- a/apps/web/src/app/guard/spend/page.tsx
+++ b/apps/web/src/app/guard/spend/page.tsx
@@ -18,6 +18,9 @@ interface DeveloperSpend {
   tokens_after: number
   cost_usd: number
   saved_usd: number
+  detected_tools: string[]
+  mcp_registered: string[]
+  hook_registered: string[]
 }
 
 interface AiToolBreakdown {
@@ -117,6 +120,16 @@ function GuardShell({ children }: { children: React.ReactNode }) {
       {children}
     </div>
   )
+}
+
+// ─── Tool coverage ────────────────────────────────────────────────────────────
+
+const TOOL_LABELS: Record<string, string> = {
+  "claude-code": "Claude",
+  "codex":       "Codex",
+  "cursor":      "Cursor",
+  "windsurf":    "Windsurf",
+  "vscode":      "VS Code",
 }
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -769,8 +782,8 @@ function SpendContent() {
           By developer
         </div>
         {/* Header row */}
-        <div style={{ display: "grid", gridTemplateColumns: "1.8fr 0.8fr 0.9fr 0.9fr 0.9fr 1.3fr", gap: 14, padding: "10px 20px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
-          {["Developer", "Sessions", "Tokens", "Est. cost", "Saved", "Budget"].map((h, i) => (
+        <div style={{ display: "grid", gridTemplateColumns: "1.8fr 0.8fr 0.9fr 0.9fr 0.9fr 1.4fr 1.3fr", gap: 14, padding: "10px 20px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
+          {["Developer", "Sessions", "Tokens", "Est. cost", "Saved", "Coverage", "Budget"].map((h, i) => (
             <div key={i} className="eyebrow" style={{ fontSize: 10 }}>{h}</div>
           ))}
         </div>
@@ -792,7 +805,7 @@ function SpendContent() {
             return (
               <div key={dev.email}>
                 <div
-                  style={{ display: "grid", gridTemplateColumns: "1.8fr 0.8fr 0.9fr 0.9fr 0.9fr 1.3fr", gap: 14, padding: "12px 20px", borderBottom: "1px solid var(--border)", alignItems: "center", cursor: "pointer" }}
+                  style={{ display: "grid", gridTemplateColumns: "1.8fr 0.8fr 0.9fr 0.9fr 0.9fr 1.4fr 1.3fr", gap: 14, padding: "12px 20px", borderBottom: "1px solid var(--border)", alignItems: "center", cursor: "pointer" }}
                   onClick={() => setExpandedDev(isExpanded ? null : dev.email)}
                 >
                   <div className="mono" style={{ fontSize: 12.5, fontWeight: 550 }}>{dev.email}</div>
@@ -803,6 +816,26 @@ function SpendContent() {
                   </div>
                   <div className="mono" style={{ fontSize: 12.5, color: "var(--ok)" }}>
                     {CURRENCY_SYMBOLS[currency]}{fromUsd(dev.saved_usd, currency).toFixed(2)}
+                  </div>
+                  <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
+                    {(dev.detected_tools ?? []).map(tool => {
+                      const covered = (dev.mcp_registered ?? []).includes(tool)
+                      return (
+                        <span key={tool} style={{
+                          display: "inline-flex", alignItems: "center", gap: 3,
+                          fontSize: 10.5, fontWeight: 600, padding: "2px 7px",
+                          borderRadius: 20,
+                          background: covered ? "var(--ok-bg)" : "var(--warn-bg)",
+                          color: covered ? "var(--ok)" : "var(--warn)",
+                          border: `1px solid ${covered ? "var(--ok-bd)" : "var(--warn-bd)"}`,
+                        }}>
+                          {covered ? "✓" : "!"} {TOOL_LABELS[tool] ?? tool}
+                        </span>
+                      )
+                    })}
+                    {(dev.detected_tools ?? []).length === 0 && (
+                      <span style={{ fontSize: 11, color: "var(--text-muted)" }}>—</span>
+                    )}
                   </div>
                   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                     <BudgetBar used={dev.cost_usd} limit={budgetLimit} />

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -10,6 +10,15 @@ interface RunEvent {
   created_at?: string
 }
 
+interface FailureSummary {
+  code?: string
+  category?: string
+  stop_reason?: string
+  message?: string
+  block_id?: string | null
+  next_action?: string
+}
+
 interface RunMeta {
   triggered_by: string | null
   started_at: string | null
@@ -186,6 +195,8 @@ interface BlockRow {
   model?: string
   routingReason?: string
   timedOut?: boolean
+  failure?: FailureSummary
+  nextAction?: string
 }
 
 const PROVIDER_LABELS: Record<string, string> = {
@@ -396,6 +407,21 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
           </p>
         )}
 
+        {row.status === "failed" && (row.failure?.code || row.nextAction) && (
+          <div style={{ marginTop: 4 }}>
+            {row.failure?.code && (
+              <p className="mono" style={{ fontSize: 11, color: "var(--text-3, #78716c)", margin: 0 }}>
+                Reason: {row.failure.code}
+              </p>
+            )}
+            {row.nextAction && (
+              <p style={{ fontSize: 12, color: "var(--text-3, #78716c)", margin: "2px 0 0", lineHeight: 1.35 }}>
+                Next: {row.nextAction}
+              </p>
+            )}
+          </div>
+        )}
+
         {/* Summary line */}
         {summary && row.status !== "failed" && (
           <p style={{ marginTop: 4, fontSize: 12.5, color: isSkipped ? "var(--text-muted, #a8a29e)" : "var(--text-3, #78716c)", lineHeight: 1.4, fontStyle: isSkipped ? "italic" : undefined }}>
@@ -489,6 +515,9 @@ function RunTerminalRow({ runFailed, runCompleted }: {
 
   const isReaped = runFailed?.payload?.reaped === true
   const errMsg   = typeof runFailed?.payload?.error === "string" ? runFailed.payload.error : ""
+  const failure = (runFailed?.payload?.failure as FailureSummary | undefined) ?? undefined
+  const reasonCode = typeof runFailed?.payload?.reason_code === "string" ? runFailed.payload.reason_code : failure?.code
+  const nextAction = typeof runFailed?.payload?.next_action === "string" ? runFailed.payload.next_action : failure?.next_action
 
   if (runFailed) {
     if (isReaped) {
@@ -526,6 +555,16 @@ function RunTerminalRow({ runFailed, runCompleted }: {
           <p style={{ fontWeight: 600, color: "var(--err, #dc2626)", margin: 0, fontSize: 13.5 }}>
             Run failed{errMsg ? ` — ${errMsg}` : ""}
           </p>
+          {reasonCode && (
+            <p className="mono" style={{ marginTop: 4, fontSize: 11, color: "var(--text-3, #78716c)" }}>
+              Reason: {reasonCode}
+            </p>
+          )}
+          {nextAction && (
+            <p style={{ marginTop: 2, fontSize: 12.5, color: "var(--text-3, #78716c)", lineHeight: 1.4 }}>
+              Next: {nextAction}
+            </p>
+          )}
         </div>
       </div>
     )
@@ -680,10 +719,14 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       }
     } else if (ev.kind === "block_failed" && blockMap[ev.block_id]) {
       const errStr = ev.payload.error as string
+      const failure = (ev.payload.failure as FailureSummary | undefined) ?? undefined
+      const nextAction = (ev.payload.next_action as string | undefined) ?? failure?.next_action
       blockMap[ev.block_id].status = "failed"
       blockMap[ev.block_id].completedAt = ev.created_at
       blockMap[ev.block_id].error = errStr
       blockMap[ev.block_id].timedOut = isTimeoutError(errStr)
+      blockMap[ev.block_id].failure = failure
+      blockMap[ev.block_id].nextAction = nextAction
     } else if (ev.kind === "block_skipped") {
       const row: BlockRow = {
         blockId: ev.block_id,

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -190,7 +190,15 @@ interface BlockRow {
   filesChanged?: FileChanged[]
   diffStat?: string
   toolCalls?: ToolCall[]
-  budgetExhausted?: { turns: number; costUsd: number }
+  budgetExhausted?: {
+    turns: number
+    costUsd: number
+    reason?: string
+    stopReason?: string
+    nextAction?: string
+    maxTurns?: number
+    maxCostUsd?: number
+  }
   provider?: string
   model?: string
   routingReason?: string
@@ -395,9 +403,17 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
 
         {/* Budget exhausted warning */}
         {row.budgetExhausted && (
-          <p style={{ marginTop: 6, fontSize: 10, fontWeight: 500, color: "var(--warn, #d97706)", background: "var(--warn-bg, #fffbeb)", border: "1px solid var(--warn-bd, #fde68a)", borderRadius: 4, padding: "1px 6px", display: "inline-block" }}>
-            ⚠ Turn budget exhausted ({row.budgetExhausted.turns} turns · ${row.budgetExhausted.costUsd.toFixed(4)})
-          </p>
+          <div style={{ marginTop: 6 }}>
+            <p style={{ fontSize: 10, fontWeight: 500, color: "var(--warn, #d97706)", background: "var(--warn-bg, #fffbeb)", border: "1px solid var(--warn-bd, #fde68a)", borderRadius: 4, padding: "1px 6px", display: "inline-block", margin: 0 }}>
+              ⚠ Budget exhausted ({row.budgetExhausted.reason ?? row.budgetExhausted.stopReason ?? "max_turns_reached"})
+              {` · ${row.budgetExhausted.turns} turns · $${row.budgetExhausted.costUsd.toFixed(4)}`}
+            </p>
+            {row.budgetExhausted.nextAction && (
+              <p style={{ marginTop: 2, fontSize: 12, color: "var(--text-3, #78716c)", lineHeight: 1.35 }}>
+                Next: {row.budgetExhausted.nextAction}
+              </p>
+            )}
+          </div>
         )}
 
         {/* Error */}
@@ -741,6 +757,11 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       blockMap[ev.block_id].budgetExhausted = {
         turns: ev.payload.turns as number,
         costUsd: ev.payload.cost_usd as number,
+        reason: ev.payload.reason as string | undefined,
+        stopReason: ev.payload.stop_reason as string | undefined,
+        nextAction: ev.payload.next_action as string | undefined,
+        maxTurns: ev.payload.max_turns as number | undefined,
+        maxCostUsd: ev.payload.max_cost_usd as number | undefined,
       }
     } else if (ev.kind === "brain_tool_call" && blockMap[ev.block_id]) {
       const call: ToolCall = {

--- a/docs/phase2-cost-rate-testing-playbook.md
+++ b/docs/phase2-cost-rate-testing-playbook.md
@@ -1,0 +1,140 @@
+# Phase 2 Playbook: Cost Predictability and Rate Freshness
+
+Status: Proposed
+Owner: Engineering + QA
+Last updated: 2026-06-04
+
+## Why this exists
+
+Phase 2 issue #6 is cost unpredictability. We need two properties at the same time:
+
+1. Rates stay current as providers change pricing.
+2. In-flight runs remain deterministic and auditable.
+
+The operating rule is: dynamic rates for future runs, frozen rates per active run.
+
+## Current code map (today)
+
+1. Runtime LLM call cost calculation is in [apps/api/app/runtime/llm_client.py](apps/api/app/runtime/llm_client.py).
+2. Brain run aggregates token/cost usage and emits provider/model fields in [apps/api/app/runtime/executor.py](apps/api/app/runtime/executor.py).
+3. Workflow estimate endpoint currently uses static Sonnet pricing constants in [apps/api/app/routers/workflows.py](apps/api/app/routers/workflows.py).
+
+Implication: runtime cost and pre-run estimate can drift unless both read the same rate source.
+
+## Target model (Phase 2)
+
+1. Introduce a pricing registry (single source of truth).
+2. Sync rates on schedule (for example daily), with safe fallback.
+3. Freeze a `rate_version` snapshot at run start.
+4. Use frozen rates for all cost math until run completion.
+
+## Test matrix
+
+### A) Rate lookup and math
+
+1. Lookup returns correct rate for provider/model/version.
+2. Unknown model uses explicit fallback policy (and logs warning event).
+3. Cost formula is correct for input and output tokens.
+4. Rounding is consistent (6 dp internal, 4 dp presentation).
+
+Expected: deterministic values for the same inputs.
+
+### B) Freshness and sync safety
+
+1. Sync job imports valid provider feed and creates new version.
+2. Invalid provider payload does not overwrite active rates.
+3. Partial sync failure keeps previous version active.
+4. Approval gate required before activating new version (if configured).
+
+Expected: no accidental rate corruption.
+
+### C) Freeze-per-run behavior
+
+1. Run starts with `rate_version=A`.
+2. Global active rates change to `B` mid-run.
+3. In-flight run remains on `A`; next run uses `B`.
+
+Expected: no mid-run repricing.
+
+### D) Budget guardrails
+
+1. Warning emitted when spend crosses 70% soft threshold.
+2. Warning emitted when spend crosses 90% threshold.
+3. Hard cap crossing stops run with `budget_exhausted` reason.
+4. Retry step checks affordability before next turn.
+
+Expected: zero hard-cap overruns.
+
+### E) Estimate vs actual drift
+
+1. Pre-run estimate computed from same rate source/version as runtime.
+2. Post-run drift metric is recorded: `(actual - estimate_expected) / estimate_expected`.
+3. Drift alerts trigger when threshold is exceeded (for example >15%).
+
+Expected: median drift stays within agreed target.
+
+## CI test suite plan
+
+Use these test groups in CI (names illustrative):
+
+1. `tests/test_pricing_registry.py`
+2. `tests/test_pricing_sync_job.py`
+3. `tests/test_executor_cost_freeze.py`
+4. `tests/test_budget_enforcement.py`
+5. `tests/test_estimate_actual_drift.py`
+
+Suggested command:
+
+```bash
+cd apps/api
+.venv/bin/pytest \
+  tests/test_pricing_registry.py \
+  tests/test_pricing_sync_job.py \
+  tests/test_executor_cost_freeze.py \
+  tests/test_budget_enforcement.py \
+  tests/test_estimate_actual_drift.py -q
+```
+
+## Ops runbook: keeping rates latest
+
+1. Scheduler runs pricing sync job daily.
+2. Job writes a new candidate `rate_version` with source timestamp.
+3. Validation checks pass (schema, monotonicity, non-negative values).
+4. Candidate is approved (manual or policy-driven) and activated.
+5. Reconciliation compares recent run costs to invoice exports.
+6. Alert if drift crosses threshold; do not auto-edit active rates on drift alert.
+
+## Observability requirements
+
+For each run, store:
+
+1. `rate_version`
+2. `provider`
+3. `model`
+4. `input_tokens`, `output_tokens`
+5. `cost_usd`
+6. `budget_soft_usd`, `budget_hard_usd`
+7. `budget_stop_reason` (if stopped)
+
+For each sync job, store:
+
+1. source fetched time
+2. candidate version id
+3. activation status
+4. validation failures
+
+## Phase 2 acceptance gates for issue #6
+
+1. No run exceeds hard budget in staging soak tests.
+2. Every run has provider/model/rate_version attached.
+3. Estimate and runtime use the same versioned rates.
+4. Sync failure leaves active rates intact.
+5. Drift dashboard and alerting are live.
+
+## Rollout order
+
+1. Build registry + versioning.
+2. Switch runtime cost reads to registry.
+3. Switch pre-run estimator to registry.
+4. Enforce budget gates.
+5. Enable sync automation and drift alerts.

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-cli"
-version = "0.4.27"
+version = "0.4.28"
 description = "CLI for Conduct AI — install agents, manage projects, run tests"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-cli"
-version = "0.4.28"
+version = "0.4.29"
 description = "CLI for Conduct AI — install agents, manage projects, run tests"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -31,8 +31,9 @@ Repository  = "https://github.com/sseshachala/conductai"
 "Bug Tracker" = "https://github.com/sseshachala/conductai/issues"
 
 [project.scripts]
-conduct          = "conduct_cli.main:main"
-conductguard-mcp = "conduct_cli.guardmcp:main"
+conduct           = "conduct_cli.main:main"
+conduct-mcp       = "conduct_cli.mcp_server:main"
+conductguard-mcp  = "conduct_cli.guardmcp:main"
 conductguard-post = "conduct_cli.guard:post_usage_main"
 
 [tool.setuptools.packages.find]

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-cli"
-version = "0.4.29"
+version = "0.4.30"
 description = "CLI for Conduct AI — install agents, manage projects, run tests"
 readme = "README.md"
 license = { text = "MIT" }

--- a/packages/conduct-cli/src/conduct_cli/guard.py
+++ b/packages/conduct-cli/src/conduct_cli/guard.py
@@ -832,6 +832,124 @@ def cmd_guard_join(args):
     )
 
 
+def _report_tools_to_server() -> None:
+    """Detect AI coding tools on this machine and POST coverage to Guard API. Silent on failure."""
+    home = Path.home()
+
+    def _check_json_key(path: Path, *keys) -> bool:
+        try:
+            d = json.loads(path.read_text()) if path.exists() else {}
+            for k in keys:
+                d = d.get(k, {}) if isinstance(d, dict) else {}
+            return bool(d) and isinstance(d, dict) and len(d) > 0
+        except Exception:
+            return False
+
+    def _check_json_mcp(path: Path) -> bool:
+        try:
+            d = json.loads(path.read_text()) if path.exists() else {}
+            return "conduct" in d.get("mcpServers", {})
+        except Exception:
+            return False
+
+    def _check_json_hook(path: Path) -> bool:
+        try:
+            d = json.loads(path.read_text()) if path.exists() else {}
+            hooks = d.get("hooks", {})
+            pre = hooks.get("PreToolUse", [])
+            return any("conductguard" in str(h) or "conduct" in str(h).lower() for h in pre)
+        except Exception:
+            return False
+
+    def _check_toml_str(path: Path, needle: str) -> bool:
+        try:
+            return needle in (path.read_text() if path.exists() else "")
+        except Exception:
+            return False
+
+    tools = []
+
+    claude_dir = home / ".claude"
+    if claude_dir.exists():
+        settings = claude_dir / "settings.json"
+        tools.append({
+            "name": "claude-code",
+            "mcp_registered": _check_json_mcp(settings),
+            "hook_registered": _check_json_hook(settings),
+        })
+
+    codex_dir = home / ".codex"
+    if codex_dir.exists():
+        config = codex_dir / "config.toml"
+        tools.append({
+            "name": "codex",
+            "mcp_registered": _check_toml_str(config, "conduct-mcp"),
+            "hook_registered": _check_toml_str(config, "conductguard"),
+        })
+
+    cursor_dir = home / ".cursor"
+    if cursor_dir.exists():
+        tools.append({
+            "name": "cursor",
+            "mcp_registered": _check_json_mcp(cursor_dir / "mcp.json"),
+            "hook_registered": False,
+        })
+
+    windsurf_dir = home / ".codeium" / "windsurf"
+    if windsurf_dir.exists():
+        tools.append({
+            "name": "windsurf",
+            "mcp_registered": _check_json_mcp(windsurf_dir / "mcp_config.json"),
+            "hook_registered": False,
+        })
+
+    vscode_candidates = [
+        home / "Library" / "Application Support" / "Code" / "User" / "settings.json",
+        home / ".config" / "Code" / "User" / "settings.json",
+        home / ".vscode" / "settings.json",
+    ]
+    vscode_settings = next((p for p in vscode_candidates if p.exists()), None)
+    if vscode_settings:
+        try:
+            d = json.loads(vscode_settings.read_text())
+            mcp_reg = "conduct" in d.get("mcp", {}).get("servers", {})
+        except Exception:
+            mcp_reg = False
+        tools.append({
+            "name": "vscode",
+            "mcp_registered": mcp_reg,
+            "hook_registered": False,
+        })
+
+    if not tools:
+        return
+
+    try:
+        cfg = _load_guard_config()
+        base_url = _api_url(cfg)
+        email = cfg.get("user_email", "")
+        token = cfg.get("member_token", "")
+        api_key = cfg.get("api_key", "")
+
+        if not email:
+            return
+
+        payload = json.dumps({"email": email, "tools": tools}).encode()
+        auth = token or api_key
+        req = urllib.request.Request(
+            f"{base_url}/guard/developer-tools",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {auth}",
+            },
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=8)
+    except Exception:
+        pass  # Never surface errors — this is background telemetry
+
+
 def cmd_guard_sync(args):
     cfg          = _require_guard_config()
     workspace_id = cfg.get("workspace_id")
@@ -860,6 +978,12 @@ def cmd_guard_sync(args):
 
     # Capture savings from RTK and Agent Booster
     _report_savings(cfg, base_url, api_key)
+
+    # Report AI tool coverage
+    try:
+        _report_tools_to_server()
+    except Exception:
+        pass
 
     print(f"\n{BOLD}Policy refreshed ({rule_count} rule(s)).{RESET}")
 

--- a/packages/conduct-cli/src/conduct_cli/main.py
+++ b/packages/conduct-cli/src/conduct_cli/main.py
@@ -283,6 +283,138 @@ def _write_vscode_mcp_config() -> bool:
         return False
 
 
+def _detect_ai_tools() -> list:
+    """
+    Detect which AI coding tools are installed and whether Guard/conduct-mcp is registered.
+    Returns list of {name, mcp_registered, hook_registered} for each detected tool.
+    Only includes tools whose config directory exists on this machine.
+    """
+    home = Path.home()
+    results = []
+
+    def _check_json_mcp(path: Path) -> bool:
+        try:
+            d = json.loads(path.read_text()) if path.exists() else {}
+            return "conduct" in d.get("mcpServers", {})
+        except Exception:
+            return False
+
+    def _check_json_hook(path: Path, hook_key: str = "hooks") -> bool:
+        try:
+            d = json.loads(path.read_text()) if path.exists() else {}
+            hooks = d.get(hook_key, {})
+            pre = hooks.get("PreToolUse", [])
+            return any("conductguard" in str(h) or "conduct" in str(h).lower() for h in pre)
+        except Exception:
+            return False
+
+    def _check_toml_str(path: Path, needle: str) -> bool:
+        try:
+            return needle in (path.read_text() if path.exists() else "")
+        except Exception:
+            return False
+
+    # Claude Code
+    claude_dir = home / ".claude"
+    if claude_dir.exists():
+        settings = claude_dir / "settings.json"
+        results.append({
+            "name": "claude-code",
+            "mcp_registered": _check_json_mcp(settings),
+            "hook_registered": _check_json_hook(settings),
+        })
+
+    # Codex
+    codex_dir = home / ".codex"
+    if codex_dir.exists():
+        config = codex_dir / "config.toml"
+        results.append({
+            "name": "codex",
+            "mcp_registered": _check_toml_str(config, "conduct-mcp"),
+            "hook_registered": _check_toml_str(config, "conductguard"),
+        })
+
+    # Cursor
+    cursor_dir = home / ".cursor"
+    if cursor_dir.exists():
+        results.append({
+            "name": "cursor",
+            "mcp_registered": _check_json_mcp(cursor_dir / "mcp.json"),
+            "hook_registered": False,  # Cursor uses MCP only, no hook
+        })
+
+    # Windsurf
+    windsurf_dir = home / ".codeium" / "windsurf"
+    if windsurf_dir.exists():
+        results.append({
+            "name": "windsurf",
+            "mcp_registered": _check_json_mcp(windsurf_dir / "mcp_config.json"),
+            "hook_registered": False,  # Windsurf uses MCP only
+        })
+
+    # VS Code (Copilot)
+    vscode_settings_candidates = [
+        home / "Library" / "Application Support" / "Code" / "User" / "settings.json",
+        home / ".config" / "Code" / "User" / "settings.json",
+        home / ".vscode" / "settings.json",
+    ]
+    vscode_settings = next((p for p in vscode_settings_candidates if p.exists()), None)
+    if vscode_settings:
+        try:
+            d = json.loads(vscode_settings.read_text())
+            mcp_reg = "conduct" in d.get("mcp", {}).get("servers", {})
+        except Exception:
+            mcp_reg = False
+        results.append({
+            "name": "vscode",
+            "mcp_registered": mcp_reg,
+            "hook_registered": False,  # VS Code uses MCP only
+        })
+
+    return results
+
+
+def _report_tool_coverage() -> None:
+    """Detect AI tools on this machine and POST coverage to Guard API. Silent on failure."""
+    try:
+        cfg = _load_config()
+        server  = cfg.get("server", "").rstrip("/")
+        api_key = cfg.get("api_key", "")
+        token   = cfg.get("token", "")
+        email   = cfg.get("email", "")
+
+        # also check guard config for email/token
+        guard_cfg_path = Path.home() / ".conductguard" / "config.json"
+        if guard_cfg_path.exists():
+            gcfg = json.loads(guard_cfg_path.read_text())
+            if not email:
+                email = gcfg.get("user_email", "")
+            if not token:
+                token = gcfg.get("member_token", "")
+
+        if not server or not email:
+            return
+
+        tools = _detect_ai_tools()
+        if not tools:
+            return
+
+        payload = json.dumps({"email": email, "tools": tools}).encode()
+        auth = token or api_key
+        req = urllib.request.Request(
+            f"{server}/guard/developer-tools",
+            data=payload,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": f"Bearer {auth}",
+            },
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=8)
+    except Exception:
+        pass  # Never surface errors — this is background telemetry
+
+
 def cmd_mcp_install(args):
     """Register conduct-mcp in Claude Code, Codex, Cursor, Windsurf, and VS Code."""
     import shutil
@@ -332,6 +464,16 @@ def cmd_mcp_install(args):
         print(f"{YELLOW}⚠ No supported AI tools detected on this machine.{RESET}")
         print(f"{GRAY}  Supported: Claude Code, Codex, Cursor, Windsurf, VS Code{RESET}")
         print(f"{GRAY}  After installing any of these, re-run: conduct mcp install{RESET}")
+
+    tools = _detect_ai_tools()
+    if tools:
+        print(f"{GRAY}  Detected tools: {', '.join(t['name'] for t in tools)}{RESET}")
+        covered = [t['name'] for t in tools if t['mcp_registered']]
+        if covered:
+            print(f"{GREEN}  MCP registered: {', '.join(covered)}{RESET}")
+        uncovered = [t['name'] for t in tools if not t['mcp_registered']]
+        if uncovered:
+            print(f"{YELLOW}  Not covered: {', '.join(uncovered)} — run: conduct mcp install{RESET}")
 
 
 def cmd_login(args):
@@ -402,6 +544,12 @@ def cmd_login(args):
         cmd_mcp_install(types.SimpleNamespace())
     except Exception:
         pass  # Never block login on MCP registration errors
+
+    # Report tool coverage to Guard
+    try:
+        _report_tool_coverage()
+    except Exception:
+        pass
 
 
 def cmd_agents(args):

--- a/packages/conduct-cli/src/conduct_cli/main.py
+++ b/packages/conduct-cli/src/conduct_cli/main.py
@@ -217,7 +217,7 @@ def _write_codex_mcp_config() -> bool:
     try:
         content = config_path.read_text() if config_path.exists() else ""
         if "conduct-mcp" in content:
-            return True  # already registered
+            return True
         mcp_block = '\n[[mcp_servers]]\nname = "conduct"\ncommand = "conduct-mcp"\nargs = []\n'
         config_path.write_text(content + mcp_block)
         return True
@@ -225,8 +225,66 @@ def _write_codex_mcp_config() -> bool:
         return False
 
 
+def _write_cursor_mcp_config() -> bool:
+    """Write conduct-mcp into ~/.cursor/mcp.json. Returns True if written."""
+    cursor_dir = Path.home() / ".cursor"
+    if not cursor_dir.exists():
+        return False
+    config_path = cursor_dir / "mcp.json"
+    try:
+        existing = json.loads(config_path.read_text()) if config_path.exists() else {}
+        servers = existing.setdefault("mcpServers", {})
+        if "conduct" in servers:
+            return True
+        servers["conduct"] = {"command": "conduct-mcp", "args": []}
+        config_path.write_text(json.dumps(existing, indent=2))
+        return True
+    except Exception:
+        return False
+
+
+def _write_windsurf_mcp_config() -> bool:
+    """Write conduct-mcp into ~/.codeium/windsurf/mcp_config.json. Returns True if written."""
+    config_path = Path.home() / ".codeium" / "windsurf" / "mcp_config.json"
+    if not config_path.parent.exists():
+        return False
+    try:
+        existing = json.loads(config_path.read_text()) if config_path.exists() else {}
+        servers = existing.setdefault("mcpServers", {})
+        if "conduct" in servers:
+            return True
+        servers["conduct"] = {"command": "conduct-mcp", "args": []}
+        config_path.write_text(json.dumps(existing, indent=2))
+        return True
+    except Exception:
+        return False
+
+
+def _write_vscode_mcp_config() -> bool:
+    """Write conduct-mcp into VS Code settings.json (mcp.servers). Returns True if written."""
+    # Check both standard locations
+    candidates = [
+        Path.home() / ".vscode" / "settings.json",
+        Path.home() / "Library" / "Application Support" / "Code" / "User" / "settings.json",
+        Path.home() / ".config" / "Code" / "User" / "settings.json",
+    ]
+    settings_path = next((p for p in candidates if p.exists()), None)
+    if not settings_path:
+        return False
+    try:
+        existing = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+        servers = existing.setdefault("mcp", {}).setdefault("servers", {})
+        if "conduct" in servers:
+            return True
+        servers["conduct"] = {"command": "conduct-mcp", "args": []}
+        settings_path.write_text(json.dumps(existing, indent=2))
+        return True
+    except Exception:
+        return False
+
+
 def cmd_mcp_install(args):
-    """Register conduct-mcp in Claude Code and Codex CLI."""
+    """Register conduct-mcp in Claude Code, Codex, Cursor, Windsurf, and VS Code."""
     import shutil
     import subprocess
 
@@ -242,29 +300,38 @@ def cmd_mcp_install(args):
             if result.returncode == 0:
                 registered.append("Claude Code")
             else:
-                # claude mcp add is idempotent; also try writing settings.json directly as fallback
                 _write_claude_mcp_settings()
                 registered.append("Claude Code (settings.json)")
         except Exception:
             _write_claude_mcp_settings()
             registered.append("Claude Code (settings.json)")
     else:
-        # claude CLI not found but .claude/ might exist (IDE extension)
-        written = _write_claude_mcp_settings()
-        if written:
+        if _write_claude_mcp_settings():
             registered.append("Claude Code (settings.json)")
 
     # --- Codex CLI ---
-    written = _write_codex_mcp_config()
-    if written:
+    if _write_codex_mcp_config():
         registered.append("Codex")
+
+    # --- Cursor ---
+    if _write_cursor_mcp_config():
+        registered.append("Cursor")
+
+    # --- Windsurf ---
+    if _write_windsurf_mcp_config():
+        registered.append("Windsurf")
+
+    # --- VS Code (Copilot) ---
+    if _write_vscode_mcp_config():
+        registered.append("VS Code (Copilot)")
 
     if registered:
         print(f"{GREEN}✓ conduct-mcp registered in: {', '.join(registered)}{RESET}")
-        print(f"{GRAY}  Restart Claude Code / Codex to pick up the new MCP server.{RESET}")
+        print(f"{GRAY}  Restart your AI tools to pick up the new MCP server.{RESET}")
     else:
-        print(f"{YELLOW}⚠ No supported AI tools detected. Install Claude Code or Codex first.{RESET}")
-        print(f"{GRAY}  Then re-run: conduct mcp install{RESET}")
+        print(f"{YELLOW}⚠ No supported AI tools detected on this machine.{RESET}")
+        print(f"{GRAY}  Supported: Claude Code, Codex, Cursor, Windsurf, VS Code{RESET}")
+        print(f"{GRAY}  After installing any of these, re-run: conduct mcp install{RESET}")
 
 
 def cmd_login(args):

--- a/packages/conduct-cli/src/conduct_cli/main.py
+++ b/packages/conduct-cli/src/conduct_cli/main.py
@@ -192,6 +192,81 @@ def _poll_run(server: str, workflow_id: str, run_id: str, hdrs: dict) -> bool:
 
 # ── Commands ──────────────────────────────────────────────────────────────────
 
+def _write_claude_mcp_settings() -> bool:
+    """Write conduct-mcp into ~/.claude/settings.json. Returns True if written."""
+    settings_path = Path.home() / ".claude" / "settings.json"
+    try:
+        existing = json.loads(settings_path.read_text()) if settings_path.exists() else {}
+        servers = existing.setdefault("mcpServers", {})
+        if "conduct" in servers:
+            return True  # already registered
+        servers["conduct"] = {"command": "conduct-mcp", "args": []}
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text(json.dumps(existing, indent=2))
+        return True
+    except Exception:
+        return False
+
+
+def _write_codex_mcp_config() -> bool:
+    """Write conduct-mcp into ~/.codex/config.toml. Returns True if written."""
+    codex_dir = Path.home() / ".codex"
+    if not codex_dir.exists():
+        return False
+    config_path = codex_dir / "config.toml"
+    try:
+        content = config_path.read_text() if config_path.exists() else ""
+        if "conduct-mcp" in content:
+            return True  # already registered
+        mcp_block = '\n[[mcp_servers]]\nname = "conduct"\ncommand = "conduct-mcp"\nargs = []\n'
+        config_path.write_text(content + mcp_block)
+        return True
+    except Exception:
+        return False
+
+
+def cmd_mcp_install(args):
+    """Register conduct-mcp in Claude Code and Codex CLI."""
+    import shutil
+    import subprocess
+
+    registered = []
+
+    # --- Claude Code ---
+    if shutil.which("claude"):
+        try:
+            result = subprocess.run(
+                ["claude", "mcp", "add", "conduct", "conduct-mcp"],
+                capture_output=True, text=True, timeout=15,
+            )
+            if result.returncode == 0:
+                registered.append("Claude Code")
+            else:
+                # claude mcp add is idempotent; also try writing settings.json directly as fallback
+                _write_claude_mcp_settings()
+                registered.append("Claude Code (settings.json)")
+        except Exception:
+            _write_claude_mcp_settings()
+            registered.append("Claude Code (settings.json)")
+    else:
+        # claude CLI not found but .claude/ might exist (IDE extension)
+        written = _write_claude_mcp_settings()
+        if written:
+            registered.append("Claude Code (settings.json)")
+
+    # --- Codex CLI ---
+    written = _write_codex_mcp_config()
+    if written:
+        registered.append("Codex")
+
+    if registered:
+        print(f"{GREEN}✓ conduct-mcp registered in: {', '.join(registered)}{RESET}")
+        print(f"{GRAY}  Restart Claude Code / Codex to pick up the new MCP server.{RESET}")
+    else:
+        print(f"{YELLOW}⚠ No supported AI tools detected. Install Claude Code or Codex first.{RESET}")
+        print(f"{GRAY}  Then re-run: conduct mcp install{RESET}")
+
+
 def cmd_login(args):
     server    = args.server
     api_key   = args.api_key
@@ -253,6 +328,13 @@ def cmd_login(args):
             pass  # Guard not found — skip silently
         except Exception:
             pass  # Never block login on Guard errors
+
+    # Auto-register MCP servers in Claude Code / Codex
+    try:
+        import types
+        cmd_mcp_install(types.SimpleNamespace())
+    except Exception:
+        pass  # Never block login on MCP registration errors
 
 
 def cmd_agents(args):
@@ -1179,6 +1261,11 @@ def main():
     # conduct guard
     guard_p, _guard_sub = _guard.register_guard_parser(sub)
 
+    # conduct mcp
+    mcp_p = sub.add_parser("mcp", help="Manage the Conduct MCP server")
+    mcp_sub = mcp_p.add_subparsers(dest="mcp_command")
+    mcp_sub.add_parser("install", help="Register conduct-mcp in Claude Code and Codex")
+
     args = parser.parse_args()
 
     if args.command == "login":
@@ -1223,6 +1310,11 @@ def main():
         cmd_run(args)
     elif args.command == "guard":
         _guard.dispatch_guard(args, guard_p)
+    elif args.command == "mcp":
+        if getattr(args, "mcp_command", None) == "install":
+            cmd_mcp_install(args)
+        else:
+            mcp_p.print_help()
     else:
         parser.print_help()
 

--- a/packages/conduct-cli/src/conduct_cli/mcp_server.py
+++ b/packages/conduct-cli/src/conduct_cli/mcp_server.py
@@ -1,0 +1,334 @@
+#!/usr/bin/env python3
+"""
+conduct-mcp — Conduct AI MCP server.
+
+Runs as a subprocess started by Claude Code / Cursor / Windsurf via the
+mcpServers config written by `conduct mcp install`. Communicates over
+stdin/stdout using JSON-RPC 2.0 (MCP stdio transport).
+
+Exposes six tools:
+  conduct_list_agents    — list agents in the workspace
+  conduct_list_projects  — list projects in the workspace
+  conduct_list_playbooks — list available playbook templates
+  conduct_run_workflow   — trigger a workflow run
+  conduct_get_run        — get run status / result
+  conduct_guard_status   — ConductGuard policy status
+"""
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+CONDUCT_CONFIG_PATH = Path.home() / ".conduct" / "config.json"
+GUARD_DIR           = Path.home() / ".conductguard"
+GUARD_POLICY_PATH   = GUARD_DIR / "policy.json"
+GUARD_CONFIG_PATH   = GUARD_DIR / "config.json"
+
+PROTOCOL_VERSION = "2024-11-05"
+
+_TOOLS = [
+    {
+        "name": "conduct_list_agents",
+        "description": "List all installed agents in your Conduct workspace.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "conduct_list_projects",
+        "description": "List all projects in your Conduct workspace.",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "conduct_list_playbooks",
+        "description": "List available Conduct playbooks (workflow templates).",
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
+        "name": "conduct_run_workflow",
+        "description": "Trigger a workflow run in Conduct. Returns the run ID.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workflow_id": {
+                    "type": "string",
+                    "description": "The workflow UUID to run",
+                },
+                "payload": {
+                    "type": "object",
+                    "description": "Optional trigger payload (key-value pairs)",
+                },
+            },
+            "required": ["workflow_id"],
+        },
+    },
+    {
+        "name": "conduct_get_run",
+        "description": "Get the status and result of a workflow run.",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "workflow_id": {"type": "string"},
+                "run_id":      {"type": "string"},
+            },
+            "required": ["workflow_id", "run_id"],
+        },
+    },
+    {
+        "name": "conduct_guard_status",
+        "description": (
+            "Show current ConductGuard policy status — active rules, "
+            "today's spend, and your team info."
+        ),
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+]
+
+
+# ── Config helpers ─────────────────────────────────────────────────────────────
+
+def _load_conduct_config() -> dict:
+    if CONDUCT_CONFIG_PATH.exists():
+        try:
+            return json.loads(CONDUCT_CONFIG_PATH.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def _load_guard_policy() -> dict:
+    if GUARD_POLICY_PATH.exists():
+        try:
+            return json.loads(GUARD_POLICY_PATH.read_text())
+        except Exception:
+            pass
+    return {"rules": []}
+
+
+def _load_guard_config() -> dict:
+    if GUARD_CONFIG_PATH.exists():
+        try:
+            return json.loads(GUARD_CONFIG_PATH.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+# ── HTTP helpers ───────────────────────────────────────────────────────────────
+
+def _api_get(url: str, token: str | None, api_key: str | None) -> dict | list:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    elif api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+def _api_post(url: str, body: dict, token: str | None, api_key: str | None) -> dict | list:
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    elif api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+    data = json.dumps(body).encode()
+    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+    with urllib.request.urlopen(req, timeout=10) as resp:
+        return json.loads(resp.read())
+
+
+# ── Tool handlers ──────────────────────────────────────────────────────────────
+
+def _handle_list_agents(server: str, workspace_id: str, token: str | None, api_key: str | None) -> str:
+    try:
+        url    = f"{server}/agents?workspace_id={workspace_id}"
+        result = _api_get(url, token, api_key)
+        agents = [
+            {"id": a.get("id"), "name": a.get("name"), "status": a.get("status")}
+            for a in (result if isinstance(result, list) else result.get("items", []))
+        ]
+        return json.dumps(agents, indent=2)
+    except urllib.error.HTTPError as e:
+        return f"Error — HTTP {e.code}: {e.read().decode()[:200]}"
+    except Exception as e:
+        return f"Error — {e}"
+
+
+def _handle_list_projects(server: str, workspace_id: str, token: str | None, api_key: str | None) -> str:
+    try:
+        url    = f"{server}/projects?workspace_id={workspace_id}"
+        result = _api_get(url, token, api_key)
+        return json.dumps(result, indent=2)
+    except urllib.error.HTTPError as e:
+        return f"Error — HTTP {e.code}: {e.read().decode()[:200]}"
+    except Exception as e:
+        return f"Error — {e}"
+
+
+def _handle_list_playbooks(server: str, workspace_id: str, token: str | None, api_key: str | None) -> str:
+    try:
+        url    = f"{server}/playbooks?workspace_id={workspace_id}"
+        result = _api_get(url, token, api_key)
+        return json.dumps(result, indent=2)
+    except urllib.error.HTTPError as e:
+        return f"Error — HTTP {e.code}: {e.read().decode()[:200]}"
+    except Exception as e:
+        return f"Error — {e}"
+
+
+def _handle_run_workflow(
+    arguments: dict,
+    server: str,
+    workspace_id: str,
+    token: str | None,
+    api_key: str | None,
+) -> str:
+    workflow_id = arguments.get("workflow_id", "")
+    payload     = arguments.get("payload") or {}
+    if not workflow_id:
+        return "Error — workflow_id is required."
+    try:
+        url  = f"{server}/workflows/{workflow_id}/runs"
+        body = {"workspace_id": workspace_id, "payload": payload}
+        run  = _api_post(url, body, token, api_key)
+        return json.dumps({"run_id": run.get("id") or run.get("run_id"), "status": run.get("status")}, indent=2)
+    except urllib.error.HTTPError as e:
+        return f"Error — HTTP {e.code}: {e.read().decode()[:200]}"
+    except Exception as e:
+        return f"Error — {e}"
+
+
+def _handle_get_run(
+    arguments: dict,
+    server: str,
+    token: str | None,
+    api_key: str | None,
+) -> str:
+    workflow_id = arguments.get("workflow_id", "")
+    run_id      = arguments.get("run_id", "")
+    if not workflow_id or not run_id:
+        return "Error — workflow_id and run_id are both required."
+    try:
+        url = f"{server}/workflows/{workflow_id}/runs/{run_id}"
+        run = _api_get(url, token, api_key)
+        return json.dumps(
+            {
+                "status":       run.get("status"),
+                "outcome":      run.get("outcome"),
+                "started_at":   run.get("started_at"),
+                "completed_at": run.get("completed_at"),
+            },
+            indent=2,
+        )
+    except urllib.error.HTTPError as e:
+        return f"Error — HTTP {e.code}: {e.read().decode()[:200]}"
+    except Exception as e:
+        return f"Error — {e}"
+
+
+def _handle_guard_status(workspace_id: str) -> str:
+    cfg    = _load_guard_config()
+    policy = _load_guard_policy()
+    return json.dumps(
+        {
+            "workspace_id":   workspace_id,
+            "email":          cfg.get("user_email", ""),
+            "rules_active":   len(policy.get("rules", [])),
+            "policy_version": policy.get("version", ""),
+        },
+        indent=2,
+    )
+
+
+def _dispatch_tool(
+    name: str,
+    arguments: dict,
+    server: str,
+    workspace_id: str,
+    token: str | None,
+    api_key: str | None,
+) -> str:
+    if name == "conduct_list_agents":
+        return _handle_list_agents(server, workspace_id, token, api_key)
+    if name == "conduct_list_projects":
+        return _handle_list_projects(server, workspace_id, token, api_key)
+    if name == "conduct_list_playbooks":
+        return _handle_list_playbooks(server, workspace_id, token, api_key)
+    if name == "conduct_run_workflow":
+        return _handle_run_workflow(arguments, server, workspace_id, token, api_key)
+    if name == "conduct_get_run":
+        return _handle_get_run(arguments, server, token, api_key)
+    if name == "conduct_guard_status":
+        return _handle_guard_status(workspace_id)
+    return f"Unknown tool: {name}"
+
+
+# ── JSON-RPC helpers ───────────────────────────────────────────────────────────
+
+def _send(obj: dict) -> None:
+    print(json.dumps(obj), flush=True)
+
+
+def _ok(msg_id, result: dict) -> None:
+    _send({"jsonrpc": "2.0", "id": msg_id, "result": result})
+
+
+def _err(msg_id, code: int, message: str) -> None:
+    _send({"jsonrpc": "2.0", "id": msg_id, "error": {"code": code, "message": message}})
+
+
+# ── Main loop ──────────────────────────────────────────────────────────────────
+
+def main() -> None:
+    cfg          = _load_conduct_config()
+    server       = cfg.get("server", "").rstrip("/")
+    workspace_id = cfg.get("workspace", "")
+    api_key      = cfg.get("api_key")
+    token        = cfg.get("token")
+
+    for raw in sys.stdin:
+        raw = raw.strip()
+        if not raw:
+            continue
+
+        try:
+            msg = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+
+        msg_id = msg.get("id")          # None for notifications
+        method = msg.get("method", "")
+        params = msg.get("params") or {}
+
+        if method == "initialize":
+            _ok(msg_id, {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities":    {"tools": {}},
+                "serverInfo":      {"name": "conduct", "version": "1.0.0"},
+            })
+
+        elif method == "notifications/initialized":
+            pass  # notification — no response
+
+        elif method == "tools/list":
+            _ok(msg_id, {"tools": _TOOLS})
+
+        elif method == "tools/call":
+            tool_name = params.get("name", "")
+            arguments = params.get("arguments") or {}
+            text      = _dispatch_tool(tool_name, arguments, server, workspace_id, token, api_key)
+            _ok(msg_id, {"content": [{"type": "text", "text": text}]})
+
+        elif method == "ping":
+            _ok(msg_id, {})
+
+        else:
+            if msg_id is not None:
+                _err(msg_id, -32601, f"Method not found: {method}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This branch delivers a large batch of platform improvements across CLI, API, runtime, and frontend.

### conduct-mcp — MCP server for all AI tools
- New `conduct-mcp` binary (zero-dependency JSON-RPC stdio server) exposing 6 tools: list_agents, list_projects, list_playbooks, run_workflow, get_run, guard_status
- `conduct mcp install` auto-registers in Claude Code, Codex, Cursor, Windsurf, and VS Code on first run
- Hooked into `conduct login` so first-time setup is fully automatic
- CLI v0.4.28 → v0.4.30 on PyPI

### Guard — AI tool coverage tracking
- New `guard_developer_tools` table + migration (0056)
- `POST /guard/developer-tools` — CLI upserts detected/mcp_registered/hook_registered snapshot
- Runs automatically on `conduct login` and `conduct guard sync`
- Guard Spend page: Coverage column shows per-tool green ✓ / yellow ! chips per developer

### Run detail page — 11 design gaps closed
- Default tab: Summary (was Steps)
- Page width: 1120px (was 900px)
- Pulse dot: amber on wait/paused, blue on run
- AI Trace tool calls: dark inverse background
- Cost tab: 26px values, correct input/output token colors, 2 decimal places, mono font
- Steps tab: uppercase block type labels (BRAIN, TOOL CALL, GUARD…)
- Chip color variants: bk-trigger on issue chip, bk-approval on approvals chip

### Backend UX gaps (from design session)
- Executor: writes `turns` to brain block state (single-call path)
- `RunDetailOut.actual_turns`: sums brain turns from state via model_validator
- Dashboard: `guard_blocks_today` KPI from GuardAuditEvent
- Runs list: Duration column computed client-side from started_at/completed_at

### Other
- Freeze per-run pricing snapshot for cost predictability
- Explicit run input contract enforced at run start
- Deterministic brain stop boundaries with explicit reasons
- Structured actionable failure summaries in run trace
- Docs: MCP Server section added to CLI tab

## Test plan
- [ ] `pip install conduct-cli==0.4.30` then `conduct login` → verify MCP registered in Claude/Codex/VS Code
- [ ] `conduct mcp install` prints detected vs covered tools
- [ ] Guard Spend page shows Coverage column for logged-in developer
- [ ] Run detail page opens on Summary tab at 1120px width
- [ ] Cost tab shows correct colors and 2 decimal cost values
- [ ] `guard_blocks_today` shows on dashboard (non-zero if any blocks today)