### PR TITLE
fix(agent-identity): hydration mismatch on Last used cell

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -867,7 +867,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                         </td>
                         <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-muted)" }} title={id.last_used_at ?? undefined}>
                           {id.last_used_at
-                            ? new Date(id.last_used_at).toLocaleString()
+                            ? id.last_used_at.slice(0, 16).replace("T", " ") + " UTC"
                             : <span>never</span>}
                         </td>
                         <td style={{ padding: "8px 12px", textAlign: "right" }}>


### PR DESCRIPTION
`new Date(id.last_used_at).toLocaleString()` renders in **UTC on the Vercel server** and the visitor's **local timezone on the client** — every render differs, React error #418 tears down the whole tabpanel subtree, and the visible table silently drops to 5 columns (Last certified + Last used + Certify all invisible).

Swap to `id.last_used_at.slice(0, 16).replace('T', ' ') + ' UTC'` — deterministic on both sides, still human-readable, hover title still shows the full ISO for anyone who cares about their local time.

## Root cause

Confirmed via user's browser console — running `console.log([...document.querySelectorAll('#tabpanel-identities thead th')].map(t=>t.textContent))` triggered React error #418 (`text` args), classic hydration text mismatch.

## Not doing here
- 'Last certified' uses `toLocaleDateString()` (date-only). Same class of bug is possible near midnight but rarely surfaces — leaving as-is for a minimal diff.

Refs #1064.