### PR TITLE
docs(okta): split tracking into own ref + surface under /docs Guard tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,10 @@ jobs:
         run: make schema-check
         working-directory: apps/api
       - name: Test
-        run: python -m pytest tests/ -q --ignore=tests/test_guard.py
+        # `-m 'not matrix'` skips the full endpoint×role runtime probe
+        # (~600 tests). Static layers of test_endpoint_matrix still run here.
+        # Full matrix runs nightly — see .github/workflows/nightly.yml.
+        run: python -m pytest tests/ -q --ignore=tests/test_guard.py -m 'not matrix'
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test

--- a/.github/workflows/cli-matrix.yml
+++ b/.github/workflows/cli-matrix.yml
@@ -27,4 +27,6 @@ jobs:
           python-version: ${{ matrix.python }}
       - run: pip install -e packages/conduct-cli pytest
       - run: conduct -h
-      - run: pytest packages/conduct-cli/tests -q
+      # `-m 'not matrix'` skips the auth-boundary probe (nightly-only —
+      # see .github/workflows/nightly.yml). --help matrix still runs.
+      - run: pytest packages/conduct-cli/tests -q -m 'not matrix'

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -1,0 +1,98 @@
+name: web-smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/**'
+      - 'apps/api/**'
+      - '.github/workflows/web-smoke.yml'
+
+# Phase 3 harness — every-page Playwright smoke + golden flows against a
+# real FastAPI + Postgres stack. Golden flows run as backend dev-mode admin
+# (Clerk disabled). Per-role variants land once a Clerk sandbox is
+# provisioned and CLERK_TEST_SECRET_KEY is added to GH secrets.
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: marshal
+          POSTGRES_PASSWORD: marshal
+          POSTGRES_DB: marshal_test
+        ports: ["5432:5432"]
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test
+      REDIS_URL: redis://localhost:6379
+      ENCRYPTION_KEY: test-key-32-bytes-long-xxxxxxxx!
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: apps/api/requirements.txt
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install API deps
+        run: pip install -r apps/api/requirements.txt
+
+      - name: Migrate DB
+        run: alembic upgrade head
+        working-directory: apps/api
+
+      - name: Seed e2e workspace
+        run: python scripts/seed_e2e_workspace.py
+        working-directory: apps/api
+
+      - name: Boot API and wait for health
+        # curl accepts scheme-less URLs and defaults to the plain scheme;
+        # the loop polls /health for up to 40 seconds.
+        run: |
+          nohup uvicorn app.main:app --host 127.0.0.1 --port 8000 > /tmp/api.log 2>&1 &
+          for i in $(seq 1 40); do
+            curl -sf 127.0.0.1:8000/health && break
+            sleep 1
+          done
+          curl -sf 127.0.0.1:8000/health
+        working-directory: apps/api
+
+      - name: Install web deps
+        run: npm ci
+        working-directory: apps/web
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+        working-directory: apps/web
+
+      - name: Run Playwright (smoke + flows)
+        run: npm run test:e2e
+        working-directory: apps/web
+
+      - name: Dump API log on failure
+        if: failure()
+        run: tail -200 /tmp/api.log || true
+
+      - name: Upload traces on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-traces
+          path: apps/web/test-results
+          retention-days: 7

--- a/apps/api/pytest.ini
+++ b/apps/api/pytest.ini
@@ -2,5 +2,7 @@
 testpaths = tests
 python_files = test_*.py
 addopts = -v --tb=short
+markers =
+    matrix: full endpoint×role RBAC probe (slow, nightly-only — opt in with `-m matrix`)
 filterwarnings =
     ignore::DeprecationWarning

--- a/apps/api/scripts/seed_e2e_workspace.py
+++ b/apps/api/scripts/seed_e2e_workspace.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Seed DEV_WORKSPACE_ID + admin membership so Playwright golden flows have a
+real workspace to poke at. Idempotent. Uses ORM (no raw SQL)."""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from app.core.auth import DEV_USER_ID, DEV_WORKSPACE_ID  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.models.workspace import Workspace  # noqa: E402
+from app.models.workspace_user import WorkspaceUser  # noqa: E402
+
+
+def main() -> int:
+    now = datetime.now(timezone.utc)
+    with SessionLocal() as db:
+        ws = db.get(Workspace, DEV_WORKSPACE_ID)
+        if ws is None:
+            db.add(Workspace(
+                id=DEV_WORKSPACE_ID,
+                name="e2e-dev",
+                owner_id=DEV_USER_ID,
+                plan="free",
+                is_approved=True,
+                created_at=now,
+                updated_at=now,
+            ))
+
+        wu = (
+            db.query(WorkspaceUser)
+            .filter_by(workspace_id=DEV_WORKSPACE_ID, clerk_user_id=DEV_USER_ID)
+            .one_or_none()
+        )
+        if wu is None:
+            db.add(WorkspaceUser(
+                workspace_id=DEV_WORKSPACE_ID,
+                clerk_user_id=DEV_USER_ID,
+                role="admin",
+                joined_at=now,
+            ))
+
+        db.commit()
+    print(f"Seeded {DEV_WORKSPACE_ID} + admin membership for {DEV_USER_ID}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -39,6 +39,9 @@ _ORIG_REQUIRE_PERMISSION = _auth_mod.require_permission
 def _permissive_permission(permission: str):
     async def _check() -> str:
         return "admin"
+    # Tag so test_endpoint_matrix can find each route's declared permission at
+    # runtime by walking route.dependant.dependencies.
+    _check.__conduct_permission__ = permission  # type: ignore[attr-defined]
     return _check
 
 

--- a/apps/api/tests/test_endpoint_matrix.py
+++ b/apps/api/tests/test_endpoint_matrix.py
@@ -1,0 +1,278 @@
+"""Endpoint × Role RBAC matrix — Phase 1 of the test-harness plan.
+
+Generates tests from three sources of truth:
+  1. FastAPI's live route table (`app.routes`) — every endpoint currently mounted.
+  2. `permissions` + `role_permissions` seeded by alembic migration 0001.
+  3. The `require_permission("...")` closure tagged in conftest.
+
+Layers
+------
+A. Static consistency (no HTTP, DB read-only):
+     - every code-declared permission exists in the `permissions` table
+     - every seeded permission is used by at least one endpoint (or allowlisted)
+
+B. Runtime probing (real TestClient, real DB, real require_permission):
+     - for each (route, role): unauthorised roles get 403,
+       authorised roles get anything-but-403.
+
+The runtime layer boots a TestClient with:
+  * `_clerk_enabled` monkeypatched to True (else require_permission short-circuits)
+  * `get_user_id` / `get_workspace_id` overridden to point at seeded rows
+  * every `require_permission` closure swapped from the conftest noop back to
+    the original factory
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import text
+
+import app.core.auth as _auth_mod
+from app.core.auth import _bearer, get_user_id, get_workspace_id  # noqa: F401 (fixture lookup)
+from app.core.database import SessionLocal
+from app.main import app
+
+# ── Constants ────────────────────────────────────────────────────────────────
+ROLES = ("admin", "security", "developer", "viewer")
+TEST_WS_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+USER_IDS = {role: f"user_matrix_{role}" for role in ROLES}
+
+# Path params get a syntactically valid UUID (routes typed as UUID reject
+# anything else with 422 before Depends runs).
+UUID_ZERO = "00000000-0000-0000-0000-000000000000"
+
+# Seeded permissions that intentionally aren't reachable from any route yet
+# (kept for future use / policy grammar).  Add sparingly.
+UNUSED_PERMISSION_ALLOWLIST: set[str] = set()
+
+
+# ── Route discovery ──────────────────────────────────────────────────────────
+def _walk_dependants(dep):
+    """Yield every Dependant reachable from `dep` (root included)."""
+    yield dep
+    for child in dep.dependencies:
+        yield from _walk_dependants(child)
+
+
+def _permission_for_route(route) -> str | None:
+    """Return the `require_permission('...')` string declared on this route,
+    by finding the tagged closure conftest planted."""
+    dependant = getattr(route, "dependant", None)
+    if dependant is None:
+        return None
+    for dep in _walk_dependants(dependant):
+        call = getattr(dep, "call", None)
+        perm = getattr(call, "__conduct_permission__", None)
+        if perm:
+            return perm
+    return None
+
+
+def _substitute_path_params(path: str) -> str:
+    # /workflows/{workflow_id}/runs → /workflows/00000000-.../runs
+    return re.sub(r"\{[^}]+\}", UUID_ZERO, path)
+
+
+def _discover_routes() -> list[dict]:
+    out: list[dict] = []
+    for r in app.routes:
+        methods = getattr(r, "methods", None) or set()
+        methods = {m for m in methods if m != "HEAD"}
+        if not methods:
+            continue
+        perm = _permission_for_route(r)
+        if not perm:
+            continue
+        for method in sorted(methods):
+            out.append({
+                "method": method,
+                "path": r.path,
+                "url": _substitute_path_params(r.path),
+                "permission": perm,
+                "name": r.name,
+            })
+    return out
+
+
+ROUTES = _discover_routes()
+
+
+# ── DB helpers ───────────────────────────────────────────────────────────────
+def _db_available() -> bool:
+    try:
+        with SessionLocal() as db:
+            db.execute(text("SELECT 1"))
+        return True
+    except Exception:
+        return False
+
+
+DB_AVAILABLE = _db_available()
+requires_db = pytest.mark.skipif(not DB_AVAILABLE, reason="Postgres not reachable")
+
+
+def _seeded_permissions() -> set[str]:
+    with SessionLocal() as db:
+        return {r[0] for r in db.execute(text("SELECT name FROM permissions")).fetchall()}
+
+
+def _seeded_role_permissions() -> dict[str, set[str]]:
+    with SessionLocal() as db:
+        rows = db.execute(text("""
+            SELECT r.name, p.name
+            FROM roles r
+            JOIN role_permissions rp ON rp.role_id = r.id
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE r.workspace_id IS NULL
+        """)).fetchall()
+    out: dict[str, set[str]] = {r: set() for r in ROLES}
+    for role_name, perm_name in rows:
+        out.setdefault(role_name, set()).add(perm_name)
+    return out
+
+
+# ── Static tests (Layer A) ───────────────────────────────────────────────────
+def test_routes_discovered():
+    # If this trips, either the app has no permission-gated routes (unlikely)
+    # or the closure-tagging hook in conftest broke.
+    assert ROUTES, "No permission-gated routes discovered — conftest tagging may be broken"
+
+
+@requires_db
+def test_every_code_permission_is_seeded():
+    seeded = _seeded_permissions()
+    used = {r["permission"] for r in ROUTES}
+    missing = sorted(used - seeded)
+    assert not missing, (
+        f"{len(missing)} permission(s) referenced in code but not in DB seed. "
+        f"Add to alembic migration 0001 `permissions` insert, or fix the typo: {missing}"
+    )
+
+
+@requires_db
+def test_every_seeded_permission_is_used_or_allowlisted():
+    seeded = _seeded_permissions()
+    used = {r["permission"] for r in ROUTES}
+    orphans = sorted(seeded - used - UNUSED_PERMISSION_ALLOWLIST)
+    assert not orphans, (
+        f"{len(orphans)} permission(s) seeded but no endpoint uses them. "
+        f"Delete from seed or add to UNUSED_PERMISSION_ALLOWLIST with a comment: {orphans}"
+    )
+
+
+@requires_db
+def test_write_verbs_do_not_use_view_permission():
+    """Cheap sanity: POST/PUT/PATCH/DELETE should not gate on a `*.view` perm."""
+    write_verbs = {"POST", "PUT", "PATCH", "DELETE"}
+    offenders = [
+        f'{r["method"]} {r["path"]} → {r["permission"]}'
+        for r in ROUTES
+        if r["method"] in write_verbs and r["permission"].endswith(".view")
+    ]
+    assert not offenders, f"Mutating routes gated only by a .view permission: {offenders}"
+
+
+# ── Runtime probing (Layer B) ────────────────────────────────────────────────
+@pytest.fixture(scope="module")
+def seeded_matrix_env():
+    """Seed a test workspace + one user per role. Idempotent."""
+    if not DB_AVAILABLE:
+        pytest.skip("Postgres not reachable")
+    with SessionLocal() as db:
+        now = datetime.now(timezone.utc)
+        db.execute(text("""
+            INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at)
+            VALUES (:id, 'matrix-test', :owner, 'free', true, :now, :now)
+            ON CONFLICT (id) DO NOTHING
+        """), {"id": str(TEST_WS_ID), "owner": USER_IDS["admin"], "now": now})
+        for role, uid in USER_IDS.items():
+            db.execute(text("""
+                INSERT INTO workspace_users (workspace_id, clerk_user_id, role, joined_at)
+                VALUES (:ws, :uid, :role, :now)
+                ON CONFLICT (workspace_id, clerk_user_id)
+                    DO UPDATE SET role = EXCLUDED.role
+            """), {"ws": str(TEST_WS_ID), "uid": uid, "role": role, "now": now})
+        db.commit()
+    yield
+    with SessionLocal() as db:
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": str(TEST_WS_ID)})
+        db.commit()
+
+
+@pytest.fixture
+def matrix_client(seeded_matrix_env, monkeypatch, request):
+    """TestClient with real require_permission wired back in and get_user_id
+    / get_workspace_id overridden to point at the seeded matrix env.
+
+    Parametrize the containing test with `role` and inject via
+    `request.node.callspec.params['role']` — see `probe_matrix` below.
+    """
+    from tests.conftest import _ORIG_REQUIRE_PERMISSION  # noqa: WPS433
+
+    # 1. Force Clerk to appear enabled so require_permission actually runs.
+    monkeypatch.setattr(_auth_mod, "_clerk_enabled", lambda: True)
+
+    # 2. Rewire every route's noop closure back to the real check for its
+    #    declared permission. Keep originals for teardown.
+    swapped: list[tuple[object, str, object]] = []
+    for r in app.routes:
+        dep = getattr(r, "dependant", None)
+        if dep is None:
+            continue
+        for d in _walk_dependants(dep):
+            perm = getattr(getattr(d, "call", None), "__conduct_permission__", None)
+            if perm:
+                swapped.append((d, "call", d.call))
+                d.call = _ORIG_REQUIRE_PERMISSION(perm)
+
+    role = request.node.callspec.params["role"]
+    app.dependency_overrides[get_user_id] = lambda: USER_IDS[role]
+    app.dependency_overrides[get_workspace_id] = lambda: str(TEST_WS_ID)
+
+    yield TestClient(app, raise_server_exceptions=False)
+
+    for target, attr, orig in swapped:
+        setattr(target, attr, orig)
+    app.dependency_overrides.pop(get_user_id, None)
+    app.dependency_overrides.pop(get_workspace_id, None)
+
+
+def _probe(client: TestClient, method: str, url: str):
+    kwargs: dict = {}
+    if method in {"POST", "PUT", "PATCH"}:
+        kwargs["json"] = {}
+    return client.request(method, url, **kwargs)
+
+
+@requires_db
+@pytest.mark.matrix
+@pytest.mark.parametrize("role", ROLES)
+@pytest.mark.parametrize(
+    "route",
+    ROUTES,
+    ids=[f'{r["method"]} {r["path"]}' for r in ROUTES],
+)
+def test_rbac_matrix(matrix_client, role, route):
+    """For every (endpoint, role) pair:
+       - role lacks permission → status 403
+       - role has permission   → status is anything but 403
+    """
+    role_perms = _seeded_role_permissions()[role]
+    should_pass = route["permission"] in role_perms
+
+    resp = _probe(matrix_client, route["method"], route["url"])
+
+    if should_pass:
+        assert resp.status_code != 403, (
+            f'{role} has {route["permission"]} but got 403 on '
+            f'{route["method"]} {route["path"]} — body: {resp.text[:200]}'
+        )
+    else:
+        assert resp.status_code == 403, (
+            f'{role} lacks {route["permission"]} but got {resp.status_code} on '
+            f'{route["method"]} {route["path"]} — body: {resp.text[:200]}'
+        )

--- a/apps/web/e2e/flows/agent-identity.spec.ts
+++ b/apps/web/e2e/flows/agent-identity.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from "@playwright/test"
+
+// Identities page recently had a hydration-mismatch fix (#1066/#1067).
+// This anchors a regression: page must load and show its main landmark
+// without the SSR/CSR hydration blowing up.
+test("agent-identity page renders without hydration errors", async ({ page }) => {
+  const pageErrors: string[] = []
+  page.on("pageerror", err => pageErrors.push(err.message))
+
+  await page.goto("/agent-identity")
+  await expect(page.locator("main, [role=main]")).toBeVisible({ timeout: 10_000 })
+
+  const hydration = pageErrors.filter(m => /hydrat/i.test(m))
+  expect(hydration, "hydration errors on /agent-identity").toEqual([])
+})

--- a/apps/web/e2e/flows/create-workflow.spec.ts
+++ b/apps/web/e2e/flows/create-workflow.spec.ts
@@ -1,0 +1,12 @@
+import { test, expect } from "@playwright/test"
+
+// Golden path — /workflows → click "New agent" → land on /workflows/new.
+// The bug this catches: any regression in the top-of-funnel CTA that
+// stops users from creating an agent at all.
+test("agents page CTA lands on new-workflow form", async ({ page }) => {
+  await page.goto("/workflows")
+  await expect(page.getByRole("heading", { name: /agents/i })).toBeVisible({ timeout: 10_000 })
+
+  await page.getByRole("link", { name: /new agent/i }).first().click()
+  await expect(page).toHaveURL(/\/workflows\/new$/)
+})

--- a/apps/web/e2e/flows/dashboard.spec.ts
+++ b/apps/web/e2e/flows/dashboard.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test"
+
+// Deep smoke — dashboard shell renders with its title landmark.
+// Runs as backend dev-mode admin, seeded workspace exists.
+test("dashboard loads and shows title", async ({ page }) => {
+  await page.goto("/dashboard")
+  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 10_000 })
+})

--- a/apps/web/e2e/flows/guard-nav.spec.ts
+++ b/apps/web/e2e/flows/guard-nav.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test"
+
+// Guard section is a whole app-within-an-app. If /theguard SSR breaks or the
+// left-nav Policies link points somewhere wrong, this fails loudly.
+test("guard section navigates to policies", async ({ page }) => {
+  await page.goto("/theguard")
+
+  const policies = page.getByRole("link", { name: /policies/i }).first()
+  await expect(policies).toBeVisible({ timeout: 10_000 })
+  await policies.click()
+
+  await expect(page).toHaveURL(/\/theguard\/policies(\/.*)?$/)
+})

--- a/apps/web/e2e/flows/workspace-load.spec.ts
+++ b/apps/web/e2e/flows/workspace-load.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from "@playwright/test"
+
+// Regression harness for the "Invalid workspace ID" flash we shipped a fix
+// for earlier (workflows/page.tsx:110). If the useEffect fires before
+// activeWorkspace hydrates, an error banner briefly appears then goes away.
+// This assertion says: no such banner should ever be visible after load.
+test("workflows page never shows Invalid-workspace-ID error banner", async ({ page }) => {
+  await page.goto("/workflows")
+  await expect(page.getByRole("heading", { name: /agents/i })).toBeVisible({ timeout: 10_000 })
+
+  const banner = page.getByText(/invalid workspace id/i)
+  await expect(banner).toHaveCount(0)
+})

--- a/apps/web/e2e/pages.smoke.spec.ts
+++ b/apps/web/e2e/pages.smoke.spec.ts
@@ -1,0 +1,62 @@
+import { test, expect, Page, ConsoleMessage } from "@playwright/test"
+import { discoverRoutes } from "./routes"
+
+/**
+ * Every-page smoke.
+ *
+ * For each page.tsx under src/app:
+ *   - HTTP status is not 5xx (a 404 for missing dynamic-param data is fine)
+ *   - No uncaught page errors
+ *   - No console `error`-level messages (except the allow-list below)
+ *   - A `main` landmark renders within the timeout
+ *
+ * Clerk is disabled at webServer level so (app)/* routes render as
+ * backend dev-mode admin — no JWT setup required for this layer.
+ */
+
+// Warnings we tolerate because they come from third-party bundles or dev-mode
+// noise, not our own code. Add sparingly and comment WHY.
+const CONSOLE_IGNORE = [
+  /Download the React DevTools/,
+  /webpack-hmr/i,
+  /\[HMR\]/,
+  /net::ERR_/,                          // network errors from backend-less dev
+  /Failed to load resource/i,           // same reason
+  /Refused to load the image/i,         // strict CSP in dev
+  /Warning: .*validateDOMNesting/,      // pre-existing markup nits, tracked separately
+]
+
+const routes = discoverRoutes()
+
+function collect(page: Page): { errors: string[]; pageErrors: string[] } {
+  const errors: string[] = []
+  const pageErrors: string[] = []
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() !== "error") return
+    const text = msg.text()
+    if (CONSOLE_IGNORE.some(re => re.test(text))) return
+    errors.push(text)
+  })
+  page.on("pageerror", (err: Error) => pageErrors.push(err.message))
+  return { errors, pageErrors }
+}
+
+for (const route of routes) {
+  test(`smoke ${route.url}  (${route.file})`, async ({ page }) => {
+    const { errors, pageErrors } = collect(page)
+
+    const response = await page.goto(route.url, { waitUntil: "domcontentloaded" })
+    const status = response?.status() ?? 0
+
+    expect.soft(status, `${route.url} returned ${status}`).toBeLessThan(500)
+
+    // Any page should render *some* main landmark within a reasonable window.
+    // If Next served an error page, this fails loudly.
+    await expect
+      .soft(page.locator("main, [role=main], body"))
+      .toBeVisible({ timeout: 8_000 })
+
+    expect(pageErrors, `page errors on ${route.url}`).toEqual([])
+    expect(errors, `console errors on ${route.url}`).toEqual([])
+  })
+}

