### PR TITLE
test(mcp): drop stale token= kwarg from TestMcpEndpointAuth

### DIFF
--- a/apps/api/tests/test_agent_identity_auth.py
+++ b/apps/api/tests/test_agent_identity_auth.py
@@ -538,7 +538,7 @@ class TestMcpEndpointAuth:
             mock_db.query.return_value.filter.return_value.first.return_value = _mock_guard_config()
             mock_sl.return_value = mock_db
 
-            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None, token=None))
+            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None))
 
         assert response.status_code == 200
         body = json.loads(response.body)
@@ -562,7 +562,7 @@ class TestMcpEndpointAuth:
             mock_db.query.return_value.filter.return_value.first.return_value = _mock_guard_config()
             mock_sl.return_value = mock_db
 
-            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None, token=None))
+            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None))
 
         assert response.status_code == 200
 
@@ -571,7 +571,7 @@ class TestMcpEndpointAuth:
         from app.modules.guard.routers.mcp import mcp_endpoint
 
         req = _make_mcp_request(bearer=None)
-        response = asyncio.run(mcp_endpoint(request=req, workspace_id=None, token=None))
+        response = asyncio.run(mcp_endpoint(request=req, workspace_id=None))
         assert response.status_code == 401
 
     def test_invalid_token_returns_401(self):
@@ -586,7 +586,7 @@ class TestMcpEndpointAuth:
         ):
             mock_db = MagicMock()
             mock_sl.return_value = mock_db
-            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None, token=None))
+            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None))
 
         assert response.status_code == 401
 
@@ -606,7 +606,7 @@ class TestMcpEndpointAuth:
             mock_db = MagicMock()
             mock_db.query.return_value.filter.return_value.first.return_value = None
             mock_sl.return_value = mock_db
-            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None, token=None))
+            response = asyncio.run(mcp_endpoint(request=req, workspace_id=None))
 
         assert response.status_code == 401
         assert "WWW-Authenticate" in response.headers


### PR DESCRIPTION
Closes #1059. Discovered while running the auth regression suite for #1056.

## Symptom
```
FAILED tests/test_agent_identity_auth.py::TestMcpEndpointAuth::test_valid_cond_agt_token_returns_200_initialize
TypeError: mcp_endpoint() got an unexpected keyword argument 'token'
```
5 tests failed, all with the same error.

## Fix
`mcp_endpoint`'s signature has been `(request, workspace_id=Query(None))` since commit d3b8c5b (Bearer auth moved to the `Authorization` header). Dropped the ghost `token=None` kwarg from the 5 call sites in `TestMcpEndpointAuth`. Tokens already flow via `_make_mcp_request(bearer=...)`.

Before: 5 failed, 31 passed.
After: 36 passed.