### PR TITLE
feat(okta): JWT verifier — RS256, JWKS cache, no algorithm downgrade

### DIFF
--- a/apps/api/app/core/okta_jwt.py
+++ b/apps/api/app/core/okta_jwt.py
@@ -1,0 +1,162 @@
+"""
+Okta JWT verifier — RS256 only, per-issuer JWKS cache, no algorithm downgrade.
+
+Standalone. Wired into `app.core.auth._resolve_agent_token` by issue #1056.
+
+Non-negotiables (enforced here, tested in tests/test_okta_jwt.py):
+- alg MUST be RS256 (HS256, none, symmetric algs are rejected outright)
+- iss MUST match exactly
+- aud MUST match exactly (string or list per RFC 7519)
+- exp MUST be future (30s skew)
+- iat/nbf if present, must be past
+- Signature verified against a JWKS-fetched RSA public key matching `kid`
+- On unknown kid: one JWKS refresh permitted (natural cache-miss path), then fail
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import jwt
+import structlog
+
+log = structlog.get_logger(__name__)
+
+_JWKS_TTL_S = 3600
+_CLOCK_SKEW_S = 30
+_HTTP_TIMEOUT_S = 5
+
+
+class OktaJWTError(Exception):
+    """Base for all Okta JWT verification failures."""
+
+
+class OktaJWTInvalid(OktaJWTError):
+    """Malformed, wrong-audience, wrong-signature, bad alg, or unknown key."""
+
+
+class OktaJWTExpired(OktaJWTError):
+    """Token past exp (with clock-skew allowance)."""
+
+
+class OktaJWTUntrusted(OktaJWTError):
+    """Token issuer does not match the configured issuer for this workspace."""
+
+
+@dataclass
+class _CachedJWKS:
+    keys: dict[str, Any] = field(default_factory=dict)  # kid -> public key
+    fetched_at: float = 0.0
+
+
+class OktaJWKSCache:
+    """Per-issuer JWKS cache. TTL + refresh-on-unknown-kid via natural miss path."""
+
+    def __init__(self, ttl_s: int = _JWKS_TTL_S, http_timeout_s: int = _HTTP_TIMEOUT_S):
+        self._ttl = ttl_s
+        self._data: dict[str, _CachedJWKS] = {}
+        self._lock = threading.Lock()
+        # ponytail: shared client — connection pooling, matches auth.py pattern
+        self._http = httpx.Client(timeout=http_timeout_s)
+
+    def _fetch(self, issuer: str) -> dict:
+        # ponytail: Okta convention — {issuer}/v1/keys. Non-Okta OIDC would fetch
+        # /.well-known/openid-configuration and read jwks_uri; add when we add another provider.
+        url = f"{issuer.rstrip('/')}/v1/keys"
+        r = self._http.get(url)
+        r.raise_for_status()
+        return r.json()
+
+    def _load(self, issuer: str) -> dict[str, Any]:
+        try:
+            jwks = self._fetch(issuer)
+        except Exception as e:
+            log.warning("okta.jwks.fetch_failed", issuer=issuer, error=str(e))
+            raise OktaJWTInvalid(f"jwks fetch failed: {e}") from e
+        keys: dict[str, Any] = {}
+        for k in jwks.get("keys", []):
+            kid = k.get("kid")
+            if not kid:
+                continue
+            try:
+                keys[kid] = jwt.PyJWK(k).key
+            except Exception as e:  # bad JWK entry — skip, don't fail the whole set
+                log.warning("okta.jwks.bad_key", kid=kid, error=str(e))
+        with self._lock:
+            self._data[issuer] = _CachedJWKS(keys=keys, fetched_at=time.time())
+        return keys
+
+    def get_key(self, issuer: str, kid: str) -> Any:
+        with self._lock:
+            entry = self._data.get(issuer)
+            fresh = entry is not None and (time.time() - entry.fetched_at) <= self._ttl
+            if fresh and kid in entry.keys:
+                return entry.keys[kid]
+        # miss: unknown issuer, expired, or unknown kid → single fetch, then decide
+        keys = self._load(issuer)
+        if kid not in keys:
+            raise OktaJWTInvalid(f"unknown kid: {kid}")
+        return keys[kid]
+
+    def invalidate(self, issuer: str | None = None) -> None:
+        with self._lock:
+            if issuer is None:
+                self._data.clear()
+            else:
+                self._data.pop(issuer, None)
+
+
+_default_cache = OktaJWKSCache()
+
+
+def verify_okta_jwt(
+    token: str,
+    issuer: str,
+    audience: str,
+    *,
+    cache: OktaJWKSCache | None = None,
+    leeway_s: int = _CLOCK_SKEW_S,
+) -> dict:
+    """
+    Verify an Okta-issued JWT and return validated claims.
+
+    Raises OktaJWTError subclasses on any failure. Never returns unverified claims.
+    """
+    cache = cache or _default_cache
+
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as e:
+        raise OktaJWTInvalid(f"malformed token: {e}") from e
+
+    alg = header.get("alg")
+    if alg != "RS256":
+        raise OktaJWTInvalid(f"unsupported alg: {alg!r}")
+
+    kid = header.get("kid")
+    if not kid:
+        raise OktaJWTInvalid("missing kid")
+
+    key = cache.get_key(issuer, kid)
+
+    try:
+        claims = jwt.decode(
+            token,
+            key=key,
+            algorithms=["RS256"],
+            audience=audience,
+            issuer=issuer,
+            leeway=leeway_s,
+            options={"require": ["exp", "iss", "aud", "sub"]},
+        )
+    except jwt.ExpiredSignatureError as e:
+        raise OktaJWTExpired("token expired") from e
+    except jwt.InvalidIssuerError as e:
+        raise OktaJWTUntrusted(f"wrong issuer: {e}") from e
+    except jwt.PyJWTError as e:
+        raise OktaJWTInvalid(str(e)) from e
+
+    return claims

--- a/apps/api/tests/test_okta_jwt.py
+++ b/apps/api/tests/test_okta_jwt.py
@@ -1,0 +1,232 @@
+"""
+Tests for app.core.okta_jwt — 13 cases from issue #1055 acceptance criteria.
+
+No network. RSA keys generated in-fixture, JWKS fetch monkeypatched on the cache.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core.okta_jwt import (
+    OktaJWKSCache,
+    OktaJWTExpired,
+    OktaJWTInvalid,
+    OktaJWTUntrusted,
+    verify_okta_jwt,
+)
+
+ISSUER = "https://example.okta.com/oauth2/default"
+AUD = "api://default"
+KID = "test-kid-1"
+
+
+@pytest.fixture(scope="module")
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def rsa_key_2():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwk_pub(priv, kid: str) -> dict:
+    d = json.loads(pyjwt.algorithms.RSAAlgorithm.to_jwk(priv.public_key()))
+    d["kid"] = kid
+    d["alg"] = "RS256"
+    d["use"] = "sig"
+    return d
+
+
+def _base_claims(**overrides) -> dict:
+    now = int(time.time())
+    c = {
+        "iss": ISSUER,
+        "aud": AUD,
+        "sub": "0oa1677gbczxbjmcI698",
+        "iat": now - 5,
+        "exp": now + 300,
+    }
+    c.update(overrides)
+    return c
+
+
+def _make_token(priv, claims: dict, *, kid: str | None = KID, alg: str = "RS256", key=None) -> str:
+    headers = {"kid": kid} if kid else None
+    signing_key = key if key is not None else priv
+    return pyjwt.encode(claims, signing_key, algorithm=alg, headers=headers)
+
+
+@pytest.fixture
+def cache_with_key(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        return {"keys": [_jwk_pub(rsa_key, KID)]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+    cache.calls = call_count  # type: ignore[attr-defined]
+    return cache
+
+
+# 1
+def test_valid_jwt_returns_claims(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims())
+    claims = verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    assert claims["sub"] == "0oa1677gbczxbjmcI698"
+    assert claims["iss"] == ISSUER
+    assert claims["aud"] == AUD
+
+
+# 2
+def test_wrong_signature_rejected(rsa_key_2, cache_with_key):
+    tok = _make_token(rsa_key_2, _base_claims())  # signed by different key
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 3
+def test_expired_token_raises_expired(rsa_key, cache_with_key):
+    now = int(time.time())
+    tok = _make_token(rsa_key, _base_claims(exp=now - 120, iat=now - 3600))
+    with pytest.raises(OktaJWTExpired):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 4
+def test_not_yet_valid_nbf_future(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(nbf=int(time.time()) + 300))
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 5
+def test_wrong_issuer_untrusted(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(iss="https://evil.example.com/oauth2/default"))
+    with pytest.raises(OktaJWTUntrusted):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 6
+def test_wrong_audience_invalid(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(aud="api://wrong"))
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 7
+def test_alg_none_rejected(cache_with_key):
+    # alg=none — classic no-signature attack
+    tok = pyjwt.encode(_base_claims(), key="", algorithm="none", headers={"kid": KID})
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 8
+def test_hs256_downgrade_rejected(rsa_key, cache_with_key):
+    # Classic algorithm-confusion: attacker hand-builds an HS256 token using the
+    # public key PEM as the shared secret. PyJWT's `encode` refuses to do this,
+    # so we construct the wire format directly — that's what an attacker does.
+    pub_pem = rsa_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    def _b64u(b: bytes) -> str:
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    header = _b64u(json.dumps({"alg": "HS256", "typ": "JWT", "kid": KID}).encode())
+    payload = _b64u(json.dumps(_base_claims()).encode())
+    signing_input = f"{header}.{payload}".encode()
+    sig = _b64u(hmac.new(pub_pem, signing_input, hashlib.sha256).digest())
+    tok = f"{header}.{payload}.{sig}"
+
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 9
+def test_missing_kid_rejected(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(), kid=None)
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 10
+def test_unknown_kid_triggers_refresh_then_succeeds(rsa_key, rsa_key_2, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"keys": [_jwk_pub(rsa_key, KID)]}
+        # rotation: second fetch includes the new kid
+        return {"keys": [_jwk_pub(rsa_key, KID), _jwk_pub(rsa_key_2, "new-kid")]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+
+    # Prime cache with the old JWKS
+    verify_okta_jwt(_make_token(rsa_key, _base_claims(), kid=KID), ISSUER, AUD, cache=cache)
+    assert call_count["n"] == 1
+
+    # New-kid token triggers a fresh fetch (unknown-kid path) and succeeds
+    claims = verify_okta_jwt(
+        _make_token(rsa_key_2, _base_claims(), kid="new-kid"),
+        ISSUER,
+        AUD,
+        cache=cache,
+    )
+    assert claims["sub"] == "0oa1677gbczxbjmcI698"
+    assert call_count["n"] == 2
+
+
+# 11
+def test_cache_hit_no_second_fetch(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims())
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    assert cache_with_key.calls["n"] == 1
+
+
+# 12
+def test_cache_expires_and_refetches(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=1)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        return {"keys": [_jwk_pub(rsa_key, KID)]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+
+    tok = _make_token(rsa_key, _base_claims())
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache)
+    time.sleep(1.2)
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache)
+    assert call_count["n"] == 2
+
+
+# 13
+def test_jwks_unreachable_typed_error_no_accept(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+
+    def _boom(issuer: str) -> dict:
+        raise ConnectionError("network down")
+
+    monkeypatch.setattr(cache, "_fetch", _boom)
+
+    tok = _make_token(rsa_key, _base_claims())
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache)


### PR DESCRIPTION
Sub-issue 1 of #1052 (Okta Phase 3 runtime enforcement). Closes #1055.

Standalone JWT verifier module. **Nothing is wired into `app.core.auth` yet** — that's #1056.

## What's here

- `apps/api/app/core/okta_jwt.py`
  - `verify_okta_jwt(token, issuer, audience, *, cache=None, leeway_s=30) -> dict`
  - `OktaJWKSCache` — per-issuer, threading-lock, default 1h TTL, `.invalidate()` for #1056 to call on identity PATCH
  - `OktaJWTError` base + `OktaJWTInvalid`, `OktaJWTExpired`, `OktaJWTUntrusted`

- `apps/api/tests/test_okta_jwt.py` — 13 tests, all pass

## Non-negotiables (enforced + tested)

- `alg` MUST be `RS256`. HS256, `none`, and any symmetric alg are rejected at the header gate before any signature work.
- `iss` MUST match exactly → `OktaJWTUntrusted`.
- `aud` MUST match exactly (string or list per RFC 7519).
- `exp` MUST be future with 30s clock-skew allowance → `OktaJWTExpired`.
- `iat`/`nbf` if present, must be past.
- Signature verified against a JWKS-fetched RSA public key matching the token's `kid`.
- Unknown `kid` triggers a single JWKS refresh via the natural cache-miss path, then fails cleanly.
- No `verify_signature=False`, no `options={}` overrides that could disable checks.

## Deps

`PyJWT[crypto]==2.12.0` and `cryptography==46.0.6` were already in `apps/api/requirements.txt`. No dep bump needed.

## Tests

```
13 passed in 1.83s
```

Covers: valid claims, wrong signature, expired, `nbf` future, wrong issuer, wrong audience, `alg: none`, HS256-downgrade (hand-built wire format — PyJWT's own `encode` refuses to build the attacker token), missing `kid`, unknown-kid triggers refresh + succeeds, cache hit no second fetch, TTL expiry re-fetches, JWKS unreachable.

## Not doing here

- No changes to `_resolve_agent_token` → #1056
- No Integration schema/config UI → #1056
- No CLI → #1057

Refs #1052.