### PR TITLE
test(auth-setup): exact-match Continue button (dodge Google OAuth match)

### DIFF
--- a/apps/web/e2e/auth-setup.ts
+++ b/apps/web/e2e/auth-setup.ts
@@ -48,9 +48,11 @@ export default async function globalSetup(config: FullConfig) {
     // Clerk's ClerkJS component uses <input name=identifier> then transitions
     // to <input name=password>. Field labels are stable across versions.
     await page.getByLabel(/email address/i).fill(account.email)
-    await page.getByRole("button", { name: /continue/i }).click()
+    // { exact: true } dodges the "Sign in with Google Continue" OAuth button.
+    await page.getByRole("button", { name: "Continue", exact: true }).click()
     await page.getByLabel(/password/i).fill(account.password)
-    await page.getByRole("button", { name: /continue/i }).click()
+    // { exact: true } dodges the "Sign in with Google Continue" OAuth button.
+    await page.getByRole("button", { name: "Continue", exact: true }).click()
 
     // App should redirect us past /sign-in after successful auth.
     await page.waitForURL(url => !/\/sign-in/.test(url.pathname), { timeout: 20_000 }).catch(() => {})


### PR DESCRIPTION
Form-based sign-in from PR #1086 works — email field filled successfully — but the next click failed with strict-mode violation because /continue/i matched both 'Sign in with Google Continue' and the actual 'Continue' submit. One-line switch to { exact: true }.