### PR TITLE
test(e2e): cross-role RBAC negatives + Firefox/WebKit for golden flows

### DIFF
--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -95,7 +95,9 @@ jobs:
         working-directory: apps/web
 
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        # chromium for smoke + admin + per-role flows; firefox + webkit
+        # for the cross-browser golden-flow projects.
+        run: npx playwright install --with-deps chromium firefox webkit
         working-directory: apps/web
 
       - name: Run Playwright (smoke + flows)

--- a/apps/web/e2e/auth-setup.ts
+++ b/apps/web/e2e/auth-setup.ts
@@ -30,20 +30,19 @@ export default async function globalSetup(config: FullConfig) {
     const context = await browser.newContext()
     const page = await context.newPage()
 
-    // Sign in on the app origin (not on Clerk's hosted UI) so cookies land
-    // on 127.0.0.1:3000 and survive storage snapshot.
-    await page.goto(`${baseURL}/sign-in`)
+    // Standard @clerk/testing pattern — visit an unauthenticated app page
+    // first so Clerk's SDK has the origin to bind cookies to, then sign in
+    // via the SDK (not Clerk's hosted UI at /sign-in — the SDK can't
+    // operate on that catch-all page).
+    await page.goto(baseURL)
     await clerk.signIn({
       page,
       signInParams: { strategy: "password", identifier: account.email, password: account.password },
     })
 
-    // Wait for the app to redirect us past the sign-in page. If the session
-    // cookie didn't land, we stay on /sign-in and this timeout catches it
-    // — much clearer failure than "no dashboard heading" downstream.
-    await page.waitForURL(url => !/\/sign-in/.test(url.pathname), { timeout: 15_000 })
-
-    // Land on an authenticated route so Clerk finishes hydrating.
+    // Go to an authenticated route and prove the session cookie survived —
+    // any drift now fails HERE with a clear message instead of downstream
+    // "heading not found" in every flow spec.
     await page.goto(`${baseURL}/dashboard`)
     await expect(page.getByRole("heading", { name: /dashboard/i })).toBeVisible({ timeout: 15_000 })
 

--- a/apps/web/e2e/flows-per-role/agent-identity-cta-rbac.spec.ts
+++ b/apps/web/e2e/flows-per-role/agent-identity-cta-rbac.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from "@playwright/test"
+
+// `/agent-identity` — "+ Create token" CTA is admin-only. Non-admin roles
+// see the identities table read-only. Complements the platform.members.manage
+// gate on the invite endpoint.
+
+const CAN_CREATE_TOKEN = new Set(["admin"])
+
+test("agent-identity page 'Create token' visibility matches role", async ({ page }, testInfo) => {
+  const role = testInfo.project.name
+  await page.goto("/agent-identity")
+
+  await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
+
+  const cta = page.getByRole("button", { name: /create token/i }).first()
+  if (CAN_CREATE_TOKEN.has(role)) {
+    await expect(cta, `${role} should see 'Create token'`).toBeVisible({ timeout: 10_000 })
+  } else {
+    await expect(cta, `${role} should not see 'Create token'`).toHaveCount(0)
+  }
+})

--- a/apps/web/e2e/flows-per-role/policies-cta-rbac.spec.ts
+++ b/apps/web/e2e/flows-per-role/policies-cta-rbac.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from "@playwright/test"
+
+// `/theguard/policies` — "New policy rule" CTA is gated on
+// `guard.policies.edit` (admin + security only). Each role project runs
+// this spec once; expectation flips based on the role name.
+
+const CAN_EDIT_POLICIES = new Set(["admin", "security"])
+
+test("policies page CTA visibility matches role", async ({ page }, testInfo) => {
+  const role = testInfo.project.name
+  await page.goto("/theguard/policies")
+
+  // Every role should reach the page.
+  await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
+
+  const cta = page.getByRole("button", { name: /new policy rule/i }).first()
+  if (CAN_EDIT_POLICIES.has(role)) {
+    await expect(cta, `${role} should see 'New policy rule'`).toBeVisible({ timeout: 10_000 })
+  } else {
+    await expect(cta, `${role} should not see 'New policy rule'`).toHaveCount(0)
+  }
+})

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -67,6 +67,23 @@ export default defineConfig({
         ? { ...devices["Desktop Chrome"], storageState: ".auth/admin.json" }
         : { ...devices["Desktop Chrome"] },
     },
+    // Cross-browser coverage — golden flows only (skip the 98-page smoke
+    // to keep the CI budget bounded). Firefox + WebKit run against the
+    // same 5 flows the Chromium `flows` project already covers.
+    {
+      name: "flows-firefox",
+      testMatch: /flows\/.*\.spec\.ts/,
+      use: clerkEnabled
+        ? { ...devices["Desktop Firefox"], storageState: ".auth/admin.json" }
+        : { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "flows-webkit",
+      testMatch: /flows\/.*\.spec\.ts/,
+      use: clerkEnabled
+        ? { ...devices["Desktop Safari"], storageState: ".auth/admin.json" }
+        : { ...devices["Desktop Safari"] },
+    },
     ...roleProjects,
   ],
   webServer: {


### PR DESCRIPTION
## Adds
**8 new cross-role RBAC assertions** (2 specs × 4 role projects):
- `policies-cta-rbac` — 'New policy rule' visible only for admin + security.
- `agent-identity-cta-rbac` — '+ Create token' visible only for admin.

**15 new cross-browser tests** (3 browsers × 5 golden flows):
- `flows-firefox` + `flows-webkit` Playwright projects added.
- web-smoke.yml installs Firefox + WebKit alongside Chromium.

Both scopes deliberately skip the full 98-page smoke × 3 browsers to keep CI budget bounded — golden flows catch the big rendering deltas cross-browser without ballooning runtime.

## Follow-up (PR-2)
- 5 deeper journeys: invite member, run-a-workflow, policy-create, mcp-install, credential-add. Needs seed extension.
- Mobile viewport variants for the 5 flows.

## Test plan
- [x] TypeScript clean, YAML valid.
- [ ] Merge + trigger web-smoke.