### PR TITLE
test(ci): commit root package-lock.json with @axe-core + dotenv

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root.
+          cache-dependency-path: package-lock.json
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
       - name: Migrate DB
@@ -160,8 +161,8 @@ jobs:
           curl -sf 127.0.0.1:8000/health
         working-directory: apps/api
       - name: Install web deps
+        # apps/web is an npm workspace — install at repo root.
         run: npm ci
-        working-directory: apps/web
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox
         working-directory: apps/web

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root (apps/web is an npm workspace).
+          cache-dependency-path: package-lock.json
 
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
@@ -91,8 +92,9 @@ jobs:
         working-directory: apps/api
 
       - name: Install web deps
+        # Install at repo root — apps/web is declared as an npm workspace,
+        # so the lock file lives here, not in apps/web/.
         run: npm ci
-        working-directory: apps/web
 
       - name: Install Playwright browsers
         # chromium for smoke + admin + per-role flows; firefox + webkit

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "zustand": "^5.0.1"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.13.0",
         "@clerk/testing": "^2.2.22",
         "@playwright/test": "^1.48.0",
         "@types/node": "^20",
@@ -2033,14 +2034,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "apps/web/node_modules/axe-core": {
-      "version": "4.11.4",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
       }
     },
     "apps/web/node_modules/axobject-query": {
@@ -6439,6 +6432,19 @@
         }
       }
     },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.13.0.tgz",
+      "integrity": "sha512-6YLx+kxXu5GJceG4ozFg+33a2EMTdjYwWGloJ3sb9Kta5pp+ZNS53uxGVog5JetIY8s++P5UrtX+cri+u0VAVg==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.13.0"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
     "node_modules/@clerk/backend": {
       "version": "3.16.4",
       "resolved": "https://registry.npmjs.org/@clerk/backend/-/backend-3.16.4.tgz",
@@ -6624,6 +6630,16 @@
         "win32"
       ]
     },
+    "node_modules/axe-core": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
+      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -6684,6 +6700,20 @@
     "node_modules/marshal-web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/standardwebhooks": {
       "version": "1.0.0",


### PR DESCRIPTION
Root lock file needed regenerating after Group F added @axe-core/playwright + dotenv. Local dev picked it up; CI's npm ci didn't have the entries so web-smoke failed at install.