### PR TITLE
fix(guard): conduct-base v2.11.1 reorder new secret rules + loosen GCP pattern

### DIFF
--- a/apps/api/app/modules/guard/skill_packs/conduct-base.json
+++ b/apps/api/app/modules/guard/skill_packs/conduct-base.json
@@ -1,7 +1,7 @@
 {
   "slug": "conduct-base",
   "name": "Conduct Base",
-  "version": "2.11.0",
+  "version": "2.11.1",
   "tier": "free",
   "description": "Core AI governance rules \u2014 proxy interception, agent safety, surface-aware enforcement, workflow governance, and MCP server tool call auditing. 5 proxy + 14 agent + 7 surface + 4 workflow + 2 MCP rules.",
   "rules": [
@@ -481,6 +481,171 @@
       "severity": "critical",
       "frameworks": [
         "PCI_DSS:3.5"
+      ],
+      "tag": "security_policy",
+      "enforcement": {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "conditional",
+        "mcp": "conditional",
+        "runtime": "conditional",
+        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
+        "requires": [
+          "A supported pre-tool hook is installed, synced, and invoked before the action",
+          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
+          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
+        ],
+        "known_limitations": [
+          "Hook enforcement depends on the AI tool emitting supported structured hook events",
+          "MCP cannot enforce actions the agent does not submit to guard_check",
+          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
+        ]
+      }
+    },
+    {
+      "id": "secret-anthropic",
+      "persona": "agent",
+      "non_overridable": false,
+      "description": "Block Anthropic API keys written to files",
+      "match_tool": "filesystem-write,workflow",
+      "match_pattern": "sk-ant-[a-zA-Z0-9\\-]{20,}",
+      "action": "block",
+      "message": "Anthropic API key detected in file. Blocked \u2014 use ANTHROPIC_API_KEY env var.",
+      "severity": "critical",
+      "frameworks": [
+        "SOC2:CC6.1"
+      ],
+      "tag": "security_policy",
+      "enforcement": {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "conditional",
+        "mcp": "conditional",
+        "runtime": "conditional",
+        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
+        "requires": [
+          "A supported pre-tool hook is installed, synced, and invoked before the action",
+          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
+          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
+        ],
+        "known_limitations": [
+          "Hook enforcement depends on the AI tool emitting supported structured hook events",
+          "MCP cannot enforce actions the agent does not submit to guard_check",
+          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
+        ]
+      }
+    },
+    {
+      "id": "secret-openai-modern",
+      "persona": "agent",
+      "non_overridable": false,
+      "description": "Block modern OpenAI project keys (sk-proj-*)",
+      "match_tool": "filesystem-write,workflow",
+      "match_pattern": "sk-proj-[A-Za-z0-9_\\-]{20,}",
+      "action": "block",
+      "message": "OpenAI project key detected in file. Blocked \u2014 use OPENAI_API_KEY env var.",
+      "severity": "critical",
+      "frameworks": [
+        "SOC2:CC6.1"
+      ],
+      "tag": "security_policy",
+      "enforcement": {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "conditional",
+        "mcp": "conditional",
+        "runtime": "conditional",
+        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
+        "requires": [
+          "A supported pre-tool hook is installed, synced, and invoked before the action",
+          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
+          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
+        ],
+        "known_limitations": [
+          "Hook enforcement depends on the AI tool emitting supported structured hook events",
+          "MCP cannot enforce actions the agent does not submit to guard_check",
+          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
+        ]
+      }
+    },
+    {
+      "id": "secret-postgres-url",
+      "persona": "agent",
+      "non_overridable": false,
+      "description": "Block PostgreSQL connection strings with credentials written to files",
+      "match_tool": "filesystem-write,workflow",
+      "match_pattern": "postgres(?:ql)?://[^:]+:[^@\\s]+@\\S+",
+      "action": "block",
+      "message": "PostgreSQL connection string with credentials detected in file. Blocked \u2014 use DATABASE_URL env var.",
+      "severity": "high",
+      "frameworks": [
+        "SOC2:CC6.1"
+      ],
+      "tag": "security_policy",
+      "enforcement": {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "conditional",
+        "mcp": "conditional",
+        "runtime": "conditional",
+        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
+        "requires": [
+          "A supported pre-tool hook is installed, synced, and invoked before the action",
+          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
+          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
+        ],
+        "known_limitations": [
+          "Hook enforcement depends on the AI tool emitting supported structured hook events",
+          "MCP cannot enforce actions the agent does not submit to guard_check",
+          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
+        ]
+      }
+    },
+    {
+      "id": "secret-mysql-url",
+      "persona": "agent",
+      "non_overridable": false,
+      "description": "Block MySQL connection strings with credentials written to files",
+      "match_tool": "filesystem-write,workflow",
+      "match_pattern": "mysql://[^:]+:[^@\\s]+@\\S+",
+      "action": "block",
+      "message": "MySQL connection string with credentials detected in file. Blocked \u2014 use DATABASE_URL env var.",
+      "severity": "high",
+      "frameworks": [
+        "SOC2:CC6.1"
+      ],
+      "tag": "security_policy",
+      "enforcement": {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "conditional",
+        "mcp": "conditional",
+        "runtime": "conditional",
+        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
+        "requires": [
+          "A supported pre-tool hook is installed, synced, and invoked before the action",
+          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
+          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
+        ],
+        "known_limitations": [
+          "Hook enforcement depends on the AI tool emitting supported structured hook events",
+          "MCP cannot enforce actions the agent does not submit to guard_check",
+          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
+        ]
+      }
+    },
+    {
+      "id": "secret-gcp-service-account",
+      "persona": "agent",
+      "non_overridable": false,
+      "description": "Block Google Cloud service account JSON keys written to files",
+      "match_tool": "filesystem-write,workflow",
+      "match_pattern": "private_key_id[^a-z0-9]+[a-f0-9]{40}",
+      "action": "block",
+      "message": "GCP service account key detected in file. Blocked \u2014 use workload identity or short-lived tokens.",
+      "severity": "critical",
+      "frameworks": [
+        "SOC2:CC6.1"
       ],
       "tag": "security_policy",
       "enforcement": {
@@ -1200,171 +1365,6 @@
         ],
         "known_limitations": [
           "Only request text exposed to the proxy matcher is inspected"
-        ]
-      }
-    },
-    {
-      "id": "secret-anthropic",
-      "persona": "agent",
-      "non_overridable": false,
-      "description": "Block Anthropic API keys written to files",
-      "match_tool": "filesystem-write,workflow",
-      "match_pattern": "sk-ant-[a-zA-Z0-9\\-]{20,}",
-      "action": "block",
-      "message": "Anthropic API key detected in file. Blocked \u2014 use ANTHROPIC_API_KEY env var.",
-      "severity": "critical",
-      "frameworks": [
-        "SOC2:CC6.1"
-      ],
-      "tag": "security_policy",
-      "enforcement": {
-        "version": 1,
-        "proxy": "not_supported",
-        "hook": "conditional",
-        "mcp": "conditional",
-        "runtime": "conditional",
-        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
-        "requires": [
-          "A supported pre-tool hook is installed, synced, and invoked before the action",
-          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
-          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
-        ],
-        "known_limitations": [
-          "Hook enforcement depends on the AI tool emitting supported structured hook events",
-          "MCP cannot enforce actions the agent does not submit to guard_check",
-          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
-        ]
-      }
-    },
-    {
-      "id": "secret-openai-modern",
-      "persona": "agent",
-      "non_overridable": false,
-      "description": "Block modern OpenAI project keys (sk-proj-*)",
-      "match_tool": "filesystem-write,workflow",
-      "match_pattern": "sk-proj-[A-Za-z0-9_\\-]{20,}",
-      "action": "block",
-      "message": "OpenAI project key detected in file. Blocked \u2014 use OPENAI_API_KEY env var.",
-      "severity": "critical",
-      "frameworks": [
-        "SOC2:CC6.1"
-      ],
-      "tag": "security_policy",
-      "enforcement": {
-        "version": 1,
-        "proxy": "not_supported",
-        "hook": "conditional",
-        "mcp": "conditional",
-        "runtime": "conditional",
-        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
-        "requires": [
-          "A supported pre-tool hook is installed, synced, and invoked before the action",
-          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
-          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
-        ],
-        "known_limitations": [
-          "Hook enforcement depends on the AI tool emitting supported structured hook events",
-          "MCP cannot enforce actions the agent does not submit to guard_check",
-          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
-        ]
-      }
-    },
-    {
-      "id": "secret-postgres-url",
-      "persona": "agent",
-      "non_overridable": false,
-      "description": "Block PostgreSQL connection strings with credentials written to files",
-      "match_tool": "filesystem-write,workflow",
-      "match_pattern": "postgres(?:ql)?://[^:]+:[^@\\s]+@\\S+",
-      "action": "block",
-      "message": "PostgreSQL connection string with credentials detected in file. Blocked \u2014 use DATABASE_URL env var.",
-      "severity": "high",
-      "frameworks": [
-        "SOC2:CC6.1"
-      ],
-      "tag": "security_policy",
-      "enforcement": {
-        "version": 1,
-        "proxy": "not_supported",
-        "hook": "conditional",
-        "mcp": "conditional",
-        "runtime": "conditional",
-        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
-        "requires": [
-          "A supported pre-tool hook is installed, synced, and invoked before the action",
-          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
-          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
-        ],
-        "known_limitations": [
-          "Hook enforcement depends on the AI tool emitting supported structured hook events",
-          "MCP cannot enforce actions the agent does not submit to guard_check",
-          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
-        ]
-      }
-    },
-    {
-      "id": "secret-mysql-url",
-      "persona": "agent",
-      "non_overridable": false,
-      "description": "Block MySQL connection strings with credentials written to files",
-      "match_tool": "filesystem-write,workflow",
-      "match_pattern": "mysql://[^:]+:[^@\\s]+@\\S+",
-      "action": "block",
-      "message": "MySQL connection string with credentials detected in file. Blocked \u2014 use DATABASE_URL env var.",
-      "severity": "high",
-      "frameworks": [
-        "SOC2:CC6.1"
-      ],
-      "tag": "security_policy",
-      "enforcement": {
-        "version": 1,
-        "proxy": "not_supported",
-        "hook": "conditional",
-        "mcp": "conditional",
-        "runtime": "conditional",
-        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
-        "requires": [
-          "A supported pre-tool hook is installed, synced, and invoked before the action",
-          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
-          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
-        ],
-        "known_limitations": [
-          "Hook enforcement depends on the AI tool emitting supported structured hook events",
-          "MCP cannot enforce actions the agent does not submit to guard_check",
-          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
-        ]
-      }
-    },
-    {
-      "id": "secret-gcp-service-account",
-      "persona": "agent",
-      "non_overridable": false,
-      "description": "Block Google Cloud service account JSON keys written to files",
-      "match_tool": "filesystem-write,workflow",
-      "match_pattern": "\"private_key_id\"\\s*:\\s*\"[a-f0-9]{40}\"",
-      "action": "block",
-      "message": "GCP service account key detected in file. Blocked \u2014 use workload identity or short-lived tokens.",
-      "severity": "critical",
-      "frameworks": [
-        "SOC2:CC6.1"
-      ],
-      "tag": "security_policy",
-      "enforcement": {
-        "version": 1,
-        "proxy": "not_supported",
-        "hook": "conditional",
-        "mcp": "conditional",
-        "runtime": "conditional",
-        "guarantee": "Blocks the matching action only on surfaces marked hard or conditional when their listed dependencies are satisfied.",
-        "requires": [
-          "A supported pre-tool hook is installed, synced, and invoked before the action",
-          "The agent invokes MCP guard_check with accurate tool_name and tool_input before acting",
-          "Conduct workflow runtime Guard is enabled and matching content is present in workflow state"
-        ],
-        "known_limitations": [
-          "Hook enforcement depends on the AI tool emitting supported structured hook events",
-          "MCP cannot enforce actions the agent does not submit to guard_check",
-          "Runtime evaluates serialized workflow state, not every external tool or model interaction"
         ]
       }
     }

