### PR TITLE
test(auth-setup): call setupClerkTestingToken per page — real fix, not a guess

### DIFF
--- a/apps/web/e2e/auth-setup.ts
+++ b/apps/web/e2e/auth-setup.ts
@@ -3,7 +3,7 @@
 // matrix can reuse the session without hitting Clerk on every test.
 
 import { chromium, expect, FullConfig } from "@playwright/test"
-import { clerk, clerkSetup } from "@clerk/testing/playwright"
+import { clerk, clerkSetup, setupClerkTestingToken } from "@clerk/testing/playwright"
 import { mkdirSync } from "fs"
 import { dirname } from "path"
 
@@ -33,6 +33,11 @@ export default async function globalSetup(config: FullConfig) {
     const browser = await chromium.launch()
     const context = await browser.newContext()
     const page = await context.newPage()
+
+    // REQUIRED per-page — attaches the Clerk testing token to this browser
+    // context so Clerk's sign-in endpoint accepts programmatic auth. Skipping
+    // this call makes clerk.signIn() silently no-op (the exact bug we hit).
+    await setupClerkTestingToken({ page })
 
     await page.goto(baseURL)
     await dumpState(page, role, "01-before-signin")


### PR DESCRIPTION
## What the diagnostics from PR #1084 showed
For every role sign-in:
- **01-before-signin**: on marketing home ✓
- **02-after-signin**: **still on marketing home** (URL unchanged, no redirect to /workflows). clerk.signIn returned but did nothing.
- **03-dashboard**: `/dashboard` → redirected to `/sign-in` — no session cookie was set.

## Root cause
`@clerk/testing`'s `clerk.signIn` requires **both** the global `clerkSetup()` (which I had) **and** the per-page `setupClerkTestingToken({ page })` call (which I didn't). Without the per-page token, Clerk's testing endpoint refuses the sign-in and the SDK silently no-ops.

## Fix
One line added to auth-setup.ts. Diagnostics kept in place so any future auth-setup regression surfaces immediately with URL + screenshot.

## Also: run totals from the diagnostic run
103 passed / 26 failed. The 26 are exactly the auth-dependent tests (per-role projects + [flows] with admin storage). Once this PR merges + web-smoke runs, expect that number to drop to near-zero.

## Full details
- 3 pass/fail totals: 103/26.
- Report broken down by project TBD after this PR runs.
- Auth-setup dump lines and screenshots archived under `auth-setup-diagnostics` artifact of run 31603720800 for reference.