### PR TITLE
feat(guard): conduct-soc2 v1.2.0 pack matrix coverage + real-logger detection fix

### DIFF
--- a/apps/api/app/modules/guard/skill_packs/conduct-soc2.json
+++ b/apps/api/app/modules/guard/skill_packs/conduct-soc2.json
@@ -1,7 +1,7 @@
 {
   "slug": "conduct-soc2",
   "name": "Conduct SOC 2",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "tier": "paid",
   "description": "SOC 2 compliance rules",
   "rules": [
@@ -11,7 +11,7 @@
       "match_tool": "edit,write",
       "match_pattern": "(password|secret|api_key)\\s*=\\s*['\"][^'\"]{8,}",
       "action": "block",
-      "message": "Hardcoded credential — use environment variables or a secrets manager.",
+      "message": "Hardcoded credential \u2014 use environment variables or a secrets manager.",
       "persona_affinity": [
         "agent"
       ],
@@ -46,9 +46,9 @@
       "id": "soc2_log_pii",
       "description": "Warn on PII logged to console (SOC2 CC7.2)",
       "match_tool": "edit,write",
-      "match_pattern": "(console\\.log|print|logger)\\(.*email",
+      "match_pattern": "(console\\.\\w+|print|logger[\\w.]*)\\s*\\(.*email",
       "action": "warn",
-      "message": "Possible PII in logs — scrub before production.",
+      "message": "Possible PII in logs \u2014 scrub before production.",
       "persona_affinity": [
         "agent"
       ],
@@ -122,7 +122,7 @@
       "match_tool": "write",
       "match_pattern": "open\\(['\"].*secret.*['\"],\\s*['\"]w",
       "action": "warn",
-      "message": "Writing sensitive data unencrypted — use a secrets manager.",
+      "message": "Writing sensitive data unencrypted \u2014 use a secrets manager.",
       "persona_affinity": [
         "agent"
       ],

--- a/apps/api/tests/fixtures/guard_packs/conduct-soc2.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-soc2.yaml
@@ -1,0 +1,101 @@
+# Conduct SOC 2 pack — per-rule E2E validation.
+#
+# All SOC 2 rules are hook-scoped (match_tool: edit,write). Each case
+# supplies tool_name + tool_input and asserts the named rule fires
+# with the expected action.
+
+pack: conduct-soc2
+source: apps/api/app/modules/guard/skill_packs/conduct-soc2.json
+
+cases:
+  # ── soc2_hardcoded_secret (block) — CC6.1 ───────────────────────────────
+  - rule_id: soc2_hardcoded_secret
+    scenario: password hardcoded blocks write
+    tool_name: write
+    tool_input:
+      file_path: config.py
+      content: "password = '<<CRED:GENERIC_SECRET>>'"
+    expected: block
+
+  - rule_id: soc2_hardcoded_secret
+    scenario: api_key hardcoded blocks write
+    tool_name: write
+    tool_input:
+      file_path: config.py
+      content: "api_key = '<<CRED:GENERIC_SECRET>>'"
+    expected: block
+
+  - rule_id: soc2_hardcoded_secret
+    scenario: secret hardcoded blocks write
+    tool_name: write
+    tool_input:
+      file_path: config.py
+      content: "secret = '<<CRED:GENERIC_SECRET>>'"
+    expected: block
+
+  - rule_id: soc2_hardcoded_secret
+    scenario: env-var reference is allowed
+    tool_name: write
+    tool_input:
+      file_path: config.py
+      content: "password = os.environ['DB_PASSWORD']"
+    expected: allow
+
+  # ── soc2_log_pii (warn) — CC6.7 ─────────────────────────────────────────
+  - rule_id: soc2_log_pii
+    scenario: console.log email warns
+    tool_name: write
+    tool_input:
+      file_path: app.js
+      content: "console.log('User email:', user.email)"
+    expected: warn
+
+  - rule_id: soc2_log_pii
+    scenario: print with email warns
+    tool_name: write
+    tool_input:
+      file_path: app.py
+      content: "print('Sending to', customer.email)"
+    expected: warn
+
+  - rule_id: soc2_log_pii
+    scenario: logger email warns
+    tool_name: write
+    tool_input:
+      file_path: app.py
+      content: "logger.info('email delivered to', target.email)"
+    expected: warn
+
+  # ── soc2_debug_mode (warn) — CC6.6 + CC8.1 ──────────────────────────────
+  - rule_id: soc2_debug_mode
+    scenario: DEBUG True in code warns
+    tool_name: write
+    tool_input:
+      file_path: settings.py
+      content: "DEBUG = True"
+    expected: warn
+
+  - rule_id: soc2_debug_mode
+    scenario: DEBUG False is allowed
+    tool_name: write
+    tool_input:
+      file_path: settings.py
+      content: "DEBUG = False"
+    expected: allow
+
+  # ── soc2_unencrypted_storage (warn) — CC6.1 ─────────────────────────────
+  - rule_id: soc2_unencrypted_storage
+    scenario: opening a secret file for write warns
+    tool_name: write
+    tool_input:
+      file_path: dump.py
+      content: "open('secret.txt', 'w').write(data)"
+    expected: warn
+
+  - rule_id: soc2_unencrypted_storage
+    scenario: opening a non-secret file for write is allowed
+    tool_name: write
+    tool_input:
+      file_path: dump.py
+      content: "open('output.log', 'w').write(data)"
+    expected: allow

--- a/apps/api/tests/test_guard_pack_matrix.py
+++ b/apps/api/tests/test_guard_pack_matrix.py
@@ -2,19 +2,20 @@
 
 For each YAML fixture under ``tests/fixtures/guard_packs/``:
   1. Load the pack JSON that the fixture points at.
-  2. For each case, evaluate the pack's rules against the case's prompt_text
-     using the same ``_rule_matches`` function the live proxy uses.
-  3. Assert the highest-severity matching rule's ID and action equal the
-     fixture's expected values.
+  2. For each case, evaluate the pack's rules against the case's input.
+  3. Assert the expected rule fires with the expected action.
 
-Framework v1 scope: pack rule-firing correctness. Full HTTP-through-proxy
-E2E (with Portkey mock + audit-log assert) is a v2 add — see #1127.
+Two case shapes:
+  * proxy case — has ``prompt_text``. Uses live proxy's ``_rule_matches``.
+  * hook case — has ``tool_name`` + ``tool_input``. Uses hook-style regex
+    match against serialised tool_input, filtering by ``match_tool``.
 
 Marker: ``pack_matrix``. Opt-in via ``pytest -m pack_matrix``.
 """
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -50,6 +51,10 @@ _CRED_STUBS = {
     "SLACK_BOT":     _h("786f78622d",       "T", 20),
     # xoxp- = 786f78702d
     "SLACK_USER":    _h("786f78702d",       "T", 20),
+    # Generic 12+ char secret-shaped string for password= / api_key= / secret= tests.
+    # Assembled at load time so YAML on disk never contains a literal
+    # secret-shaped string that trips generic-secret scanners.
+    "GENERIC_SECRET": _h("54455354", "X", 16),   # TEST + XXXXXXXXXXXXXXXX
 }
 
 
@@ -79,10 +84,57 @@ def _matching_rules(rules: list[dict], prompt_text: str, provider: str, model: s
     return matches
 
 
+# ── Hook-side matcher — mirrors packages/conduct-cli/src/conduct_cli/guard.py
+# ``_check_policy`` semantics: filter rules by match_tool, then regex against
+# JSON-serialised tool_input. Kept local so this test doesn't import the CLI
+# package (which isn't on the API test path).
+_TOOL_EXPAND = {
+    "filesystem-write": {"write", "edit", "write_file", "edit_file", "str_replace_editor"},
+    "filesystem-read":  {"read", "read_file"},
+    "shell":            {"bash"},
+    "workflow":         {"workflow"},
+    "network":          {"webfetch", "websearch"},
+}
+
+
+def _expand_tools(match_tool_str: str) -> set[str]:
+    tools = set()
+    for raw in (t.strip().lower() for t in match_tool_str.split(",")):
+        tools.update(_TOOL_EXPAND.get(raw, {raw}))
+    return tools
+
+
+def _matching_hook_rules(rules: list[dict], tool_name: str, tool_input: dict) -> list[dict]:
+    """Return every hook-eligible rule that fires for this tool call.
+
+    Mirrors CLI ``_check_policy`` semantics: rule matches when its
+    ``match_tool`` (expanded via tool_groups) contains ``tool_name`` AND
+    its ``match_pattern`` matches ``json.dumps(tool_input)``.
+    """
+    input_text = json.dumps(tool_input)
+    tool_lc = tool_name.lower()
+    matches: list[dict] = []
+    for rule in rules:
+        match_tool = (rule.get("match_tool") or "*").lower()
+        if match_tool != "*":
+            if tool_lc not in _expand_tools(match_tool):
+                continue
+        pat = rule.get("match_pattern")
+        if pat:
+            try:
+                if not re.search(pat, input_text, re.IGNORECASE):
+                    continue
+            except re.error:
+                continue
+        matches.append(rule)
+    return matches
+
+
 def _load_cases() -> list[tuple]:
     """Flatten every fixture into (pack_name, pack_rules, case) tuples.
 
-    Expands <<CRED:*>> stubs in prompt_text so YAML on disk never contains
+    Expands <<CRED:*>> stubs in both prompt_text (proxy cases) and
+    tool_input.content (hook cases) so YAML on disk never contains
     real-looking secret patterns (which trip GitGuardian / other scanners).
     """
     cases: list[tuple] = []
@@ -91,7 +143,14 @@ def _load_cases() -> list[tuple]:
         pack_name = data["pack"]
         rules = _load_pack(pack_name)
         for case in data["cases"]:
-            case["prompt_text"] = _expand_stubs(case["prompt_text"])
+            if "prompt_text" in case:
+                case["prompt_text"] = _expand_stubs(case["prompt_text"])
+            if "tool_input" in case:
+                ti = case["tool_input"]
+                if isinstance(ti.get("content"), str):
+                    ti["content"] = _expand_stubs(ti["content"])
+                if isinstance(ti.get("command"), str):
+                    ti["command"] = _expand_stubs(ti["command"])
             cases.append((pack_name, rules, case))
     return cases
 
@@ -107,33 +166,36 @@ def _case_id(case_tuple) -> str:
 @pytest.mark.parametrize("case_tuple", _load_cases(), ids=_case_id)
 def test_guard_pack_rule(case_tuple):
     pack_name, rules, case = case_tuple
-    provider = case.get("provider", "anthropic")
-    model = case.get("model", "claude-3-5-sonnet-20241022")
-    prompt_text = case["prompt_text"]
     expected = case["expected"]
 
-    matches = _matching_rules(rules, prompt_text, provider, model)
+    # Route to hook matcher if the case describes a tool call, else proxy.
+    if "tool_input" in case:
+        tool_name = case.get("tool_name", "write")
+        tool_input = case["tool_input"]
+        matches = _matching_hook_rules(rules, tool_name, tool_input)
+        input_repr = f"{tool_name} {json.dumps(tool_input)[:120]}"
+    else:
+        provider = case.get("provider", "anthropic")
+        model = case.get("model", "claude-3-5-sonnet-20241022")
+        prompt_text = case["prompt_text"]
+        matches = _matching_rules(rules, prompt_text, provider, model)
+        input_repr = f"prompt: {prompt_text!r}"
 
     if expected == "allow":
         assert not matches, (
             f"{pack_name}/{case['rule_id']}: expected no match, but "
-            f"{[m['id'] for m in matches]} fired. Prompt: {prompt_text!r}"
+            f"{[m['id'] for m in matches]} fired. Input: {input_repr}"
         )
         return
 
-    # The expected rule must be among those that fired. Multiple rules may
-    # match the same input (e.g. a GitHub PAT matches both no-gh-pat-in-code
-    # AND proxy-no-credential-leak); the fixture pins which rule we care
-    # about, but tolerates overlap from other rules of the same or higher
-    # severity.
     matched_ids = [m["id"] for m in matches]
     assert case["rule_id"] in matched_ids, (
         f"{pack_name}/{case['rule_id']}: expected this rule to fire. "
-        f"Rules that fired: {matched_ids}. Prompt: {prompt_text!r}"
+        f"Rules that fired: {matched_ids}. Input: {input_repr}"
     )
     target = next(m for m in matches if m["id"] == case["rule_id"])
     actual_action = target.get("action", "").lower()
     assert actual_action == expected, (
         f"{pack_name}/{case['rule_id']}: expected action={expected}, "
-        f"got action={actual_action}. Prompt: {prompt_text!r}"
+        f"got action={actual_action}. Input: {input_repr}"
     )


### PR DESCRIPTION
## Summary
Adds SOC 2 pack coverage to the pack matrix framework. Extends the framework to test hook-scoped rules alongside proxy-scoped ones.

**35/35 pack matrix cases now pass** (24 conduct-base + 11 SOC 2).

## Framework extension
Previous framework only tested proxy-eligible rules (no `match_tool`). SOC 2 rules all have `match_tool: edit,write` — hook-scoped. Extended with a `_matching_hook_rules` matcher that mirrors CLI `_check_policy` semantics: filter by `match_tool` (with tool_groups expansion), then regex against `json.dumps(tool_input)`.

New fixture case shape (auto-routed by presence of `tool_input`):
```yaml
- rule_id: soc2_hardcoded_secret
  tool_name: write
  tool_input:
    file_path: config.py
    content: "password = 'hunter2secret'"
  expected: block
```

## SOC 2 fixture — 11 cases
| Rule | Framework | Cases |
|---|---|---|
| `soc2_hardcoded_secret` | CC6.1 | password/api_key/secret + env-var allow-case |
| `soc2_log_pii` | CC6.7 | console.log/print/logger.info with email |
| `soc2_debug_mode` | CC6.6, CC8.1 | DEBUG=True flag + DEBUG=False allow |
| `soc2_unencrypted_storage` | CC6.1 | open('secret.*', 'w') flag + benign file allow |

## Real bug fixed
`soc2_log_pii` regex was `(console\.log|print|logger)\(.*email` — required bare `logger(...)`. Real code always uses `logger.info()`, `logger.warn()`, etc. Pattern was useless in practice.

Fixed to `(console\.\w+|print|logger[\w.]*)\s*\(.*email` — catches all logger methods and any console method.

Pack version 1.1.0 → 1.2.0.

## Test plan
- [x] 35/35 pack matrix cases pass locally
- [x] Live spin: 9 real-world SOC 2 scenarios behave correctly (blocks/warns/allows as expected)
- [ ] Merge → nightly api-matrix picks up new cases automatically