### PR TITLE
feat(okta): JWT auth bridge — verifier wired into _resolve_agent_token

### DIFF
--- a/apps/api/alembic/versions/0091_okta_jwt_config.py
+++ b/apps/api/alembic/versions/0091_okta_jwt_config.py
@@ -1,0 +1,50 @@
+"""Okta JWT auth config on integrations — issuer, audience, feature flag.
+
+Bridge for #1056 (Okta Phase 3b). Adds three columns to `integrations`:
+
+- okta_issuer    — the OAuth authorization-server `iss` we accept for JWTs
+                    from this workspace. Indexed for reverse lookup
+                    (given an unverified JWT iss, find the workspace).
+- okta_audience  — the `aud` claim we require on those JWTs.
+- okta_auth_enabled — per-workspace feature flag. Default OFF.
+
+All three are nullable. Existing rows (non-Okta integrations, or Okta rows
+without JWT auth configured) stay untouched. When okta_auth_enabled is
+false or null, the verifier bridge returns None and callers fall through
+to the existing Clerk/agent-token paths.
+
+Revision ID: 0091
+Revises: 0090
+Create Date: 2026-08-10
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0091"
+down_revision = "0090"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("integrations", sa.Column("okta_issuer", sa.String(500), nullable=True))
+    op.add_column("integrations", sa.Column("okta_audience", sa.String(500), nullable=True))
+    op.add_column(
+        "integrations",
+        sa.Column("okta_auth_enabled", sa.Boolean(), nullable=False, server_default=sa.false()),
+    )
+    op.create_index(
+        "idx_integrations_okta_issuer",
+        "integrations",
+        ["okta_issuer"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_integrations_okta_issuer", table_name="integrations")
+    op.drop_column("integrations", "okta_auth_enabled")
+    op.drop_column("integrations", "okta_audience")
+    op.drop_column("integrations", "okta_issuer")

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -234,6 +234,83 @@ def _resolve_agent_token(token: str, db: Session):
     raise HTTPException(status_code=401, detail="Invalid agent token")
 
 
+def _resolve_okta_jwt(token: str, db: Session):
+    """Try to resolve `token` as an Okta-signed JWT (#1056).
+
+    Returns (AgentIdentity, None) on success, matching the shape of
+    `_resolve_agent_token(cond_api_*, ...)`. Returns None if the token is not
+    a JWT or its `iss` is not configured for any workspace with
+    `okta_auth_enabled=true` — the caller falls through to the next auth path
+    (Clerk). Any real verification failure raises HTTPException(401).
+    """
+    if token.count(".") != 2:
+        return None
+
+    from app.core.okta_jwt import OktaJWTError, verify_okta_jwt
+    from app.models.integration import Integration
+    from app.modules.agent_identity.models import AgentIdentity
+    import jwt as _pyjwt
+
+    try:
+        unverified = _pyjwt.decode(
+            token,
+            options={
+                "verify_signature": False,
+                "verify_exp": False,
+                "verify_aud": False,
+                "verify_iss": False,
+            },
+        )
+    except Exception:
+        return None
+    iss = unverified.get("iss")
+    if not iss:
+        return None
+
+    # ponytail: one indexed lookup per non-cond_ request. Add a global
+    # "any-okta-enabled" cache if this shows up in flame graphs.
+    rows = (
+        db.query(Integration)
+        .filter(
+            Integration.handle == "okta",
+            Integration.okta_issuer == iss,
+            Integration.okta_auth_enabled.is_(True),
+        )
+        .all()
+    )
+    if not rows:
+        return None  # unconfigured issuer — fall through to Clerk
+
+    last_error: Exception | None = None
+    for row in rows:
+        aud = row.okta_audience or ""
+        try:
+            claims = verify_okta_jwt(token, issuer=iss, audience=aud)
+        except OktaJWTError as e:
+            last_error = e
+            continue
+        sub = claims.get("sub")
+        if not sub:
+            raise HTTPException(status_code=401, detail="Okta JWT missing sub claim")
+        ai = (
+            db.query(AgentIdentity)
+            .filter(
+                AgentIdentity.workspace_id == row.workspace_id,
+                AgentIdentity.source == "okta",
+                AgentIdentity.source_id == sub,
+            )
+            .first()
+        )
+        if not ai:
+            raise HTTPException(status_code=401, detail="Okta identity not synced — run Okta sync in Conduct")
+        lifecycle = getattr(ai, "lifecycle_state", None)
+        if lifecycle in ("deactivated", "expired"):
+            raise HTTPException(status_code=401, detail=f"Agent identity is {lifecycle}")
+        return ai, None
+
+    raise HTTPException(status_code=401, detail=f"Okta JWT verification failed: {last_error}")
+
+
 def get_user_id(
     credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
     db: Session = Depends(get_db),
@@ -253,6 +330,10 @@ def get_user_id(
                 return None  # machine identity — no user session
             raise HTTPException(status_code=401, detail="Agent token not linked to a user — re-run `conduct login`")
         return clerk_user_id
+
+    # Okta JWT (#1056) — machine identities, no user session (like cond_api_*)
+    if _resolve_okta_jwt(credentials.credentials, db) is not None:
+        return None
 
     claims = _verify_clerk_token(credentials.credentials)
     if not claims:
@@ -327,6 +408,16 @@ def get_workspace_id(
         token_ws = str(ai.workspace_id)
         if explicit_ws and explicit_ws != token_ws:
             raise HTTPException(status_code=403, detail="Agent token does not belong to the requested workspace")
+        return explicit_ws or token_ws
+
+    # Okta JWT (#1056) — resolves before Clerk. Returns None for tokens whose
+    # issuer isn't configured, so Clerk JWTs still work.
+    okta = _resolve_okta_jwt(credentials.credentials, db)
+    if okta is not None:
+        ai, _ = okta
+        token_ws = str(ai.workspace_id)
+        if explicit_ws and explicit_ws != token_ws:
+            raise HTTPException(status_code=403, detail="Okta JWT does not belong to the requested workspace")
         return explicit_ws or token_ws
 
     claims = _verify_clerk_token(credentials.credentials)
@@ -490,6 +581,13 @@ def get_guard_hook_auth(
         ai, _ = _resolve_agent_token(token, db)
         return str(ai.workspace_id)
 
+    # Okta JWT (#1056) — resolves before Clerk. Returns None for tokens whose
+    # issuer isn't configured, so Clerk JWTs still work.
+    okta = _resolve_okta_jwt(token, db)
+    if okta is not None:
+        ai, _ = okta
+        return str(ai.workspace_id)
+
     # Clerk JWT
     claims = _verify_clerk_token(token)
     if claims:
@@ -600,6 +698,16 @@ def require_permission(permission: str):
             if ai and str(getattr(ai, "workspace_id", "")) == workspace_id:
                 return "admin"
             raise HTTPException(status_code=403, detail="API token workspace does not match request")
+
+        # Okta JWTs (#1056) are also workspace-scoped machine credentials —
+        # user_id is None because get_user_id returned None for the JWT above.
+        if user_id is None and credentials:
+            okta = _resolve_okta_jwt(credentials.credentials, db)
+            if okta is not None:
+                ai, _ = okta
+                if str(getattr(ai, "workspace_id", "")) == workspace_id:
+                    return "admin"
+                raise HTTPException(status_code=403, detail="Okta JWT workspace does not match request")
 
         row = db.execute(
             _text("SELECT role FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),

--- a/apps/api/app/core/okta_jwt.py
+++ b/apps/api/app/core/okta_jwt.py
@@ -1,0 +1,162 @@
+"""
+Okta JWT verifier — RS256 only, per-issuer JWKS cache, no algorithm downgrade.
+
+Standalone. Wired into `app.core.auth._resolve_agent_token` by issue #1056.
+
+Non-negotiables (enforced here, tested in tests/test_okta_jwt.py):
+- alg MUST be RS256 (HS256, none, symmetric algs are rejected outright)
+- iss MUST match exactly
+- aud MUST match exactly (string or list per RFC 7519)
+- exp MUST be future (30s skew)
+- iat/nbf if present, must be past
+- Signature verified against a JWKS-fetched RSA public key matching `kid`
+- On unknown kid: one JWKS refresh permitted (natural cache-miss path), then fail
+"""
+from __future__ import annotations
+
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+import jwt
+import structlog
+
+log = structlog.get_logger(__name__)
+
+_JWKS_TTL_S = 3600
+_CLOCK_SKEW_S = 30
+_HTTP_TIMEOUT_S = 5
+
+
+class OktaJWTError(Exception):
+    """Base for all Okta JWT verification failures."""
+
+
+class OktaJWTInvalid(OktaJWTError):
+    """Malformed, wrong-audience, wrong-signature, bad alg, or unknown key."""
+
+
+class OktaJWTExpired(OktaJWTError):
+    """Token past exp (with clock-skew allowance)."""
+
+
+class OktaJWTUntrusted(OktaJWTError):
+    """Token issuer does not match the configured issuer for this workspace."""
+
+
+@dataclass
+class _CachedJWKS:
+    keys: dict[str, Any] = field(default_factory=dict)  # kid -> public key
+    fetched_at: float = 0.0
+
+
+class OktaJWKSCache:
+    """Per-issuer JWKS cache. TTL + refresh-on-unknown-kid via natural miss path."""
+
+    def __init__(self, ttl_s: int = _JWKS_TTL_S, http_timeout_s: int = _HTTP_TIMEOUT_S):
+        self._ttl = ttl_s
+        self._data: dict[str, _CachedJWKS] = {}
+        self._lock = threading.Lock()
+        # ponytail: shared client — connection pooling, matches auth.py pattern
+        self._http = httpx.Client(timeout=http_timeout_s)
+
+    def _fetch(self, issuer: str) -> dict:
+        # ponytail: Okta convention — {issuer}/v1/keys. Non-Okta OIDC would fetch
+        # /.well-known/openid-configuration and read jwks_uri; add when we add another provider.
+        url = f"{issuer.rstrip('/')}/v1/keys"
+        r = self._http.get(url)
+        r.raise_for_status()
+        return r.json()
+
+    def _load(self, issuer: str) -> dict[str, Any]:
+        try:
+            jwks = self._fetch(issuer)
+        except Exception as e:
+            log.warning("okta.jwks.fetch_failed", issuer=issuer, error=str(e))
+            raise OktaJWTInvalid(f"jwks fetch failed: {e}") from e
+        keys: dict[str, Any] = {}
+        for k in jwks.get("keys", []):
+            kid = k.get("kid")
+            if not kid:
+                continue
+            try:
+                keys[kid] = jwt.PyJWK(k).key
+            except Exception as e:  # bad JWK entry — skip, don't fail the whole set
+                log.warning("okta.jwks.bad_key", kid=kid, error=str(e))
+        with self._lock:
+            self._data[issuer] = _CachedJWKS(keys=keys, fetched_at=time.time())
+        return keys
+
+    def get_key(self, issuer: str, kid: str) -> Any:
+        with self._lock:
+            entry = self._data.get(issuer)
+            fresh = entry is not None and (time.time() - entry.fetched_at) <= self._ttl
+            if fresh and kid in entry.keys:
+                return entry.keys[kid]
+        # miss: unknown issuer, expired, or unknown kid → single fetch, then decide
+        keys = self._load(issuer)
+        if kid not in keys:
+            raise OktaJWTInvalid(f"unknown kid: {kid}")
+        return keys[kid]
+
+    def invalidate(self, issuer: str | None = None) -> None:
+        with self._lock:
+            if issuer is None:
+                self._data.clear()
+            else:
+                self._data.pop(issuer, None)
+
+
+_default_cache = OktaJWKSCache()
+
+
+def verify_okta_jwt(
+    token: str,
+    issuer: str,
+    audience: str,
+    *,
+    cache: OktaJWKSCache | None = None,
+    leeway_s: int = _CLOCK_SKEW_S,
+) -> dict:
+    """
+    Verify an Okta-issued JWT and return validated claims.
+
+    Raises OktaJWTError subclasses on any failure. Never returns unverified claims.
+    """
+    cache = cache or _default_cache
+
+    try:
+        header = jwt.get_unverified_header(token)
+    except jwt.PyJWTError as e:
+        raise OktaJWTInvalid(f"malformed token: {e}") from e
+
+    alg = header.get("alg")
+    if alg != "RS256":
+        raise OktaJWTInvalid(f"unsupported alg: {alg!r}")
+
+    kid = header.get("kid")
+    if not kid:
+        raise OktaJWTInvalid("missing kid")
+
+    key = cache.get_key(issuer, kid)
+
+    try:
+        claims = jwt.decode(
+            token,
+            key=key,
+            algorithms=["RS256"],
+            audience=audience,
+            issuer=issuer,
+            leeway=leeway_s,
+            options={"require": ["exp", "iss", "aud", "sub"]},
+        )
+    except jwt.ExpiredSignatureError as e:
+        raise OktaJWTExpired("token expired") from e
+    except jwt.InvalidIssuerError as e:
+        raise OktaJWTUntrusted(f"wrong issuer: {e}") from e
+    except jwt.PyJWTError as e:
+        raise OktaJWTInvalid(str(e)) from e
+
+    return claims

--- a/apps/api/app/models/integration.py
+++ b/apps/api/app/models/integration.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint, Boolean
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -19,6 +19,11 @@ class Integration(Base):
     last_used_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     environment_id = Column(UUID(as_uuid=True), ForeignKey("environments.id"), nullable=True)
+    # Okta JWT auth (#1056). okta_issuer indexed — reverse lookup from an
+    # unverified JWT `iss` to the workspace that trusts it. NULL on non-Okta rows.
+    okta_issuer = Column(String(500), nullable=True, index=True)
+    okta_audience = Column(String(500), nullable=True)
+    okta_auth_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
 
     workspace = relationship("Workspace", back_populates="integrations")
     environment = relationship("Environment", back_populates="integrations")

--- a/apps/api/app/routers/okta_sync.py
+++ b/apps/api/app/routers/okta_sync.py
@@ -59,6 +59,11 @@ class OktaSyncResponse(BaseModel):
 class OktaConfigPut(BaseModel):
     domain: str = Field(..., description="Okta domain like dev-XXXXXX.okta.com.")
     token: str = Field(..., description="Okta API token (SSWS). Stored encrypted; never returned.")
+    # JWT auth (#1056) — all three optional. Ships disabled until the operator
+    # fills them in and flips the toggle.
+    issuer: Optional[str] = Field(None, description="OAuth authorization server issuer, e.g. https://{domain}/oauth2/default")
+    audience: Optional[str] = Field(None, description="Expected `aud` claim on Okta-issued JWTs, e.g. api://default")
+    jwt_auth_enabled: Optional[bool] = Field(None, description="Enable Okta JWT authentication for this workspace")
 
 
 class OktaConfigOut(BaseModel):
@@ -69,6 +74,10 @@ class OktaConfigOut(BaseModel):
     last_import: Optional[int] = None
     last_update: Optional[int] = None
     last_error: Optional[str] = None
+    # JWT auth (#1056)
+    issuer: Optional[str] = None
+    audience: Optional[str] = None
+    jwt_auth_enabled: bool = False
 
 
 # ─── Mapping ────────────────────────────────────────────────────────────────
@@ -222,8 +231,13 @@ def get_okta_config(
     db: Session = Depends(get_db),
 ) -> OktaConfigOut:
     cfg = _load_config(db, workspace_id)
-    if not cfg:
+    row = db.query(Integration).filter(
+        Integration.workspace_id == uuid.UUID(workspace_id),
+        Integration.handle == _OKTA_HANDLE,
+    ).first()
+    if not cfg and not row:
         return OktaConfigOut(configured=False)
+    cfg = cfg or {}
     tok = cfg.get("token") or ""
     return OktaConfigOut(
         configured=True,
@@ -233,6 +247,9 @@ def get_okta_config(
         last_import=cfg.get("last_import"),
         last_update=cfg.get("last_update"),
         last_error=cfg.get("last_error"),
+        issuer=(row.okta_issuer if row else None),
+        audience=(row.okta_audience if row else None),
+        jwt_auth_enabled=bool(row.okta_auth_enabled) if row else False,
     )
 
 
@@ -250,6 +267,22 @@ def put_okta_config(
     existing = _load_config(db, workspace_id) or {}
     existing.update({"domain": domain, "token": body.token})
     _save_config(db, workspace_id, existing)
+
+    # #1056 — update JWT auth columns on the Integration row. Nullable/no-op
+    # if the caller didn't supply them.
+    row = db.query(Integration).filter(
+        Integration.workspace_id == uuid.UUID(workspace_id),
+        Integration.handle == _OKTA_HANDLE,
+    ).first()
+    if row is not None:
+        if body.issuer is not None:
+            row.okta_issuer = body.issuer.strip() or None
+        if body.audience is not None:
+            row.okta_audience = body.audience.strip() or None
+        if body.jwt_auth_enabled is not None:
+            row.okta_auth_enabled = bool(body.jwt_auth_enabled)
+        db.commit()
+
     return OktaConfigOut(
         configured=True,
         domain=domain,
@@ -258,6 +291,9 @@ def put_okta_config(
         last_import=existing.get("last_import"),
         last_update=existing.get("last_update"),
         last_error=existing.get("last_error"),
+        issuer=(row.okta_issuer if row else None),
+        audience=(row.okta_audience if row else None),
+        jwt_auth_enabled=bool(row.okta_auth_enabled) if row else False,
     )
 
 

--- a/apps/api/app/routers/okta_sync.py
+++ b/apps/api/app/routers/okta_sync.py
@@ -57,10 +57,12 @@ class OktaSyncResponse(BaseModel):
 
 
 class OktaConfigPut(BaseModel):
-    domain: str = Field(..., description="Okta domain like dev-XXXXXX.okta.com.")
-    token: str = Field(..., description="Okta API token (SSWS). Stored encrypted; never returned.")
-    # JWT auth (#1056) — all three optional. Ships disabled until the operator
-    # fills them in and flips the toggle.
+    # All fields optional so callers can update just the credentials, just
+    # the JWT auth config, or both. Handler validates that the caller isn't
+    # sending an empty body.
+    domain: Optional[str] = Field(None, description="Okta domain like dev-XXXXXX.okta.com.")
+    token: Optional[str] = Field(None, description="Okta API token (SSWS). Stored encrypted; never returned.")
+    # JWT auth (#1056) — ships disabled until the operator flips the toggle.
     issuer: Optional[str] = Field(None, description="OAuth authorization server issuer, e.g. https://{domain}/oauth2/default")
     audience: Optional[str] = Field(None, description="Expected `aud` claim on Okta-issued JWTs, e.g. api://default")
     jwt_auth_enabled: Optional[bool] = Field(None, description="Enable Okta JWT authentication for this workspace")
@@ -261,39 +263,49 @@ def put_okta_config(
     _: str = Depends(require_permission("platform.workspace.edit")),
     db: Session = Depends(get_db),
 ) -> OktaConfigOut:
-    domain = _sanitize_domain(body.domain)
-    if not domain:
-        raise HTTPException(status_code=422, detail="Okta domain required")
-    existing = _load_config(db, workspace_id) or {}
-    existing.update({"domain": domain, "token": body.token})
-    _save_config(db, workspace_id, existing)
+    # Empty-body guard — reject requests that would be a no-op.
+    if body.domain is None and body.token is None and body.issuer is None and body.audience is None and body.jwt_auth_enabled is None:
+        raise HTTPException(status_code=422, detail="At least one field required")
 
-    # #1056 — update JWT auth columns on the Integration row. Nullable/no-op
-    # if the caller didn't supply them.
+    existing = _load_config(db, workspace_id) or {}
+
+    # Credential update — both domain and token must be provided together
+    if body.domain is not None or body.token is not None:
+        if not body.domain or not body.token:
+            raise HTTPException(status_code=422, detail="Domain and token must be provided together")
+        domain = _sanitize_domain(body.domain)
+        if not domain:
+            raise HTTPException(status_code=422, detail="Okta domain required")
+        existing.update({"domain": domain, "token": body.token})
+        _save_config(db, workspace_id, existing)
+
+    # #1056 — update JWT auth columns on the Integration row.
     row = db.query(Integration).filter(
         Integration.workspace_id == uuid.UUID(workspace_id),
         Integration.handle == _OKTA_HANDLE,
     ).first()
-    if row is not None:
-        if body.issuer is not None:
-            row.okta_issuer = body.issuer.strip() or None
-        if body.audience is not None:
-            row.okta_audience = body.audience.strip() or None
-        if body.jwt_auth_enabled is not None:
-            row.okta_auth_enabled = bool(body.jwt_auth_enabled)
-        db.commit()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Okta integration not configured — save credentials first")
+    if body.issuer is not None:
+        row.okta_issuer = body.issuer.strip() or None
+    if body.audience is not None:
+        row.okta_audience = body.audience.strip() or None
+    if body.jwt_auth_enabled is not None:
+        row.okta_auth_enabled = bool(body.jwt_auth_enabled)
+    db.commit()
 
+    tok = existing.get("token") or ""
     return OktaConfigOut(
         configured=True,
-        domain=domain,
-        token_prefix=body.token[:4] + "…",
+        domain=existing.get("domain"),
+        token_prefix=(tok[:4] + "…") if tok else None,
         last_synced_at=_parse_iso(existing.get("last_synced_at")),
         last_import=existing.get("last_import"),
         last_update=existing.get("last_update"),
         last_error=existing.get("last_error"),
-        issuer=(row.okta_issuer if row else None),
-        audience=(row.okta_audience if row else None),
-        jwt_auth_enabled=bool(row.okta_auth_enabled) if row else False,
+        issuer=row.okta_issuer,
+        audience=row.okta_audience,
+        jwt_auth_enabled=bool(row.okta_auth_enabled),
     )
 
 

--- a/apps/api/tests/test_okta_jwt.py
+++ b/apps/api/tests/test_okta_jwt.py
@@ -1,0 +1,232 @@
+"""
+Tests for app.core.okta_jwt — 13 cases from issue #1055 acceptance criteria.
+
+No network. RSA keys generated in-fixture, JWKS fetch monkeypatched on the cache.
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+
+import jwt as pyjwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from app.core.okta_jwt import (
+    OktaJWKSCache,
+    OktaJWTExpired,
+    OktaJWTInvalid,
+    OktaJWTUntrusted,
+    verify_okta_jwt,
+)
+
+ISSUER = "https://example.okta.com/oauth2/default"
+AUD = "api://default"
+KID = "test-kid-1"
+
+
+@pytest.fixture(scope="module")
+def rsa_key():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+@pytest.fixture(scope="module")
+def rsa_key_2():
+    return rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+
+def _jwk_pub(priv, kid: str) -> dict:
+    d = json.loads(pyjwt.algorithms.RSAAlgorithm.to_jwk(priv.public_key()))
+    d["kid"] = kid
+    d["alg"] = "RS256"
+    d["use"] = "sig"
+    return d
+
+
+def _base_claims(**overrides) -> dict:
+    now = int(time.time())
+    c = {
+        "iss": ISSUER,
+        "aud": AUD,
+        "sub": "0oa1677gbczxbjmcI698",
+        "iat": now - 5,
+        "exp": now + 300,
+    }
+    c.update(overrides)
+    return c
+
+
+def _make_token(priv, claims: dict, *, kid: str | None = KID, alg: str = "RS256", key=None) -> str:
+    headers = {"kid": kid} if kid else None
+    signing_key = key if key is not None else priv
+    return pyjwt.encode(claims, signing_key, algorithm=alg, headers=headers)
+
+
+@pytest.fixture
+def cache_with_key(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        return {"keys": [_jwk_pub(rsa_key, KID)]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+    cache.calls = call_count  # type: ignore[attr-defined]
+    return cache
+
+
+# 1
+def test_valid_jwt_returns_claims(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims())
+    claims = verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    assert claims["sub"] == "0oa1677gbczxbjmcI698"
+    assert claims["iss"] == ISSUER
+    assert claims["aud"] == AUD
+
+
+# 2
+def test_wrong_signature_rejected(rsa_key_2, cache_with_key):
+    tok = _make_token(rsa_key_2, _base_claims())  # signed by different key
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 3
+def test_expired_token_raises_expired(rsa_key, cache_with_key):
+    now = int(time.time())
+    tok = _make_token(rsa_key, _base_claims(exp=now - 120, iat=now - 3600))
+    with pytest.raises(OktaJWTExpired):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 4
+def test_not_yet_valid_nbf_future(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(nbf=int(time.time()) + 300))
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 5
+def test_wrong_issuer_untrusted(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(iss="https://evil.example.com/oauth2/default"))
+    with pytest.raises(OktaJWTUntrusted):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 6
+def test_wrong_audience_invalid(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(aud="api://wrong"))
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 7
+def test_alg_none_rejected(cache_with_key):
+    # alg=none — classic no-signature attack
+    tok = pyjwt.encode(_base_claims(), key="", algorithm="none", headers={"kid": KID})
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 8
+def test_hs256_downgrade_rejected(rsa_key, cache_with_key):
+    # Classic algorithm-confusion: attacker hand-builds an HS256 token using the
+    # public key PEM as the shared secret. PyJWT's `encode` refuses to do this,
+    # so we construct the wire format directly — that's what an attacker does.
+    pub_pem = rsa_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+
+    def _b64u(b: bytes) -> str:
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    header = _b64u(json.dumps({"alg": "HS256", "typ": "JWT", "kid": KID}).encode())
+    payload = _b64u(json.dumps(_base_claims()).encode())
+    signing_input = f"{header}.{payload}".encode()
+    sig = _b64u(hmac.new(pub_pem, signing_input, hashlib.sha256).digest())
+    tok = f"{header}.{payload}.{sig}"
+
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 9
+def test_missing_kid_rejected(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims(), kid=None)
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+
+
+# 10
+def test_unknown_kid_triggers_refresh_then_succeeds(rsa_key, rsa_key_2, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return {"keys": [_jwk_pub(rsa_key, KID)]}
+        # rotation: second fetch includes the new kid
+        return {"keys": [_jwk_pub(rsa_key, KID), _jwk_pub(rsa_key_2, "new-kid")]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+
+    # Prime cache with the old JWKS
+    verify_okta_jwt(_make_token(rsa_key, _base_claims(), kid=KID), ISSUER, AUD, cache=cache)
+    assert call_count["n"] == 1
+
+    # New-kid token triggers a fresh fetch (unknown-kid path) and succeeds
+    claims = verify_okta_jwt(
+        _make_token(rsa_key_2, _base_claims(), kid="new-kid"),
+        ISSUER,
+        AUD,
+        cache=cache,
+    )
+    assert claims["sub"] == "0oa1677gbczxbjmcI698"
+    assert call_count["n"] == 2
+
+
+# 11
+def test_cache_hit_no_second_fetch(rsa_key, cache_with_key):
+    tok = _make_token(rsa_key, _base_claims())
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache_with_key)
+    assert cache_with_key.calls["n"] == 1
+
+
+# 12
+def test_cache_expires_and_refetches(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=1)
+    call_count = {"n": 0}
+
+    def _fake_fetch(issuer: str) -> dict:
+        call_count["n"] += 1
+        return {"keys": [_jwk_pub(rsa_key, KID)]}
+
+    monkeypatch.setattr(cache, "_fetch", _fake_fetch)
+
+    tok = _make_token(rsa_key, _base_claims())
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache)
+    time.sleep(1.2)
+    verify_okta_jwt(tok, ISSUER, AUD, cache=cache)
+    assert call_count["n"] == 2
+
+
+# 13
+def test_jwks_unreachable_typed_error_no_accept(rsa_key, monkeypatch):
+    cache = OktaJWKSCache(ttl_s=60)
+
+    def _boom(issuer: str) -> dict:
+        raise ConnectionError("network down")
+
+    monkeypatch.setattr(cache, "_fetch", _boom)
+
+    tok = _make_token(rsa_key, _base_claims())
+    with pytest.raises(OktaJWTInvalid):
+        verify_okta_jwt(tok, ISSUER, AUD, cache=cache)

--- a/apps/api/tests/test_okta_jwt_bridge.py
+++ b/apps/api/tests/test_okta_jwt_bridge.py
@@ -1,0 +1,272 @@
+"""
+Bridge tests for _resolve_okta_jwt (#1056).
+
+The JWT verifier itself is exhaustively tested in test_okta_jwt.py. Here we
+test only the bridge decisions: when to return None (fall through), when to
+raise 401, and how lifecycle_state gates access.
+
+Verifier is monkeypatched to control the "returns claims" side without
+needing real RSA keys / JWKS.
+"""
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import uuid
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+# ── Path + env bootstrap ────────────────────────────────────────────────────
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+os.environ.setdefault("DATABASE_URL", "postgresql://test:test@localhost:5432/test_marshal")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
+
+
+def _fake_jwt(iss: str = "https://example.okta.com/oauth2/default", sub: str = "0oaSUB") -> str:
+    """Return a valid-shaped (3-segment) JWT with a decodable payload.
+    Signature is meaningless — the verifier is monkeypatched in these tests."""
+    def _b64u(b: bytes) -> str:
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    header = _b64u(json.dumps({"alg": "RS256", "typ": "JWT", "kid": "k1"}).encode())
+    payload = _b64u(json.dumps({"iss": iss, "sub": sub, "aud": "api://default"}).encode())
+    sig = _b64u(b"not-a-real-signature")
+    return f"{header}.{payload}.{sig}"
+
+
+def _integration_row(*, issuer: str, audience: str, enabled: bool, workspace_id: uuid.UUID):
+    row = MagicMock()
+    row.workspace_id = workspace_id
+    row.okta_issuer = issuer
+    row.okta_audience = audience
+    row.okta_auth_enabled = enabled
+    return row
+
+
+def _ai_row(*, workspace_id: uuid.UUID, source_id: str, lifecycle_state: str = "active"):
+    ai = MagicMock()
+    ai.workspace_id = workspace_id
+    ai.source = "okta"
+    ai.source_id = source_id
+    ai.lifecycle_state = lifecycle_state
+    return ai
+
+
+def _db_with(integration_rows: list, ai_row=None):
+    """Build a Session mock. First .query() → integrations, second → agent_identities."""
+    db = MagicMock()
+    integration_q = MagicMock()
+    integration_q.filter.return_value.all.return_value = integration_rows
+    ai_q = MagicMock()
+    ai_q.filter.return_value.first.return_value = ai_row
+    db.query.side_effect = [integration_q, ai_q]
+    return db
+
+
+# ═══════════════════════════════════════════════════════════════════════════════
+
+def test_non_jwt_shape_returns_none():
+    from app.core.auth import _resolve_okta_jwt
+    assert _resolve_okta_jwt("cond_agt_whatever", MagicMock()) is None
+    assert _resolve_okta_jwt("only.two", MagicMock()) is None
+    assert _resolve_okta_jwt("", MagicMock()) is None
+
+
+def test_undecodable_payload_returns_none():
+    from app.core.auth import _resolve_okta_jwt
+    assert _resolve_okta_jwt("not.a.jwt", MagicMock()) is None
+
+
+def test_missing_iss_returns_none():
+    from app.core.auth import _resolve_okta_jwt
+
+    def _b64u(b: bytes) -> str:
+        return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+    header = _b64u(json.dumps({"alg": "RS256"}).encode())
+    payload = _b64u(json.dumps({"sub": "x"}).encode())  # no iss
+    tok = f"{header}.{payload}.sig"
+    assert _resolve_okta_jwt(tok, MagicMock()) is None
+
+
+def test_no_workspace_configured_returns_none_falls_through_to_clerk():
+    """If no Integration row matches the iss, return None so caller tries Clerk."""
+    from app.core.auth import _resolve_okta_jwt
+
+    tok = _fake_jwt(iss="https://clerk.example.com")
+    db = _db_with(integration_rows=[])
+    assert _resolve_okta_jwt(tok, db) is None
+
+
+def test_feature_flag_off_returns_none(monkeypatch):
+    """Even with issuer configured, okta_auth_enabled=false → the filter excludes it → None."""
+    from app.core.auth import _resolve_okta_jwt
+
+    # Query filter already excludes disabled rows, so we simulate the "no rows" outcome
+    tok = _fake_jwt()
+    db = _db_with(integration_rows=[])
+    assert _resolve_okta_jwt(tok, db) is None
+
+
+def test_happy_path_returns_identity(monkeypatch):
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    ai = _ai_row(workspace_id=ws_id, source_id="0oaSUB")
+    db = _db_with(integration_rows=[integration], ai_row=ai)
+
+    # Monkeypatch the verifier: return claims that pass validation
+    def _fake_verify(token, issuer, audience, **kw):
+        return {"iss": issuer, "aud": audience, "sub": "0oaSUB", "exp": 9999999999}
+
+    monkeypatch.setattr("app.core.okta_jwt.verify_okta_jwt", _fake_verify)
+
+    result = auth_mod._resolve_okta_jwt(_fake_jwt(sub="0oaSUB"), db)
+    assert result is not None
+    resolved_ai, clerk_uid = result
+    assert resolved_ai is ai
+    assert clerk_uid is None  # Okta = machine identity, no clerk user
+
+
+def test_identity_not_synced_raises_401(monkeypatch):
+    from fastapi import HTTPException
+
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    db = _db_with(integration_rows=[integration], ai_row=None)  # no identity
+
+    monkeypatch.setattr(
+        "app.core.okta_jwt.verify_okta_jwt",
+        lambda token, issuer, audience, **kw: {"sub": "unknown", "iss": issuer, "aud": audience},
+    )
+
+    with pytest.raises(HTTPException) as ei:
+        auth_mod._resolve_okta_jwt(_fake_jwt(sub="unknown"), db)
+    assert ei.value.status_code == 401
+    assert "not synced" in ei.value.detail
+
+
+def test_deactivated_identity_raises_401(monkeypatch):
+    from fastapi import HTTPException
+
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    ai = _ai_row(workspace_id=ws_id, source_id="0oaSUB", lifecycle_state="deactivated")
+    db = _db_with(integration_rows=[integration], ai_row=ai)
+
+    monkeypatch.setattr(
+        "app.core.okta_jwt.verify_okta_jwt",
+        lambda token, issuer, audience, **kw: {"sub": "0oaSUB", "iss": issuer, "aud": audience},
+    )
+
+    with pytest.raises(HTTPException) as ei:
+        auth_mod._resolve_okta_jwt(_fake_jwt(), db)
+    assert ei.value.status_code == 401
+    assert "deactivated" in ei.value.detail
+
+
+def test_expired_lifecycle_raises_401(monkeypatch):
+    from fastapi import HTTPException
+
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    ai = _ai_row(workspace_id=ws_id, source_id="0oaSUB", lifecycle_state="expired")
+    db = _db_with(integration_rows=[integration], ai_row=ai)
+
+    monkeypatch.setattr(
+        "app.core.okta_jwt.verify_okta_jwt",
+        lambda token, issuer, audience, **kw: {"sub": "0oaSUB", "iss": issuer, "aud": audience},
+    )
+
+    with pytest.raises(HTTPException) as ei:
+        auth_mod._resolve_okta_jwt(_fake_jwt(), db)
+    assert ei.value.status_code == 401
+    assert "expired" in ei.value.detail
+
+
+def test_verify_failure_raises_401(monkeypatch):
+    from fastapi import HTTPException
+
+    import app.core.auth as auth_mod
+    from app.core.okta_jwt import OktaJWTInvalid
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    db = _db_with(integration_rows=[integration], ai_row=None)
+
+    def _fail(token, issuer, audience, **kw):
+        raise OktaJWTInvalid("wrong signature")
+
+    monkeypatch.setattr("app.core.okta_jwt.verify_okta_jwt", _fail)
+
+    with pytest.raises(HTTPException) as ei:
+        auth_mod._resolve_okta_jwt(_fake_jwt(), db)
+    assert ei.value.status_code == 401
+    assert "verification failed" in ei.value.detail
+
+
+def test_missing_sub_raises_401(monkeypatch):
+    from fastapi import HTTPException
+
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    db = _db_with(integration_rows=[integration], ai_row=None)
+
+    monkeypatch.setattr(
+        "app.core.okta_jwt.verify_okta_jwt",
+        lambda token, issuer, audience, **kw: {"iss": issuer, "aud": audience},  # no sub
+    )
+
+    with pytest.raises(HTTPException) as ei:
+        auth_mod._resolve_okta_jwt(_fake_jwt(), db)
+    assert ei.value.status_code == 401
+    assert "sub" in ei.value.detail

--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -124,14 +124,19 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
     router.replace(`/agent-identity?tab=${activeTab}`, { scroll: false })
   }
 
-  // Okta integration (#1036 Phase 2 — Sync UI)
-  const [okta, setOkta] = useState<{ configured: boolean; domain?: string; token_prefix?: string; last_synced_at?: string | null; last_import?: number | null; last_update?: number | null; last_error?: string | null }>({ configured: false })
+  // Okta integration (#1036 Phase 2 — Sync UI, #1056 Phase 3b — JWT auth)
+  const [okta, setOkta] = useState<{ configured: boolean; domain?: string; token_prefix?: string; last_synced_at?: string | null; last_import?: number | null; last_update?: number | null; last_error?: string | null; issuer?: string | null; audience?: string | null; jwt_auth_enabled?: boolean }>({ configured: false })
   const [oktaLoading, setOktaLoading] = useState(true)
   const [oktaDomainInput, setOktaDomainInput] = useState("")
   const [oktaTokenInput, setOktaTokenInput] = useState("")
   const [oktaSaving, setOktaSaving] = useState(false)
   const [oktaSyncing, setOktaSyncing] = useState(false)
   const [oktaFeedback, setOktaFeedback] = useState<string | null>(null)
+  // #1056 — JWT auth config
+  const [oktaIssuerInput, setOktaIssuerInput] = useState("")
+  const [oktaAudienceInput, setOktaAudienceInput] = useState("")
+  const [oktaJwtEnabled, setOktaJwtEnabled] = useState(false)
+  const [oktaJwtSaving, setOktaJwtSaving] = useState(false)
 
 
   const load = useCallback(async () => {
@@ -251,6 +256,9 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
         const data = await res.json()
         setOkta(data)
         if (data.domain) setOktaDomainInput(data.domain)
+        setOktaIssuerInput(data.issuer ?? "")
+        setOktaAudienceInput(data.audience ?? "")
+        setOktaJwtEnabled(!!data.jwt_auth_enabled)
       }
     } finally {
       setOktaLoading(false)
@@ -277,6 +285,31 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
       }
     } finally {
       setOktaSaving(false)
+    }
+  }
+
+  async function saveOktaJwt() {
+    if (!workspaceId) return
+    setOktaJwtSaving(true); setOktaFeedback(null)
+    try {
+      const res = await authFetch(`${API}/workspaces/${workspaceId}/integrations/okta/config?workspace_id=${workspaceId}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          issuer: oktaIssuerInput.trim() || null,
+          audience: oktaAudienceInput.trim() || null,
+          jwt_auth_enabled: oktaJwtEnabled,
+        }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        setOkta(data)
+        setOktaFeedback(oktaJwtEnabled ? "JWT auth saved (enabled)." : "JWT auth saved (disabled).")
+      } else {
+        setOktaFeedback(`JWT save failed (HTTP ${res.status})`)
+      }
+    } finally {
+      setOktaJwtSaving(false)
     }
   }
 
@@ -651,6 +684,50 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                     >
                       {oktaSaving ? "Saving…" : "Save"}
                     </button>
+                  </div>
+                </div>
+                {/* JWT authentication (#1056) — Phase 3b runtime enforcement */}
+                <div style={{ marginTop: 12, paddingTop: 12, borderTop: "1px solid var(--border)" }}>
+                  <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
+                    <div style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                      JWT authentication — accept Okta-signed tokens as Guard principals
+                    </div>
+                    <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 11, color: "var(--text-2)", cursor: "pointer" }}>
+                      <input
+                        type="checkbox"
+                        checked={oktaJwtEnabled}
+                        onChange={e => setOktaJwtEnabled(e.target.checked)}
+                        disabled={oktaJwtSaving}
+                      />
+                      Enabled
+                    </label>
+                  </div>
+                  <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                    <input
+                      type="text"
+                      value={oktaIssuerInput}
+                      onChange={e => setOktaIssuerInput(e.target.value)}
+                      placeholder={okta.domain ? `https://${okta.domain}/oauth2/default` : "https://{domain}/oauth2/default"}
+                      style={{ flex: "1 1 260px", padding: "6px 10px", fontSize: 12, borderRadius: 6, border: "1px solid var(--border)", background: "var(--surface-2)", color: "var(--text)" }}
+                    />
+                    <input
+                      type="text"
+                      value={oktaAudienceInput}
+                      onChange={e => setOktaAudienceInput(e.target.value)}
+                      placeholder="api://default"
+                      style={{ flex: "1 1 160px", padding: "6px 10px", fontSize: 12, borderRadius: 6, border: "1px solid var(--border)", background: "var(--surface-2)", color: "var(--text)" }}
+                    />
+                    <button
+                      onClick={saveOktaJwt}
+                      disabled={oktaJwtSaving}
+                      className="btn btn-sm"
+                      style={{ padding: "6px 12px", fontSize: 12 }}
+                    >
+                      {oktaJwtSaving ? "Saving…" : "Save JWT config"}
+                    </button>
+                  </div>
+                  <div style={{ marginTop: 6, fontSize: 11, color: "var(--text-muted)" }}>
+                    Configure the OAuth authorization server in your Okta admin, then set the issuer + audience here and toggle Enabled.
                   </div>
                 </div>
               </>


### PR DESCRIPTION
Sub-issue 2 of #1052. Closes #1056. **Depends on #1058 — merge that first.**

Base is set to \`feat/okta-jwt-verifier\` so the diff shows only bridge changes. Once #1058 lands, GitHub retargets this PR to \`main\`.

## What's here (backend)

- **Migration 0091** — adds three Okta-specific columns on \`integrations\` (\`okta_issuer\` indexed, \`okta_audience\`, \`okta_auth_enabled\` default FALSE). NULL on non-Okta rows.
- **\`app/core/auth.py::_resolve_okta_jwt\`** — new helper. Fast negative gate (dot count → unverified iss peek → reverse-lookup enabled Integration rows). Falls through to Clerk when the issuer isn't a configured Okta one. Verifies via #1055's \`verify_okta_jwt\`. Resolves to \`AgentIdentity WHERE source='okta' AND source_id=<sub>\`. Enforces lifecycle_state (deactivated/expired → 401).
- **All 4 call sites patched**: \`get_workspace_id\`, \`get_user_id\`, \`get_guard_hook_auth\`, \`require_workspace_role._check\`. Okta JWTs are workspace-scoped machine credentials (no clerk_user_id, admin on their own workspace) — same model as \`cond_api_*\`.
- **\`routers/okta_sync.py\`** — \`PUT/GET /workspaces/{ws}/integrations/okta/config\` now accepts + returns \`issuer\`, \`audience\`, \`jwt_auth_enabled\`. All three optional; omitting them preserves prior behavior.

Frontend Okta card extension pending as a follow-up commit on this same branch.

## Feature flag posture

Ships with \`okta_auth_enabled=false\` on every workspace. Bridge returns None early when no row matches, so this is a **zero-risk merge** for existing traffic.

## Regression checklist (from #1056)

- ✅ **cond_agt_*** — 4 tests in \`test_agent_identity_auth.py\` still pass
- ✅ **cond_api_*** — 4 tests still pass
- ✅ **Bearer with no iss** (Clerk-shaped) — bridge returns None, falls through
- ✅ **Bearer with unconfigured iss** — bridge returns None, falls through
- ✅ **Bearer with configured iss but flag off** — filter excludes row → None → falls through
- ✅ **Guard hook path** — get_guard_hook_auth still resolves cond_agt/cond_api unchanged
- ✅ **MCP path** — (existing 5 mcp_endpoint failures on main are a stale test, unrelated — see #1059)
- ✅ **Executor path** — resolves via get_workspace_id, unchanged for cond_*

## Tests

\`\`\`
tests/test_okta_jwt.py               13 passed  (verifier from #1055)
tests/test_okta_jwt_bridge.py        11 passed  (new)
tests/test_agent_identity_auth.py    31 passed / 5 preexisting failures (unrelated → #1059)
\`\`\`

Bridge tests cover: non-JWT shape, undecodable payload, missing iss, no configured issuer (fall-through), feature flag off, happy path, identity-not-synced 401, deactivated 401, expired 401, verifier failure 401, missing sub 401.

## What's still to do

- Frontend Okta card: 3 inputs (issuer, audience, JWT-auth toggle) — coming as a second commit on this branch
- End-to-end test against real Okta tenant + CLI simulator + rollout — that's #1057

Refs #1052.