### PR TITLE
feat(playbooks): oss-issue-sweep — dependency-aware bulk OSS issue fixer

### DIFF
--- a/apps/api/playbooks/oss-issue-sweep.yaml
+++ b/apps/api/playbooks/oss-issue-sweep.yaml
@@ -1,0 +1,288 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# oss-issue-sweep — dependency-aware bulk issue fixer for open source repos
+#
+# Fetches all open issues, maps dependencies between them, orders fixes from
+# simplest/most-blocked to complex, then fixes and PRs each one in sequence.
+# Memory accumulates across fixes — the agent gets smarter with every issue.
+# ──────────────────────────────────────────────────────────────────────────────
+extends: base-autopilot
+name: OSS Issue Sweep
+version: 1
+description: >
+  Fetches every open issue from a GitHub repo, maps cross-issue dependencies,
+  orders fixes by blast radius (blockers first, complex last), then implements
+  each fix and opens a PR. Memory carries context forward — lessons from issue
+  #3 inform how issue #7 is fixed. Designed for third-party OSS repos where
+  you want to contribute a batch of fixes in one run.
+
+inputs:
+  upstream_owner:
+    label: Upstream repo owner
+    type: string
+    placeholder: "openclaw"
+    description: GitHub username or org that owns the target repo.
+
+  upstream_repo:
+    label: Upstream repo name
+    type: string
+    placeholder: "Peekaboo"
+    description: Repo name only (not owner/repo — just the repo name).
+
+  max_issues:
+    label: Max issues to fix
+    type: string
+    default: "10"
+    description: >
+      Cap on how many issues to attempt. Set lower for a trial run.
+      Issues are ordered — simplest and most blocking come first.
+
+  label_filter:
+    label: Label filter (optional)
+    type: string
+    placeholder: "bug, good first issue"
+    description: >
+      Only attempt issues with these labels (comma-separated).
+      Leave blank to attempt all open issues.
+    required: false
+
+  skip_issues:
+    label: Skip issue numbers (optional)
+    type: string
+    placeholder: "12, 34, 56"
+    description: >
+      Comma-separated issue numbers to skip (e.g. too large, needs discussion).
+    required: false
+
+  model:
+    label: AI model
+    type: select
+    default: claude-sonnet-4-6
+    options:
+      - claude-sonnet-4-6
+      - claude-opus-4-7
+    description: Opus for complex multi-file fixes. Sonnet for most issues.
+
+on:
+  manual:
+    next: fetch_all_issues
+
+blocks:
+
+  # ── 1. Fetch all open issues ─────────────────────────────────────────────────
+  fetch_all_issues:
+    type: brain
+    mode: agentic
+    model: "{{inputs.model}}"
+    label: Fetch open issues
+    description: Pull all open issues from the upstream repo via GitHub API.
+    credentials:
+      github: github
+    prompt: |
+      Fetch all open issues from https://github.com/{{inputs.upstream_owner}}/{{inputs.upstream_repo}}
+
+      Use the GitHub API:
+        GET https://api.github.com/repos/{{inputs.upstream_owner}}/{{inputs.upstream_repo}}/issues?state=open&per_page=100
+
+      For each issue collect:
+        - number
+        - title
+        - body (full text)
+        - labels (name list)
+        - created_at
+        - comments count
+        - any issue numbers referenced in the body or title
+          (look for "#123", "fixes #123", "blocked by #123", "depends on #123", "related to #123")
+
+      {% if inputs.label_filter %}
+      Only include issues with at least one of these labels: {{inputs.label_filter}}
+      {% endif %}
+
+      {% if inputs.skip_issues %}
+      Exclude these issue numbers: {{inputs.skip_issues}}
+      {% endif %}
+
+      Return ONLY a JSON array on the last line:
+      [{"number":42,"title":"...","body":"...","labels":["bug"],"comments":3,"references":[12,15]}]
+    next: triage_and_order
+
+  # ── 2. Dependency-aware triage and ordering ───────────────────────────────────
+  triage_and_order:
+    type: brain
+    mode: single
+    allowed_tools: []
+    label: Triage and order issues
+    description: >
+      Map cross-issue dependencies and produce a safe fix order.
+      Blockers first. Issues with unresolved dependencies deferred.
+    prompt: |
+      You are triaging a batch of open issues to determine the safest fix order.
+
+      All open issues:
+      {{fetch_all_issues.output}}
+
+      Max issues to fix: {{inputs.max_issues}}
+
+      Rules for ordering:
+      1. An issue A "blocks" issue B if B's body references A's number.
+         Fix A before B.
+      2. Issues with no cross-references to others are independent — fix these first.
+      3. Simple issues (short body, single file implied, "typo", "missing", "add") before complex ones.
+      4. If an issue references another that is ALSO in the list:
+         - put the referenced issue earlier
+         - note the dependency chain
+      5. If an issue references another that is NOT in the list (already closed or out of scope):
+         - treat it as independent (no blocker)
+      6. If an issue is ambiguous, requires design discussion, or is a feature request
+         rather than a bug/fix — mark it as SKIP with reason.
+      7. Cap the output list at {{inputs.max_issues}} actionable issues.
+
+      Return ONLY compact JSON on the last line — no prose:
+      {
+        "ordered": [
+          {"number": 12, "title": "...", "complexity": "small|medium|large", "rationale": "no deps, single file fix", "blocks": [], "blocked_by": []},
+          {"number": 34, "title": "...", "complexity": "medium", "rationale": "fix #12 first — shares same module", "blocks": [42], "blocked_by": [12]}
+        ],
+        "skipped": [
+          {"number": 99, "title": "...", "reason": "feature request, needs maintainer discussion"}
+        ]
+      }
+    next: fork_upstream
+
+  # ── 3. Fork once, reuse across all fixes ────────────────────────────────────
+  fork_upstream:
+    type: tool
+    integration: github
+    action: fork_repo
+    label: Fork upstream repo
+    description: Fork into authenticated user's account (reuses existing fork).
+    params:
+      owner: "{{inputs.upstream_owner}}"
+      repo: "{{inputs.upstream_repo}}"
+    next: read_memory
+
+  # ── 4. Read accumulated memory for this repo ────────────────────────────────
+  read_memory:
+    $use: base-autopilot.recall_context
+    key: "{{inputs.upstream_owner}}/{{inputs.upstream_repo}}"
+    next: fix_loop
+
+  # ── 5. Dependency-aware fix loop ─────────────────────────────────────────────
+  fix_loop:
+    type: brain
+    mode: agentic
+    model: "{{inputs.model}}"
+    max_turns: 80
+    label: Fix issues in dependency order
+    description: |
+      Iterates through the ordered issue list. For each issue: plans the fix,
+      implements it on a branch, pushes, opens a PR. Carries lessons forward.
+      Skips an issue and continues if a fix fails — never halts the whole run.
+    credentials:
+      github: github
+    system: |
+      You are an expert open-source contributor fixing a batch of issues in sequence.
+
+      You have:
+      - A fork of the repo already created
+      - An ordered list of issues to fix (blockers first)
+      - Prior memory from this repo (patterns, pitfalls, lessons)
+
+      For EACH issue in the ordered list:
+        1. Plan the fix (read relevant files if needed via GitHub API)
+        2. Implement via a single run_shell call that: clones the fork,
+           creates a branch fix/issue-{number}, makes the change, lints, commits, pushes
+        3. Open a PR to upstream via GitHub API
+        4. Record the outcome (success/failure/lesson) before moving to the next
+
+      Rules:
+        - Always push to the fork, PR to upstream
+        - Branch name: fix/issue-{number} for each issue
+        - If a push returns 403, record failure and move to the next issue
+        - If the fix would affect files also touched by a previous fix in this run,
+          git fetch the fork branch first to avoid conflicts
+        - Lint before every commit (ruff/black for Python, eslint/prettier for JS, cargo fmt for Rust)
+        - PR body must include "Fixes #N" and the attribution block
+        - After each PR is opened, summarise the lesson learned in one line
+          and carry it into the next fix
+
+      Attribution to add to every PR body (after the fix description):
+      ---
+      This fix was implemented autonomously by **[Conduct AI](https://conductai.ai)** — an open-source platform for AI agent automation.
+      > Want Conduct AI to automate fixes in your repo? [Get started free →](https://conductai.ai)
+
+    prompt: |
+      Repo: {{inputs.upstream_owner}}/{{inputs.upstream_repo}}
+      Fork: {{fork_upstream.fork_full_name}} (owner: {{fork_upstream.fork_owner}})
+      Default branch: {{fork_upstream.default_branch}}
+
+      Prior memory for this repo:
+      {{read_memory.entries}}
+
+      Ordered issue list (fix in this exact order):
+      {{triage_and_order.output}}
+
+      Work through every issue in the ordered list. After completing all of them,
+      output a JSON summary on the very last line:
+      {
+        "fixed": [{"number": 12, "pr_url": "https://github.com/.../pull/99", "branch": "fix/issue-12", "summary": "one line"}],
+        "failed": [{"number": 34, "reason": "push 403 — token scope"}],
+        "lessons": ["lesson from issue 12", "lesson from issue 34"]
+      }
+    next: write_memory
+
+  # ── 6. Write memory ──────────────────────────────────────────────────────────
+  write_memory:
+    type: memory
+    label: Record sweep outcome
+    action: write
+    scope: repo
+    key: "{{inputs.upstream_owner}}/{{inputs.upstream_repo}}"
+    summary: |
+      OSS Issue Sweep on {{inputs.upstream_owner}}/{{inputs.upstream_repo}}
+      Fixed: {{fix_loop.output.fixed | length}} issues
+      Failed: {{fix_loop.output.failed | length}} issues
+      Skipped at triage: {{triage_and_order.output.skipped | length}} issues
+      Lessons: {{fix_loop.output.lessons}}
+    next: notify_complete
+
+  # ── 7. Final summary ─────────────────────────────────────────────────────────
+  notify_complete:
+    type: output
+    label: Sweep complete
+    output:
+      via: slack
+      slack:
+        channel: "#engineering"
+        approval: false
+      template: |
+        *OSS Issue Sweep complete* — `{{inputs.upstream_owner}}/{{inputs.upstream_repo}}`
+
+        *Fixed:* {{fix_loop.output.fixed | length}} PRs opened
+        {% for f in fix_loop.output.fixed %}
+        • #{{f.number}} → {{f.pr_url}} — {{f.summary}}
+        {% endfor %}
+
+        {% if fix_loop.output.failed %}
+        *Failed (skipped, run continues):*
+        {% for f in fix_loop.output.failed %}
+        • #{{f.number}} — {{f.reason}}
+        {% endfor %}
+        {% endif %}
+
+        {% if triage_and_order.output.skipped %}
+        *Skipped at triage:*
+        {% for s in triage_and_order.output.skipped %}
+        • #{{s.number}} — {{s.reason}}
+        {% endfor %}
+        {% endif %}
+
+        View PRs → https://github.com/{{inputs.upstream_owner}}/{{inputs.upstream_repo}}/pulls
+
+test_trigger:
+  payload:
+    upstream_owner: "openclaw"
+    upstream_repo: "Peekaboo"
+    max_issues: "5"
+    label_filter: ""
+    skip_issues: ""
+    model: claude-sonnet-4-6

--- a/apps/api/playbooks/oss-issue-sweep.yaml
+++ b/apps/api/playbooks/oss-issue-sweep.yaml
@@ -122,19 +122,27 @@ blocks:
 
       Max issues to fix: {{inputs.max_issues}}
 
-      Rules for ordering:
-      1. An issue A "blocks" issue B if B's body references A's number.
-         Fix A before B.
-      2. Issues with no cross-references to others are independent — fix these first.
-      3. Simple issues (short body, single file implied, "typo", "missing", "add") before complex ones.
-      4. If an issue references another that is ALSO in the list:
-         - put the referenced issue earlier
-         - note the dependency chain
-      5. If an issue references another that is NOT in the list (already closed or out of scope):
-         - treat it as independent (no blocker)
-      6. If an issue is ambiguous, requires design discussion, or is a feature request
-         rather than a bug/fix — mark it as SKIP with reason.
-      7. Cap the output list at {{inputs.max_issues}} actionable issues.
+      Step 1 — Score every issue by impact (higher = fix sooner):
+        +3  confirmed bug with repro steps
+        +2  affects multiple users (many comments, "me too" replies)
+        +2  blocks another open issue
+        +1  labelled "bug" or "good first issue"
+        +1  short body — likely a simple targeted fix
+        -2  feature request or enhancement
+        -2  needs design discussion or maintainer input
+        -3  ambiguous — no repro, no clear expected behaviour
+
+      Step 2 — Dependency ordering within the top N:
+        If issue A is referenced by issue B ("fixes #A", "blocked by #A"), A must come before B.
+        Independent issues (no cross-references) sorted highest score first.
+
+      Step 3 — Skip anything that:
+        - Is a feature request or RFC
+        - Has no actionable description
+        - Requires a breaking API change
+        - Explicitly says "needs discussion" or is labelled "wontfix"
+
+      Cap the output list at {{inputs.max_issues}} actionable issues — the highest-impact, fixable ones.
 
       Return ONLY compact JSON on the last line — no prose:
       {

--- a/apps/api/playbooks/registry.yaml
+++ b/apps/api/playbooks/registry.yaml
@@ -30,6 +30,14 @@ playbooks:
     description: "Implement fix → run tests → human approves in Slack → open PR. Nothing ships without a gate."
     github_events: [issues]
 
+  oss_issue_sweep:
+    file: oss-issue-sweep.yaml
+    icon: "🧹"
+    category: Issue to PR
+    tags: [github, oss, code, autopilot]
+    featured: true
+    description: "Point it at any OSS repo. It reads all open issues, picks the top ones by impact, maps dependencies between them, and fixes each one in the right order — opening a PR per fix. Memory accumulates so later fixes learn from earlier ones."
+
   thirdparty_autopilot_fix:
     file: thirdparty-autopilot-fix.yaml
     icon: "🔀"

--- a/apps/web/src/app/(app)/workflows/page.tsx
+++ b/apps/web/src/app/(app)/workflows/page.tsx
@@ -49,31 +49,22 @@ function statusKey(label: string): string {
   return ({ Running: "run", Awaiting: "wait", Succeeded: "ok", Failed: "err", "Never run": "idle" } as Record<string, string>)[label] ?? "idle"
 }
 
+// Explicit status sort order (#20)
+const STATUS_SORT_ORDER = ["run", "wait", "err", "idle", "ok"]
+
 function AgentStatusPill({ s }: { s: string }) {
-  const m = ({ ok: ["ok", "Succeeded"], wait: ["warn", "Awaiting approval"], run: ["run", "Running"], err: ["err", "Failed"], idle: ["idle", "Never run"], warn: ["warn", "Degraded"] } as Record<string, [string, string]>)[s] || ["idle", "Never run"]
-  return (
-    <span className={"sbadge " + m[0]}>
-      {(s === "run" || s === "wait") && (
-        <span className="dot pulse" style={{ background: m[0] === "warn" ? "var(--warn)" : "var(--info)" }} />
-      )}
-      {m[1]}
-    </span>
-  )
+  const map: Record<string, { label: string; bg: string; color: string }> = {
+    run: { label: "Running", bg: "var(--info-weak, #eff6ff)", color: "var(--info, #2563eb)" },
+    wait: { label: "Awaiting", bg: "var(--warn-weak, #fffbeb)", color: "var(--warn, #d97706)" },
+    ok: { label: "Succeeded", bg: "var(--ok-weak, #f0fdf4)", color: "var(--ok, #16a34a)" },
+    err: { label: "Failed", bg: "var(--err-weak, #fff5f5)", color: "var(--err, #dc2626)" },
+    idle: { label: "Never run", bg: "var(--surface-2)", color: "var(--text-muted)" },
+  }
+  const { label, bg, color } = map[s] ?? map.idle
+  return <span style={{ fontSize: 11, fontWeight: 650, padding: "2px 8px", borderRadius: 20, background: bg, color }}>{label}</span>
 }
 
-function MiniSpark({ pct, runs }: { pct: number; runs: number }) {
-  if (runs === 0) return <span style={{ fontSize: 12, color: "var(--text-muted)" }}>—</span>
-  const c = pct >= 0.9 ? "var(--ok)" : pct >= 0.75 ? "var(--info)" : pct >= 0.5 ? "var(--warn)" : "var(--err)"
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 9 }}>
-      <div style={{ width: 64, height: 6, borderRadius: 6, background: "var(--surface-3)", overflow: "hidden" }}>
-        <div style={{ width: `${pct * 100}%`, height: "100%", borderRadius: 6, background: c }} />
-      </div>
-      <span className="mono" style={{ fontSize: 12, color: "var(--text-3)", width: 30, textAlign: "right" }}>{Math.round(pct * 100)}%</span>
-    </div>
-  )
-}
-
+// #1: Toggle component kept but grid toggle wired or removed per #4 — kept for list use only
 const Toggle = ({ on, onClick }: { on: boolean; onClick: () => void }) => (
   <span
     onClick={(e) => { e.stopPropagation(); onClick() }}
@@ -82,6 +73,57 @@ const Toggle = ({ on, onClick }: { on: boolean; onClick: () => void }) => (
     <span style={{ position: "absolute", top: 2.5, left: on ? 17.5 : 2.5, width: 16, height: 16, borderRadius: "50%", background: "#fff", transition: "left .15s", boxShadow: "var(--shadow-sm)" }} />
   </span>
 )
+
+// #18: Extracted WorkflowMenu component used in both list and grid views
+function WorkflowMenu({
+  wfId,
+  wfName,
+  menuOpen,
+  onToggleMenu,
+  onRename,
+  onDelete,
+}: {
+  wfId: string
+  wfName: string
+  menuOpen: string | null
+  onToggleMenu: (id: string) => void
+  onRename: (id: string, name: string) => void
+  onDelete: (id: string) => void
+}) {
+  const isOpen = menuOpen === wfId
+  return (
+    <div style={{ position: "relative" }}>
+      <button
+        className="btn btn-ghost btn-icon btn-sm"
+        title="More"
+        aria-label="Workflow options"  // #17
+        onClick={e => { e.stopPropagation(); onToggleMenu(wfId) }}
+      >⋯</button>
+      {isOpen && (
+        <div
+          role="menu"  // #17
+          onMouseDown={e => e.stopPropagation()}
+          style={{ position: "absolute", right: 0, top: "100%", marginTop: 4, zIndex: 20, minWidth: 130, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 10, boxShadow: "var(--shadow-md)", padding: "4px 0" }}
+        >
+          <button
+            role="menuitem"  // #17
+            onClick={e => { e.stopPropagation(); onToggleMenu(wfId); onRename(wfId, wfName) }}
+            style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--text)", background: "none", border: "none", cursor: "pointer" }}
+            onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
+            onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
+          >Rename</button>
+          <button
+            role="menuitem"  // #17
+            onMouseDown={e => { e.stopPropagation(); onToggleMenu(wfId); onDelete(wfId) }}
+            style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--err, #dc2626)", background: "none", border: "none", cursor: "pointer" }}
+            onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
+            onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
+          >Delete</button>
+        </div>
+      )}
+    </div>
+  )
+}
 
 export default function WorkflowsPage() {
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
@@ -107,26 +149,30 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
   const [workflows, setWorkflows] = useState<Workflow[]>([])
   const [project, setProject] = useState<{ id: string; name: string } | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)  // #5
   const [isAdmin, setIsAdmin] = useState(!clerkEnabled)
   const [q, setQ] = useState("")
   const [status, setStatus] = useState("All")
   const [sort, setSort] = useState("recent")
   const [view, setView] = useState<"list" | "grid">("list")
