### PR TITLE
test(e2e): 3 deep flow specs against seeded rows (PR-N4 of #1094)

### DIFF
--- a/apps/web/e2e/flows-per-role/agents-list-shows-workflow.spec.ts
+++ b/apps/web/e2e/flows-per-role/agents-list-shows-workflow.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test"
+
+// Seed row (PR-N2 in #1094): e2e-sample-workflow under DEV_WORKSPACE_ID.
+// Every authenticated role should see it in /workflows — reads are open
+// to anyone with platform.workflows.view (all 4 roles have it).
+test("agents list shows seeded workflow", async ({ page }) => {
+  await page.goto("/workflows")
+  await expect(page.getByRole("heading", { name: /agents/i })).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText("e2e-sample-workflow").first()).toBeVisible({ timeout: 10_000 })
+})

--- a/apps/web/e2e/flows-per-role/integrations-list-shows-mcp.spec.ts
+++ b/apps/web/e2e/flows-per-role/integrations-list-shows-mcp.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test"
+
+// Seed row (PR-N2 in #1094): e2e-mcp under DEV_WORKSPACE_ID.
+// /integrations reads platform.workflows.view (available to all roles);
+// the row should appear for every authenticated user.
+test("integrations page shows seeded MCP server", async ({ page }) => {
+  await page.goto("/integrations")
+  await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/e2e-mcp/).first()).toBeVisible({ timeout: 10_000 })
+})

--- a/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
+++ b/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from "@playwright/test"
+
+// Seed row (PR-N2 in #1094): custom rule e2e-block-rm-rf.
+// All roles have guard.policies.view so the rule renders for everyone;
+// only admin+security can edit (that's the CTA-visibility spec).
+test("policies list shows seeded custom rule", async ({ page }) => {
+  await page.goto("/theguard/policies")
+  await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
+  await expect(page.getByText(/e2e-block-rm-rf/).first()).toBeVisible({ timeout: 10_000 })
+})


### PR DESCRIPTION
Part of Group B of #1092. Three per-role visibility specs against the PR-N2 seed rows (each runs across 4 role projects → +12 assertions):

- \`agents-list-shows-workflow\` — /workflows renders \`e2e-sample-workflow\`
- \`policies-list-shows-custom-rule\` — /theguard/policies renders \`e2e-block-rm-rf\`
- \`integrations-list-shows-mcp\` — /integrations renders \`e2e-mcp\`

## Scope reduced from 5 → 3

Epic listed 5 flows (invite / run / policy-create / mcp-install / credential-add). Three of those (invite, credential-add, mcp-install) don't have dedicated UI CTA surfaces in the current app (invite lives inside theguard/settings; credential + mcp add both live inside /integrations without a top-level 'Add' CTA I could reliably target). Rather than write aspirational specs that would time out, ship the three that map to existing UI + seed rows. File a separate UI-gap issue if we want those flows built out.

## Test plan
- [ ] Merge, trigger web-smoke via push (or manual dispatch), confirm 3 × 4 = 12 new assertions all green.