### PR TITLE
test(e2e): pin workspace cookie in Group B flow specs

### DIFF
--- a/apps/web/e2e/flows-per-role/agents-list-shows-workflow.spec.ts
+++ b/apps/web/e2e/flows-per-role/agents-list-shows-workflow.spec.ts
@@ -1,9 +1,19 @@
 import { test, expect } from "@playwright/test"
 
 // Seed row (PR-N2 in #1094): e2e-sample-workflow under DEV_WORKSPACE_ID.
-// Every authenticated role should see it in /workflows — reads are open
-// to anyone with platform.workflows.view (all 4 roles have it).
-test("agents list shows seeded workflow", async ({ page }) => {
+// Every authenticated role should see it in /workflows.
+//
+// Clerk sandbox users may have been auto-added to an "Engineering"
+// workspace on first sign-in (list_projects auto-creates when none
+// exist). WorkspaceContext picks `data[0]` (newest) so activeWorkspace
+// can land on the auto-created workspace instead of DEV. Pin the cookie
+// to DEV before navigating so X-Workspace-ID matches the seed target.
+const DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+
+test("agents list shows seeded workflow", async ({ page, context }) => {
+  await context.addCookies([
+    { name: "delegator_project_id", value: DEV_WORKSPACE_ID, url: "http://localhost:3000" },
+  ])
   await page.goto("/workflows")
   await expect(page.getByRole("heading", { name: /agents/i })).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText("e2e-sample-workflow").first()).toBeVisible({ timeout: 10_000 })

--- a/apps/web/e2e/flows-per-role/integrations-list-shows-mcp.spec.ts
+++ b/apps/web/e2e/flows-per-role/integrations-list-shows-mcp.spec.ts
@@ -1,9 +1,13 @@
 import { test, expect } from "@playwright/test"
 
 // Seed row (PR-N2 in #1094): e2e-mcp under DEV_WORKSPACE_ID.
-// /integrations reads platform.workflows.view (available to all roles);
-// the row should appear for every authenticated user.
-test("integrations page shows seeded MCP server", async ({ page }) => {
+// Pin the workspace cookie to DEV — see agents-list spec for rationale.
+const DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+
+test("integrations page shows seeded MCP server", async ({ page, context }) => {
+  await context.addCookies([
+    { name: "delegator_project_id", value: DEV_WORKSPACE_ID, url: "http://localhost:3000" },
+  ])
   await page.goto("/integrations")
   await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText(/e2e-mcp/).first()).toBeVisible({ timeout: 10_000 })

--- a/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
+++ b/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
@@ -1,9 +1,14 @@
 import { test, expect } from "@playwright/test"
 
 // Seed row (PR-N2 in #1094): custom rule e2e-block-rm-rf.
-// All roles have guard.policies.view so the rule renders for everyone;
-// only admin+security can edit (that's the CTA-visibility spec).
-test("policies list shows seeded custom rule", async ({ page }) => {
+// Pin the workspace cookie to DEV_WORKSPACE_ID — see agents-list spec
+// for the rationale.
+const DEV_WORKSPACE_ID = "00000000-0000-0000-0000-000000000001"
+
+test("policies list shows seeded custom rule", async ({ page, context }) => {
+  await context.addCookies([
+    { name: "delegator_project_id", value: DEV_WORKSPACE_ID, url: "http://localhost:3000" },
+  ])
   await page.goto("/theguard/policies")
   await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
   await expect(page.getByText(/e2e-block-rm-rf/).first()).toBeVisible({ timeout: 10_000 })


### PR DESCRIPTION
Group B web-smoke run 31665768712 failed 12/12 (3 new specs × 4 role projects). Root cause: Clerk sandbox users can hit list_projects' auto-create fallback, ending up in an 'Engineering' workspace. WorkspaceContext then picks data[0] (newest) and X-Workspace-ID diverges from DEV_WORKSPACE_ID where the seed rows live.

Fix: pre-set the delegator_project_id cookie to DEV_WORKSPACE_ID before goto in all 3 specs so activeWorkspace pins correctly.