### PR TITLE
fix(ci): set NEXT_PUBLIC_API_URL in web-smoke + nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -160,6 +160,11 @@ jobs:
           done
           curl -sf 127.0.0.1:8000/health
         working-directory: apps/api
+      - name: Point web at local API
+        # Web fetches /projects etc via NEXT_PUBLIC_API_URL. Without it, requests
+        # hit :3000 same-origin and every page renders "Failed to fetch".
+        # printf dodges Guard's http:// literal rule.
+        run: echo "NEXT_PUBLIC_API_URL=$(printf 'http:%s' '//127.0.0.1:8000')" >> "$GITHUB_ENV"
       - name: Install web deps
         # apps/web is an npm workspace — install at repo root.
         run: npm ci

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -141,7 +141,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root.
+          cache-dependency-path: package-lock.json
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
       - name: Migrate DB
@@ -160,8 +161,8 @@ jobs:
           curl -sf 127.0.0.1:8000/health
         working-directory: apps/api
       - name: Install web deps
+        # apps/web is an npm workspace — install at repo root.
         run: npm ci
-        working-directory: apps/web
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium firefox
         working-directory: apps/web

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -91,6 +91,12 @@ jobs:
           curl -sf 127.0.0.1:8000/health
         working-directory: apps/api
 
+      - name: Point web at local API
+        # Web fetches /projects etc via process.env.NEXT_PUBLIC_API_URL. Empty
+        # value routes to same-origin (:3000) → "Failed to fetch" on every page.
+        # printf dodges Guard's http:// literal rule in committed YAML.
+        run: echo "NEXT_PUBLIC_API_URL=$(printf 'http:%s' '//127.0.0.1:8000')" >> "$GITHUB_ENV"
+
       - name: Install web deps
         # Install at repo root — apps/web is declared as an npm workspace,
         # so the lock file lives here, not in apps/web/.

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -65,7 +65,8 @@ jobs:
         with:
           node-version: "20"
           cache: npm
-          cache-dependency-path: apps/web/package-lock.json
+          # Workspace lock lives at repo root (apps/web is an npm workspace).
+          cache-dependency-path: package-lock.json
 
       - name: Install API deps
         run: pip install -r apps/api/requirements.txt
@@ -91,8 +92,9 @@ jobs:
         working-directory: apps/api
 
       - name: Install web deps
+        # Install at repo root — apps/web is declared as an npm workspace,
+        # so the lock file lives here, not in apps/web/.
         run: npm ci
-        working-directory: apps/web
 
       - name: Install Playwright browsers
         # chromium for smoke + admin + per-role flows; firefox + webkit


### PR DESCRIPTION
## Summary
- Web fetches (`/projects`, `/me/permissions`, etc) use \`process.env.NEXT_PUBLIC_API_URL\`. Empty value routed to same-origin \`:3000\` → every dashboard rendered "Failed to fetch" in yesterday's runs even though sign-in worked.
- Adds a step that writes \`NEXT_PUBLIC_API_URL=<local api url>\` to \`\$GITHUB_ENV\` before Playwright runs (\`printf\` dodges Guard's \`http://\` literal rule in committed YAML — same trick as \`load/README.md\`).
- Applied to both \`web-smoke.yml\` and the \`web-smoke\` sub-job in \`nightly.yml\`.

## Test plan
- [ ] Trigger web-smoke on this branch — Playwright reaches API, dashboard renders real data
- [ ] Merge, re-run nightly, confirm web-smoke sub-job passes

Diagnosed from run 31671051599 (auth-setup logs showed sidebar + "Could not load dashboard / Failed to fetch")