### PR TITLE
Add module docstring to apps/api/app/main.py

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,3 +1,9 @@
+"""
+FastAPI app entrypoint for the Conduct backend.
+
+This module configures and initializes the main FastAPI application, including
+middleware, exception handlers, and all API routers for the Conduct platform.
+"""
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, FileResponse


### PR DESCRIPTION
Adds a 3-sentence module-level docstring at the top of the main FastAPI app entrypoint file, describing what this module does.

Fixes #793 (autopilot smoke test)