### PR TITLE
test(ci): bump web-smoke timeout 25 → 45 min after Group F expansion

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,7 +101,8 @@ jobs:
     # (dependency updates, upstream Clerk changes, etc).
     if: ${{ github.event.inputs.only == '' || github.event.inputs.only == 'all' || github.event.inputs.only == 'web-smoke' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 45 min: matches web-smoke.yml — Group F expanded runtime past 25.
+    timeout-minutes: 45
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root.
+          cache-dependency-path: package-lock.json
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
       - name: Migrate DB
@@ -160,8 +161,8 @@ jobs:
           curl -sf 127.0.0.1:8000/health
         working-directory: apps/api
       - name: Install web deps
+        # apps/web is an npm workspace — install at repo root.
         run: npm ci
-        working-directory: apps/web
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox
         working-directory: apps/web

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -17,7 +17,9 @@ on:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    # 45 min: Group F added a11y sweeps + visual regression + 2 mobile
+    # viewport projects (98 pages × 2). Old 25-min cap was blown ~25:19.
+    timeout-minutes: 45
     services:
       postgres:
         image: pgvector/pgvector:pg16

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root (apps/web is an npm workspace).
+          cache-dependency-path: package-lock.json
 
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
@@ -91,8 +92,9 @@ jobs:
         working-directory: apps/api
 
       - name: Install web deps
+        # Install at repo root — apps/web is declared as an npm workspace,
+        # so the lock file lives here, not in apps/web/.
         run: npm ci
-        working-directory: apps/web
 
       - name: Install Playwright browsers
         # chromium for smoke + admin + per-role flows; firefox + webkit


### PR DESCRIPTION
Runtime blew past 25 min once Group F added: axe a11y × 4 pages, visual-regression screenshots × 4 pages (baseline creation is slow), 2 mobile-viewport smoke projects (98 pages × 2). Last 3 web-smoke lanes cancelled at 25:19 by the timeout — jobs were still progressing, not hung. Bumping web-smoke.yml + nightly.yml's web-smoke job to 45 min.