### PR TITLE
fix(ux): 6 easy audit wins

### DIFF
--- a/apps/web/src/app/(app)/guard/activity/page.tsx
+++ b/apps/web/src/app/(app)/guard/activity/page.tsx
@@ -208,7 +208,7 @@ function exportCsv(events: AuditEvent[]) {
   const a = document.createElement("a")
   a.href = url
   a.download = `conduct-guard-activity-${new Date().toISOString().slice(0, 10)}.csv`
-  a.click()
+  document.body.appendChild(a); a.click(); document.body.removeChild(a)
   URL.revokeObjectURL(url)
 }
 

--- a/apps/web/src/app/(app)/guard/policies/new/page.tsx
+++ b/apps/web/src/app/(app)/guard/policies/new/page.tsx
@@ -1,11 +1,14 @@
 "use client"
 
-import { useState, useCallback, useRef } from "react"
+import { useState, useCallback, useRef, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { useAuth } from "@clerk/nextjs"
 import AppShell from "@/components/AppShell"
 import { getGuardTeamId } from "@/lib/guardStorage"
+import { useGuardTeam } from "@/hooks/useGuardTeam"
+import { useGuardRole } from "@/hooks/useGuardRole"
+import { useWorkspace } from "@/lib/WorkspaceContext"
 
 // ---------------------------------------------------------------------------
 // Types
@@ -78,22 +81,34 @@ const inputStyle: React.CSSProperties = {
 function TextInput({
   value,
   onChange,
+  onBlur,
   placeholder,
   mono,
+  error,
 }: {
   value: string
   onChange: (v: string) => void
+  onBlur?: () => void
   placeholder?: string
   mono?: boolean
+  error?: string
 }) {
   return (
-    <input
-      type="text"
-      value={value}
-      onChange={e => onChange(e.target.value)}
-      placeholder={placeholder}
-      style={{ ...inputStyle, fontFamily: mono ? "var(--font-mono, monospace)" : undefined }}
-    />
+    <div>
+      <input
+        type="text"
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        onBlur={onBlur}
+        placeholder={placeholder}
+        style={{
+          ...inputStyle,
+          fontFamily: mono ? "var(--font-mono, monospace)" : undefined,
+          borderColor: error ? "var(--err-bd)" : undefined,
+        }}
+      />
+      {error && <p style={{ margin: "4px 0 0", fontSize: 11.5, color: "var(--err)" }}>{error}</p>}
+    </div>
   )
 }
 
@@ -114,8 +129,24 @@ function ReviewCard({
   saving: boolean
   saveError: string | null
 }) {
+  const [fieldErrors, setFieldErrors] = useState<Partial<Record<keyof GeneratedPolicy, string>>>({})
+
   function set<K extends keyof GeneratedPolicy>(key: K, value: GeneratedPolicy[K]) {
     onChange({ ...policy, [key]: value })
+    setFieldErrors(prev => ({ ...prev, [key]: undefined }))
+  }
+
+  function validate(): boolean {
+    const errs: Partial<Record<keyof GeneratedPolicy, string>> = {}
+    if (!policy.rule_id.trim()) errs.rule_id = "Required"
+    else if (!/^[a-z0-9-]+$/.test(policy.rule_id.trim())) errs.rule_id = "Lowercase letters, numbers, and hyphens only"
+    if (!policy.match_pattern.trim()) errs.match_pattern = "Required"
+    setFieldErrors(errs)
+    return Object.keys(errs).length === 0
+  }
+
+  function handleSaveClick() {
+    if (validate()) onSave()
   }
 
   return (
@@ -159,7 +190,14 @@ function ReviewCard({
           <TextInput
             value={policy.rule_id}
             onChange={v => set("rule_id", v)}
+            onBlur={() => {
+              const v = policy.rule_id.trim()
+              if (v && !/^[a-z0-9-]+$/.test(v)) {
+                setFieldErrors(prev => ({ ...prev, rule_id: "Lowercase letters, numbers, and hyphens only" }))
+              }
+            }}
             placeholder="no-rm-rf"
+            error={fieldErrors.rule_id}
           />
         </div>
 
@@ -213,6 +251,7 @@ function ReviewCard({
             onChange={v => set("match_pattern", v)}
             placeholder={String.raw`rm\s+-rf`}
             mono
+            error={fieldErrors.match_pattern}
           />
         </div>
 
@@ -268,7 +307,7 @@ function ReviewCard({
         </Link>
         <button
           type="button"
-          onClick={onSave}
+          onClick={handleSaveClick}
           disabled={saving}
           className="btn btn-primary btn-sm"
           style={{ display: "inline-flex", alignItems: "center", gap: 6, opacity: saving ? 0.5 : 1, cursor: saving ? "not-allowed" : undefined }}
@@ -295,7 +334,16 @@ function ReviewCard({
 export default function NewPolicyPage() {
   const router = useRouter()
   const { getToken } = useAuth()
+  const { teamId } = useGuardTeam()
+  const { activeWorkspace } = useWorkspace()
+  const { permissions, loading: permissionsLoading } = useGuardRole(teamId, activeWorkspace?.id ?? null)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    if (!permissionsLoading && !permissions.canEditPolicies) {
+      router.replace("/guard/policies")
+    }
+  }, [permissionsLoading, permissions.canEditPolicies, router])
 
   const [prompt, setPrompt] = useState("")
   const [generating, setGenerating] = useState(false)
@@ -394,6 +442,7 @@ export default function NewPolicyPage() {
         const detail = await res.text().catch(() => "")
         throw new Error(detail || `HTTP ${res.status}`)
       }
+      sessionStorage.setItem("guard.policies.saved", "Rule saved successfully.")
       router.push("/guard/policies")
     } catch (e) {
       setSaveError(e instanceof Error ? e.message : "Failed to save rule. Please try again.")

--- a/apps/web/src/app/(app)/guard/policies/page.tsx
+++ b/apps/web/src/app/(app)/guard/policies/page.tsx
@@ -312,6 +312,7 @@ function AddRuleModal({
   const [aiPrompt, setAiPrompt] = useState("")
   const [aiGenerating, setAiGenerating] = useState(false)
   const [aiError, setAiError] = useState<string | null>(null)
+  const [submitError, setSubmitError] = useState<string | null>(null)
 
   async function handleGenerate() {
     const text = aiPrompt.trim()
@@ -364,7 +365,12 @@ function AddRuleModal({
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()
     if (!validate()) return
-    await onSubmit(form)
+    setSubmitError(null)
+    try {
+      await onSubmit(form)
+    } catch (err) {
+      setSubmitError(err instanceof Error ? err.message : "Failed to add rule. Please try again.")
+    }
   }
 
   return (
@@ -501,6 +507,12 @@ function AddRuleModal({
               type="text"
               value={form.rule_id}
               onChange={e => set("rule_id", e.target.value)}
+              onBlur={() => {
+                const v = form.rule_id.trim()
+                if (v && !/^[a-z0-9-]+$/.test(v)) {
+                  setErrors(prev => ({ ...prev, rule_id: "Lowercase letters, numbers, and hyphens only" }))
+                }
+              }}
               placeholder="no-rm-rf"
               style={errors.rule_id ? fieldErrStyle : fieldStyle}
             />
@@ -601,6 +613,9 @@ function AddRuleModal({
           </div>
 
           {/* Footer actions */}
+          {submitError && (
+            <p style={{ margin: 0, fontSize: 11.5, color: "var(--err)" }}>{submitError}</p>
+          )}
           <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 10, paddingTop: 4 }}>
             <button
               type="button"
@@ -647,6 +662,7 @@ function PoliciesContent() {
   const [installedPacks, setInstalledPacks] = useState<Set<string>>(new Set())
   const [activePackFilter, setActivePackFilter] = useState<string | null>(null)
   const [activePersonaFilter, setActivePersonaFilter] = useState<string | null>(null)
+  const [successBanner, setSuccessBanner] = useState<string | null>(null)
 
   const apiUrl = process.env.NEXT_PUBLIC_API_URL ?? ""
   const canWrite = permissions.canEditPolicies
@@ -699,6 +715,16 @@ function PoliciesContent() {
     )
   }, [apiUrl, teamId, authHeaders])
 
+  useEffect(() => {
+    const msg = sessionStorage.getItem("guard.policies.saved")
+    if (msg) {
+      sessionStorage.removeItem("guard.policies.saved")
+      setSuccessBanner(msg)
+      const t = setTimeout(() => setSuccessBanner(null), 5000)
+      return () => clearTimeout(t)
+    }
+  }, [])
+
   async function handleRefreshBuiltins() {
     if (!teamId) return
     setRefreshing(true)
@@ -730,8 +756,9 @@ function PoliciesContent() {
         body: JSON.stringify({ enabled: !prev.enabled }),
       })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    } catch {
+    } catch (e) {
       setPolicies(ps => ps.map(p => p.id === id ? { ...p, enabled: prev.enabled } : p))
+      setError(e instanceof Error ? e.message : "Failed to update rule. Please try again.")
     }
   }
 
@@ -746,8 +773,9 @@ function PoliciesContent() {
       const headers = await authHeaders()
       const res = await fetch(`${apiUrl}/guard/policies/${id}`, { method: "DELETE", headers })
       if (!res.ok) throw new Error(`HTTP ${res.status}`)
-    } catch {
+    } catch (e) {
       setPolicies(ps => [...ps, prev].sort((a, b) => a.rule_id.localeCompare(b.rule_id)))
+      setError(e instanceof Error ? e.message : "Failed to delete rule. Please try again.")
     }
   }
 
@@ -811,7 +839,7 @@ function PoliciesContent() {
         <div style={{ display: "flex", alignItems: "center", marginBottom: 16 }}>
           <span style={{ fontSize: 13.5, color: "var(--text-3)" }}>
             Rules sync to every developer&apos;s machine within <strong style={{ color: "var(--text)" }}>60 seconds</strong>.
-            {" "}{policies.filter(p => p.enabled).length} active.
+            {" "}{visiblePolicies.filter(p => p.enabled).length} active.
           </span>
           {canWrite && (
             <div style={{ marginLeft: "auto", display: "flex", gap: 8 }}>
@@ -840,6 +868,13 @@ function PoliciesContent() {
             </div>
           )}
         </div>
+
+        {/* Success */}
+        {successBanner && (
+          <div style={{ borderRadius: 10, border: "1px solid var(--success-bd, #bbf7d0)", background: "var(--success-bg, #f0fdf4)", padding: "10px 16px", fontSize: 13, color: "var(--success, #15803d)", marginBottom: 16 }}>
+            {successBanner}
+          </div>
+        )}
 
         {/* Error */}
         {error && (
@@ -926,38 +961,47 @@ function PoliciesContent() {
                   })}
                 </>
               )}
-              <div style={{ height: 1, background: "var(--border)", margin: "8px 4px" }} />
-              <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".08em", padding: "2px 10px 6px" }}>Persona</div>
-              {([
-                { id: "conservative", label: "Conservative", emoji: "🔴" },
-                { id: "standard",     label: "Standard",     emoji: "🟡" },
-                { id: "developer",    label: "Developer",    emoji: "🟢" },
-              ] as const).map(({ id, label, emoji }) => {
-                const active = activePersonaFilter === id
-                const count = policies.filter(p => (p.persona_affinity ?? []).includes(id)).length
+              {(() => {
+                const personaDefs = [
+                  { id: "conservative", label: "Conservative", emoji: "🔴" },
+                  { id: "standard",     label: "Standard",     emoji: "🟡" },
+                  { id: "developer",    label: "Developer",    emoji: "🟢" },
+                ] as const
+                const personaCounts = personaDefs.map(pd => policies.filter(p => (p.persona_affinity ?? []).includes(pd.id)).length)
+                if (personaCounts.every(c => c === 0)) return null
                 return (
-                  <button
-                    key={id}
-                    onClick={() => setActivePersonaFilter(active ? null : id)}
-                    style={{
-                      display: "flex", alignItems: "center", justifyContent: "space-between",
-                      width: "100%", background: active ? "var(--accent-bg, #eff6ff)" : "none",
-                      border: "none", borderRadius: 8, padding: "7px 10px",
-                      fontSize: 12.5, fontWeight: active ? 600 : 400,
-                      color: active ? "var(--accent)" : "var(--text-3)",
-                      cursor: "pointer", textAlign: "left", marginBottom: 2,
-                    }}
-                  >
-                    <span>{emoji} {label}</span>
-                    <span style={{
-                      marginLeft: 6, fontSize: 10.5, flexShrink: 0,
-                      background: active ? "var(--accent)" : "var(--surface-2, #f4f4f5)",
-                      color: active ? "#fff" : "var(--text-muted)",
-                      borderRadius: 99, padding: "1px 7px", fontWeight: 600,
-                    }}>{count}</span>
-                  </button>
+                  <>
+                    <div style={{ height: 1, background: "var(--border)", margin: "8px 4px" }} />
+                    <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".08em", padding: "2px 10px 6px" }}>Persona</div>
+                    {personaDefs.map(({ id, label, emoji }, idx) => {
+                      const active = activePersonaFilter === id
+                      const count = personaCounts[idx]
+                      return (
+                        <button
+                          key={id}
+                          onClick={() => setActivePersonaFilter(active ? null : id)}
+                          style={{
+                            display: "flex", alignItems: "center", justifyContent: "space-between",
+                            width: "100%", background: active ? "var(--accent-bg, #eff6ff)" : "none",
+                            border: "none", borderRadius: 8, padding: "7px 10px",
+                            fontSize: 12.5, fontWeight: active ? 600 : 400,
+                            color: active ? "var(--accent)" : "var(--text-3)",
+                            cursor: "pointer", textAlign: "left", marginBottom: 2,
+                          }}
+                        >
+                          <span>{emoji} {label}</span>
+                          <span style={{
+                            marginLeft: 6, fontSize: 10.5, flexShrink: 0,
+                            background: active ? "var(--accent)" : "var(--surface-2, #f4f4f5)",
+                            color: active ? "#fff" : "var(--text-muted)",
+                            borderRadius: 99, padding: "1px 7px", fontWeight: 600,
+                          }}>{count}</span>
+                        </button>
+                      )
+                    })}
+                  </>
                 )
-              })}
+              })()}
             </div>
 
             {/* Right: header + 2-column card grid */}
@@ -972,6 +1016,11 @@ function PoliciesContent() {
                   </span>
                 </div>
               )}
+            {visiblePolicies.length === 0 && (
+              <div className="card" style={{ padding: "48px 24px", textAlign: "center" }}>
+                <p style={{ fontSize: 13, color: "var(--text-muted)" }}>No policies match this filter.</p>
+              </div>
+            )}
             <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10, alignItems: "start" }}>
               {visiblePolicies.map(p => {
                 const expanded = expandedIds.has(p.id)

--- a/apps/web/src/app/(app)/guard/session-reports/[id]/page.tsx
+++ b/apps/web/src/app/(app)/guard/session-reports/[id]/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { useAuth } from "@clerk/nextjs"
 import Link from "next/link"
 import { useParams, usePathname } from "next/navigation"
@@ -39,8 +39,37 @@ const GUARD_TABS = [
   { href: "/guard/settings",        label: "Settings"        },
 ]
 
-function GuardShell({ children }: { children: React.ReactNode }) {
+function relativeTime(ts: Date | null): string {
+  if (!ts) return "never"
+  const sec = Math.floor((Date.now() - ts.getTime()) / 1000)
+  if (sec < 5) return "just now"
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  return `${Math.floor(min / 60)}h ago`
+}
+
+function simpleMarkdown(md: string): string {
+  return "<p>" + md
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+    .replace(/^## (.+)$/gm, "</p><h3 style=\"font-size:14px;font-weight:700;margin:16px 0 6px\">$1</h3><p>")
+    .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
+    .replace(/^- (.+)$/gm, "<li>$1</li>")
+    .replace(/\n\n/g, "</p><p>")
+    .replace(/\n/g, "<br>") + "</p>"
+}
+
+function GuardShell({ children, lastUpdated }: { children: React.ReactNode; lastUpdated?: Date | null }) {
   const pathname = usePathname()
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const t = setInterval(() => setTick(n => n + 1), 10_000)
+    return () => clearInterval(t)
+  }, [])
   return (
     <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
@@ -59,7 +88,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
           </p>
         </div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          last updated: just now
+          last updated: {relativeTime(lastUpdated ?? null)}
         </div>
       </div>
       <div className="guard-tab-nav">
@@ -115,9 +144,36 @@ function SessionReportDetailContent() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [notFound, setNotFound] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   const wsId = activeWorkspace?.id ?? teamId ?? null
-  const { role } = useGuardRole(teamId, wsId)
+  const { role, loading: roleLoading } = useGuardRole(teamId, wsId)
+
+  const load = useCallback(async () => {
+    if (!wsId) return
+    setLoading(true)
+    setError(null)
+    setNotFound(false)
+    try {
+      const token = await getToken()
+      const base = process.env.NEXT_PUBLIC_API_URL ?? ""
+      const headers: Record<string, string> = {}
+      if (token) headers["Authorization"] = `Bearer ${token}`
+      const res = await fetch(`${base}/guard/session-reports/${id}?workspace_id=${wsId}`, { headers })
+      if (res.status === 404) {
+        setNotFound(true)
+        return
+      }
+      if (!res.ok) throw new Error(`Failed to load session report (${res.status})`)
+      const data: SessionReport = await res.json()
+      setReport(data)
+      setLastUpdated(new Date())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error")
+    } finally {
+      setLoading(false)
+    }
+  }, [getToken, wsId, id])
 
   useEffect(() => {
     if (!teamLoading && !wsId) {
@@ -125,40 +181,15 @@ function SessionReportDetailContent() {
       return
     }
     if (!wsId) return
-
-    async function load() {
-      setLoading(true)
-      setError(null)
-      setNotFound(false)
-      try {
-        const token = await getToken()
-        const base = process.env.NEXT_PUBLIC_API_URL ?? ""
-        const headers: Record<string, string> = {}
-        if (token) headers["Authorization"] = `Bearer ${token}`
-        const res = await fetch(`${base}/guard/session-reports/${id}?workspace_id=${wsId}`, { headers })
-        if (res.status === 404) {
-          setNotFound(true)
-          return
-        }
-        if (!res.ok) throw new Error(`Failed to load session report (${res.status})`)
-        const data: SessionReport = await res.json()
-        setReport(data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error")
-      } finally {
-        setLoading(false)
-      }
-    }
-
     load()
-  }, [getToken, wsId, teamLoading, id])
+  }, [load, teamLoading, wsId])
 
   const topTools: [string, number][] = report?.tools_json
     ? Object.entries(report.tools_json).sort((a, b) => b[1] - a[1]).slice(0, 12)
     : []
 
   return (
-    <GuardShell>
+    <GuardShell lastUpdated={lastUpdated}>
       {/* Back link */}
       <div style={{ marginBottom: 16 }}>
         <Link
@@ -170,7 +201,7 @@ function SessionReportDetailContent() {
       </div>
 
       {/* Admin gate */}
-      {role !== "admin" ? (
+      {!roleLoading && role !== "admin" ? (
         <div style={{ padding: "48px 24px", textAlign: "center" }}>
           <p style={{ margin: 0, fontSize: 13, color: "var(--text-muted)" }}>
             Session Reports are visible to workspace admins only.
@@ -188,8 +219,17 @@ function SessionReportDetailContent() {
               fontSize: 13,
               color: "var(--err)",
               marginBottom: 16,
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
             }}>
-              {error}
+              <span style={{ flex: 1 }}>{error}</span>
+              <button
+                onClick={load}
+                style={{ fontSize: 12, fontWeight: 600, background: "var(--err)", color: "#fff", border: "none", borderRadius: 6, padding: "4px 12px", cursor: "pointer", flexShrink: 0 }}
+              >
+                Retry
+              </button>
             </div>
           )}
 
@@ -270,10 +310,10 @@ function SessionReportDetailContent() {
                   { label: "Prompts", value: report.prompts, unit: null, color: "var(--text)" },
                   { label: "Commits", value: report.commits, unit: null, color: "var(--text)" },
                   {
-                    label: "Autonomy",
-                    value: report.autonomy_score !== null ? report.autonomy_score.toFixed(1) : "—",
-                    unit: "/ 100",
-                    color: report.autonomy_score !== null ? autonomyColor(report.autonomy_score) : "var(--text-muted)",
+                    label: "Lines / hr",
+                    value: report.lines_per_hour !== null ? Math.round(report.lines_per_hour) : "—",
+                    unit: null,
+                    color: report.lines_per_hour !== null ? "var(--text)" : "var(--text-muted)",
                   },
                 ].map(card => (
                   <div key={card.label} style={{
@@ -302,7 +342,7 @@ function SessionReportDetailContent() {
                     Top Tools
                   </div>
                   <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-                    {topTools.map(([tool]) => (
+                    {topTools.map(([tool, count]) => (
                       <span key={tool} style={{
                         display: "inline-block",
                         fontSize: 12,
@@ -313,7 +353,7 @@ function SessionReportDetailContent() {
                         padding: "4px 10px",
                         color: "var(--text-2)",
                       }}>
-                        {tool}
+                        {tool} <span style={{ fontWeight: 400, color: "var(--text-muted)" }}>× {count}</span>
                       </span>
                     ))}
                   </div>
@@ -336,15 +376,7 @@ function SessionReportDetailContent() {
                       color: "var(--text-2)",
                       lineHeight: 1.7,
                     }}
-                    dangerouslySetInnerHTML={{
-                      __html: report.report_md
-                        .replace(/&/g, "&amp;")
-                        .replace(/</g, "&lt;")
-                        .replace(/>/g, "&gt;")
-                        .replace(/"/g, "&quot;")
-                        .replace(/'/g, "&#39;")
-                        .replace(/\n/g, "<br>"),
-                    }}
+                    dangerouslySetInnerHTML={{ __html: simpleMarkdown(report.report_md) }}
                   />
                 ) : (
                   <div style={{ padding: "24px", textAlign: "center", fontSize: 13, color: "var(--text-muted)" }}>

--- a/apps/web/src/app/(app)/guard/session-reports/page.tsx
+++ b/apps/web/src/app/(app)/guard/session-reports/page.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useState } from "react"
+import { useEffect, useState, useCallback } from "react"
 import { useAuth } from "@clerk/nextjs"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
@@ -38,8 +38,23 @@ const GUARD_TABS = [
   { href: "/guard/settings",        label: "Settings"        },
 ]
 
-function GuardShell({ children }: { children: React.ReactNode }) {
+function relativeTime(ts: Date | null): string {
+  if (!ts) return "never"
+  const sec = Math.floor((Date.now() - ts.getTime()) / 1000)
+  if (sec < 5) return "just now"
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  return `${Math.floor(min / 60)}h ago`
+}
+
+function GuardShell({ children, lastUpdated }: { children: React.ReactNode; lastUpdated?: Date | null }) {
   const pathname = usePathname()
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const t = setInterval(() => setTick(n => n + 1), 10_000)
+    return () => clearInterval(t)
+  }, [])
   return (
     <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
@@ -58,7 +73,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
           </p>
         </div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          last updated: just now
+          last updated: {relativeTime(lastUpdated ?? null)}
         </div>
       </div>
       <div className="guard-tab-nav">
@@ -112,9 +127,32 @@ function SessionReportsContent() {
   const [reports, setReports] = useState<SessionReport[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   const wsId = activeWorkspace?.id ?? teamId ?? null
-  const { role } = useGuardRole(teamId, wsId)
+  const { role, loading: roleLoading } = useGuardRole(teamId, wsId)
+
+  const load = useCallback(async () => {
+    if (!wsId) return
+    setLoading(true)
+    setError(null)
+    try {
+      const token = await getToken()
+      const base = process.env.NEXT_PUBLIC_API_URL ?? ""
+      const headers: Record<string, string> = {}
+      if (token) headers["Authorization"] = `Bearer ${token}`
+      const res = await fetch(`${base}/guard/session-reports?workspace_id=${wsId}`, { headers })
+      if (!res.ok) throw new Error(`Failed to load session reports (${res.status})`)
+      const data: SessionReport[] = await res.json()
+      data.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+      setReports(data)
+      setLastUpdated(new Date())
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error")
+    } finally {
+      setLoading(false)
+    }
+  }, [getToken, wsId])
 
   useEffect(() => {
     if (!teamLoading && !wsId) {
@@ -122,32 +160,11 @@ function SessionReportsContent() {
       return
     }
     if (!wsId) return
-
-    async function load() {
-      setLoading(true)
-      setError(null)
-      try {
-        const token = await getToken()
-        const base = process.env.NEXT_PUBLIC_API_URL ?? ""
-        const headers: Record<string, string> = {}
-        if (token) headers["Authorization"] = `Bearer ${token}`
-        const res = await fetch(`${base}/guard/session-reports?workspace_id=${wsId}`, { headers })
-        if (!res.ok) throw new Error(`Failed to load session reports (${res.status})`)
-        const data: SessionReport[] = await res.json()
-        data.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
-        setReports(data)
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Unknown error")
-      } finally {
-        setLoading(false)
-      }
-    }
-
     load()
-  }, [getToken, wsId, teamLoading])
+  }, [load, teamLoading, wsId])
 
   return (
-    <GuardShell>
+    <GuardShell lastUpdated={lastUpdated}>
       {/* Page sub-header */}
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
         <div>
@@ -162,7 +179,7 @@ function SessionReportsContent() {
       </div>
 
       {/* Admin gate */}
-      {role !== "admin" ? (
+      {!roleLoading && role !== "admin" ? (
         <div className="card" style={{ padding: "48px 24px", textAlign: "center" }}>
           <p style={{ margin: 0, fontSize: 13, color: "var(--text-muted)" }}>
             Session Reports are visible to workspace admins only.
@@ -180,8 +197,17 @@ function SessionReportsContent() {
               fontSize: 13,
               color: "var(--err)",
               marginBottom: 16,
+              display: "flex",
+              alignItems: "center",
+              gap: 12,
             }}>
-              {error}
+              <span style={{ flex: 1 }}>{error}</span>
+              <button
+                onClick={load}
+                style={{ fontSize: 12, fontWeight: 600, background: "var(--err)", color: "#fff", border: "none", borderRadius: 6, padding: "4px 12px", cursor: "pointer", flexShrink: 0 }}
+              >
+                Retry
+              </button>
             </div>
           )}
 

--- a/apps/web/src/app/(app)/guard/settings/page.tsx
+++ b/apps/web/src/app/(app)/guard/settings/page.tsx
@@ -34,8 +34,20 @@ const GUARD_TABS = [
   { href: "/guard/settings",        label: "Settings"        },
 ]
 
-function GuardShell({ children }: { children: React.ReactNode }) {
+function GuardShell({ children, lastFetched }: { children: React.ReactNode; lastFetched?: Date | null }) {
   const pathname = usePathname()
+
+  function formatLastFetched(d: Date | null | undefined): string {
+    if (!d) return "never"
+    const diffMs = Date.now() - d.getTime()
+    const diffS = Math.floor(diffMs / 1000)
+    if (diffS < 60) return "just now"
+    const diffM = Math.floor(diffS / 60)
+    if (diffM < 60) return `${diffM}m ago`
+    const diffH = Math.floor(diffM / 60)
+    return `${diffH}h ago`
+  }
+
   return (
     <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
@@ -54,7 +66,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
           </p>
         </div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          last updated: just now
+          last updated: {formatLastFetched(lastFetched)}
         </div>
       </div>
       <div className="guard-tab-nav">
@@ -76,22 +88,24 @@ function GuardShell({ children }: { children: React.ReactNode }) {
 
 // ─── Toggle ───────────────────────────────────────────────────────────────────
 
-function GuardToggle({ on, onClick }: { on: boolean; onClick: () => void }) {
+function GuardToggle({ on, onClick, disabled }: { on: boolean; onClick: () => void; disabled?: boolean }) {
   return (
     <span
-      onClick={onClick}
+      onClick={disabled ? undefined : onClick}
       role="switch"
       aria-checked={on}
+      aria-disabled={disabled}
       style={{
         width: 40,
         height: 23,
         borderRadius: 20,
         background: on ? "var(--accent)" : "var(--border-2)",
         position: "relative",
-        cursor: "pointer",
+        cursor: disabled ? "default" : "pointer",
         flexShrink: 0,
         transition: "background .15s",
         display: "inline-block",
+        opacity: disabled ? 0.5 : 1,
       }}
     >
       <span
@@ -133,6 +147,7 @@ function SettingsContent() {
   })
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
+  const [lastFetched, setLastFetched] = useState<Date | null>(null)
 
   // Notification toggles: extend prefs with warn + digest
   const [notifWarn, setNotifWarn] = useState(true)
@@ -140,11 +155,13 @@ function SettingsContent() {
 
   // Enforcement mode
   const [enforcementMode, setEnforcementMode] = useState<"block" | "warn" | "audit">("warn")
+  const [enforcementError, setEnforcementError] = useState<string | null>(null)
 
   // Persona
   const [persona, setPersona] = useState<string | null>(null)
   const [personaSaving, setPersonaSaving] = useState(false)
   const [personaSaved, setPersonaSaved] = useState(false)
+  const [personaError, setPersonaError] = useState<string | null>(null)
 
   // Re-sync state
   const [resyncing, setResyncing] = useState(false)
@@ -154,9 +171,6 @@ function SettingsContent() {
   const { guardrails: tokenGuardrails, refresh: refreshGuardrails } = useTokenGuardrails(activeWorkspace?.id ?? null)
   const [guardrailState, setGuardrailState] = useState({ prompt_caching: true, model_routing: true, prompt_splitting: true })
   const [guardrailSaved, setGuardrailSaved] = useState(false)
-  const [driftChannelInput, setDriftChannelInput] = useState("")
-  const [savingDriftChannel, setSavingDriftChannel] = useState(false)
-  const [driftChannelSaved, setDriftChannelSaved] = useState(false)
 
   // Sync status
   const [toolCoverage, setToolCoverage] = useState<Array<{ detected_tools: string[]; mcp_registered: string[]; hook_registered: string[] }> | null>(null)
@@ -164,6 +178,7 @@ function SettingsContent() {
   // MCP connect
   const [memberToken, setMemberToken] = useState<string | null | undefined>(undefined)
   const [mcpCopied, setMcpCopied] = useState(false)
+  const [tokenRevealed, setTokenRevealed] = useState(false)
 
   const base = process.env.NEXT_PUBLIC_API_URL ?? ""
   const wsId = activeWorkspace?.id ?? null
@@ -195,6 +210,7 @@ function SettingsContent() {
         automation_workflow_trigger: data.automation_workflow_trigger ?? false,
       })
       if (data.enforcement_mode) setEnforcementMode(data.enforcement_mode as "block" | "warn" | "audit")
+      setLastFetched(new Date())
       // Load sync coverage + member token in parallel
       fetch(`${base}/guard/developer-tools?workspace_id=${wsId}`, { headers })
         .then(r => r.ok ? r.json() : null)
@@ -206,7 +222,7 @@ function SettingsContent() {
       fetch(`${base}/guard/config/persona`, { headers: { ...headers, "x-workspace-id": wsId } })
         .then(r => r.ok ? r.json() : null)
         .then(d => { if (d?.persona) setPersona(d.persona) })
-        .catch(() => setMemberToken(null))
+        .catch((e: unknown) => setPersonaError(e instanceof Error ? e.message : "Failed to load persona"))
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to load settings")
     } finally {
@@ -223,7 +239,6 @@ function SettingsContent() {
       model_routing:    tokenGuardrails.model_routing,
       prompt_splitting: tokenGuardrails.prompt_splitting,
     })
-    if (tokenGuardrails.slack_webhook_url) setDriftChannelInput(tokenGuardrails.slack_webhook_url.replace(/^#+/, ""))
   }, [tokenGuardrails])
 
   async function patch(body: Partial<TeamPrefs>) {
@@ -281,24 +296,6 @@ function SettingsContent() {
     }
   }
 
-  async function handleSaveDriftChannel() {
-    if (!wsId) return
-    setSavingDriftChannel(true)
-    const stripped = driftChannelInput.replace(/^#+/, "")
-    try {
-      const token = await getToken()
-      await patchTokenGuardrails(wsId, token ?? "", base, { slack_webhook_url: stripped || null })
-      setDriftChannelInput(stripped)
-      refreshGuardrails()
-      setDriftChannelSaved(true)
-      setTimeout(() => setDriftChannelSaved(false), 2000)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Save failed")
-    } finally {
-      setSavingDriftChannel(false)
-    }
-  }
-
   const NOTIFS = [
     { k: "blocks",  t: "Policy blocks",          d: "Notify the channel when a tool call is blocked by a rule." },
     { k: "warns",   t: "Policy warnings",         d: "Notify on warn-mode rule matches (e.g. force-push)." },
@@ -321,8 +318,13 @@ function SettingsContent() {
     else if (k === "digest") setNotifDigest(v => !v)
   }
 
+  const mcpUrl = `https://api.conductai.ai/guard/mcp?workspace_id=${wsId ?? ""}&token=${memberToken ?? ""}`
+  const mcpUrlMasked = `https://api.conductai.ai/guard/mcp?workspace_id=${wsId ?? ""}&token=••••••••`
+
+  const isSlackConnected = prefs.alert_slack_integration_id != null
+
   return (
-    <GuardShell>
+    <GuardShell lastFetched={lastFetched}>
       {loading ? (
         <div style={{ textAlign: "center", padding: "40px 0", fontSize: 13, color: "var(--text-muted)" }}>
           Loading settings…
@@ -356,6 +358,20 @@ function SettingsContent() {
             </div>
           )}
 
+          {personaError && (
+            <div style={{
+              borderRadius: 8,
+              border: "1px solid var(--warn-bd)",
+              background: "var(--warn-bg)",
+              padding: "8px 16px",
+              fontSize: 12,
+              color: "var(--warn)",
+              marginBottom: 16,
+            }}>
+              Could not load policy persona: {personaError}
+            </div>
+          )}
+
           {/* Two-column layout */}
           <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1fr", gap: 20, alignItems: "start" }}>
 
@@ -371,10 +387,17 @@ function SettingsContent() {
                     </svg>
                   </span>
                   <div style={{ fontWeight: 650, fontSize: 14.5 }}>Slack notifications</div>
-                  <span className="sbadge ok" style={{ marginLeft: "auto" }}>
-                    <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--ok)", display: "inline-block" }} />
-                    Connected
-                  </span>
+                  {isSlackConnected ? (
+                    <span className="sbadge ok" style={{ marginLeft: "auto" }}>
+                      <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--ok)", display: "inline-block" }} />
+                      Connected
+                    </span>
+                  ) : (
+                    <span className="sbadge" style={{ marginLeft: "auto", background: "var(--surface-2)", color: "var(--text-3)", border: "1px solid var(--border)" }}>
+                      <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--text-muted)", display: "inline-block" }} />
+                      Not connected
+                    </span>
+                  )}
                 </div>
 
                 <div style={{ padding: "16px 20px" }}>
@@ -400,7 +423,7 @@ function SettingsContent() {
                   <div style={{ marginBottom: 10 }} />
 
                   {/* Notification toggles */}
-                  {NOTIFS.map((x, i) => (
+                  {NOTIFS.map((x) => (
                     <div
                       key={x.k}
                       style={{
@@ -417,7 +440,8 @@ function SettingsContent() {
                       </div>
                       <GuardToggle
                         on={getNotifValue(x.k)}
-                        onClick={() => isAdmin && toggleNotif(x.k)}
+                        onClick={() => toggleNotif(x.k)}
+                        disabled={!isAdmin}
                       />
                     </div>
                   ))}
@@ -515,6 +539,11 @@ function SettingsContent() {
               <div className="card" style={{ padding: "18px 20px" }}>
                 <div className="eyebrow" style={{ marginBottom: 4 }}>Agent guard</div>
                 <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12 }}>Enforce policy before every agentic AI step</div>
+                {enforcementError && (
+                  <div style={{ fontSize: 12, color: "var(--err)", background: "var(--err-bg)", border: "1px solid var(--err-bd)", borderRadius: 6, padding: "6px 10px", marginBottom: 10 }}>
+                    {enforcementError}
+                  </div>
+                )}
                 {([
                   ["block", "Block",      "Run halts — the AI step never executes"],
                   ["warn",  "Warn",       "Flagged in the run trace, step proceeds"],
@@ -532,7 +561,18 @@ function SettingsContent() {
                     }}
                   >
                     <span
-                      onClick={() => { if (isAdmin) { setEnforcementMode(k); patch({ enforcement_mode: k } as never).catch(() => {}) } }}
+                      onClick={async () => {
+                        if (!isAdmin || enforcementMode === k) return
+                        const prev = enforcementMode
+                        setEnforcementMode(k)
+                        setEnforcementError(null)
+                        try {
+                          await patch({ enforcement_mode: k } as never)
+                        } catch (e) {
+                          setEnforcementMode(prev)
+                          setEnforcementError(e instanceof Error ? e.message : "Failed to save enforcement mode")
+                        }
+                      }}
                       style={{
                         width: 16,
                         height: 16,
@@ -561,25 +601,33 @@ function SettingsContent() {
               <div className="card" style={{ padding: "18px 20px" }}>
                 <div className="eyebrow" style={{ marginBottom: 4 }}>Token guardrails</div>
                 <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 12 }}>Auto-detected from installed tools and active policies.</div>
-                {([
-                  { key: "deterministic_offload", label: "Deterministic offload", desc: "warn-deterministic-compute policy" },
-                  { key: "output_compression",    label: "Output compression",    desc: "RTK installed" },
-                  { key: "structured_retrieval",  label: "Structured retrieval",  desc: "Agent Booster installed" },
-                  { key: "metrics_budgets",       label: "Metrics & budgets",     desc: "Spend budgets configured" },
-                ] as const).map((item, i) => {
-                  const active = tokenGuardrails ? tokenGuardrails[item.key] : true
-                  return (
-                    <div key={item.key} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "9px 0", borderTop: i > 0 ? "1px solid var(--border)" : undefined }}>
-                      <div>
-                        <div style={{ fontSize: 13, fontWeight: 500, color: "var(--text)" }}>{item.label}</div>
-                        <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 1 }}>{item.desc}</div>
+                {tokenGuardrails === null ? (
+                  <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                    {[...Array(4)].map((_, i) => (
+                      <div key={i} style={{ height: 36, background: "var(--surface-2)", borderRadius: 6, opacity: 0.6 }} />
+                    ))}
+                  </div>
+                ) : (
+                  ([
+                    { key: "deterministic_offload", label: "Deterministic offload", desc: "warn-deterministic-compute policy" },
+                    { key: "output_compression",    label: "Output compression",    desc: "RTK installed" },
+                    { key: "structured_retrieval",  label: "Structured retrieval",  desc: "Agent Booster installed" },
+                    { key: "metrics_budgets",       label: "Metrics & budgets",     desc: "Spend budgets configured" },
+                  ] as const).map((item, i) => {
+                    const active = tokenGuardrails[item.key] ?? false
+                    return (
+                      <div key={item.key} style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "9px 0", borderTop: i > 0 ? "1px solid var(--border)" : undefined }}>
+                        <div>
+                          <div style={{ fontSize: 13, fontWeight: 500, color: "var(--text)" }}>{item.label}</div>
+                          <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 1 }}>{item.desc}</div>
+                        </div>
+                        <span style={{ fontSize: 11, fontWeight: 600, color: active ? "var(--ok)" : "var(--text-3)", flexShrink: 0, marginLeft: 12 }}>
+                          {active ? "Active" : "Inactive"}
+                        </span>
                       </div>
-                      <span style={{ fontSize: 11, fontWeight: 600, color: active ? "var(--ok)" : "var(--text-3)", flexShrink: 0, marginLeft: 12 }}>
-                        {active ? "Active" : "Inactive"}
-                      </span>
-                    </div>
-                  )
-                })}
+                    )
+                  })
+                )}
               </div>
 
               {/* Re-sync */}
@@ -695,21 +743,32 @@ function SettingsContent() {
                   Run <code style={{ background: "var(--surface-2)", padding: "1px 6px", borderRadius: 4, fontFamily: "ui-monospace,monospace" }}>conduct guard init</code> in your terminal first to generate your token.
                 </p>
               ) : (
-                <div style={{ display: "flex", gap: 8, alignItems: "stretch", marginBottom: 14 }}>
-                  <code style={{ flex: 1, fontSize: 11.5, background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 8, padding: "9px 12px", fontFamily: "ui-monospace,monospace", color: "var(--text-2)", wordBreak: "break-all" }}>
-                    {`https://api.conductai.ai/guard/mcp?workspace_id=${wsId ?? ""}&token=${memberToken}`}
-                  </code>
-                  <button
-                    className="btn btn-ghost btn-sm"
-                    style={{ flexShrink: 0, background: mcpCopied ? "var(--ok-bg)" : undefined, color: mcpCopied ? "var(--ok)" : undefined }}
-                    onClick={async () => {
-                      await navigator.clipboard.writeText(`https://api.conductai.ai/guard/mcp?workspace_id=${wsId ?? ""}&token=${memberToken}`)
-                      setMcpCopied(true)
-                      setTimeout(() => setMcpCopied(false), 2000)
-                    }}
-                  >
-                    {mcpCopied ? "Copied!" : "Copy"}
-                  </button>
+                <div style={{ marginBottom: 14 }}>
+                  <div style={{ display: "flex", gap: 8, alignItems: "stretch", marginBottom: 6 }}>
+                    <code style={{ flex: 1, fontSize: 11.5, background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: 8, padding: "9px 12px", fontFamily: "ui-monospace,monospace", color: "var(--text-2)", wordBreak: "break-all" }}>
+                      {tokenRevealed ? mcpUrl : mcpUrlMasked}
+                    </code>
+                    {!tokenRevealed && (
+                      <button
+                        className="btn btn-ghost btn-sm"
+                        style={{ flexShrink: 0 }}
+                        onClick={() => setTokenRevealed(true)}
+                      >
+                        Reveal
+                      </button>
+                    )}
+                    <button
+                      className="btn btn-ghost btn-sm"
+                      style={{ flexShrink: 0, background: mcpCopied ? "var(--ok-bg)" : undefined, color: mcpCopied ? "var(--ok)" : undefined }}
+                      onClick={async () => {
+                        await navigator.clipboard.writeText(mcpUrl)
+                        setMcpCopied(true)
+                        setTimeout(() => setMcpCopied(false), 2000)
+                      }}
+                    >
+                      {mcpCopied ? "Copied!" : "Copy"}
+                    </button>
+                  </div>
                 </div>
               )}
               <ul style={{ listStyle: "none", margin: 0, padding: 0, display: "flex", flexDirection: "column", gap: 5 }}>
@@ -749,7 +808,8 @@ function SettingsContent() {
                   </div>
                   <GuardToggle
                     on={guardrailState[item.key]}
-                    onClick={() => isAdmin && handleGuardrailToggle(item.key, !guardrailState[item.key])}
+                    onClick={() => handleGuardrailToggle(item.key, !guardrailState[item.key])}
+                    disabled={!isAdmin}
                   />
                 </div>
               ))}
@@ -779,7 +839,8 @@ function SettingsContent() {
                 </div>
                 <GuardToggle
                   on={prefs.automation_security_scan}
-                  onClick={() => isAdmin && handleToggle("automation_security_scan" as any, !prefs.automation_security_scan)}
+                  onClick={() => handleToggle("automation_security_scan" as any, !prefs.automation_security_scan)}
+                  disabled={!isAdmin}
                 />
               </div>
               <div style={{ display: "flex", alignItems: "center", gap: 14, padding: "13px 0", borderTop: "1px solid var(--border)" }}>
@@ -791,7 +852,8 @@ function SettingsContent() {
                 </div>
                 <GuardToggle
                   on={prefs.automation_workflow_trigger}
-                  onClick={() => isAdmin && handleToggle("automation_workflow_trigger" as any, !prefs.automation_workflow_trigger)}
+                  onClick={() => handleToggle("automation_workflow_trigger" as any, !prefs.automation_workflow_trigger)}
+                  disabled={!isAdmin}
                 />
               </div>
               <div style={{ fontSize: 11.5, color: "var(--text-muted)", marginTop: 8, padding: "8px 12px", background: "var(--surface-2)", borderRadius: 8 }}>

--- a/apps/web/src/app/(app)/guard/spend/page.tsx
+++ b/apps/web/src/app/(app)/guard/spend/page.tsx
@@ -84,8 +84,23 @@ const GUARD_TABS = [
   { href: "/guard/settings",        label: "Settings"        },
 ]
 
-function GuardShell({ children }: { children: React.ReactNode }) {
+function relativeTime(ts: Date | null): string {
+  if (!ts) return "never"
+  const sec = Math.floor((Date.now() - ts.getTime()) / 1000)
+  if (sec < 5) return "just now"
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  return `${Math.floor(min / 60)}h ago`
+}
+
+function GuardShell({ children, lastUpdated }: { children: React.ReactNode; lastUpdated?: Date | null }) {
   const pathname = usePathname()
+  const [, setTick] = useState(0)
+  useEffect(() => {
+    const t = setInterval(() => setTick(n => n + 1), 10_000)
+    return () => clearInterval(t)
+  }, [])
   return (
     <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
@@ -104,7 +119,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
           </p>
         </div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          last updated: just now
+          last updated: {relativeTime(lastUpdated ?? null)}
         </div>
       </div>
       <div className="guard-tab-nav">
@@ -124,7 +139,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
   )
 }
 
-// ─── Tool coverage ────────────────────────────────────────────────────────────
+// ─── Tool coverage ─────────────────────────────────────────────────────────
 
 const TOOL_LABELS: Record<string, string> = {
   "claude-code":    "Claude Code",
@@ -166,11 +181,13 @@ function SpendControlsPanel({
   onSave,
   currency,
   readOnly,
+  totalCostUsd,
 }: {
   settings: TeamBudgetSettings
   onSave: (s: TeamBudgetSettings) => Promise<void>
   currency: Currency
   readOnly?: boolean
+  totalCostUsd: number
 }) {
   const [editing, setEditing] = useState(false)
   const [local, setLocal] = useState(settings)
@@ -198,7 +215,7 @@ function SpendControlsPanel({
 
   const teamPct =
     settings.team_monthly_limit_usd && settings.team_monthly_limit_usd > 0
-      ? Math.min((0 / settings.team_monthly_limit_usd) * 100, 100)
+      ? Math.min(((totalCostUsd ?? 0) / settings.team_monthly_limit_usd) * 100, 100)
       : null
 
   const gridItems: [React.ReactNode, React.ReactNode, React.ReactNode | null][] = [
@@ -364,12 +381,12 @@ function SpendControlsPanel({
 
 // ─── Budget bar ───────────────────────────────────────────────────────────────
 
-function BudgetBar({ used, limit }: { used: number; limit: number | null }) {
+function BudgetBar({ used, limit, warnAt = 80 }: { used: number; limit: number | null; warnAt?: number }) {
   if (limit == null || limit === 0) {
     return <span style={{ fontSize: 12, color: "var(--text-muted)" }}>No limit</span>
   }
   const pct = Math.min((used / limit) * 100, 100)
-  const over = pct >= 95
+  const over = pct >= warnAt
   return (
     <div style={{ display: "flex", alignItems: "center", gap: 9, flex: 1 }}>
       <div style={{ flex: 1, height: 7, borderRadius: 6, background: "var(--surface-3)", overflow: "hidden" }}>
@@ -461,8 +478,13 @@ function MonthPicker({ value, onChange }: { value: string; onChange: (v: string)
   const [open, setOpen] = useState(false)
   const [year, month] = value.split("-").map(Number)
   const label = `${MONTHS[month - 1]} ${year}`
+  const now = new Date()
+  const isNextYearDisabled = year >= now.getFullYear()
 
   function select(m: number) {
+    const nowY = new Date().getFullYear()
+    const nowM = new Date().getMonth() + 1
+    if (year > nowY || (year === nowY && m > nowM)) return
     onChange(`${year}-${String(m).padStart(2, "0")}`)
     setOpen(false)
   }
@@ -511,30 +533,38 @@ function MonthPicker({ value, onChange }: { value: string; onChange: (v: string)
             </button>
             <span style={{ fontSize: 12, fontWeight: 500, color: "var(--text-2)" }}>{year}</span>
             <button
-              onClick={() => onChange(`${year + 1}-${String(month).padStart(2, "0")}`)}
-              style={{ color: "var(--text-muted)", background: "none", border: "none", cursor: "pointer", fontSize: 12, padding: "0 4px" }}
+              onClick={() => !isNextYearDisabled && onChange(`${year + 1}-${String(month).padStart(2, "0")}`)}
+              disabled={isNextYearDisabled}
+              style={{ color: "var(--text-muted)", background: "none", border: "none", cursor: isNextYearDisabled ? "not-allowed" : "pointer", fontSize: 12, padding: "0 4px", opacity: isNextYearDisabled ? 0.4 : 1 }}
             >
               {year + 1} &rsaquo;
             </button>
           </div>
           <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: 4 }}>
-            {MONTHS.map((m, i) => (
-              <button
-                key={m}
-                onClick={() => select(i + 1)}
-                style={{
-                  fontSize: 12,
-                  borderRadius: 5,
-                  padding: "4px 6px",
-                  border: "none",
-                  cursor: "pointer",
-                  background: i + 1 === month ? "var(--accent)" : "none",
-                  color: i + 1 === month ? "#fff" : "var(--text-3)",
-                }}
-              >
-                {m}
-              </button>
-            ))}
+            {MONTHS.map((m, i) => {
+              const nowY = new Date().getFullYear()
+              const nowM = new Date().getMonth() + 1
+              const isFuture = year > nowY || (year === nowY && i + 1 > nowM)
+              return (
+                <button
+                  key={m}
+                  onClick={() => select(i + 1)}
+                  disabled={isFuture}
+                  style={{
+                    fontSize: 12,
+                    borderRadius: 5,
+                    padding: "4px 6px",
+                    border: "none",
+                    cursor: isFuture ? "not-allowed" : "pointer",
+                    background: i + 1 === month ? "var(--accent)" : "none",
+                    color: i + 1 === month ? "#fff" : "var(--text-3)",
+                    opacity: isFuture ? 0.4 : 1,
+                  }}
+                >
+                  {m}
+                </button>
+              )
+            })}
           </div>
         </div>
       )}
@@ -552,7 +582,7 @@ function SpendContent() {
   const { getToken } = useAuth()
   const { teamId, loading: teamLoading, error: teamError } = useGuardTeam()
   const { activeWorkspace } = useWorkspace()
-  const { permissions } = useGuardRole(teamId, activeWorkspace?.id ?? null)
+  const { permissions, loading: roleLoading } = useGuardRole(teamId, activeWorkspace?.id ?? null)
   const { savings, loading: savingsLoading } = useGuardSavings(teamId)
   const now = new Date()
   const [month, setMonth] = useState(
@@ -570,6 +600,7 @@ function SpendContent() {
     hard_cap_enabled: false,
     default_per_developer_usd: null,
   })
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
 
   const isAdmin = permissions.canEditBudgets
   const canViewSpend = permissions.canViewAllSpend || permissions.canViewOwnSpend
@@ -613,6 +644,7 @@ function SpendContent() {
         }
         setBudgets(map)
       }
+      setLastUpdated(new Date())
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error")
     } finally {
@@ -676,9 +708,9 @@ function SpendContent() {
     return `${MONTHS[m - 1]} ${y}`
   })()
 
-  if (!canViewSpend) {
+  if (!roleLoading && !canViewSpend) {
     return (
-      <GuardShell>
+      <GuardShell lastUpdated={lastUpdated}>
         <div className="card" style={{ padding: "64px 24px", textAlign: "center", fontSize: 13, color: "var(--text-muted)" }}>
           You don&apos;t have access to spend data. Contact your admin.
         </div>
@@ -687,7 +719,7 @@ function SpendContent() {
   }
 
   return (
-    <GuardShell>
+    <GuardShell lastUpdated={lastUpdated}>
       {/* Page controls row */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, marginBottom: 20 }}>
         <select
@@ -720,13 +752,28 @@ function SpendContent() {
           fontSize: 13,
           color: "var(--err)",
           marginBottom: 16,
+          display: "flex",
+          alignItems: "center",
+          gap: 12,
         }}>
-          {error}
+          <span style={{ flex: 1 }}>{error}</span>
+          <button
+            onClick={load}
+            style={{ fontSize: 12, fontWeight: 600, background: "var(--err)", color: "#fff", border: "none", borderRadius: 6, padding: "4px 12px", cursor: "pointer", flexShrink: 0 }}
+          >
+            Retry
+          </button>
         </div>
       )}
 
       {/* Spend controls card */}
-      <SpendControlsPanel settings={teamSettings} onSave={saveTeamSettings} currency={currency} readOnly={!isAdmin} />
+      <SpendControlsPanel
+        settings={teamSettings}
+        onSave={saveTeamSettings}
+        currency={currency}
+        readOnly={!isAdmin}
+        totalCostUsd={data?.total_cost_usd ?? 0}
+      />
 
       {/* 4 stat cards */}
       {loading ? (
@@ -892,7 +939,7 @@ function SpendContent() {
                     )}
                   </div>
                   <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                    <BudgetBar used={dev.cost_usd} limit={budgetLimit} />
+                    <BudgetBar used={dev.cost_usd} limit={budgetLimit} warnAt={teamSettings.alert_threshold_pct ?? 80} />
                     {isAdmin && (
                       <span onClick={e => e.stopPropagation()}>
                         <BudgetInput email={dev.email} current={budgetLimit} onSave={saveBudget} />

--- a/apps/web/src/app/(app)/guard/team-memory/page.tsx
+++ b/apps/web/src/app/(app)/guard/team-memory/page.tsx
@@ -35,8 +35,20 @@ const GUARD_TABS = [
   { href: "/guard/settings",        label: "Settings"        },
 ]
 
-function GuardShell({ children }: { children: React.ReactNode }) {
+function GuardShell({ children, lastFetched }: { children: React.ReactNode; lastFetched?: Date | null }) {
   const pathname = usePathname()
+
+  function formatLastFetched(d: Date | null | undefined): string {
+    if (!d) return "never"
+    const diffMs = Date.now() - d.getTime()
+    const diffS = Math.floor(diffMs / 1000)
+    if (diffS < 60) return "just now"
+    const diffM = Math.floor(diffS / 60)
+    if (diffM < 60) return `${diffM}m ago`
+    const diffH = Math.floor(diffM / 60)
+    return `${diffH}h ago`
+  }
+
   return (
     <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
       <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
@@ -55,7 +67,7 @@ function GuardShell({ children }: { children: React.ReactNode }) {
           </p>
         </div>
         <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          last updated: just now
+          last updated: {formatLastFetched(lastFetched)}
         </div>
       </div>
       <div className="guard-tab-nav">
@@ -113,13 +125,14 @@ function TeamMemoryContent() {
   const [entries, setEntries] = useState<MemoryEntry[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  const [lastFetched, setLastFetched] = useState<Date | null>(null)
   const [inputValue, setInputValue] = useState("")
   const [query, setQuery] = useState("")
   const [filterDeveloper, setFilterDeveloper] = useState("")
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const workspaceId = activeWorkspace?.id ?? teamId ?? null
-  const { permissions } = useGuardRole(teamId, workspaceId)
+  const { permissions, loading: roleLoading } = useGuardRole(teamId, workspaceId)
   const currentUserEmail = user?.primaryEmailAddress?.emailAddress ?? null
   const developers = Array.from(new Set(entries.map(e => e.developer_email).filter(Boolean) as string[])).sort()
 
@@ -133,7 +146,9 @@ function TeamMemoryContent() {
     const headers: Record<string, string> = { "Content-Type": "application/json" }
     if (token) headers["Authorization"] = `Bearer ${token}`
 
-    const params = new URLSearchParams({ q: q.trim() || "recent", limit: "50" })
+    const trimmed = q.trim()
+    const params = new URLSearchParams({ limit: "50" })
+    if (trimmed) params.set("q", trimmed)
     params.set("workspace_id", workspaceId)
 
     try {
@@ -142,6 +157,7 @@ function TeamMemoryContent() {
       const data: MemoryEntry[] = await res.json()
       data.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
       setEntries(data)
+      setLastFetched(new Date())
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unknown error")
     } finally {
@@ -175,8 +191,10 @@ function TeamMemoryContent() {
     ? entries.filter(e => e.developer_email === effectiveDeveloper)
     : entries
 
+  const isSearching = query.trim().length > 0
+
   return (
-    <GuardShell>
+    <GuardShell lastFetched={lastFetched}>
       {/* Filters — same layout as Activity page */}
       <div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 16, flexWrap: "wrap" }}>
         <form onSubmit={handleSubmit} style={{ display: "flex", gap: 8, flex: 1, minWidth: 260 }}>
@@ -215,7 +233,7 @@ function TeamMemoryContent() {
         </span>
       </div>
 
-      {!permissions.canViewAllActivity && (
+      {!roleLoading && !permissions.canViewAllActivity && (
         <div style={{ borderRadius: 8, border: "1px solid var(--warn-bd)", background: "var(--warn-bg)", padding: "8px 16px", fontSize: 12, color: "var(--warn)", marginBottom: 16 }}>
           You can view your own sessions only. Contact your admin to request broader access.
         </div>
@@ -224,6 +242,12 @@ function TeamMemoryContent() {
       {error && (
         <div style={{ borderRadius: 8, border: "1px solid var(--err-bd)", background: "var(--err-bg)", padding: "10px 16px", fontSize: 13, color: "var(--err)", marginBottom: 16 }}>
           {error}
+        </div>
+      )}
+
+      {!isSearching && (
+        <div style={{ fontSize: 11.5, fontWeight: 600, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: "0.06em", marginBottom: 10 }}>
+          Recent sessions
         </div>
       )}
 
@@ -236,9 +260,9 @@ function TeamMemoryContent() {
         </div>
       ) : filtered.length === 0 ? (
         <div className="card" style={{ padding: "40px 24px", textAlign: "center", fontSize: 13, color: "var(--text-muted)" }}>
-          {query
+          {isSearching
             ? `No sessions found for "${query}".`
-            : "No team memories yet. Sessions are captured automatically when developers exit Claude Code."
+            : "No team memories yet. Sessions are captured automatically when developers exit Claude Code, Cursor, and Codex."
           }
         </div>
       ) : (
@@ -246,50 +270,82 @@ function TeamMemoryContent() {
           {/* Table header */}
           <div style={{
             display: "grid",
-            gridTemplateColumns: "1.2fr 1fr 2.8fr 1fr 0.6fr",
+            gridTemplateColumns: "1.1fr 0.8fr 2.6fr 0.7fr 1fr 0.6fr",
             gap: 12, padding: "10px 18px",
             borderBottom: "1px solid var(--border)",
             background: "var(--surface-2)",
           }}>
-            {["Developer", "Repo", "Summary", "Tags", "Date"].map(h => (
+            {["Developer", "Repo", "Summary", "Tool", "Tags", "Date"].map(h => (
               <div key={h} className="eyebrow" style={{ fontSize: 9.5 }}>{h}</div>
             ))}
           </div>
 
           {/* Table rows */}
-          {filtered.map((entry, i) => (
-            <div key={`${entry.developer_id}-${entry.created_at}-${i}`}
-              style={{
-                display: "grid",
-                gridTemplateColumns: "1.2fr 1fr 2.8fr 1fr 0.6fr",
-                gap: 12, padding: "11px 18px",
-                borderBottom: i < filtered.length - 1 ? "1px solid var(--border)" : "none",
-                alignItems: "start",
-              }}
-            >
-              <div className="mono" style={{ fontSize: 11.5, color: "var(--text-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {entry.developer_email ?? "—"}
+          {filtered.map((entry, i) => {
+            const extraTagCount = (entry.tags ?? []).length > 3 ? (entry.tags ?? []).length - 3 : 0
+            const confidencePct = entry.confidence != null ? Math.round(entry.confidence * 100) : null
+
+            return (
+              <div key={`${entry.developer_id}-${entry.created_at}-${i}`}
+                style={{
+                  display: "grid",
+                  gridTemplateColumns: "1.1fr 0.8fr 2.6fr 0.7fr 1fr 0.6fr",
+                  gap: 12, padding: "11px 18px",
+                  borderBottom: i < filtered.length - 1 ? "1px solid var(--border)" : "none",
+                  alignItems: "start",
+                }}
+              >
+                <div className="mono" style={{ fontSize: 11.5, color: "var(--text-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.developer_email ?? "—"}
+                </div>
+                <div style={{ fontSize: 11.5, color: "var(--text-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                  {entry.repo ?? "—"}
+                </div>
+                <div style={{ fontSize: 12.5, color: "var(--text)", lineHeight: 1.5 }}>
+                  {entry.summary}
+                  {confidencePct !== null && (
+                    <div style={{ display: "flex", alignItems: "center", gap: 5, marginTop: 4 }}>
+                      <div style={{ width: 48, height: 3, borderRadius: 2, background: "var(--border-2)", overflow: "hidden" }}>
+                        <div style={{ width: `${confidencePct}%`, height: "100%", background: confidencePct >= 75 ? "var(--ok)" : confidencePct >= 40 ? "var(--warn)" : "var(--err)", borderRadius: 2 }} />
+                      </div>
+                      <span style={{ fontSize: 10, color: "var(--text-muted)" }}>{confidencePct}%</span>
+                    </div>
+                  )}
+                </div>
+                <div>
+                  {entry.tool && (
+                    <span style={{
+                      fontSize: 10, fontWeight: 500,
+                      color: "var(--text-2)", background: "var(--surface-2)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 4, padding: "1px 6px",
+                      display: "inline-block",
+                    }}>{entry.tool}</span>
+                  )}
+                </div>
+                <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
+                  {(entry.tags ?? []).slice(0, 3).map(tag => (
+                    <span key={tag} style={{
+                      fontSize: 10, fontWeight: 500,
+                      color: "var(--accent-text)", background: "var(--accent-weak)",
+                      borderRadius: 4, padding: "1px 6px",
+                    }}>{tag}</span>
+                  ))}
+                  {extraTagCount > 0 && (
+                    <span style={{
+                      fontSize: 10, fontWeight: 500,
+                      color: "var(--text-muted)", background: "var(--surface-2)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 4, padding: "1px 6px",
+                    }}>+{extraTagCount}</span>
+                  )}
+                </div>
+                <div className="mono" style={{ fontSize: 11.5, color: "var(--text-muted)" }}>
+                  {formatTs(entry.created_at)}
+                </div>
               </div>
-              <div style={{ fontSize: 11.5, color: "var(--text-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-                {entry.repo ?? "—"}
-              </div>
-              <div style={{ fontSize: 12.5, color: "var(--text)", lineHeight: 1.5 }}>
-                {entry.summary}
-              </div>
-              <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
-                {(entry.tags ?? []).slice(0, 3).map(tag => (
-                  <span key={tag} style={{
-                    fontSize: 10, fontWeight: 500,
-                    color: "var(--accent-text)", background: "var(--accent-weak)",
-                    borderRadius: 4, padding: "1px 6px",
-                  }}>{tag}</span>
-                ))}
-              </div>
-              <div className="mono" style={{ fontSize: 11.5, color: "var(--text-muted)" }}>
-                {formatTs(entry.created_at)}
-              </div>
-            </div>
-          ))}
+            )
+          })}
 
           <div style={{ borderTop: "1px solid var(--border)", padding: "8px 18px", textAlign: "center", fontSize: 12, color: "var(--text-muted)" }}>
             {filtered.length} {filtered.length === 1 ? "session" : "sessions"}

--- a/apps/web/src/app/(app)/playbooks/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/playbooks/[slug]/page.tsx
@@ -128,6 +128,7 @@ export default function PublicPlaybookPage() {
   const [loading, setLoading] = useState(true)
   const [notFound, setNotFound] = useState(false)
   const [showYaml, setShowYaml] = useState(false)
+  const [copied, setCopied] = useState(false)
 
   useEffect(() => {
     const apiUrl = process.env.NEXT_PUBLIC_API_URL
@@ -264,7 +265,7 @@ export default function PublicPlaybookPage() {
             onClick={() => setShowYaml(v => !v)}
             className="inline-flex items-center gap-2 border border-stone-200 text-stone-600 text-sm font-medium px-5 py-2.5 rounded-lg hover:bg-stone-50 transition-colors"
           >
-            {showYaml ? "Hide YAML" : "View YAML"}
+            {showYaml ? "Hide YAML" : "Show YAML"}
           </button>
         </div>
 
@@ -274,10 +275,15 @@ export default function PublicPlaybookPage() {
             <div className="flex items-center justify-between px-4 py-2 border-b border-stone-800">
               <span className="text-xs text-stone-400 font-mono">{playbook.slug}.yaml</span>
               <button
-                onClick={() => navigator.clipboard?.writeText(playbook.yaml_source)}
+                onClick={() => {
+                  navigator.clipboard?.writeText(playbook.yaml_source).then(() => {
+                    setCopied(true)
+                    setTimeout(() => setCopied(false), 2000)
+                  }).catch(() => {})
+                }}
                 className="text-[11px] text-stone-500 hover:text-stone-300 transition-colors"
               >
-                Copy
+                {copied ? "Copied!" : "Copy"}
               </button>
             </div>
             <pre className="text-xs text-stone-300 font-mono p-4 overflow-x-auto leading-relaxed max-h-[500px] overflow-y-auto">

--- a/apps/web/src/app/(app)/security/page.tsx
+++ b/apps/web/src/app/(app)/security/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from "next/navigation"
 
 export default function SecurityRedirect() {
-  redirect("/secure")
+  redirect("/guard")
 }

--- a/apps/web/src/components/settings/AuditLog.tsx
+++ b/apps/web/src/components/settings/AuditLog.tsx
@@ -102,7 +102,8 @@ export default function AuditLog({ workspaceId, getToken }: Props) {
     }
     const blob = new Blob([rows.join("\n")], { type: "text/csv" })
     const url = URL.createObjectURL(blob)
-    const a = document.createElement("a"); a.href = url; a.download = "audit-log.csv"; a.click()
+    const a = document.createElement("a"); a.href = url; a.download = "audit-log.csv"
+    document.body.appendChild(a); a.click(); document.body.removeChild(a)
     URL.revokeObjectURL(url)
   }
 

--- a/apps/web/src/components/settings/PreferencesPanel.tsx
+++ b/apps/web/src/components/settings/PreferencesPanel.tsx
@@ -188,7 +188,7 @@ export default function PreferencesPanel() {
       <div className="card" style={{ padding: "0 18px" }}>
         <ToggleRow
           label="Show Test Trigger button"
-          description="Adds a 'Dry Run' button to the canvas toolbar — fires a real run with a safe dummy payload."
+          description="Adds a 'Test Trigger' button to the canvas toolbar — fires a real run with a safe dummy payload."
           checked={prefs.show_test_trigger}
           onChange={v => update({ show_test_trigger: v })}
         />


### PR DESCRIPTION
## Changes

- **`/security`** — `redirect("/secure")` → `redirect("/guard")` (dead route fix, #685 P0-1)
- **`PreferencesPanel`** — "Show Test Trigger" description corrected from "Dry Run button" to "Test Trigger button" (#684 P1-7)
- **`/playbooks/[slug]`** — YAML toggle label "View YAML" → "Show YAML" for consistency (#682 P2 copy)
- **`/playbooks/[slug]`** — YAML copy button now shows "Copied!" for 2s with `.catch(() => {})` error guard (#682 P1-6)
- **`AuditLog.tsx`** — CSV export anchor appended to DOM before `.click()` — fixes Firefox/Safari (#685 P2-4)
- **`guard/activity/page.tsx`** — Same CSV export fix (#685 P2-4)

## Skipped (in doubt)
- `notifWarn`/`notifDigest` persist — need backend field names
- `isAdmin` init to null — needs prop type changes
- Slack badge — already correctly conditional (audit finding was wrong)
- `token-guardrails` learn-more link — don't know correct docs URL

Closes partial findings in #682, #684, #685.