-  const [enabled, setEnabled] = useState<Record<string, boolean>>({})
   const [confirming, setConfirming] = useState<string | null>(null)
   const [confirmValue, setConfirmValue] = useState("")
   const [menuOpen, setMenuOpen] = useState<string | null>(null)
   const [renaming, setRenaming] = useState<string | null>(null)
   const [renameValue, setRenameValue] = useState("")
-  const menuRef = useRef<HTMLDivElement>(null)
+  // #22: menuRef keyed by workflow id to avoid sharing a single ref across rows
+  const menuRefs = useRef<Map<string, HTMLDivElement | null>>(new Map())
   const confirmInputRef = useRef<HTMLInputElement>(null)
   const renameInputRef = useRef<HTMLInputElement>(null)
+  const runModalRef = useRef<HTMLDivElement>(null)  // #7
   const [runModal, setRunModal] = useState<{ id: string; name: string } | null>(null)
   const [runParams, setRunParams] = useState("")
   const [runDryRun, setRunDryRun] = useState(false)
   const [runGuard, setRunGuard] = useState(true)
   const [runLoading, setRunLoading] = useState(false)
   const [runError, setRunError] = useState<string | null>(null)
+  // #11: escape flag to prevent blur from committing rename when Escape pressed
+  const escapePressed = useRef(false)
 
   async function authHeaders(): Promise<Record<string, string>> {
     const h: Record<string, string> = {}
@@ -152,11 +198,21 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
     if (renaming !== null) renameInputRef.current?.focus()
   }, [renaming])
 
