### PR TITLE
fix(cli): guard commands exit non-zero when not connected

### DIFF
--- a/packages/conduct-cli/src/conduct_cli/guard.py
+++ b/packages/conduct-cli/src/conduct_cli/guard.py
@@ -353,10 +353,10 @@ def _require_guard_config() -> dict:
     ws = cfg.get("workspace_id") or cfg.get("workspace")
     if not cfg or not ws:
         print(f"{RED}Guard not connected. Run: conduct login{RESET}", file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
     if not cfg.get("agent_token"):
         print(f"{RED}Guard config is missing credentials. Run: conduct login{RESET}", file=sys.stderr)
-        sys.exit(0)
+        sys.exit(1)
     return cfg
 
 


### PR DESCRIPTION
## Summary
\`_require_guard_config()\` printed "Guard not connected" / "missing credentials" to stderr, then \`sys.exit(0)\` — silent success from a script's point of view. Change both to \`sys.exit(1)\`.

Callers this affects: \`sync\`, \`verify\` (top-level shims), plus every \`guard <cmd>\` that requires auth (sync, verify, discover, join, session, etc). Any script wrapping these no longer gets false-positive success on unauth.

## Test plan
- [ ] Local unauth'd \`conduct guard sync\` → exits 1, message unchanged
- [ ] Local unauth'd \`conduct sync\` → exits 1
- [ ] cli-matrix nightly lane goes green (paired with #1119)