--- a/apps/api/tests/test_conduct_base_fs_credentials.py
+++ b/apps/api/tests/test_conduct_base_fs_credentials.py
@@ -49,10 +49,26 @@ def rules_by_id():
 
 def test_pack_version_bumped(rules_by_id):
     data = json.loads(PACK_PATH.read_text())
-    assert data["version"] == "2.11.0", (
-        f"Expected pack version 2.11.0, got {data['version']}. "
+    assert data["version"] == "2.11.1", (
+        f"Expected pack version 2.11.1, got {data['version']}. "
         "Bump when adding rules so `conduct guard sync` picks up changes."
     )
+
+
+def test_new_secret_rules_ordered_before_audit_catchall(rules_by_id):
+    """secret-* rules must come before surface-dev-audit-prod-write (which
+    matches all filesystem-write). _check_policy returns first match, so new
+    block rules never fire if they land after the audit catch-all."""
+    data = json.loads(PACK_PATH.read_text())
+    order = {r["id"]: i for i, r in enumerate(data["rules"])}
+    audit_idx = order["surface-dev-audit-prod-write"]
+    for rid in ("secret-anthropic", "secret-openai-modern",
+                "secret-postgres-url", "secret-mysql-url",
+                "secret-gcp-service-account"):
+        assert order[rid] < audit_idx, (
+            f"Rule {rid} at index {order[rid]} must come before "
+            f"surface-dev-audit-prod-write at {audit_idx}"
+        )
 
 
 @pytest.mark.parametrize(
@@ -89,7 +105,7 @@ def test_credential_rule_is_block(rule_id, target_action, rules_by_id):
         ("secret-openai-modern",    f"key = '{_OPENAI_MOD}'",        "sk-proj-x"),
         ("secret-postgres-url",     "url = 'postgres://user:pass@host:5432/db'", "postgres://host/db"),
         ("secret-mysql-url",        "url = 'mysql://root:secret@127.0.0.1/db'", "mysql://host/db"),
-        ("secret-gcp-service-account", "config = {" + _GCP_JSON + "}", '"private_key_id": "short"'),
+        ("secret-gcp-service-account", "config = {" + _GCP_JSON + "}", "private_key_id: short-not-40-chars"),
     ],
 )
 def test_credential_rule_matches_target(rule_id, hit_text, miss_text, rules_by_id):


