### PR TITLE
fix(agent-identity): let Identities table scroll horizontally

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -797,7 +797,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
               <span style={{ color: "var(--text-muted)" }}>({identities.filter(i => i.source === sourceFilter).length} of {identities.length})</span>
             </div>
           )}
-          <div className="card" style={{ overflow: "hidden" }}>
+          <div className="card" style={{ overflowX: "auto" }}>
             {identitiesLoading ? (
               <div style={{ padding: 16, fontSize: 12, color: "var(--text-muted)" }}>Loading identities…</div>
             ) : (() => {


### PR DESCRIPTION
Card was overflow:hidden. With 8 columns the last three (Last certified, Last used, Certify) get clipped past the right edge - they were in the DOM (copy-paste worked) but invisible. overflowX: auto reveals them on horizontal scroll.