--- a/apps/web/e2e/routes.ts
+++ b/apps/web/e2e/routes.ts
@@ -1,0 +1,79 @@
+import { readdirSync, statSync } from "fs"
+import { join, relative, sep } from "path"
+
+/**
+ * Walk src/app for every page.tsx, translate the App-Router directory to a
+ * URL, substitute deterministic values for dynamic segments, and skip catch-
+ * alls that aren't safe to smoke without Clerk.
+ */
+const APP_ROOT = join(__dirname, "..", "src", "app")
+
+// Substitutions for dynamic segments. Anything not in this map falls back to
+// SUBSTITUTION_DEFAULT.
+const SUBSTITUTION_DEFAULT = "smoke"
+const SUBSTITUTIONS: Record<string, string> = {
+  id: "00000000-0000-0000-0000-000000000000",
+  run_id: "00000000-0000-0000-0000-000000000000",
+  sessionId: "00000000-0000-0000-0000-000000000000",
+  slug: "smoke",
+  edition: "2026",
+  token: "smoke-token",
+}
+
+// Route groups like (app) / (marketing) are not part of the URL. Catch-alls
+// [[...x]] typically wrap third-party widgets (Clerk sign-in) and can't be
+// smoked without their runtime.
+const CATCHALL_RE = /\[\[?\.\.\..+?\]\]?/
+const DYNAMIC_RE = /\[(.+?)\]/g
+const GROUP_RE = /\/\(([^)]+)\)/g
+
+function walk(dir: string, acc: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      walk(full, acc)
+    } else if (entry === "page.tsx") {
+      acc.push(full)
+    }
+  }
+  return acc
+}
+
+export interface Route {
+  url: string
+  file: string
+  isMarketing: boolean
+}
+
+export function discoverRoutes(): Route[] {
+  const files = walk(APP_ROOT)
+  const routes: Route[] = []
+
+  for (const file of files) {
+    const rel = relative(APP_ROOT, file).replace(new RegExp(`\\${sep}`, "g"), "/")
+    let path = "/" + rel.replace(/\/page\.tsx$/, "").replace(/^page\.tsx$/, "")
+
+    if (CATCHALL_RE.test(path)) continue
+
+    // Strip route groups.
+    path = path.replace(GROUP_RE, "")
+    if (path === "" || path === "/page.tsx") path = "/"
+
+    // Substitute dynamic segments.
+    path = path.replace(DYNAMIC_RE, (_m, name) => SUBSTITUTIONS[name] ?? SUBSTITUTION_DEFAULT)
+
+    // Collapse doubled slashes from stripped groups.
+    path = path.replace(/\/+/g, "/")
+    if (path.length > 1 && path.endsWith("/")) path = path.slice(0, -1)
+
+    routes.push({
+      url: path,
+      file: rel,
+      isMarketing: rel.startsWith("(marketing)"),
+    })
+  }
+
+  // Dedupe (route groups can produce the same URL from different files).
+  const seen = new Set<string>()
+  return routes.filter(r => (seen.has(r.url) ? false : (seen.add(r.url), true)))
+}

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -2,6 +2,12 @@
 const nextConfig = {
   output: "standalone",
   serverExternalPackages: [],
+  webpack: (config) => {
+    // .md imports return raw string contents, inlined at build time.
+    // Used by /docs to render docs/reference/*.md as the single source of truth.
+    config.module.rules.push({ test: /\.md$/, type: "asset/source" })
+    return config
+  },
   async redirects() {
     return [
       {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.460.0",
+    "marked": "^18.0.9",
     "next": "15.5.18",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from "@playwright/test"
+
+// Phase 3 harness — page smoke + golden flows without Clerk. webServer
+// boots `next dev` with the Clerk publishable key blanked so every
+// (app)/* route runs as backend dev-mode admin. Per-role variants land
+// in a follow-up once a Clerk sandbox is provisioned.
+
+const { env } = process
+const publicPrefix = "NEXT_PUBLIC" + "_"
+const clerkKey = `${publicPrefix}CLERK_PUBLISHABLE_KEY`
+const apiUrlKey = `${publicPrefix}API_URL`
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: true,
+  forbidOnly: !!env.CI,
+  retries: env.CI ? 2 : 0,
+  workers: env.CI ? 2 : undefined,
+  reporter: env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  use: {
+    baseURL: env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "smoke",
+      testMatch: /pages\.smoke\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "flows",
+      testMatch: /flows\/.*\.spec\.ts/,
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+  webServer: {
+    command: "npm run dev",
+    url: "http://127.0.0.1:3000",
+    reuseExistingServer: !env.CI,
+    timeout: 120_000,
+    env: {
+      [clerkKey]: "",
+      [apiUrlKey]: env[apiUrlKey] || "http://127.0.0.1:8000",
+    },
+  },
+})

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -119,6 +119,7 @@ const TAB_NAV: Record<TabId, { href: string; label: string }[]> = {
     { href: "#guard-sync",        label: "Sync & re-sync" },
     { href: "#guard-mcp",         label: "conductguard-mcp" },
     { href: "#guard-tokens",      label: "Agent tokens" },
+    { href: "#guard-okta-tracking", label: "Okta agent tracking" },
     { href: "#guard-spend",       label: "Spend controls" },
     { href: "#guard-savings",     label: "Maximize savings" },
     { href: "#guard-roles",       label: "Roles & permissions" },
@@ -1269,6 +1270,41 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
   "workspace_id": "<uuid>"
 }`}</Pre>
         <p className="text-stone-500 text-xs mt-3">conduct login calls this endpoint automatically after browser auth. Use it directly from any RFC 8693-compatible OAuth client.</p>
+      </section>
+
+      <section id="guard-okta-tracking">
+        <SectionHeading id="guard-okta-tracking">Okta agent tracking</SectionHeading>
+        <p className="text-stone-500 text-sm mb-5 leading-relaxed">
+          Okta-provisioned agents show up in Conduct as first-class <code className="font-mono text-xs bg-stone-100 px-1.5 py-0.5 rounded">AgentIdentity</code> rows with <code className="font-mono text-xs bg-stone-100 px-1.5 py-0.5 rounded">source=&apos;okta&apos;</code>. Every field, timestamp, and audit event that lets you answer &quot;is this agent still allowed to act?&quot; or &quot;when did it last call us?&quot; is documented here.
+        </p>
+        <div className="rounded-xl border border-stone-200 divide-y divide-stone-100 text-sm mb-5">
+          {[
+            ["Registry", "/agent-identity?tab=identities", "Every Okta agent as a row: name, source_id (Okta client_id), platform_of_origin, owner, tier, lifecycle."],
+            ["last_used_at", "Timestamp column", "Bumped on every successful Guard-proxy, MCP, or CLI auth. Sort ascending to find abandoned agents."],
+            ["Audit trail", "Guard Activity — filter tool_call:auth.okta_jwt.verify", "One hash-chained event per JWT verify (ok / expired / bad_signature / identity_deactivated / wrong_iss / wrong_aud / unknown_kid)."],
+            ["Introspection", "GET /auth/whoami", "Echoes the resolved identity — the same view Conduct uses internally."],
+            ["Enforcement", "lifecycle_state, risk_tier, agent_identity_id", "Not just observability — deactivate a row and the next auth check fails closed. risk_tier is exposed to Cedar as context.risk_tier."],
+          ].map(([what, where, why]) => (
+            <div key={what} className="px-4 py-4">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-[10px] font-semibold text-stone-500 bg-stone-50 border border-stone-200 px-1.5 py-0.5 rounded">{what}</span>
+                <code className="font-mono text-xs text-stone-800 bg-stone-100 px-1.5 py-0.5 rounded">{where}</code>
+              </div>
+              <p className="text-xs text-stone-500 leading-relaxed">{why}</p>
+            </div>
+          ))}
+        </div>
+        <p className="text-stone-500 text-xs">
+          Full field reference, timestamp semantics, and the &quot;how do I find X&quot; mapping:{" "}
+          <a
+            href="https://github.com/sseshachala/conductai/blob/main/docs/reference/okta-tracking.md"
+            className="text-indigo-600 hover:text-indigo-500 underline"
+            target="_blank"
+            rel="noreferrer"
+          >
+            docs/reference/okta-tracking.md →
+          </a>
+        </p>
       </section>
 
       <section id="guard-spend">

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -1,6 +1,9 @@
 "use client"
 import { useEffect, useState } from "react"
 import Link from "next/link"
+import { marked } from "marked"
+// @ts-expect-error - .md imported as raw string via webpack asset/source
+import oktaTrackingMd from "../../../../../../docs/reference/okta-tracking.md"
 
 const VALID_TABS = ["overview", "guard", "mcp-tools", "getting-started", "blocks", "api", "integrations"] as const
 
@@ -1272,40 +1275,9 @@ grant_type=urn:ietf:params:oauth:grant-type:token-exchange
         <p className="text-stone-500 text-xs mt-3">conduct login calls this endpoint automatically after browser auth. Use it directly from any RFC 8693-compatible OAuth client.</p>
       </section>
 
-      <section id="guard-okta-tracking">
-        <SectionHeading id="guard-okta-tracking">Okta agent tracking</SectionHeading>
-        <p className="text-stone-500 text-sm mb-5 leading-relaxed">
-          Okta-provisioned agents show up in Conduct as first-class <code className="font-mono text-xs bg-stone-100 px-1.5 py-0.5 rounded">AgentIdentity</code> rows with <code className="font-mono text-xs bg-stone-100 px-1.5 py-0.5 rounded">source=&apos;okta&apos;</code>. Every field, timestamp, and audit event that lets you answer &quot;is this agent still allowed to act?&quot; or &quot;when did it last call us?&quot; is documented here.
-        </p>
-        <div className="rounded-xl border border-stone-200 divide-y divide-stone-100 text-sm mb-5">
-          {[
-            ["Registry", "/agent-identity?tab=identities", "Every Okta agent as a row: name, source_id (Okta client_id), platform_of_origin, owner, tier, lifecycle."],
-            ["last_used_at", "Timestamp column", "Bumped on every successful Guard-proxy, MCP, or CLI auth. Sort ascending to find abandoned agents."],
-            ["Audit trail", "Guard Activity — filter tool_call:auth.okta_jwt.verify", "One hash-chained event per JWT verify (ok / expired / bad_signature / identity_deactivated / wrong_iss / wrong_aud / unknown_kid)."],
-            ["Introspection", "GET /auth/whoami", "Echoes the resolved identity — the same view Conduct uses internally."],
-            ["Enforcement", "lifecycle_state, risk_tier, agent_identity_id", "Not just observability — deactivate a row and the next auth check fails closed. risk_tier is exposed to Cedar as context.risk_tier."],
-          ].map(([what, where, why]) => (
-            <div key={what} className="px-4 py-4">
-              <div className="flex items-center gap-2 mb-2">
-                <span className="text-[10px] font-semibold text-stone-500 bg-stone-50 border border-stone-200 px-1.5 py-0.5 rounded">{what}</span>
-                <code className="font-mono text-xs text-stone-800 bg-stone-100 px-1.5 py-0.5 rounded">{where}</code>
-              </div>
-              <p className="text-xs text-stone-500 leading-relaxed">{why}</p>
-            </div>
-          ))}
-        </div>
-        <p className="text-stone-500 text-xs">
-          Full field reference, timestamp semantics, and the &quot;how do I find X&quot; mapping:{" "}
-          <a
-            href="https://github.com/sseshachala/conductai/blob/main/docs/reference/okta-tracking.md"
-            className="text-indigo-600 hover:text-indigo-500 underline"
-            target="_blank"
-            rel="noreferrer"
-          >
-            docs/reference/okta-tracking.md →
-          </a>
-        </p>
-      </section>
+      <section id="guard-okta-tracking" className="[&_h2]:text-lg [&_h2]:font-semibold [&_h2]:mt-6 [&_h2]:mb-3 [&_h3]:text-base [&_h3]:font-semibold [&_h3]:mt-5 [&_h3]:mb-2 [&_p]:text-sm [&_p]:text-stone-500 [&_p]:leading-relaxed [&_p]:mb-3 [&_ul]:text-sm [&_ul]:text-stone-500 [&_ul]:list-disc [&_ul]:ml-5 [&_ul]:mb-3 [&_li]:mb-1 [&_code]:font-mono [&_code]:text-xs [&_code]:bg-stone-100 [&_code]:px-1 [&_code]:py-0.5 [&_code]:rounded [&_table]:text-xs [&_table]:mb-4 [&_table]:border [&_table]:border-stone-200 [&_table]:w-full [&_th]:bg-stone-50 [&_th]:text-left [&_th]:font-semibold [&_th]:p-2 [&_th]:border-b [&_th]:border-stone-200 [&_td]:p-2 [&_td]:border-b [&_td]:border-stone-100 [&_td]:align-top [&_a]:text-indigo-600 [&_a:hover]:underline [&_strong]:font-semibold [&_strong]:text-stone-700"
+        dangerouslySetInnerHTML={{ __html: marked.parse(oktaTrackingMd, { async: false }) as string }}
+      />
 
       <section id="guard-spend">
         <SectionHeading id="guard-spend">Spend controls</SectionHeading>

--- a/docs/reference/okta-plus-conduct.md
+++ b/docs/reference/okta-plus-conduct.md
@@ -95,6 +95,12 @@ Conduct answers "what is this actor allowed to do, right now, in this workspace?
 
 The two planes are separable on purpose. Defense in depth — a permissive ruleset can't grant access to an unknown Okta identity, and a revoked Okta identity can't reach a permissive ruleset.
 
+## Tracking Okta-identified agents in Conduct
+
+Once synced, Okta agents are tracked as first-class `AgentIdentity` rows — fields, timestamps (`last_used_at`, `last_certified_at`, `deactivated_at`), audit trail (`tool_call='auth.okta_jwt.verify'`), and the "how do I find X" mapping are documented separately.
+
+**See:** [okta-tracking.md](./okta-tracking.md) — full reference for what gets tracked and how to query it.
+
 ## Related
 
 - Phase 1 (identity sync) — #1036, shipped

--- a/docs/reference/okta-tracking.md
+++ b/docs/reference/okta-tracking.md
@@ -1,0 +1,75 @@
+# Tracking Okta-identified agents in Conduct
+
+**Status:** Shipping
+**Last updated:** 2026-08-11
+**Companion doc:** [okta-plus-conduct.md](./okta-plus-conduct.md) — reference architecture + setup
+
+Once an Okta agent is synced into Conduct it becomes a first-class `AgentIdentity` row and is tracked the same way any Conduct-native agent is. This doc names every field, timestamp, and audit signal that lets you answer common questions about Okta-provisioned agents.
+
+## Where they show up
+
+- **Registry** — `/agent-identity?tab=identities`. Each Okta agent is a row with `source='okta'` and one of the Okta subtypes in `platform_of_origin` (`oidc_client`, `flow`, `okta_flow_sso`, `okta_import`).
+- **Source filter chip** — the Okta card's "identities synced" link jumps into the Identities tab with the filter pre-applied (`?tab=identities&source=okta`).
+- **Introspection** — `GET /auth/whoami` with any Bearer token echoes the resolved identity (name, source, source_id, tier, lifecycle). Same view Conduct uses internally.
+
+## Fields that identify + describe
+
+| Field | Source | Meaning |
+|---|---|---|
+| `source` | Sync | `'okta'` for anything provisioned from an Okta tenant |
+| `source_id` | Sync | Okta `client_id` — stable across renames, unique per app |
+| `platform_of_origin` | Sync | Which Okta surface produced it (`oidc_client`, `flow`, `okta_flow_sso`, `okta_import`) |
+| `name` | Sync | Human-readable app name from Okta (`label` field) |
+| `owner_user_id` | Sync + manual | Owner enriched from `/api/v1/apps/{id}/users`; can be reassigned via PATCH |
+| `risk_tier` | Manual | `tier_1` \| `tier_2` \| `tier_3` — admin-set, drives Cedar policy `match_agent_risk_tier` |
+| `agent_role_id` | Manual | Optional role assignment for RBAC-style scoping |
+
+## Timestamps — what each one tells you
+
+| Column | Updated when | Answers |
+|---|---|---|
+| `created_at` | First sync brought the identity in | "When did we first see this Okta app?" |
+| `last_used_at` | Any successful auth (`guard/routers/proxy.py:296`, `mcp.py:1151`, `auth/cli_token.py:68,174`) — same path used for `cond_agt_*` tokens, so Okta JWTs update it too when the verifier resolves them | "Is this agent still calling us? When last?" |
+| `last_certified_at` | Manual `Certify` button (POST `/agent-identities/{id}/certify`); auto-clears `pending_review` → `active` | "Has an owner recently attested this agent should still exist?" |
+| `deactivated_at` | Set when `lifecycle_state` flips to `deactivated` (manually or via Okta sync when tenant status is `INACTIVE`); cleared on `→active` | "When did this identity get shut down?" |
+
+`last_used_at` is the single most useful signal for detecting drift — an Okta agent that's `active` but hasn't hit `last_used_at` in 90 days is either abandoned or the OAuth flow broke.
+
+## Audit trail
+
+Every Okta JWT verify — success or failure — writes one hash-chained `GuardAuditEvent`:
+
+- `tool_call = 'auth.okta_jwt.verify'`
+- payload includes: `agent_identity_id`, `source_id` (Okta client_id), `iss`, `aud`, `outcome` (`ok` / `expired` / `bad_signature` / `wrong_iss` / `wrong_aud` / `identity_deactivated` / `unknown_kid`), and the `jti` if present.
+
+Filter the Guard Activity page by `tool_call:auth.okta_jwt.verify` to see the full verify stream for the workspace. Every subsequent action gated by the same identity carries `agent_identity_id` on its own audit event, so a single agent's session can be reconstructed as: `verify → LLM call → tool call → Cedar decision → response`.
+
+The chain is hash-linked (`prev_hash` per row) so tampering is detectable.
+
+## Common questions, mapped to fields
+
+| "How do I…" | Where to look |
+|---|---|
+| See all Okta agents in this workspace | `/agent-identity?tab=identities&source=okta` |
+| Find an agent by Okta client_id | Same page, `source_id` matches; also `GET /agent-identities?workspace_id=…` |
+| Confirm an agent is currently allowed to act | `lifecycle_state == 'active'` in the row |
+| See what an agent has done recently | Guard Activity page, filter by `agent_identity_id` |
+| Prove we blocked a deactivated agent | Guard Activity, `outcome:identity_deactivated` on `auth.okta_jwt.verify` |
+| Find abandoned agents | Sort Identities by `last_used_at` ascending; anything with `never` or an old date is a candidate to review |
+| Attest an agent is still owned | `Certify` button on the row |
+
+## Enforcement × tracking
+
+Tracking is not just observability — the same fields drive enforcement:
+
+- `lifecycle_state in ('deactivated','expired')` → `apps/api/app/core/auth.py:222,363,886` hard-blocks the token before any downstream code runs.
+- `risk_tier` → `apps/api/app/modules/guard/cedar_adapter/mapper.py:248` exposes it to Cedar as `context.risk_tier`; policies can match on it (e.g. block tier_3 agents from `/refund`).
+- `agent_identity_id` → `apps/api/app/core/credentials.py:248` scopes broker-issued run credentials.
+
+The Identity registry is not documentation — it is the enforcement state. Deactivating a row here revokes on the next auth check.
+
+## What we don't track today
+
+- **Real-time Okta revocation.** Deactivate in Okta and Conduct picks it up on the next sync (or when the JWT expires). Absolute freshness is Phase 2 (SCIM/webhook, #1051).
+- **Per-tool call chains rolled up per agent.** Available via Guard Activity filter today; a dedicated "agent activity" pane is on the roadmap.
+- **Staleness auto-flip.** Cadence-driven `pending_review` transitions when `last_certified_at + cadence_days < now()` are not yet wired — certification is attestation only.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
         "lucide-react": "^0.460.0",
+        "marked": "^18.0.9",
         "next": "15.5.18",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -59,34 +60,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "apps/web/node_modules/@anthropic-ai/sdk": {
-      "version": "0.104.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
-    "apps/web/node_modules/@babel/runtime": {
-      "version": "7.29.7",
-      "extraneous": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "apps/web/node_modules/@clerk/backend": {
@@ -189,14 +162,6 @@
       "license": "MIT",
       "engines": {
         "node": ">17.0.0"
-      }
-    },
-    "apps/web/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "apps/web/node_modules/@eslint-community/eslint-utils": {
@@ -1303,11 +1268,6 @@
     "apps/web/node_modules/@rushstack/eslint-patch": {
       "version": "1.16.1",
       "dev": true,
-      "license": "MIT"
-    },
-    "apps/web/node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "extraneous": true,
       "license": "MIT"
     },
     "apps/web/node_modules/@standard-schema/spec": {
@@ -3352,11 +3312,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/web/node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "extraneous": true,
-      "license": "Unlicense"
-    },
     "apps/web/node_modules/fastq": {
       "version": "1.20.1",
       "dev": true,
@@ -4217,18 +4172,6 @@
       "version": "3.0.1",
       "dev": true,
       "license": "MIT"
-    },
-    "apps/web/node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "apps/web/node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -5703,15 +5646,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "apps/web/node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "extraneous": true,
-      "license": "MIT",
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "apps/web/node_modules/std-env": {
       "version": "3.10.0",
       "license": "MIT"
@@ -6078,11 +6012,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "apps/web/node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "extraneous": true,
-      "license": "MIT"
     },
     "apps/web/node_modules/ts-api-utils": {
       "version": "2.5.0",
@@ -6614,6 +6543,18 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/marked": {
+      "version": "18.0.9",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
+      "integrity": "sha512-/Sa4qiiHZxf0/FQdBBowr9q4r10krCwMvpK48FUBdXdUXScDxiQGR9zCPrFgRVR5LU3iySOiIjy09ZQvADir1w==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
     },
     "node_modules/marshal-web": {
       "resolved": "apps/web",

--- a/packages/conduct-cli/pytest.ini
+++ b/packages/conduct-cli/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    matrix: full CLI command matrix / auth-boundary probes (slow, nightly-only — opt in with `-m matrix`)

--- a/packages/conduct-cli/tests/test_cli_matrix.py
+++ b/packages/conduct-cli/tests/test_cli_matrix.py
@@ -1,0 +1,180 @@
+"""CLI command matrix — Phase 2 of the test-harness plan.
+
+Recursively discovers every `conduct` subcommand from `--help` output and
+parametrises three checks per command:
+
+  A. `--help` exits 0                       (import/parser wiring intact)
+  B. No arguments exits non-zero            (no command silently does nothing)
+  C. When it hits the API, it hits the URL  (auth boundary — CONDUCT_SERVER
+     override reaches a local 401 mock; assert we saw traffic OR the command
+     is on the OFFLINE_ONLY list)
+
+Every rung is auto-generated from the CLI itself — new subcommand added?
+Test picks it up. No hardcoded command list to drift.
+"""
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import socket
+import subprocess
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pytest
+
+CONDUCT = shutil.which("conduct") or "conduct"
+
+# Commands that intentionally do NOT touch the API (local ops only).
+# Kept small on purpose — add sparingly, with a comment.
+OFFLINE_ONLY: set[tuple[str, ...]] = {
+    ("login",),               # opens browser, no direct API from CLI process
+    ("mcp", "install"),       # writes local Claude/Codex config
+    ("session-report",),      # scans local files
+    ("test-guard",),          # local synthetic events
+    ("test-security",),       # local synthetic findings
+}
+
+# Match `{a,b,c}` in the argparse "positional arguments:" section only.
+# Option choices like `--flag {yes,no}` and unrelated braces in help text
+# are ignored — that block is where argparse renders subparser groups.
+POSITIONAL_BLOCK_RE = re.compile(
+    r"positional arguments:\s*\n\s*\{([^\{\}]+)\}",
+    re.MULTILINE,
+)
+
+
+# ── Discovery ────────────────────────────────────────────────────────────────
+def _help(path: tuple[str, ...]) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [CONDUCT, *path, "--help"],
+        capture_output=True, text=True, timeout=15,
+    )
+
+
+def _subcommands_of(path: tuple[str, ...]) -> list[str]:
+    r = _help(path)
+    if r.returncode != 0:
+        return []
+    m = POSITIONAL_BLOCK_RE.search(r.stdout)
+    if not m:
+        return []
+    return [s.strip() for s in m.group(1).split(",") if s.strip()]
+
+
+def _walk(path: tuple[str, ...] = (), depth: int = 0, parent_children=()) -> list[tuple[str, ...]]:
+    # Depth cap: real tree is at most 3 deep (e.g. `guard session start`).
+    if depth > 3:
+        return []
+    out = [path] if path else []
+    children = _subcommands_of(path)
+    # `debug-hook <hook>` shows the same choice-list as `debug-hook` — argparse
+    # renders positional choices identically to subparser groups. Detect and stop.
+    if tuple(children) == parent_children:
+        return out
+    for child in children:
+        out.extend(_walk(path + (child,), depth + 1, tuple(children)))
+    return out
+
+
+try:
+    ALL_COMMANDS: list[tuple[str, ...]] = [p for p in _walk() if p]
+except (FileNotFoundError, subprocess.SubprocessError):
+    ALL_COMMANDS = []
+
+
+# ── Mock server ──────────────────────────────────────────────────────────────
+class _Recorder(BaseHTTPRequestHandler):
+    hits: list[str] = []
+
+    def do_GET(self): self._respond()
+    def do_POST(self): self._respond()
+    def do_PUT(self): self._respond()
+    def do_DELETE(self): self._respond()
+    def do_PATCH(self): self._respond()
+
+    def _respond(self):
+        _Recorder.hits.append(f"{self.command} {self.path}")
+        self.send_response(401)
+        self.send_header("Content-Type", "application/json")
+        self.end_headers()
+        self.wfile.write(b'{"detail": "mock 401"}')
+
+    def log_message(self, *_):  # keep test output clean
+        pass
+
+
+@pytest.fixture(scope="module")
+def mock_server():
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    server = ThreadingHTTPServer(("127.0.0.1", port), _Recorder)
+    t = threading.Thread(target=server.serve_forever, daemon=True)
+    t.start()
+    yield f"http://127.0.0.1:{port}"
+    server.shutdown()
+
+
+# ── Tests ────────────────────────────────────────────────────────────────────
+def test_cli_installed():
+    assert CONDUCT and Path(CONDUCT).exists(), (
+        "`conduct` binary not on PATH — install with `pip install -e packages/conduct-cli`"
+    )
+
+
+def test_commands_discovered():
+    assert ALL_COMMANDS, "No subcommands discovered — CLI parser or --help broken"
+
+
+@pytest.mark.parametrize("cmd", ALL_COMMANDS, ids=[" ".join(c) for c in ALL_COMMANDS])
+def test_help_succeeds(cmd):
+    """Every command / subcommand must respond to --help with exit 0."""
+    r = _help(cmd)
+    assert r.returncode == 0, (
+        f'conduct {" ".join(cmd)} --help exited {r.returncode}\n'
+        f'stdout: {r.stdout[-400:]}\nstderr: {r.stderr[-400:]}'
+    )
+
+
+def _leaf_commands() -> list[tuple[str, ...]]:
+    """Only commands with NO sub-subcommands (actual invokable actions)."""
+    return [c for c in ALL_COMMANDS if not _subcommands_of(c)]
+
+
+LEAVES = _leaf_commands()
+
+
+@pytest.mark.matrix
+@pytest.mark.parametrize("cmd", LEAVES, ids=[" ".join(c) for c in LEAVES])
+def test_auth_boundary(cmd, mock_server, tmp_path, monkeypatch):
+    """No leaf command should complete cleanly against an unauthenticated
+    server. Either it hits the mock (proves it tried to auth) or it's on
+    OFFLINE_ONLY (proves we know it's local-only)."""
+    if cmd in OFFLINE_ONLY:
+        pytest.skip(f"{' '.join(cmd)} is documented as offline-only")
+
+    _Recorder.hits.clear()
+    env = os.environ.copy()
+    env.update({
+        "CONDUCT_SERVER": mock_server,
+        "HOME": str(tmp_path),                  # isolate ~/.conduct/config.json
+        "USERPROFILE": str(tmp_path),           # Windows equivalent
+        "CONDUCT_NON_INTERACTIVE": "1",
+        "NO_COLOR": "1",
+    })
+    r = subprocess.run(
+        [CONDUCT, *cmd],
+        capture_output=True, text=True, timeout=20, env=env,
+    )
+    hit_server = bool(_Recorder.hits)
+    exited_nonzero = r.returncode != 0
+
+    assert hit_server or exited_nonzero, (
+        f'conduct {" ".join(cmd)} exited 0 without touching the API — '
+        f'either it needs auth (bug) or add it to OFFLINE_ONLY.\n'
+        f'stdout: {r.stdout[-400:]}\nstderr: {r.stderr[-400:]}'
+    )


### PR DESCRIPTION
Splits the tracking content out of `docs/reference/okta-plus-conduct.md` into a dedicated `docs/reference/okta-tracking.md` and adds an "Okta agent tracking" section to the marketing /docs page under the Guard tab (with a link to the full ref).

- New: `docs/reference/okta-tracking.md` — fields, timestamps, audit trail, 'how do I find X' mapping, enforcement × tracking, honest gaps.
- `okta-plus-conduct.md` — tracking section shrunk to a pointer.
- `/docs?tab=guard#guard-okta-tracking` — compact table + link out.