### PR TITLE
ci: schema sync check — fail if v1.yaml drifts from schema.py

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
       - name: Lint
         run: python -m flake8 app --max-line-length 100 || true
         working-directory: apps/api
+      - name: Schema sync check
+        run: make schema-check
+        working-directory: apps/api
       - name: Test
         run: python -m pytest tests/ -v --tb=short || true
         working-directory: apps/api


### PR DESCRIPTION
## What

Adds a `Schema sync check` step to the API CI job that runs `make schema-check`.

Fails the build if `app/dsl/schema/v1.yaml` is out of sync with `app/dsl/schema.py`.

## Why

`schema.py` (Pydantic models) is now the single source of truth. `v1.yaml` is auto-generated via `scripts/generate_schema.py`. Without this gate, someone could update `schema.py` and forget to regenerate — the YAML would silently drift.

## How to fix a failure

```bash
cd apps/api && make schema
git add app/dsl/schema/v1.yaml && git commit -m "chore: regenerate schema/v1.yaml"
```