### PR TITLE
feat(agent-identity): add "Last used" column to Identities table

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -813,6 +813,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                     <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600, color: "var(--text-muted)" }}>Tier</th>
                     <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600, color: "var(--text-muted)" }}>Lifecycle</th>
                     <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600, color: "var(--text-muted)" }}>Last certified</th>
+                    <th style={{ textAlign: "left", padding: "8px 12px", fontWeight: 600, color: "var(--text-muted)" }}>Last used</th>
                     <th style={{ padding: "8px 12px" }}></th>
                   </tr>
                 </thead>
@@ -862,6 +863,11 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                         <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-muted)" }}>
                           {id.last_certified_at
                             ? new Date(id.last_certified_at).toLocaleDateString()
+                            : <span>never</span>}
+                        </td>
+                        <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-muted)" }} title={id.last_used_at ?? undefined}>
+                          {id.last_used_at
+                            ? new Date(id.last_used_at).toLocaleString()
                             : <span>never</span>}
                         </td>
                         <td style={{ padding: "8px 12px", textAlign: "right" }}>


### PR DESCRIPTION
One extra column on the Identities tab of /agent-identity, showing when each AgentIdentity last authenticated (cond_agt_, cond_api_, or Okta JWT — sourced from `last_used_at`).

The field was already on the model and API response; this just renders it. Hover shows raw ISO, cell shows `toLocaleString()`, "never" if null.

Noticed while eyeballing the Identities tab post-Okta rollout.

Refs #1052.