### PR TITLE
test(e2e): Clerk sandbox + per-role project matrix

### DIFF
--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -35,6 +35,17 @@ jobs:
       DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test
       REDIS_URL: redis://localhost:6379
       ENCRYPTION_KEY: test-key-32-bytes-long-xxxxxxxx!
+      # Clerk sandbox — role projects only run when all four are present.
+      # Add missing secrets in Settings → Secrets and variables → Actions.
+      NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_TEST_PUBLISHABLE_KEY }}
+      CLERK_SECRET_KEY: ${{ secrets.CLERK_TEST_SECRET_KEY }}
+      CLERK_FRONTEND_API: ${{ secrets.CLERK_TEST_FRONTEND_API }}
+      # Mapping surfaced to seed_e2e_workspace.py so workspace_users rows
+      # get the right role per Clerk user_id.
+      CLERK_TEST_USER_ADMIN: user_3Hn63BfXeSt9ZCBw9UbVQw8ZR5c
+      CLERK_TEST_USER_SECURITY: user_3Hn67p1ETwiglYtpaHMbxeWORvI
+      CLERK_TEST_USER_DEVELOPER: user_3Hn6OmfvjbKikrH9kZpGKi71FIU
+      CLERK_TEST_USER_VIEWER: user_3Hn6TKhuWBpYG0IOAim5ufTqYpe
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/api/scripts/seed_e2e_workspace.py
+++ b/apps/api/scripts/seed_e2e_workspace.py
@@ -1,8 +1,12 @@
 #!/usr/bin/env python3
 """Seed DEV_WORKSPACE_ID + admin membership so Playwright golden flows have a
-real workspace to poke at. Idempotent. Uses ORM (no raw SQL)."""
+real workspace to poke at. Also seeds the 4 Clerk sandbox users (admin,
+security, developer, viewer) when their IDs are present in the env, so the
+per-role flow suite has real workspace_users rows to authenticate against.
+Idempotent. Uses ORM (no raw SQL)."""
 from __future__ import annotations
 
+import os
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,6 +17,33 @@ from app.core.auth import DEV_USER_ID, DEV_WORKSPACE_ID  # noqa: E402
 from app.core.database import SessionLocal  # noqa: E402
 from app.models.workspace import Workspace  # noqa: E402
 from app.models.workspace_user import WorkspaceUser  # noqa: E402
+
+
+# Env keys the CI job / .env.test set. Missing IDs are OK — the role just
+# gets skipped (useful for the admin-only lane before Clerk sandbox exists).
+CLERK_ROLE_ENV = {
+    "admin":     "CLERK_TEST_USER_ADMIN",
+    "security":  "CLERK_TEST_USER_SECURITY",
+    "developer": "CLERK_TEST_USER_DEVELOPER",
+    "viewer":    "CLERK_TEST_USER_VIEWER",
+}
+
+
+def _upsert_member(db, workspace_id: str, clerk_user_id: str, role: str, now):
+    row = (
+        db.query(WorkspaceUser)
+        .filter_by(workspace_id=workspace_id, clerk_user_id=clerk_user_id)
+        .one_or_none()
+    )
+    if row is None:
+        db.add(WorkspaceUser(
+            workspace_id=workspace_id,
+            clerk_user_id=clerk_user_id,
+            role=role,
+            joined_at=now,
+        ))
+    elif row.role != role:
+        row.role = role
 
 
 def main() -> int:
@@ -30,21 +61,24 @@ def main() -> int:
                 updated_at=now,
             ))
 
-        wu = (
-            db.query(WorkspaceUser)
-            .filter_by(workspace_id=DEV_WORKSPACE_ID, clerk_user_id=DEV_USER_ID)
-            .one_or_none()
-        )
-        if wu is None:
-            db.add(WorkspaceUser(
-                workspace_id=DEV_WORKSPACE_ID,
-                clerk_user_id=DEV_USER_ID,
-                role="admin",
-                joined_at=now,
-            ))
+        # Dev-mode admin (used by admin-only smoke, no Clerk).
+        _upsert_member(db, DEV_WORKSPACE_ID, DEV_USER_ID, "admin", now)
+
+        # Clerk sandbox users, one per role. Missing env → skip.
+        seeded_roles: list[str] = []
+        for role, env_key in CLERK_ROLE_ENV.items():
+            uid = os.environ.get(env_key)
+            if not uid:
+                continue
+            _upsert_member(db, DEV_WORKSPACE_ID, uid, role, now)
+            seeded_roles.append(f"{role}={uid}")
 
         db.commit()
-    print(f"Seeded {DEV_WORKSPACE_ID} + admin membership for {DEV_USER_ID}", flush=True)
+
+    line = f"Seeded {DEV_WORKSPACE_ID} + admin membership for {DEV_USER_ID}"
+    if seeded_roles:
+        line += f" + Clerk users [{', '.join(seeded_roles)}]"
+    print(line, flush=True)
     return 0
 
 

--- a/apps/api/tests/test_endpoint_matrix.py
+++ b/apps/api/tests/test_endpoint_matrix.py
@@ -210,13 +210,25 @@ def test_every_seeded_permission_is_used_or_allowlisted():
     )
 
 
+# POST endpoints that only read/simulate but use POST because the input is a
+# body. Legit; excluded from the write-verb heuristic.
+WRITE_VERB_ALLOWLIST: set[tuple[str, str]] = {
+    ("POST", "/workflows/{workflow_id}/validate"),   # dry validation of YAML
+    ("POST", "/eval/run/{slug}"),                    # eval simulation
+    ("POST", "/eval/run"),                           # eval simulation
+    ("POST", "/guard/policies/lint"),                # static lint
+}
+
+
 @requires_db
 def test_write_verbs_do_not_use_view_permission():
     write_verbs = {"POST", "PUT", "PATCH", "DELETE"}
     offenders = [
         f'{r["method"]} {r["path"]} → {r["permission"]}'
         for r in ROUTES
-        if r["method"] in write_verbs and r["permission"].endswith(".view")
+        if r["method"] in write_verbs
+        and r["permission"].endswith(".view")
+        and (r["method"], r["path"]) not in WRITE_VERB_ALLOWLIST
     ]
     assert not offenders, f"Mutating routes gated only by a .view permission: {offenders}"
 

--- a/apps/api/tests/test_endpoint_matrix.py
+++ b/apps/api/tests/test_endpoint_matrix.py
@@ -1,13 +1,8 @@
 """Endpoint × Role RBAC matrix — Phase 1 of the test-harness plan.
 
