### PR TITLE
fix(okta): dedupe audit events within a single request

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -11,6 +11,7 @@ Usage in routes:
     # role-gated:
     _: str = Depends(require_workspace_role("admin"))
 """
+import contextvars
 import structlog
 import threading
 from functools import lru_cache
@@ -33,6 +34,14 @@ _bearer = HTTPBearer(auto_error=False)
 
 _jwks_cache: dict | None = None
 _jwks_lock = threading.Lock()
+
+# Per-request dedupe for Okta audit emissions. FastAPI runs each request in a
+# fresh async context, so this ContextVar naturally resets between requests.
+# Same token resolved twice in one request → one audit row, not two (fixes
+# the /auth/whoami double-emit).
+_okta_audit_emitted: contextvars.ContextVar[set[str] | None] = contextvars.ContextVar(
+    "okta_audit_emitted", default=None,
+)
 
 # ponytail: shared client — connection pooling, avoids per-call TLS handshake
 _clerk_http = httpx.Client(timeout=5)
@@ -288,6 +297,16 @@ def _resolve_okta_jwt(token: str, db: Session):
     unverified_sub = unverified.get("sub", "")
 
     def _emit_audit(*, workspace_id, decision: str, sub: str, reason: str | None = None):
+        # Per-request dedupe: if the same (workspace, decision, sub) was already
+        # audited in this request, skip. See _okta_audit_emitted.
+        _seen = _okta_audit_emitted.get()
+        if _seen is None:
+            _seen = set()
+            _okta_audit_emitted.set(_seen)
+        _key = f"{workspace_id}|{decision}|{sub}"
+        if _key in _seen:
+            return
+        _seen.add(_key)
         try:
             from app.modules.guard.models import GuardAuditEvent, chain_hash_for_insert
             from datetime import datetime, timezone as _tz

--- a/apps/api/tests/test_okta_jwt_bridge.py
+++ b/apps/api/tests/test_okta_jwt_bridge.py
@@ -270,3 +270,56 @@ def test_missing_sub_raises_401(monkeypatch):
         auth_mod._resolve_okta_jwt(_fake_jwt(), db)
     assert ei.value.status_code == 401
     assert "sub" in ei.value.detail
+
+def test_audit_deduped_within_same_request(monkeypatch):
+    """/auth/whoami calls _resolve_okta_jwt twice per request (once via the
+    get_workspace_id dep, once explicitly). Both calls should share the same
+    ContextVar and emit only ONE audit event, not two."""
+    import contextvars
+
+    import app.core.auth as auth_mod
+
+    ws_id = uuid.uuid4()
+    integration = _integration_row(
+        issuer="https://example.okta.com/oauth2/default",
+        audience="api://default",
+        enabled=True,
+        workspace_id=ws_id,
+    )
+    ai = _ai_row(workspace_id=ws_id, source_id="0oaSUB")
+
+    # Two db instances (each _resolve_okta_jwt call gets a fresh Session via
+    # Depends(get_db) in prod). Both must see identical query results.
+    def _make_db():
+        return _db_with(integration_rows=[integration], ai_row=ai)
+
+    monkeypatch.setattr(
+        "app.core.okta_jwt.verify_okta_jwt",
+        lambda token, issuer, audience, **kw: {"sub": "0oaSUB", "iss": issuer, "aud": audience},
+    )
+    # Stub the hash-chain helper — MagicMock db cannot satisfy its ORM chain.
+    monkeypatch.setattr(
+        "app.modules.guard.models.chain_hash_for_insert",
+        lambda *a, **k: ("prev", "entry"),
+    )
+
+    # Run both calls inside a shared ContextVar copy so they see the same
+    # _okta_audit_emitted set — this is what FastAPI does per-request.
+    add_calls = {"n": 0}
+
+    def _run():
+        # Reset the contextvar to empty; a real request starts with default=None
+        auth_mod._okta_audit_emitted.set(None)
+        db1 = _make_db()
+        db1.add.side_effect = lambda *_a, **_kw: add_calls.__setitem__("n", add_calls["n"] + 1)
+        auth_mod._resolve_okta_jwt(_fake_jwt(sub="0oaSUB"), db1)
+        db2 = _make_db()
+        db2.add.side_effect = lambda *_a, **_kw: add_calls.__setitem__("n", add_calls["n"] + 1)
+        auth_mod._resolve_okta_jwt(_fake_jwt(sub="0oaSUB"), db2)
+
+    ctx = contextvars.copy_context()
+    ctx.run(_run)
+
+    # One request → one audit row for the same allowed decision on the same identity
+    assert add_calls["n"] == 1, f"expected 1 audit event, got {add_calls['n']}"
+


### PR DESCRIPTION
Same fix as #1062 (superseded — force-push blocked by Guard); fresh branch off latest main so no history rewrite.

Discovered during #1057 rollout verification: hitting \`GET /auth/whoami\` with a valid Okta JWT wrote **two** identical \`auth.okta_jwt.verify\` audit rows for one request.

Root cause: \`/auth/whoami\` runs \`_resolve_okta_jwt\` twice — once via \`Depends(get_workspace_id)\`, once in the handler body to populate the response.

Fix: per-request dedupe on \`(workspace_id, decision, sub)\` via a \`ContextVar\`. FastAPI runs each request in its own async context, so the var naturally resets between requests.

## Tests
\`\`\`
tests/test_okta_jwt.py         13 passed
tests/test_okta_jwt_bridge.py  12 passed (new test_audit_deduped_within_same_request)
\`\`\`

Refs #1052.