### PR TITLE
test(e2e): Group F — a11y + visual regression + mobile viewports (#1098)

### DIFF
--- a/apps/web/e2e/flows/a11y.spec.ts
+++ b/apps/web/e2e/flows/a11y.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from "@playwright/test"
+import AxeBuilder from "@axe-core/playwright"
+
+// Accessibility baseline — runs axe against a handful of representative
+// pages (marketing + app). Baseline-mode: any WCAG A/AA violation logs
+// and fails. Tune / allow-list once we see the first real report.
+
+const PAGES = [
+  "/",
+  "/dashboard",
+  "/workflows",
+  "/theguard/policies",
+]
+
+for (const path of PAGES) {
+  test(`a11y clean on ${path}`, async ({ page }) => {
+    await page.goto(path)
+    await page.waitForLoadState("domcontentloaded")
+    // Cast: @axe-core/playwright pins a slightly older Playwright Page
+    // type than we have installed; the API is identical at runtime.
+    const results = await new AxeBuilder({ page: page as any })
+      .withTags(["wcag2a", "wcag2aa"])
+      .analyze()
+    expect(
+      results.violations,
+      `Accessibility violations on ${path}:\n${JSON.stringify(results.violations, null, 2)}`,
+    ).toEqual([])
+  })
+}

--- a/apps/web/e2e/flows/visual-regression.spec.ts
+++ b/apps/web/e2e/flows/visual-regression.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from "@playwright/test"
+
+// Visual regression — one screenshot per representative page. First run
+// creates the baseline; subsequent runs diff against it. Reviewer
+// approves an intentional visual diff by updating the snapshot.
+
+const PAGES = [
+  { path: "/", name: "home" },
+  { path: "/dashboard", name: "dashboard" },
+  { path: "/workflows", name: "workflows" },
+  { path: "/theguard/policies", name: "policies" },
+]
+
+for (const { path, name } of PAGES) {
+  test(`visual snapshot ${name}`, async ({ page }) => {
+    await page.goto(path)
+    await page.waitForLoadState("domcontentloaded")
+    // Give animations a beat to settle.
+    await page.waitForTimeout(500)
+    await expect(page).toHaveScreenshot(`${name}.png`, {
+      fullPage: true,
+      // 0.5% pixel-diff tolerance — pixel-perfect is too flaky in CI.
+      maxDiffPixelRatio: 0.005,
+    })
+  })
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -36,6 +36,7 @@
     "zustand": "^5.0.1"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.13.0",
     "@clerk/testing": "^2.2.22",
     "@playwright/test": "^1.48.0",
     "@types/node": "^20",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -90,6 +90,18 @@ export default defineConfig({
     //     ? { ...devices["Desktop Safari"], storageState: ".auth/admin.json" }
     //     : { ...devices["Desktop Safari"] },
     // },
+    // Mobile viewport smoke — pages.smoke on iPhone + Pixel. Kept scope
+    // tight (smoke only, not flows) so runtime stays bounded.
+    {
+      name: "smoke-mobile-iphone",
+      testMatch: /pages\.smoke\.spec\.ts/,
+      use: { ...devices["iPhone 14"] },
+    },
+    {
+      name: "smoke-mobile-pixel",
+      testMatch: /pages\.smoke\.spec\.ts/,
+      use: { ...devices["Pixel 7"] },
+    },
     ...roleProjects,
   ],
   webServer: {


### PR DESCRIPTION
Group F of #1092. All three sub-scopes in one PR since they share no files with C/D/G.

## What's in
- `a11y.spec.ts` — @axe-core/playwright, 4 representative pages (marketing home + dashboard + workflows + policies), WCAG 2 A/AA
- `visual-regression.spec.ts` — Playwright toHaveScreenshot on same 4 pages; 0.5% pixel-diff tolerance
- `playwright.config.ts` — smoke-mobile-iphone + smoke-mobile-pixel projects

## Expected first-run behaviour
- **a11y** likely finds real violations (colour contrast, missing labels, etc.). Report will drive allow-listing.
- **Visual regression** creates baselines. First run passes; subsequent runs diff.
- **Mobile smoke** either green (marketing works on mobile) or reveals real layout issues.

## Test plan
- [ ] Merge, trigger web-smoke, capture first a11y report + baseline screenshots.
- [ ] Triage a11y violations into fixable vs allow-listable.