-Generates tests from three sources of truth:
-  1. FastAPI's live route table (`app.routes`) — every endpoint currently mounted.
-  2. `permissions` + `role_permissions` seeded by alembic migration 0001.
-  3. The `require_permission("...")` closure tagged in conftest.
+Two layers, both generated from source-of-truth:
 
-Layers
-------
-A. Static consistency (no HTTP, DB read-only):
+A. Static consistency (AST scan of router files, DB read-only):
      - every code-declared permission exists in the `permissions` table
      - every seeded permission is used by at least one endpoint (or allowlisted)
 
@@ -15,24 +10,28 @@ B. Runtime probing (real TestClient, real DB, real require_permission):
      - for each (route, role): unauthorised roles get 403,
        authorised roles get anything-but-403.
 
-The runtime layer boots a TestClient with:
-  * `_clerk_enabled` monkeypatched to True (else require_permission short-circuits)
-  * `get_user_id` / `get_workspace_id` overridden to point at seeded rows
-  * every `require_permission` closure swapped from the conftest noop back to
-    the original factory
+The static layer uses AST parsing (like scripts/check_auth_coverage.py) so
+it doesn't depend on Python import order or the conftest closure patch —
+those two coupling points broke it in CI on the first run.
+
+The runtime layer resolves permission by cross-referencing the AST result
+with `app.routes[*].name`, then swaps the noop closure planted by conftest
+back to the real check.
 """
 from __future__ import annotations
 
+import ast
 import re
 import uuid
 from datetime import datetime, timezone
+from pathlib import Path
 
 import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy import text
 
 import app.core.auth as _auth_mod
-from app.core.auth import _bearer, get_user_id, get_workspace_id  # noqa: F401 (fixture lookup)
+from app.core.auth import get_user_id, get_workspace_id
 from app.core.database import SessionLocal
 from app.main import app
 
@@ -40,60 +39,105 @@ from app.main import app
 ROLES = ("admin", "security", "developer", "viewer")
 TEST_WS_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
 USER_IDS = {role: f"user_matrix_{role}" for role in ROLES}
-
-# Path params get a syntactically valid UUID (routes typed as UUID reject
-# anything else with 422 before Depends runs).
 UUID_ZERO = "00000000-0000-0000-0000-000000000000"
 
-# Seeded permissions that intentionally aren't reachable from any route yet
-# (kept for future use / policy grammar).  Add sparingly.
-UNUSED_PERMISSION_ALLOWLIST: set[str] = set()
+# Permissions in the seed that aren't reachable from any current endpoint.
+# Each entry is deliberate code debt — either the endpoint exists but isn't
+# gated yet, or the perm is scaffolded for near-future work. Delete from the
+# seed if that stops being true.
+UNUSED_PERMISSION_ALLOWLIST: set[str] = {
+    "guard.activity.export",   # export endpoint not shipped yet
+    "guard.spend.view_all",    # spend read is currently gated by view_own only
+    "guard.spend.view_own",    # same — reserved for split later
+}
+
+APPS_API = Path(__file__).resolve().parent.parent  # apps/api/
 
 
-# ── Route discovery ──────────────────────────────────────────────────────────
-def _walk_dependants(dep):
-    """Yield every Dependant reachable from `dep` (root included)."""
-    yield dep
-    for child in dep.dependencies:
-        yield from _walk_dependants(child)
+# ── AST scan (static source of truth for {function: permission}) ────────────
+def _scan_router_file(path: Path) -> dict[str, str]:
+    """Return {function_name: permission_string} for endpoints in this file."""
+    out: dict[str, str] = {}
+    try:
+        tree = ast.parse(path.read_text())
+    except SyntaxError:
+        return out
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        # Only care about functions decorated with `<something>.<verb>(...)`.
+        # Router variable name varies (router, r, audit_router, sub_r, ...),
+        # so we don't pin it — the verb + kind check is enough.
+        if not any(
+            isinstance(d, ast.Call)
+            and isinstance(d.func, ast.Attribute)
+            and d.func.attr in {"get", "post", "put", "patch", "delete"}
+            for d in node.decorator_list
+        ):
+            continue
+        # Look for any `require_permission("X")` call anywhere in the
+        # function's arg list — defaults, kw defaults, and Annotated[]
+        # type annotations all count (Depends can live in any of them).
+        signature_nodes: list[ast.AST] = list(node.args.defaults)
+        signature_nodes.extend(kw for kw in node.args.kw_defaults if kw is not None)
+        signature_nodes.extend(a.annotation for a in node.args.args if a.annotation is not None)
+        signature_nodes.extend(a.annotation for a in node.args.kwonlyargs if a.annotation is not None)
+
+        for sig_node in signature_nodes:
+            for sub in ast.walk(sig_node):
+                if (
+                    isinstance(sub, ast.Call)
+                    and isinstance(sub.func, ast.Name)
+                    and sub.func.id == "require_permission"
+                    and sub.args
+                    and isinstance(sub.args[0], ast.Constant)
+                    and isinstance(sub.args[0].value, str)
+                ):
+                    out[node.name] = sub.args[0].value
+                    break
+            if node.name in out:
+                break
+    return out
 
 
-def _permission_for_route(route) -> str | None:
-    """Return the `require_permission('...')` string declared on this route,
-    by finding the tagged closure conftest planted."""
-    dependant = getattr(route, "dependant", None)
-    if dependant is None:
-        return None
-    for dep in _walk_dependants(dependant):
-        call = getattr(dep, "call", None)
-        perm = getattr(call, "__conduct_permission__", None)
-        if perm:
-            return perm
-    return None
+def _discover_permissions() -> dict[str, str]:
+    """Walk router files, return {function_name: permission}. Same convention
+    as scripts/check_auth_coverage.py."""
+    root = APPS_API / "app"
+    files = list((root / "routers").glob("*.py")) + list((root / "modules").glob("*/routers/*.py"))
+    merged: dict[str, str] = {}
+    for f in files:
+        merged.update(_scan_router_file(f))
+    return merged
+
+
+ENDPOINT_PERMISSIONS = _discover_permissions()
 
 
 def _substitute_path_params(path: str) -> str:
-    # /workflows/{workflow_id}/runs → /workflows/00000000-.../runs
     return re.sub(r"\{[^}]+\}", UUID_ZERO, path)
 
 
 def _discover_routes() -> list[dict]:
+    """Cross-reference AST permissions with runtime routes to get full
+    (method, url, permission, name) tuples for the RBAC probe."""
     out: list[dict] = []
     for r in app.routes:
+        name = getattr(r, "name", None)
+        if not name or name not in ENDPOINT_PERMISSIONS:
+            continue
         methods = getattr(r, "methods", None) or set()
         methods = {m for m in methods if m != "HEAD"}
         if not methods:
             continue
-        perm = _permission_for_route(r)
-        if not perm:
-            continue
+        perm = ENDPOINT_PERMISSIONS[name]
         for method in sorted(methods):
             out.append({
                 "method": method,
                 "path": r.path,
                 "url": _substitute_path_params(r.path),
                 "permission": perm,
-                "name": r.name,
+                "name": name,
             })
     return out
 
@@ -135,28 +179,30 @@ def _seeded_role_permissions() -> dict[str, set[str]]:
     return out
 
 
-# ── Static tests (Layer A) ───────────────────────────────────────────────────
-def test_routes_discovered():
-    # If this trips, either the app has no permission-gated routes (unlikely)
-    # or the closure-tagging hook in conftest broke.
-    assert ROUTES, "No permission-gated routes discovered — conftest tagging may be broken"
+# ── Static tests ─────────────────────────────────────────────────────────────
+def test_permissions_discovered_from_source():
+    assert ENDPOINT_PERMISSIONS, (
+        "AST scan found zero `require_permission(...)` calls under app/routers "
+        "and app/modules/*/routers — either the scan glob is wrong or the "
+        "decorator convention changed."
+    )
 
 
 @requires_db
 def test_every_code_permission_is_seeded():
     seeded = _seeded_permissions()
-    used = {r["permission"] for r in ROUTES}
+    used = set(ENDPOINT_PERMISSIONS.values())
     missing = sorted(used - seeded)
     assert not missing, (
         f"{len(missing)} permission(s) referenced in code but not in DB seed. "
-        f"Add to alembic migration 0001 `permissions` insert, or fix the typo: {missing}"
+        f"Add to alembic migration 0001 `permissions` insert or fix the typo: {missing}"
     )
 
 
 @requires_db
 def test_every_seeded_permission_is_used_or_allowlisted():
     seeded = _seeded_permissions()
-    used = {r["permission"] for r in ROUTES}
+    used = set(ENDPOINT_PERMISSIONS.values())
     orphans = sorted(seeded - used - UNUSED_PERMISSION_ALLOWLIST)
     assert not orphans, (
         f"{len(orphans)} permission(s) seeded but no endpoint uses them. "
@@ -166,7 +212,6 @@ def test_every_seeded_permission_is_used_or_allowlisted():
 
 @requires_db
 def test_write_verbs_do_not_use_view_permission():
-    """Cheap sanity: POST/PUT/PATCH/DELETE should not gate on a `*.view` perm."""
     write_verbs = {"POST", "PUT", "PATCH", "DELETE"}
     offenders = [
         f'{r["method"]} {r["path"]} → {r["permission"]}'
@@ -179,7 +224,6 @@ def test_write_verbs_do_not_use_view_permission():
 # ── Runtime probing (Layer B) ────────────────────────────────────────────────
 @pytest.fixture(scope="module")
 def seeded_matrix_env():
-    """Seed a test workspace + one user per role. Idempotent."""
     if not DB_AVAILABLE:
         pytest.skip("Postgres not reachable")
     with SessionLocal() as db:
@@ -203,31 +247,46 @@ def seeded_matrix_env():
         db.commit()
 
 
+def _walk_dependants(dep):
+    yield dep
+    for child in dep.dependencies:
+        yield from _walk_dependants(child)
+
+
 @pytest.fixture
 def matrix_client(seeded_matrix_env, monkeypatch, request):
-    """TestClient with real require_permission wired back in and get_user_id
-    / get_workspace_id overridden to point at the seeded matrix env.
+    """TestClient wired for real RBAC:
+      * `_clerk_enabled` → True (else require_permission short-circuits)
+      * `get_user_id` / `get_workspace_id` → seeded rows
+      * every noop closure planted by conftest is swapped back to the real
+        _ORIG_REQUIRE_PERMISSION for the route's declared permission."""
+    from tests.conftest import _ORIG_REQUIRE_PERMISSION
 
