### PR TITLE
test(e2e): per-role Clerk passwords from env / GH secrets

### DIFF
--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -46,6 +46,12 @@ jobs:
       CLERK_TEST_USER_SECURITY: user_3Hn67p1ETwiglYtpaHMbxeWORvI
       CLERK_TEST_USER_DEVELOPER: user_3Hn6OmfvjbKikrH9kZpGKi71FIU
       CLERK_TEST_USER_VIEWER: user_3Hn6TKhuWBpYG0IOAim5ufTqYpe
+      # Per-role Clerk passwords. Env var names match .env.test — apps/web/e2e/roles.ts
+      # reads process.env[role]. Add these four as GH repository secrets.
+      admin:     ${{ secrets.CLERK_TEST_PASSWORD_ADMIN }}
+      security:  ${{ secrets.CLERK_TEST_PASSWORD_SECURITY }}
+      developer: ${{ secrets.CLERK_TEST_PASSWORD_DEVELOPER }}
+      viewer:    ${{ secrets.CLERK_TEST_PASSWORD_VIEWER }}
     steps:
       - uses: actions/checkout@v4
 

--- a/apps/web/e2e/roles.ts
+++ b/apps/web/e2e/roles.ts
@@ -2,8 +2,9 @@
 // exist in the Clerk instance (dashboard → Users) and the same emails must
 // have workspace_users rows seeded by apps/api/scripts/seed_e2e_workspace.py.
 //
-// The Clerk user IDs are surfaced to the API via CLERK_TEST_USER_* env vars
-// so the seed script can build the mapping (see the CLI job in web-smoke.yml).
+// Passwords are per-role, loaded from env (from .env.test locally, from GH
+// secrets in CI). Env var name is just the role name so it matches the
+// user-visible .env.test format.
 
 export type Role = "admin" | "security" | "developer" | "viewer"
 
@@ -14,16 +15,24 @@ export interface RoleAccount {
   password: string
 }
 
-// One password across the board keeps the config boring. Override via env
-// if you rotate — CLERK_TEST_PASSWORD wins if set.
 const { env } = process
-const DEFAULT_PASSWORD = env.CLERK_TEST_PASSWORD || "E2eTests!2026"
+
+function passwordFor(role: Role): string {
+  const pw = env[role]
+  if (!pw) {
+    throw new Error(
+      `Missing Clerk sandbox password for role '${role}'. Set env var '${role}' ` +
+      `in .env.test (local) or GH secret CLERK_TEST_PASSWORD_${role.toUpperCase()} (CI).`
+    )
+  }
+  return pw
+}
 
 export const ROLE_ACCOUNTS: Record<Role, RoleAccount> = {
-  admin:     { email: "admin@example.com",     password: DEFAULT_PASSWORD },
-  security:  { email: "security@example.com",  password: DEFAULT_PASSWORD },
-  developer: { email: "developer@example.com", password: DEFAULT_PASSWORD },
-  viewer:    { email: "viewer@example.com",    password: DEFAULT_PASSWORD },
+  admin:     { email: "admin@example.com",     password: passwordFor("admin") },
+  security:  { email: "security@example.com",  password: passwordFor("security") },
+  developer: { email: "developer@example.com", password: passwordFor("developer") },
+  viewer:    { email: "viewer@example.com",    password: passwordFor("viewer") },
 }
 
 export function storageStatePath(role: Role): string {


### PR DESCRIPTION
## Summary
Web-smoke was blocked on Clerk sign-in ("Password is incorrect"). The 4 sandbox users have per-role passwords, not a shared one. Load them from env.

- `apps/web/e2e/roles.ts` reads `process.env[role]` for each role.
- `.github/workflows/web-smoke.yml` pipes 4 new GH secrets in.
- Missing password fails fast with a message naming the env var + GH secret.

## Prereqs before this PR is useful
Add these 4 repository secrets (Settings → Secrets and variables → Actions):
- CLERK_TEST_PASSWORD_ADMIN
- CLERK_TEST_PASSWORD_SECURITY
- CLERK_TEST_PASSWORD_DEVELOPER
- CLERK_TEST_PASSWORD_VIEWER

Values match the .env.test entries. Once merged + secrets added, next web-smoke run should sign in successfully.