+  // #7: Escape closes run modal; focus first focusable element on open
   useEffect(() => {
     function handleEsc(e: KeyboardEvent) { if (e.key === "Escape") setRunModal(null) }
     document.addEventListener("keydown", handleEsc)
     return () => document.removeEventListener("keydown", handleEsc)
   }, [])
+
+  useEffect(() => {
+    if (runModal && runModalRef.current) {
+      const focusable = runModalRef.current.querySelector<HTMLElement>(
+        "button, [href], input, select, textarea, [tabindex]:not([tabindex='-1'])"
+      )
+      focusable?.focus()
+    }
+  }, [runModal])
 
   async function runWorkflow() {
     if (!runModal) return
@@ -188,13 +244,16 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
 
   useEffect(() => {
     function handleClick(e: MouseEvent) {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) setMenuOpen(null)
+      // #22: check against per-workflow refs
+      const openRef = menuOpen ? menuRefs.current.get(menuOpen) : null
+      if (openRef && !openRef.contains(e.target as Node)) setMenuOpen(null)
     }
     document.addEventListener("mousedown", handleClick)
     return () => document.removeEventListener("mousedown", handleClick)
-  }, [])
+  }, [menuOpen])
 
   async function loadRole(projectId: string) {
+    // TODO: replace with /projects/{id}/my-role endpoint (#6)
     try {
       const h = await authHeaders()
       h["X-Workspace-Id"] = projectId
@@ -206,6 +265,9 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
   }
 
   async function loadWorkflows(pid: string | null) {
+    // #10: guard against missing user id when auth is enabled
+    if (clerkEnabled && !currentUserId) return
+    setError(null)
     try {
       const headers = await authHeaders()
       if (pid) headers["X-Workspace-ID"] = pid
@@ -213,10 +275,14 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
       if (res.ok) {
         const data: Workflow[] = await res.json()
         setWorkflows(data)
-        const init: Record<string, boolean> = {}
-        data.forEach(w => { init[w.id] = true })
-        setEnabled(init)
+      } else {
+        // #5: surface API errors
+        const body = await res.json().catch(() => ({}))
+        setError(body.detail ?? `Failed to load workflows (${res.status})`)
       }
+    } catch (err) {
+      // #5: surface network errors
+      setError(err instanceof Error ? err.message : "Failed to load workflows")
     } finally {
       setLoading(false)
     }
@@ -234,6 +300,10 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
     if (res.ok) {
       const updated = await res.json()
       setWorkflows(prev => prev.map(w => w.id === id ? { ...w, name: updated.name } : w))
+    } else {
+      // #12: rename failure feedback
+      const body = await res.json().catch(() => ({}))
+      setError(body.detail ?? "Rename failed")
     }
   }
 
@@ -245,12 +315,25 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
     const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/workflows/${id}${qParam}`, { method: "DELETE", headers: h })
     if (!res.ok) {
       const body = await res.json().catch(() => ({}))
-      alert(body.detail ?? `Delete failed (${res.status})`)
+      // #13: replace alert() with setError
+      setError(body.detail ?? `Delete failed (${res.status})`)
       return
     }
     setWorkflows(prev => prev.filter(w => w.id !== id))
     setConfirming(null)
     setConfirmValue("")
+  }
+
+  function startDelete(id: string) {
+    setConfirming(id)
+    setConfirmValue("")
+    setMenuOpen(null)
+  }
+
+  function startRename(id: string, name: string) {
+    setRenaming(id)
+    setRenameValue(name)
+    setMenuOpen(null)
   }
 
   const filtered = workflows.filter(w => {
@@ -261,7 +344,12 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
 
   const rows = [...filtered].sort((a, b) => {
     if (sort === "name") return a.name.localeCompare(b.name)
-    if (sort === "status") return mapStatus(a.last_run_status).localeCompare(mapStatus(b.last_run_status))
+    if (sort === "status") {
+      // #20: explicit status sort order
+      const ai = STATUS_SORT_ORDER.indexOf(mapStatus(a.last_run_status))
+      const bi = STATUS_SORT_ORDER.indexOf(mapStatus(b.last_run_status))
+      return (ai === -1 ? 99 : ai) - (bi === -1 ? 99 : bi)
+    }
     return new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime()
   })
 
@@ -269,25 +357,45 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
     <AppShell>
       <div style={{ maxWidth: 1200, margin: "0 auto", padding: "30px 34px 80px" }}>
 
+        {/* #14: "Agent" → "Workflow" in page headings */}
         <div className="page-head" style={{ display: "flex", alignItems: "flex-end" }}>
           <div>
-            <h1 className="page-title">Agents</h1>
+            <h1 className="page-title">Workflows</h1>
             <p className="page-sub">Every workflow in this workspace — status, triggers, and 30-day reliability at a glance.</p>
           </div>
           <div style={{ marginLeft: "auto", display: "flex", gap: 9 }}>
-            <Link href="/workflows/new" className="btn btn-primary"><span>+</span> New agent</Link>
+            <Link href="/workflows/new" className="btn btn-primary"><span>+</span> New workflow</Link>
           </div>
         </div>
+
+        {/* #5: Error banner with retry */}
+        {error && (
+          <div style={{ marginBottom: 14, padding: "10px 14px", background: "var(--err-weak, #fff5f5)", border: "1px solid var(--err, #dc2626)", borderRadius: 8, fontSize: 13, color: "var(--err, #dc2626)", display: "flex", alignItems: "center", gap: 10 }}>
+            <span style={{ flex: 1 }}>{error}</span>
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => { setError(null); loadWorkflows(project?.id ?? null) }}
+              style={{ fontSize: 12 }}
+            >Retry</button>
+            <button
+              onClick={() => setError(null)}
+              style={{ background: "none", border: "none", cursor: "pointer", color: "var(--err)", fontWeight: 700, fontSize: 14, lineHeight: 1 }}
+            >×</button>
+          </div>
+        )}
 
         <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 14, flexWrap: "wrap" }}>
           <div style={{ position: "relative", flex: 1, minWidth: 220, maxWidth: 340 }}>
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" style={{ position: "absolute", left: 11, top: 10, color: "var(--text-muted)" }}>
               <path d="M11 19a8 8 0 1 0 0-16 8 8 0 0 0 0 16zm4.15-2.85 3.7 3.7" stroke="currentColor" strokeWidth="2" strokeLinecap="round" />
             </svg>
+            {/* #19: type="search" + aria-label */}
             <input
+              type="search"
+              aria-label="Search workflows"
               value={q}
               onChange={e => setQ(e.target.value)}
-              placeholder="Search agents…"
+              placeholder="Search workflows…"
               style={{ width: "100%", height: 36, padding: "0 12px 0 33px", borderRadius: 9, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--text)", fontSize: 13.5, outline: "none" }}
             />
           </div>
@@ -327,9 +435,10 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
           </div>
         </div>
 
+        {/* #8: chip counts from filtered (post-search) not full workflows array */}
         <div style={{ display: "flex", gap: 7, marginBottom: 16, flexWrap: "wrap" }}>
           {["All", "Running", "Awaiting", "Succeeded", "Failed", "Never run"].map(s => {
-            const n = s === "All" ? workflows.length : workflows.filter(w => mapStatus(w.last_run_status) === statusKey(s)).length
+            const n = s === "All" ? filtered.length : filtered.filter(w => mapStatus(w.last_run_status) === statusKey(s)).length
             const on = status === s
             return (
               <button
@@ -345,35 +454,42 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
         </div>
 
         {loading ? (
-          <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+          // #21: animated skeleton matching current view layout
+          <div style={{ display: view === "grid" ? "grid" : "flex", gridTemplateColumns: view === "grid" ? "repeat(auto-fill, minmax(300px, 1fr))" : undefined, flexDirection: view === "list" ? "column" : undefined, gap: 8 }}>
             {[1, 2, 3].map(i => (
-              <div key={i} style={{ height: 60, borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", opacity: 0.5 }} />
+              <div
+                key={i}
+                style={{ height: view === "grid" ? 120 : 60, borderRadius: 10, border: "1px solid var(--border)", background: "var(--surface)", opacity: 0.5, animation: "pulse 1.5s ease-in-out infinite" }}
+              />
             ))}
+            <style>{`@keyframes pulse { 0%,100% { opacity: 0.5 } 50% { opacity: 0.25 } }`}</style>
           </div>
         ) : !loading && workflows.length === 0 ? (
           <div style={{ padding: "60px 20px", textAlign: "center" }}>
-            <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No agents yet</p>
-            <p style={{ fontSize: 13.5, color: "var(--text-3)", marginBottom: 20 }}>Pick a playbook template to create your first agent.</p>
-            <Link href="/workflows/new" className="btn btn-primary">+ New agent</Link>
+            {/* #14: "agent" → "workflow" in empty state */}
+            <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No workflows yet</p>
+            <p style={{ fontSize: 13.5, color: "var(--text-3)", marginBottom: 20 }}>Pick a playbook template to create your first workflow.</p>
+            <Link href="/workflows/new" className="btn btn-primary">+ New workflow</Link>
           </div>
         ) : (
           <>
             {view === "list" && (
               <div className="card" style={{ overflow: "hidden" }}>
-                <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1.2fr 1.1fr 64px", gap: 14, padding: "10px 18px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
-                  {["Agent", "Project", "Last run", "Success 30d", ""].map((h, i) => (
+                {/* #1: removed "Success 30d" column header and MiniSpark — no sparkline data from API */}
+                <div style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1.2fr 64px", gap: 14, padding: "10px 18px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
+                  {["Workflow", "Project", "Last run", ""].map((h, i) => (
                     <div key={i} className="eyebrow" style={{ fontSize: 9.5 }}>{h}</div>
                   ))}
                 </div>
                 {rows.length === 0 && (
-                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No agents match.</div>
+                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No workflows match.</div>
                 )}
                 {rows.map(w => {
                   if (confirming === w.id) {
                     return (
                       <div key={w.id} style={{ padding: "12px 18px", borderBottom: "1px solid var(--border)", background: "var(--err-weak, #fff5f5)" }}>
                         <p style={{ fontSize: 13, color: "var(--err, #dc2626)", marginBottom: 8 }}>
-                          Type <strong>{w.name}</strong> to permanently delete this agent and all its data.
+                          Type <strong>{w.name}</strong> to permanently delete this workflow and all its data.
                         </p>
                         <div style={{ display: "flex", gap: 8 }}>
                           <input
@@ -402,9 +518,13 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                     )
                   }
                   return (
+                    // #16: keyboard nav on rows
                     <div
                       key={w.id}
-                      style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1.2fr 1.1fr 64px", gap: 14, padding: "13px 18px", borderBottom: "1px solid var(--border)", alignItems: "center", cursor: "pointer", transition: "background .12s" }}
+                      tabIndex={0}
+                      role="button"
+                      onKeyDown={e => { if (e.key === "Enter") router.push(`/workflows/${w.id}`) }}
+                      style={{ display: "grid", gridTemplateColumns: "2fr 1fr 1.2fr 64px", gap: 14, padding: "13px 18px", borderBottom: "1px solid var(--border)", alignItems: "center", cursor: "pointer", transition: "background .12s" }}
                       onClick={() => router.push(`/workflows/${w.id}`)}
                       onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
                       onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = ""}
@@ -417,6 +537,8 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                             onChange={e => setRenameValue(e.target.value)}
                             onClick={e => e.stopPropagation()}
                             onBlur={() => {
+                              // #11: skip commit if Escape was pressed
+                              if (escapePressed.current) { escapePressed.current = false; return }
                               const name = renameValue.trim()
                               if (name && name !== w.name) renameAgent(w.id, name)
                               setRenaming(null)
@@ -430,7 +552,12 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                                 setRenaming(null)
                                 setRenameValue("")
                               }
-                              if (e.key === "Escape") { setRenaming(null); setRenameValue("") }
+                              if (e.key === "Escape") {
+                                // #11: flag escape so onBlur skips commit
+                                escapePressed.current = true
+                                setRenaming(null)
+                                setRenameValue("")
+                              }
                             }}
                             style={{ fontWeight: 650, fontSize: 14, background: "transparent", border: "none", borderBottom: "1px solid var(--accent)", outline: "none", width: "100%" }}
                           />
@@ -446,11 +573,11 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                         <AgentStatusPill s={mapStatus(w.last_run_status)} />
                         <span style={{ fontSize: 11.5, color: "var(--text-muted)" }}>{w.last_run_at ? timeAgo(w.last_run_at) : ""}</span>
                       </div>
-                      <MiniSpark pct={0} runs={0} />
+                      {/* #1: MiniSpark removed — no sparkline data from API */}
                       <div style={{ display: "flex", gap: 4, justifyContent: "flex-end", position: "relative" }}>
                         <button
                           className="btn btn-ghost btn-sm"
-                          title="Trigger a manual run of this agent"
+                          title="Trigger a manual run of this workflow"
                           style={{ fontSize: 11, padding: "3px 9px" }}
                           onClick={e => { e.stopPropagation(); setRunParams(""); setRunDryRun(false); setRunGuard(true); setRunError(null); setRunModal({ id: w.id, name: w.name }) }}
                         >Run</button>
@@ -460,31 +587,15 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                           onClick={e => { e.stopPropagation(); router.push(`/workflows/${w.id}`) }}
                         >→</button>
                         {isAdmin && (
-                          <div style={{ position: "relative" }}>
-                            <button
-                              className="btn btn-ghost btn-icon btn-sm"
-                              title="More"
-                              onClick={e => { e.stopPropagation(); setMenuOpen(menuOpen === w.id ? null : w.id) }}
-                            >⋯</button>
-                            {menuOpen === w.id && (
-                              <div
-                                onMouseDown={e => e.stopPropagation()}
-                                style={{ position: "absolute", right: 0, top: "100%", marginTop: 4, zIndex: 20, minWidth: 130, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 10, boxShadow: "var(--shadow-md)", padding: "4px 0" }}
-                              >
-                                <button
-                                  onClick={e => { e.stopPropagation(); setMenuOpen(null); setRenaming(w.id); setRenameValue(w.name) }}
-                                  style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--text)", background: "none", border: "none", cursor: "pointer" }}
-                                  onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
-                                  onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
-                                >Rename</button>
-                                <button
-                                  onMouseDown={e => { e.stopPropagation(); setMenuOpen(null); setConfirming(w.id); setConfirmValue("") }}
-                                  style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--err, #dc2626)", background: "none", border: "none", cursor: "pointer" }}
-                                  onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
-                                  onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
-                                >Delete</button>
-                              </div>
-                            )}
+                          <div ref={el => { menuRefs.current.set(w.id, el) }}>
+                            <WorkflowMenu
+                              wfId={w.id}
+                              wfName={w.name}
+                              menuOpen={menuOpen}
+                              onToggleMenu={id => setMenuOpen(menuOpen === id ? null : id)}
+                              onRename={startRename}
+                              onDelete={startDelete}
+                            />
                           </div>
                         )}
                       </div>
@@ -496,58 +607,120 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
 
             {view === "grid" && (
               <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(300px, 1fr))", gap: 14 }}>
-                {rows.map(w => (
-                  <div
-                    key={w.id}
-                    onClick={() => router.push(`/workflows/${w.id}`)}
-                    className="card"
-                    style={{ padding: "16px 18px", cursor: "pointer", opacity: enabled[w.id] ? 1 : .65 }}
-                    onMouseEnter={e => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-md)"; (e.currentTarget as HTMLElement).style.borderColor = "var(--border-2)" }}
-                    onMouseLeave={e => { (e.currentTarget as HTMLElement).style.boxShadow = ""; (e.currentTarget as HTMLElement).style.borderColor = "var(--border)" }}
-                  >
-                    <div style={{ display: "flex", alignItems: "flex-start", gap: 10, marginBottom: 12 }}>
-                      <div style={{ minWidth: 0, flex: 1 }}>
-                        <div style={{ fontWeight: 650, fontSize: 15, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{w.name}</div>
-                        <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>edited {timeAgo(w.updated_at)}</div>
+                {rows.map(w => {
+                  if (confirming === w.id) {
+                    // #3: delete confirmation in grid view
+                    return (
+                      <div key={w.id} className="card" style={{ padding: "16px 18px", background: "var(--err-weak, #fff5f5)", border: "1px solid var(--err, #fca5a5)" }}>
+                        <p style={{ fontSize: 13, color: "var(--err, #dc2626)", marginBottom: 10 }}>
+                          Type <strong>{w.name}</strong> to permanently delete this workflow.
+                        </p>
+                        <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                          <input
+                            ref={confirmInputRef}
+                            value={confirmValue}
+                            onChange={e => setConfirmValue(e.target.value)}
+                            onKeyDown={e => {
+                              if (e.key === "Enter" && confirmValue === w.name) deleteAgent(w.id)
+                              if (e.key === "Escape") { setConfirming(null); setConfirmValue("") }
+                            }}
+                            placeholder={w.name}
+                            style={{ flex: 1, fontSize: 13, border: "1px solid var(--err, #fca5a5)", borderRadius: 7, padding: "5px 10px", outline: "none", background: "var(--surface)", minWidth: 0 }}
+                          />
+                          <button
+                            onClick={() => deleteAgent(w.id)}
+                            disabled={confirmValue !== w.name}
+                            className="btn btn-sm"
+                            style={{ background: "var(--err, #dc2626)", color: "#fff", opacity: confirmValue !== w.name ? 0.4 : 1, cursor: confirmValue !== w.name ? "not-allowed" : "pointer" }}
+                          >Delete</button>
+                          <button
+                            onClick={() => { setConfirming(null); setConfirmValue("") }}
+                            className="btn btn-ghost btn-sm"
+                          >Cancel</button>
+                        </div>
                       </div>
-                      <div style={{ display: "flex", alignItems: "center", gap: 6 }} onClick={e => e.stopPropagation()}>
-                        <Toggle on={!!enabled[w.id]} onClick={() => setEnabled(s => ({ ...s, [w.id]: !s[w.id] }))} />
-                        {isAdmin && (
-                          <div style={{ position: "relative" }}>
-                            <button
-                              className="btn btn-ghost btn-icon btn-sm"
-                              title="More"
-                              onClick={e => { e.stopPropagation(); setMenuOpen(menuOpen === w.id ? null : w.id) }}
-                            >⋯</button>
-                            {menuOpen === w.id && (
-                              <div
-                                onMouseDown={e => e.stopPropagation()}
-                                style={{ position: "absolute", right: 0, top: "100%", marginTop: 4, zIndex: 20, minWidth: 130, background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 10, boxShadow: "var(--shadow-md)", padding: "4px 0" }}
-                              >
-                                <button
-                                  onClick={e => { e.stopPropagation(); setMenuOpen(null); setRenaming(w.id); setRenameValue(w.name) }}
-                                  style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--text)", background: "none", border: "none", cursor: "pointer" }}
-                                  onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
-                                  onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
-                                >Rename</button>
-                                <button
-                                  onMouseDown={e => { e.stopPropagation(); setMenuOpen(null); setConfirming(w.id); setConfirmValue("") }}
-                                  style={{ width: "100%", textAlign: "left", padding: "7px 14px", fontSize: 13, color: "var(--err, #dc2626)", background: "none", border: "none", cursor: "pointer" }}
-                                  onMouseEnter={e => (e.currentTarget as HTMLElement).style.background = "var(--surface-2)"}
-                                  onMouseLeave={e => (e.currentTarget as HTMLElement).style.background = "none"}
-                                >Delete</button>
-                              </div>
-                            )}
-                          </div>
-                        )}
+                    )
+                  }
+                  return (
+                    // #16: keyboard nav on grid cards
+                    <div
+                      key={w.id}
+                      tabIndex={0}
+                      role="button"
+                      onKeyDown={e => { if (e.key === "Enter") router.push(`/workflows/${w.id}`) }}
+                      onClick={() => router.push(`/workflows/${w.id}`)}
+                      className="card"
+                      style={{ padding: "16px 18px", cursor: "pointer" }}
+                      onMouseEnter={e => { (e.currentTarget as HTMLElement).style.boxShadow = "var(--shadow-md)"; (e.currentTarget as HTMLElement).style.borderColor = "var(--border-2)" }}
+                      onMouseLeave={e => { (e.currentTarget as HTMLElement).style.boxShadow = ""; (e.currentTarget as HTMLElement).style.borderColor = "var(--border)" }}
+                    >
+                      <div style={{ display: "flex", alignItems: "flex-start", gap: 10, marginBottom: 12 }}>
+                        <div style={{ minWidth: 0, flex: 1 }}>
+                          {/* #2: rename input in grid card */}
+                          {renaming === w.id ? (
+                            <input
+                              ref={renameInputRef}
+                              value={renameValue}
+                              onChange={e => setRenameValue(e.target.value)}
+                              onClick={e => e.stopPropagation()}
+                              onBlur={() => {
+                                // #11: skip commit if Escape was pressed
+                                if (escapePressed.current) { escapePressed.current = false; return }
+                                const name = renameValue.trim()
+                                if (name && name !== w.name) renameAgent(w.id, name)
+                                setRenaming(null)
+                                setRenameValue("")
+                              }}
+                              onKeyDown={e => {
+                                e.stopPropagation()
+                                if (e.key === "Enter") {
+                                  const name = renameValue.trim()
+                                  if (name && name !== w.name) renameAgent(w.id, name)
+                                  setRenaming(null)
+                                  setRenameValue("")
+                                }
+                                if (e.key === "Escape") {
+                                  escapePressed.current = true
+                                  setRenaming(null)
+                                  setRenameValue("")
+                                }
+                              }}
+                              style={{ fontWeight: 650, fontSize: 15, background: "transparent", border: "none", borderBottom: "1px solid var(--accent)", outline: "none", width: "100%" }}
+                            />
+                          ) : (
+                            <div style={{ fontWeight: 650, fontSize: 15, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>{w.name}</div>
+                          )}
+                          <div className="mono" style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 2 }}>edited {timeAgo(w.updated_at)}</div>
+                        </div>
+                        {/* #4: Toggle removed from grid — no PATCH endpoint wired, avoid false feedback */}
+                        <div style={{ display: "flex", alignItems: "center", gap: 6 }} onClick={e => e.stopPropagation()}>
+                          {isAdmin && (
+                            <div ref={el => { menuRefs.current.set(w.id, el) }}>
+                              <WorkflowMenu
+                                wfId={w.id}
+                                wfName={w.name}
+                                menuOpen={menuOpen}
+                                onToggleMenu={id => setMenuOpen(menuOpen === id ? null : id)}
+                                onRename={startRename}
+                                onDelete={startDelete}
+                              />
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                      {/* #9: Run button in grid card + status; MiniSpark removed (#1) */}
+                      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+                        <AgentStatusPill s={mapStatus(w.last_run_status)} />
+                        <button
+                          className="btn btn-ghost btn-sm"
+                          title="Trigger a manual run of this workflow"
+                          style={{ fontSize: 11, padding: "3px 9px" }}
+                          onClick={e => { e.stopPropagation(); setRunParams(""); setRunDryRun(false); setRunGuard(true); setRunError(null); setRunModal({ id: w.id, name: w.name }) }}
+                        >Run</button>
                       </div>
                     </div>
-                    <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", paddingTop: 12, borderTop: "1px solid var(--border)" }}>
-                      <AgentStatusPill s={mapStatus(w.last_run_status)} />
-                      <MiniSpark pct={0} runs={0} />
-                    </div>
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             )}
           </>
@@ -561,43 +734,48 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
           style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.45)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center" }}
           onClick={() => setRunModal(null)}
         >
+          {/* #23: wrapped in form with onSubmit; #7: ref for focus trap */}
           <div
+            ref={runModalRef}
             style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 12, boxShadow: "var(--shadow-lg)", padding: 24, width: 440, maxWidth: "90vw" }}
             onClick={e => e.stopPropagation()}
           >
             <div style={{ fontWeight: 650, fontSize: 15, marginBottom: 16 }}>Run — {runModal.name}</div>
 
-            <div style={{ marginBottom: 14 }}>
-              <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 6 }}>Parameters (optional)</div>
-              <textarea
-                rows={4}
-                value={runParams}
-                onChange={e => setRunParams(e.target.value)}
-                placeholder={"MODEL=claude-sonnet-4-6\nBRANCH=main"}
-                style={{ width: "100%", fontSize: 12.5, fontFamily: "var(--font-mono, monospace)", border: "1px solid var(--border)", borderRadius: 8, padding: "8px 12px", background: "var(--surface-2)", color: "var(--text)", resize: "vertical", boxSizing: "border-box" }}
-              />
-              <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>One KEY=VALUE per line</div>
-            </div>
+            <form onSubmit={e => { e.preventDefault(); runWorkflow() }}>
+              <div style={{ marginBottom: 14 }}>
+                <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 6 }}>Parameters (optional)</div>
+                {/* #23: maxHeight to cap textarea resize */}
+                <textarea
+                  rows={4}
+                  value={runParams}
+                  onChange={e => setRunParams(e.target.value)}
+                  placeholder={"MODEL=claude-sonnet-4-6\nBRANCH=main"}
+                  style={{ width: "100%", fontSize: 12.5, fontFamily: "var(--font-mono, monospace)", border: "1px solid var(--border)", borderRadius: 8, padding: "8px 12px", background: "var(--surface-2)", color: "var(--text)", resize: "vertical", maxHeight: 200, boxSizing: "border-box" }}
+                />
+                <div style={{ fontSize: 11, color: "var(--text-muted)", marginTop: 4 }}>One KEY=VALUE per line</div>
+              </div>
 
-            <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
-              <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, cursor: "pointer" }}>
-                <input type="checkbox" checked={runGuard} onChange={e => setRunGuard(e.target.checked)} />
-                Enable Guard
-              </label>
-              <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, cursor: "pointer" }}>
-                <input type="checkbox" checked={runDryRun} onChange={e => setRunDryRun(e.target.checked)} />
-                Dry run (simulate without executing)
-              </label>
-            </div>
+              <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 20 }}>
+                <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, cursor: "pointer" }}>
+                  <input type="checkbox" checked={runGuard} onChange={e => setRunGuard(e.target.checked)} />
+                  Enable Guard
+                </label>
+                <label style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 13, cursor: "pointer" }}>
+                  <input type="checkbox" checked={runDryRun} onChange={e => setRunDryRun(e.target.checked)} />
+                  Dry run (simulate without executing)
+                </label>
+              </div>
 
-            {runError && <div style={{ fontSize: 12, color: "var(--err)", marginBottom: 12 }}>{runError}</div>}
+              {runError && <div style={{ fontSize: 12, color: "var(--err)", marginBottom: 12 }}>{runError}</div>}
 
-            <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
-              <button className="btn btn-ghost" onClick={() => setRunModal(null)}>Cancel</button>
-              <button className="btn btn-primary" onClick={runWorkflow} disabled={runLoading}>
-                {runLoading ? "Starting…" : "Run now"}
-              </button>
-            </div>
+              <div style={{ display: "flex", gap: 8, justifyContent: "flex-end" }}>
+                <button type="button" className="btn btn-ghost" onClick={() => setRunModal(null)}>Cancel</button>
+                <button type="submit" className="btn btn-primary" disabled={runLoading}>
+                  {runLoading ? "Starting…" : "Run now"}
+                </button>
+              </div>
+            </form>
           </div>
         </div>
       )}


### PR DESCRIPTION
## What

New playbook: `oss-issue-sweep.yaml`

Fixes every open issue in a third-party OSS repo in a single run — dependency-aware ordering, PR per issue, memory accumulates across fixes.

## Flow

```
fetch_all_issues   → GitHub API: all open issues with cross-references
triage_and_order   → maps dependencies, orders fixes (blockers first, complex last)
fork_upstream      → fork once, reused across all fixes
read_memory        → prior lessons from this repo
fix_loop           → agentic: iterates ordered list, fix → branch → push → PR per issue
write_memory       → lessons recorded for next sweep
notify_complete    → Slack summary with PR links
```

## Key features
- **Dependency mapping** — reads issue bodies for "#N", "blocked by", "depends on", orders accordingly
- **Failure resilience** — if one fix fails (403, bad diff), skip and continue — never halt the whole run
- **Memory accumulation** — lessons from issue #3 inform how issue #7 is fixed
- **Lint on every commit** — auto-detects ruff/black/eslint/cargo fmt
- **Attribution** — every PR includes Conduct AI attribution

## Test target
`openclaw/Peekaboo` with `max_issues: 5` for the first run.

## Why
Client trust deficit. The OSS campaign (fix real issues, open real PRs, publish the story) is the fastest path to credibility without a sales cycle.