### PR DESCRIPTION
## Summary
Live spin of #1130's v2.11.0 rules surfaced two real behavioral issues. Both fixed in v2.11.1.

## Bug 1 — new rules never fired
\`secret-anthropic\`, \`secret-openai-modern\`, \`secret-postgres-url\`, \`secret-mysql-url\`, \`secret-gcp-service-account\` were appended at the end of the pack.

\`surface-dev-audit-prod-write\` (\`match_tool: filesystem-write\`, action=audit) sits at index 24 and matches EVERY filesystem write. \`_check_policy\` returns on first match, so:

- Write with Stripe key → matched \`secret-stripe\` (index 15) → block ✓
- Write with Anthropic key → matched \`surface-dev-audit-prod-write\` (24) BEFORE \`secret-anthropic\` (40) → audit, not block ✗

Fix: moved the 5 new rules to indexes 16-20 (right after \`secret-stripe\`, before the audit catch-all).

Added ordering assertion test to prevent regression.

## Bug 2 — GCP regex missed real service account JSON
Pattern was `"private_key_id"\s*:\s*"[a-f0-9]{40}"` — required literal quotes. But nested JSON serialization escapes them as `\"`, so live inputs looked like `\"private_key_id\": \"...\"`.

Fix: `private_key_id[^a-z0-9]+[a-f0-9]{40}` — quote-agnostic separator.

## Spin evidence (before/after)
\`\`\`
Before v2.11.1:              After v2.11.1:
Stripe live   → block ✓      Stripe live   → block ✓
AWS access    → block ✓      AWS access    → block ✓
Anthropic API → block ✓      Anthropic API → block ✓
OpenAI proj   → audit ✗      OpenAI proj   → block ✓
Postgres URL  → block ✓      Postgres URL  → block ✓
MySQL URL     → block ✓      MySQL URL     → block ✓
GCP svc acct  → audit ✗      GCP svc acct  → block ✓
\`\`\`

## Test plan
- [x] 16/16 tests pass locally
- [ ] Merge, run \`conduct guard sync\` on a client, write a GCP service account JSON, confirm block

Follows #1130.