### PR TITLE
Add module-level docstring to apps/api/app/main.py

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,3 +1,9 @@
+"""FastAPI app entrypoint for the Conduct backend.
+
+This module initializes and configures the core FastAPI application,
+including middleware setup, router registration, and error handling.
+"""
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, FileResponse


### PR DESCRIPTION
Adds a module-level docstring to `apps/api/app/main.py` describing the file as the FastAPI app entrypoint for the Conduct backend.

Fixes #793