### PR TITLE
test(runtime): Group C — LLM test stub (PR-N5 slice of #1095)

### DIFF
--- a/apps/api/tests/llm_test_stub.py
+++ b/apps/api/tests/llm_test_stub.py
@@ -1,0 +1,85 @@
+"""Deterministic LLM stub — Group C of epic #1092.
+
+Import + call `install_llm_stub()` from any test that hits brain_block
+or the LLM client directly. Returns canned responses with realistic
+token accounting so downstream analytics/audit paths exercise fully.
+
+Rationale: real LLM calls in CI need an ANTHROPIC_API_KEY, cost money,
+and are non-deterministic. The stub gives us a fully-covered execution
+path without any of those.
+
+Usage:
+    from tests.llm_test_stub import install_llm_stub
+
+    def test_something():
+        with install_llm_stub() as calls:
+            ... # code that eventually calls AnthropicClient(...).create(...)
+        assert len(calls) == 1
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Iterator
+from unittest.mock import patch
+
+from app.runtime.llm_client import LLMResponse, LLMTextBlock, LLMUsage
+
+
+DEFAULT_TEXT = "Stubbed LLM response — test mode."
+
+
+def _canned_response(text: str = DEFAULT_TEXT) -> LLMResponse:
+    return LLMResponse(
+        content=[LLMTextBlock(type="text", text=text)],
+        stop_reason="end_turn",
+        usage=LLMUsage(input_tokens=42, output_tokens=17),
+        cost_usd=0.001,
+        _raw_content=[{"type": "text", "text": text}],
+    )
+
+
+class _StubClient:
+    """Drop-in stand-in for AnthropicClient / OpenAIClient / PerplexityClient.
+
+    Records every create() call so tests can assert on prompt shape,
+    tool selections, etc. Returns the canned response.
+    """
+
+    def __init__(self, calls: list, response_text: str = DEFAULT_TEXT, **_ignored):
+        self.calls = calls
+        self._response_text = response_text
+
+    def create(self, **kwargs):
+        self.calls.append(kwargs)
+        return _canned_response(self._response_text)
+
+    def make_assistant_turn(self, response: LLMResponse) -> list[dict]:
+        return [{"role": "assistant", "content": response.content}]
+
+
+@contextmanager
+def install_llm_stub(response_text: str = DEFAULT_TEXT) -> Iterator[list[dict]]:
+    """Context manager that swaps every concrete LLM client with the stub.
+    Yields a list that fills with every create() call's kwargs."""
+    calls: list[dict] = []
+
+    def _factory(**kwargs):
+        return _StubClient(calls, response_text=response_text, **kwargs)
+
+    targets = [
+        "app.runtime.adapters.anthropic.AnthropicClient",
+        "app.runtime.adapters.openai.OpenAIClient",
+        "app.runtime.adapters.perplexity.PerplexityClient",
+        # brain_block imports these by short name — patch there too.
+        "app.runtime.blocks.brain_block.AnthropicClient",
+        "app.runtime.blocks.brain_block.OpenAIClient",
+        "app.runtime.blocks.brain_block.PerplexityClient",
+    ]
+    patchers = [patch(t, _factory) for t in targets]
+    for p in patchers:
+        p.start()
+    try:
+        yield calls
+    finally:
+        for p in patchers:
+            p.stop()

--- a/apps/api/tests/test_llm_stub.py
+++ b/apps/api/tests/test_llm_stub.py
@@ -1,0 +1,33 @@
+"""Pin the LLM test stub's shape so downstream callers can rely on it."""
+from __future__ import annotations
+
+from tests.llm_test_stub import install_llm_stub
+
+
+def test_stub_returns_canned_response():
+    with install_llm_stub("hello from stub") as calls:
+        # Import inside the with-block so the patched symbol is resolved.
+        from app.runtime.adapters.anthropic import AnthropicClient
+
+        client = AnthropicClient(api_key="not-used")
+        resp = client.create(messages=[{"role": "user", "content": "ignored"}])
+
+    assert resp.content[0].text == "hello from stub"
+    assert resp.stop_reason == "end_turn"
+    assert resp.usage.input_tokens == 42
+    assert resp.usage.output_tokens == 17
+    assert resp.cost_usd == 0.001
+    assert len(calls) == 1
+    assert calls[0]["messages"][0]["content"] == "ignored"
+
+
+def test_stub_swaps_all_three_providers():
+    with install_llm_stub() as calls:
+        from app.runtime.adapters.anthropic import AnthropicClient
+        from app.runtime.adapters.openai import OpenAIClient
+        from app.runtime.adapters.perplexity import PerplexityClient
+
+        for cls in (AnthropicClient, OpenAIClient, PerplexityClient):
+            cls(api_key="x").create(messages=[{"role": "user", "content": "hi"}])
+
+    assert len(calls) == 3


### PR DESCRIPTION
Group C of #1092.

Ships **tests/llm_test_stub.py** — a `install_llm_stub()` context manager that swaps AnthropicClient / OpenAIClient / PerplexityClient with a deterministic stub. Every `create()` call is recorded so tests can assert on prompt shape / tool selections without paying for real LLM tokens or needing an API key.

Response = canned LLMResponse with realistic token accounting so downstream analytics/audit paths exercise fully.

Comes with **test_llm_stub.py** pinning the stub's shape.

## Not in this PR
- **PR-N6 SSE end-to-end run flow** — deferred to a follow-up now that the stub is available for it to build on. This ensures Group C ships incrementally rather than one 300-line PR.