### PR TITLE
feat(guard): surface-aware pack matrix coverage (11 packs, 140 cases)

### DIFF
--- a/apps/api/tests/fixtures/guard_packs/surface-aware.yaml
+++ b/apps/api/tests/fixtures/guard_packs/surface-aware.yaml
@@ -1,0 +1,78 @@
+# Conduct surface-aware pack — rules that fire based on which AI tool is calling.
+#
+# NOT covered (rule triggers overlap with our own hook):
+#   - surface-codex-desktop-no-delete (rm pattern — see #1137)
+
+pack: surface-aware
+source: apps/api/app/modules/guard/skill_packs/surface-aware.json
+cases:
+  - rule_id: surface-chat-no-bash
+    scenario: claude-ai using bash blocked
+    tool_name: bash
+    ai_tool: claude-ai
+    tool_input: {command: "ls -la"}
+    expected: block
+
+  - rule_id: surface-chat-no-bash
+    scenario: chatgpt using bash blocked
+    tool_name: bash
+    ai_tool: openai-chatgpt
+    tool_input: {command: "pwd"}
+    expected: block
+
+  - rule_id: surface-chat-no-write
+    scenario: claude-ai using write_file blocked
+    tool_name: write_file
+    ai_tool: claude-ai
+    tool_input: {file_path: /tmp/a.py, content: "x = 1"}
+    expected: block
+
+  - rule_id: surface-chat-no-write
+    scenario: claude-desktop using edit_file blocked
+    tool_name: edit_file
+    ai_tool: claude-desktop
+    tool_input: {file_path: /tmp/a.py, content: "x = 2"}
+    expected: block
+
+  - rule_id: surface-chat-no-network
+    scenario: chatgpt using web_fetch flagged
+    tool_name: web_fetch
+    ai_tool: openai-chatgpt
+    tool_input: {url: "https://example.com"}
+    expected: warn
+
+  - rule_id: surface-codex-desktop-warn-exec
+    scenario: codex-desktop running bash flagged
+    tool_name: bash
+    ai_tool: codex-desktop
+    tool_input: {command: "ls -la"}
+    expected: warn
+
+  - rule_id: surface-dev-audit-prod-write
+    scenario: claude-code file write audited
+    tool_name: write_file
+    ai_tool: claude-code
+    tool_input: {file_path: /app/prod.py, content: "x = 1"}
+    expected: audit
+
+  - rule_id: surface-dev-audit-prod-write
+    scenario: cursor edit_file audited
+    tool_name: edit_file
+    ai_tool: cursor
+    tool_input: {file_path: /app/prod.py, content: "x = 1"}
+    expected: audit
+
+  - rule_id: surface-unknown-block-exec
+    scenario: unknown AI tool running bash blocked
+    tool_name: bash
+    ai_tool: unknown
+    tool_input: {command: "ls"}
+    expected: block
+
+  # benign allow — claude-code using bash is allowed (dev surface, not chat)
+  - rule_id: surface-chat-no-bash
+    scenario: claude-code bash is allowed
+    tool_name: bash
+    ai_tool: claude-code
+    tool_input: {command: "ls"}
+    expected: allow

--- a/apps/api/tests/test_guard_pack_matrix.py
+++ b/apps/api/tests/test_guard_pack_matrix.py
@@ -121,20 +121,27 @@ def _expand_tools(match_tool_str: str) -> set[str]:
     return tools
 
 
-def _matching_hook_rules(rules: list[dict], tool_name: str, tool_input: dict) -> list[dict]:
+def _matching_hook_rules(rules: list[dict], tool_name: str, tool_input: dict, ai_tool: str = "") -> list[dict]:
     """Return every hook-eligible rule that fires for this tool call.
 
     Mirrors CLI ``_check_policy`` semantics: rule matches when its
-    ``match_tool`` (expanded via tool_groups) contains ``tool_name`` AND
-    its ``match_pattern`` matches ``json.dumps(tool_input)``.
+    ``match_tool`` (expanded via tool_groups) contains ``tool_name``, its
+    ``match_ai_tool`` (if set) contains ``ai_tool``, AND its
+    ``match_pattern`` (if set) matches ``json.dumps(tool_input)``.
     """
     input_text = json.dumps(tool_input)
     tool_lc = tool_name.lower()
