### PR TITLE
fix(a11y): label dropdown + view toggles, exclude iframes

### DIFF
--- a/apps/web/e2e/flows/a11y.spec.ts
+++ b/apps/web/e2e/flows/a11y.spec.ts
@@ -31,6 +31,9 @@ for (const path of PAGES) {
     // type than we have installed; the API is identical at runtime.
     const results = await new AxeBuilder({ page: page as any })
       .withTags(["wcag2a", "wcag2aa"])
+      // Exclude embedded iframes (YouTube on /). axe recurses into iframe
+      // content, and we can't fix upstream markup.
+      .exclude("iframe")
       .analyze()
     const gating = results.violations.filter((v) => !KNOWN_UX_DEBT.has(v.id))
     expect(

--- a/apps/web/src/app/(app)/workflows/page.tsx
+++ b/apps/web/src/app/(app)/workflows/page.tsx
@@ -322,6 +322,7 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
             value={sort}
             onChange={e => setSort(e.target.value)}
             className="btn btn-ghost"
+            aria-label="Sort agents"
             style={{ height: 36, fontWeight: 600 }}
           >
             <option value="recent">Sort: Recently edited</option>
@@ -333,6 +334,8 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
               <button
                 key={v}
                 onClick={() => setView(v)}
+                aria-label={v === "list" ? "List view" : "Grid view"}
+                aria-pressed={view === v}
                 style={{ border: "none", background: view === v ? "var(--surface)" : "transparent", borderRadius: 6, padding: "5px 9px", cursor: "pointer", color: view === v ? "var(--text)" : "var(--text-3)", boxShadow: view === v ? "var(--shadow-sm)" : "none" }}
               >
                 {v === "list" ? (


### PR DESCRIPTION
## Summary
Group F web-smoke surfaced 43 unique (rule, target) a11y failures. They collapse to 3 real issues + 1 external:

1. Sort dropdown on /workflows had no accessible name → `aria-label="Sort agents"`
2. List/Grid view toggle buttons on /workflows were icon-only → `aria-label` + `aria-pressed`
3. YouTube embed on / recursed and produced ~30 cascaded aria failures against Google's markup → `.exclude('iframe')` in axe config

Remaining `color-contrast` is still in KNOWN_UX_DEBT pending the palette pass.

## Test plan
- [ ] Local: /workflows renders unchanged, buttons/dropdown have accessible names
- [ ] web-smoke re-run: a11y specs drop from ~10 rule IDs → 0