### PR TITLE
test(a11y): baseline color-contrast as known UX debt

### DIFF
--- a/apps/web/e2e/flows/a11y.spec.ts
+++ b/apps/web/e2e/flows/a11y.spec.ts
@@ -2,8 +2,11 @@ import { test, expect } from "@playwright/test"
 import AxeBuilder from "@axe-core/playwright"
 
 // Accessibility baseline — runs axe against a handful of representative
-// pages (marketing + app). Baseline-mode: any WCAG A/AA violation logs
-// and fails. Tune / allow-list once we see the first real report.
+// pages (marketing + app). Known UX debt is allow-listed as a set of rule
+// IDs; anything outside that set fails the run.
+//
+// Remove entries from KNOWN_UX_DEBT as UX ships fixes. Do NOT add without
+// filing a follow-up issue and citing it here.
 
 const PAGES = [
   "/",
@@ -11,6 +14,14 @@ const PAGES = [
   "/workflows",
   "/theguard/policies",
 ]
+
+// Rule IDs graded as known UX debt (tracked separately, not gating here).
+// color-contrast: --text-muted (#a8a29e) hits 2.3–2.5:1 on the sidebar
+// section headings, ⌘K kbd, and status pills. Global palette change —
+// bundle with the next UX pass rather than piecemeal.
+const KNOWN_UX_DEBT = new Set<string>([
+  "color-contrast",
+])
 
 for (const path of PAGES) {
   test(`a11y clean on ${path}`, async ({ page }) => {
@@ -21,9 +32,10 @@ for (const path of PAGES) {
     const results = await new AxeBuilder({ page: page as any })
       .withTags(["wcag2a", "wcag2aa"])
       .analyze()
+    const gating = results.violations.filter((v) => !KNOWN_UX_DEBT.has(v.id))
     expect(
-      results.violations,
-      `Accessibility violations on ${path}:\n${JSON.stringify(results.violations, null, 2)}`,
+      gating,
+      `New accessibility violations on ${path} (outside KNOWN_UX_DEBT):\n${JSON.stringify(gating, null, 2)}`,
     ).toEqual([])
   })
 }


### PR DESCRIPTION
## Summary
Group F's \`a11y.spec.ts\` asserted zero violations — wrong bar for a first-run baseline. Every muted-text element (\`--text-muted\` \`#a8a29e\` on light bg) hits 2.3–2.5:1 contrast, well below WCAG AA 4.5:1. Fixing means a global palette change, not per-selector tweaks.

Cut: allow-list \`color-contrast\` as \`KNOWN_UX_DEBT\`, hard-fail on every other axe rule. New a11y regressions (aria, alt, structure) still block CI. When UX ships the palette fix, remove the entry.

## Not fixed here
- \`color-contrast\` on sidebar section headings, ⌘K kbd, "0 active" pill — needs \`--text-muted\` + \`--ok\` palette bump
- Recurring "Only plain objects can be passed to Client Components" — Clerk-Next 15 SDK issue, separate track
- \`headers()\` sync warnings — Clerk SDK, not our code

## Test plan
- [ ] web-smoke run on this branch: a11y specs pass, other Playwright specs unchanged
- [ ] Merge, verify nightly web-smoke lane clears