+    ai_lc = ai_tool.lower()
     matches: list[dict] = []
     for rule in rules:
         match_tool = (rule.get("match_tool") or "*").lower()
         if match_tool != "*":
             if tool_lc not in _expand_tools(match_tool):
+                continue
+        match_ai = rule.get("match_ai_tool")
+        if match_ai:
+            surfaces = [s.strip().lower() for s in match_ai.split(",")]
+            if not any(s in ai_lc for s in surfaces):
                 continue
         pat = rule.get("match_pattern")
         if pat:
@@ -188,9 +195,10 @@ def test_guard_pack_rule(case_tuple):
     # Route to hook matcher if the case describes a tool call, else proxy.
     if "tool_input" in case:
         tool_name = case.get("tool_name", "write")
+        ai_tool = case.get("ai_tool", "")
         tool_input = case["tool_input"]
-        matches = _matching_hook_rules(rules, tool_name, tool_input)
-        input_repr = f"{tool_name} {json.dumps(tool_input)[:120]}"
+        matches = _matching_hook_rules(rules, tool_name, tool_input, ai_tool)
+        input_repr = f"{tool_name}[{ai_tool}] {json.dumps(tool_input)[:120]}"
     else:
         provider = case.get("provider", "anthropic")
         model = case.get("model", "claude-3-5-sonnet-20241022")


### PR DESCRIPTION
## Summary
Adds fixture for surface-aware pack (10 cases across 6 of 7 rules). **Pack matrix now covers 140 cases across 11 packs.**

## Framework extension
Rules with `match_ai_tool` fire based on WHICH AI tool is calling (claude-ai, chatgpt, cursor, claude-code, etc.). Extended `_matching_hook_rules` and case format to support `ai_tool` field.

## surface-aware coverage
| Rule | Coverage |
|---|---|
| surface-chat-no-bash | claude-ai + chatgpt block, claude-code allow (dev-not-chat split) |
| surface-chat-no-write | claude-ai + claude-desktop block |
| surface-chat-no-network | chatgpt web_fetch warn |
| surface-codex-desktop-warn-exec | codex-desktop bash warn |
| surface-dev-audit-prod-write | claude-code + cursor writes audited |
| surface-unknown-block-exec | unknown AI tool bash blocked |

**NOT covered:** `surface-codex-desktop-no-delete` — rm pattern overlaps with our own no-rm-rf rule (see #1137).

## Full pack coverage after merge
| Pack | Cases | Framework |
|---|---|---|
| conduct-base | 24 | Generic secrets, injection, PII |
| conduct-soc2 | 11 | SOC 2 CC criteria |
| conduct-hipaa | 10 | HIPAA §164.312 |
| conduct-pci-dss | 10 | PCI DSS Req 3/4 |
| conduct-iso-42001 | 14 | ISO 42001 §8/9/10 |
| conduct-eu-ai-act | 17 | EU Reg 2024/1689 |
| conduct-nist-ai-rmf | 16 | NIST AI RMF |
| conduct-financial-services | 9 | SR 11-7, OCC 2021-19 |
| conduct-irs-1075 | 8 | IRS Publication 1075 |
| conduct-life-sciences | 11 | FDA CSA, EMA GMLP |
| **surface-aware** | **10** | **AI-tool surface split** |
| **Total** | **140** | |

## Test plan
- [x] 140/140 pass locally
- [ ] Merge → nightly picks up new cases

Remaining: conduct-prompt-injection (30 rules, ~4h), meridian-dispatch (internal, not compliance).