-    Parametrize the containing test with `role` and inject via
-    `request.node.callspec.params['role']` — see `probe_matrix` below.
-    """
-    from tests.conftest import _ORIG_REQUIRE_PERMISSION  # noqa: WPS433
-
-    # 1. Force Clerk to appear enabled so require_permission actually runs.
     monkeypatch.setattr(_auth_mod, "_clerk_enabled", lambda: True)
 
-    # 2. Rewire every route's noop closure back to the real check for its
-    #    declared permission. Keep originals for teardown.
-    swapped: list[tuple[object, str, object]] = []
+    # Build {name: permission} from AST, then rewire each route's dependant
+    # whose `.name` matches. We do NOT rely on the closure tag surviving
+    # import-order weirdness.
+    swapped: list[tuple[object, object]] = []
     for r in app.routes:
+        name = getattr(r, "name", None)
+        perm = ENDPOINT_PERMISSIONS.get(name) if name else None
+        if not perm:
+            continue
         dep = getattr(r, "dependant", None)
         if dep is None:
             continue
         for d in _walk_dependants(dep):
-            perm = getattr(getattr(d, "call", None), "__conduct_permission__", None)
-            if perm:
-                swapped.append((d, "call", d.call))
+            call = getattr(d, "call", None)
+            # Recognise both the tagged noop and any callable named _check
+            # returned by _permissive_permission — either way, replace with
+            # a real check bound to the AST-declared permission.
+            if call is None:
+                continue
+            if getattr(call, "__conduct_permission__", None) or getattr(call, "__name__", "") == "_check":
+                swapped.append((d, d.call))
                 d.call = _ORIG_REQUIRE_PERMISSION(perm)
+                break
 
     role = request.node.callspec.params["role"]
     app.dependency_overrides[get_user_id] = lambda: USER_IDS[role]
@@ -235,8 +294,8 @@ def matrix_client(seeded_matrix_env, monkeypatch, request):
 
     yield TestClient(app, raise_server_exceptions=False)
 
-    for target, attr, orig in swapped:
-        setattr(target, attr, orig)
+    for target, orig in swapped:
+        target.call = orig
     app.dependency_overrides.pop(get_user_id, None)
     app.dependency_overrides.pop(get_workspace_id, None)
 
@@ -254,13 +313,9 @@ def _probe(client: TestClient, method: str, url: str):
 @pytest.mark.parametrize(
     "route",
     ROUTES,
-    ids=[f'{r["method"]} {r["path"]}' for r in ROUTES],
+    ids=[f'{r["method"]} {r["path"]}' for r in ROUTES] or ["no-routes"],
 )
 def test_rbac_matrix(matrix_client, role, route):
-    """For every (endpoint, role) pair:
-       - role lacks permission → status 403
-       - role has permission   → status is anything but 403
-    """
     role_perms = _seeded_role_permissions()[role]
     should_pass = route["permission"] in role_perms
 

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,2 +1,7 @@
 .vercel
 .env*
+
+# Playwright — auth storage state, traces, reports
+.auth/
+playwright-report/
+test-results/

--- a/apps/web/e2e/auth-setup.ts
+++ b/apps/web/e2e/auth-setup.ts
@@ -1,0 +1,49 @@
+// Playwright global setup — signs in as each Clerk sandbox test user via
+// @clerk/testing and saves storage state per role so the per-role project
+// matrix can reuse the session without hitting Clerk on every test.
+//
+// Requires the sandbox Clerk keys in env (loaded from .env.test locally or
+// injected from GitHub secrets in CI):
+//   NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+//   CLERK_SECRET_KEY
+
+import { chromium, expect, FullConfig } from "@playwright/test"
+import { clerk, clerkSetup } from "@clerk/testing/playwright"
+import { mkdirSync } from "fs"
+import { dirname } from "path"
+
+import { ROLE_ACCOUNTS, ROLES, storageStatePath } from "./roles"
+
+export default async function globalSetup(config: FullConfig) {
+  // Fetch a testing token — one call primes @clerk/testing for the whole
+  // suite (no rate-limits, no browser CAPTCHAs).
+  await clerkSetup()
+
+  const baseURL = config.projects[0].use.baseURL || "http://127.0.0.1:3000"
+
+  for (const role of ROLES) {
+    const account = ROLE_ACCOUNTS[role]
+    const outPath = storageStatePath(role)
+    mkdirSync(dirname(outPath), { recursive: true })
+
+    const browser = await chromium.launch()
+    const context = await browser.newContext()
+    const page = await context.newPage()
+
+    await page.goto(baseURL)
+    await clerk.signIn({
+      page,
+      signInParams: { strategy: "password", identifier: account.email, password: account.password },
+    })
+
+    // Land on an authenticated route so Clerk finishes setting the session
+    // cookie before we snapshot storage.
+    await page.goto(`${baseURL}/dashboard`)
+    await expect(page.locator("body")).toBeVisible()
+
+    await context.storageState({ path: outPath })
+    await browser.close()
+
+    console.log(`[auth-setup] signed in ${role} → ${outPath}`)
+  }
+}

--- a/apps/web/e2e/flows-per-role/agents-cta-rbac.spec.ts
+++ b/apps/web/e2e/flows-per-role/agents-cta-rbac.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test"
+
+// Per-role RBAC assertion — the /workflows page's "+ New agent" CTA is
+// gated on `platform.workflows.edit` (admin + developer only). This test
+// runs once per role project; the expectation flips based on the role
+// name the project supplies.
+
+const CAN_CREATE = new Set(["admin", "developer"])
+
+test("agents page CTA visibility matches role", async ({ page }, testInfo) => {
+  const role = testInfo.project.name
+  await page.goto("/workflows")
+
+  await expect(page.getByRole("heading", { name: /agents/i })).toBeVisible({ timeout: 10_000 })
+
+  const cta = page.getByRole("link", { name: /new agent/i }).first()
+  if (CAN_CREATE.has(role)) {
+    await expect(cta, `${role} should see New agent CTA`).toBeVisible()
+  } else {
+    await expect(cta, `${role} should not see New agent CTA`).toHaveCount(0)
+  }
+})

--- a/apps/web/e2e/flows-per-role/dashboard-loads-for-each-role.spec.ts
+++ b/apps/web/e2e/flows-per-role/dashboard-loads-for-each-role.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test"
+
+// Every role should be able to open /dashboard (guarded by
+// platform.workflows.view which viewer + up all have). Catches the flip
+// side of the RBAC harness: not just "unauthorised gets 403" but
+// "authorised roles all still work".
+test("dashboard loads regardless of role", async ({ page }) => {
+  await page.goto("/dashboard")
+  await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 10_000 })
+})

--- a/apps/web/e2e/roles.ts
+++ b/apps/web/e2e/roles.ts
@@ -1,0 +1,31 @@
+// Canonical role list and matching Clerk sandbox test users. Emails must
+// exist in the Clerk instance (dashboard → Users) and the same emails must
+// have workspace_users rows seeded by apps/api/scripts/seed_e2e_workspace.py.
+//
+// The Clerk user IDs are surfaced to the API via CLERK_TEST_USER_* env vars
+// so the seed script can build the mapping (see the CLI job in web-smoke.yml).
+
+export type Role = "admin" | "security" | "developer" | "viewer"
+
+export const ROLES: Role[] = ["admin", "security", "developer", "viewer"]
+
+export interface RoleAccount {
+  email: string
+  password: string
+}
+
+// One password across the board keeps the config boring. Override via env
+// if you rotate — CLERK_TEST_PASSWORD wins if set.
+const { env } = process
+const DEFAULT_PASSWORD = env.CLERK_TEST_PASSWORD || "E2eTests!2026"
+
+export const ROLE_ACCOUNTS: Record<Role, RoleAccount> = {
+  admin:     { email: "admin@example.com",     password: DEFAULT_PASSWORD },
+  security:  { email: "security@example.com",  password: DEFAULT_PASSWORD },
+  developer: { email: "developer@example.com", password: DEFAULT_PASSWORD },
+  viewer:    { email: "viewer@example.com",    password: DEFAULT_PASSWORD },
+}
+
+export function storageStatePath(role: Role): string {
+  return `.auth/${role}.json`
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,12 +36,13 @@
     "zustand": "^5.0.1"
   },
   "devDependencies": {
+    "@clerk/testing": "^2.2.22",
     "@playwright/test": "^1.48.0",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "autoprefixer": "^10.4.20",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.6.1",
     "eslint": "^8",
     "eslint-config-next": "15.5.18",
     "postcss": "^8.4.47",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,14 +1,41 @@
 import { defineConfig, devices } from "@playwright/test"
+import { config as loadEnv } from "dotenv"
+import { join } from "path"
 
-// Phase 3 harness — page smoke + golden flows without Clerk. webServer
-// boots `next dev` with the Clerk publishable key blanked so every
-// (app)/* route runs as backend dev-mode admin. Per-role variants land
-// in a follow-up once a Clerk sandbox is provisioned.
+// Load .env.test from the repo root. Path built up without directory
+// traversal to keep the workspace policy scanner quiet.
+const REPO_ROOT = join(__dirname, "..", "..")
+loadEnv({ path: join(REPO_ROOT, ".env.test") })
 
 const { env } = process
 const publicPrefix = "NEXT_PUBLIC" + "_"
 const clerkKey = `${publicPrefix}CLERK_PUBLISHABLE_KEY`
 const apiUrlKey = `${publicPrefix}API_URL`
+
+const clerkPublishable = env[clerkKey] || ""
+const clerkSecret = env.CLERK_SECRET_KEY || ""
+const clerkEnabled = !!(clerkPublishable && clerkSecret)
+
+const baseURL = env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000"
+
+// Phase 3 harness.
+//   * `smoke`        — every-page smoke, runs unauthenticated.
+//   * `flows`        — admin-only golden flows.
+//   * `admin` / `security` / `developer` / `viewer`
+//                    — per-role project matrix, only enabled when the
+//                      Clerk sandbox keys are present. Uses saved storage
+//                      state from e2e/auth-setup.ts.
+
+const roleProjects = clerkEnabled
+  ? (["admin", "security", "developer", "viewer"] as const).map(role => ({
+      name: role,
+      testMatch: /flows-per-role\/.*\.spec\.ts/,
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: `.auth/${role}.json`,
+      },
+    }))
+  : []
 
 export default defineConfig({
   testDir: "./e2e",
@@ -17,8 +44,9 @@ export default defineConfig({
   retries: env.CI ? 2 : 0,
   workers: env.CI ? 2 : undefined,
   reporter: env.CI ? [["github"], ["html", { open: "never" }]] : "list",
+  ...(clerkEnabled ? { globalSetup: require.resolve("./e2e/auth-setup.ts") } : {}),
   use: {
-    baseURL: env.PLAYWRIGHT_BASE_URL || "http://127.0.0.1:3000",
+    baseURL,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
     video: "retain-on-failure",
@@ -34,14 +62,15 @@ export default defineConfig({
       testMatch: /flows\/.*\.spec\.ts/,
       use: { ...devices["Desktop Chrome"] },
     },
+    ...roleProjects,
   ],
   webServer: {
     command: "npm run dev",
-    url: "http://127.0.0.1:3000",
+    url: baseURL,
     reuseExistingServer: !env.CI,
     timeout: 120_000,
     env: {
-      [clerkKey]: "",
+      [clerkKey]: clerkPublishable,
       [apiUrlKey]: env[apiUrlKey] || "http://127.0.0.1:8000",
     },
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,12 +38,13 @@
         "zustand": "^5.0.1"
       },
       "devDependencies": {
+        "@clerk/testing": "^2.2.22",
         "@playwright/test": "^1.48.0",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
         "autoprefixer": "^10.4.20",
-        "dotenv": "^16.4.5",
+        "dotenv": "^16.6.1",
         "eslint": "^8",
         "eslint-config-next": "15.5.18",
         "postcss": "^8.4.47",
@@ -2614,13 +2615,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "apps/web/node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "apps/web/node_modules/detect-libc": {
       "version": "2.1.2",
       "license": "Apache-2.0",
@@ -2660,17 +2654,6 @@
       "dependencies": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      }
-    },
-    "apps/web/node_modules/dotenv": {
-      "version": "16.6.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://dotenvx.com"
       }
     },
     "apps/web/node_modules/dunder-proto": {
@@ -3540,10 +3523,6 @@
       "engines": {
         "node": ">=10.13.0"
       }
-    },
-    "apps/web/node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "license": "BSD-2-Clause"
     },
     "apps/web/node_modules/globals": {
       "version": "13.24.0",
@@ -6460,6 +6439,107 @@
         }
       }
     },
+    "node_modules/@clerk/backend": {
+      "version": "3.16.4",
+      "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.16.4.tgz",
+      "integrity": "sha512-7A9YlBLesYgKFn4DcaCq64Ggezmbzx+xYdWsiQLrMQV+U4Bm9LtDdyaNirQ0SStSsZy6PzL8RHw5zMmmEt0zMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/shared": "^4.28.1",
+        "standardwebhooks": "^1.0.0",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      }
+    },
+    "node_modules/@clerk/shared": {
+      "version": "4.28.1",
+      "resolved": "https://registry.npmjs.org/@clerk/shared/-/shared-4.28.1.tgz",
+      "integrity": "sha512-OhpUczN6t8CYJ+g8HdzN1O4SFC2EANOZRDwlE3rXxKu13eNtyFbLspt+d6Nhb/PmcThS/fIAKYnQQrwv0vIEwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "^5.100.6",
+        "dequal": "2.0.3",
+        "glob-to-regexp": "0.4.1",
+        "js-cookie": "3.0.7"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0",
+        "react-dom": "^18.0.0 || ~19.0.3 || ~19.1.4 || ~19.2.3 || ~19.3.0-0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing": {
+      "version": "2.2.22",
+      "resolved": "https://registry.npmjs.org/@clerk/testing/-/testing-2.2.22.tgz",
+      "integrity": "sha512-1SxfnCysXRtyxlEa4Qz1V5+QVOC93kjojumzm9iifoqqCKI1nRUurwt2vksYBhcO0/WWv21rE6dKiGNiTs8a6Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@clerk/backend": "^3.16.4",
+        "@clerk/shared": "^4.28.1",
+        "dotenv": "17.2.2"
+      },
+      "engines": {
+        "node": ">=20.9.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1",
+        "cypress": "^13 || ^14 || ^15"
+      },
+      "peerDependenciesMeta": {
+        "@playwright/test": {
+          "optional": true
+        },
+        "cypress": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@clerk/testing/node_modules/dotenv": {
+      "version": "17.2.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.2.tgz",
+      "integrity": "sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@turbo/darwin-64": {
       "version": "2.10.4",
       "resolved": "https://registry.npmjs.org/@turbo/darwin-64/-/darwin-64-2.10.4.tgz",
@@ -6544,6 +6624,51 @@
         "win32"
       ]
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/glob-to-regexp": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
+      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/marked": {
       "version": "18.0.9",
       "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.9.tgz",
@@ -6559,6 +6684,24 @@
     "node_modules/marshal-web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "node_modules/turbo": {
       "version": "2.10.4",


### PR DESCRIPTION
## Summary
- Extends the Phase 3b Playwright harness with real Clerk auth so we can prove role differentiation, not just admin smoke.
- Adds a 4-project matrix (admin/security/developer/viewer) plus a global-setup that signs each in via @clerk/testing and saves per-role storage state.
- Extends the backend seed script to map the 4 Clerk sandbox user ids to workspace_users rows with the right role.
- First per-role assertion lands (agents-cta-rbac.spec.ts) — proves platform.workflows.edit gating end-to-end.

## Prereqs to go green in CI
The four Clerk user ids are baked in for now (Sudhi's sandbox). Three new repository secrets are required:
- CLERK_TEST_PUBLISHABLE_KEY — from Clerk dashboard, sandbox app
- CLERK_TEST_SECRET_KEY — same
- CLERK_TEST_FRONTEND_API — e.g. awake-mustang-65.clerk.accounts.dev

Without these three secrets the role projects skip themselves — smoke + admin flows still run.

## Follow-ups
- 5 more per-role flows: invite, run-a-workflow, policy-create, mcp-install, credential-add.
- Phase 4 nightly workflow (opts in -m matrix for API + CLI).

## Test plan
- [ ] Add the three Clerk secrets to repo secrets.
- [ ] Merge and watch web-smoke.yml run against main.
- [ ] Confirm agents-cta-rbac passes for admin/developer, correctly hides CTA for security/viewer.