### PR TITLE
chore(security): add .gitleaks.toml with Conduct token patterns

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,43 @@
+# gitleaks config: default rules + Conduct-specific token prefixes.
+# ponytail: extend default, don't reinvent. Upgrade path = add rules as new prefixes ship.
+
+[extend]
+useDefault = true
+
+[[rules]]
+id = "conduct-agent-token"
+description = "Conduct agent token (cond_agt_*)"
+regex = '''cond_agt_[A-Za-z0-9_-]{16,}'''
+tags = ["conduct", "token", "secret"]
+
+[[rules]]
+id = "conduct-run-token"
+description = "Conduct run token (cond_run_*)"
+regex = '''cond_run_[A-Za-z0-9_-]{16,}'''
+tags = ["conduct", "token", "secret"]
+
+[[rules]]
+id = "conduct-credential-token"
+description = "Conduct credential broker token (cond_cred_*)"
+regex = '''cond_cred_[A-Za-z0-9_-]{16,}'''
+tags = ["conduct", "token", "secret"]
+
+[[rules]]
+id = "conduct-live-token"
+description = "Conduct live workspace token (cond_live_*)"
+regex = '''cond_live_[A-Za-z0-9_-]{16,}'''
+tags = ["conduct", "token", "secret"]
+
+[[rules]]
+id = "conduct-workspace-token"
+description = "Conduct workspace/member token (cond_ws_* / cond_wsk_*)"
+regex = '''cond_(ws|wsk)_[A-Za-z0-9_-]{16,}'''
+tags = ["conduct", "token", "secret"]
+
+[allowlist]
+description = "Fixture, test, example, and doc paths only. Real code must never contain live tokens."
+paths = [
+  '''(.*?)(_test\.py|test_.*\.py|\.example|\.example\..*|fixtures?/)''',
+  '''docs/.*\.(md|mdx)$''',
+  '''README.*\.md$''',
+]


### PR DESCRIPTION
## Summary

Adds a `.gitleaks.toml` at repo root so any local gitleaks run — pre-commit hook, ad-hoc scan, or CI job — catches Conduct-specific token shapes before they land in git history.

Extends gitleaks default rules with:

| Pattern | Purpose |
|---|---|
| `cond_agt_*` | agent tokens |
| `cond_run_*` | per-run tokens |
| `cond_cred_*` | credential broker tokens |
| `cond_live_*` | live workspace tokens |
| `cond_(ws\|wsk)_*` | workspace + member tokens |

Allowlist is **path-scoped only** — fixture folders, `_test.py` / `test_*.py`, `.example` files, `docs/*.md`, `README*.md`. Real code has zero tolerance for token-shaped strings.

## Context

Companion to server-side controls already enabled on this repo:
- GitHub secret scanning ✓
- Push protection ✓
- Dependabot security updates ✓

Server-side protects the team by blocking pushes. This config gives an equivalent local signal via the pre-commit hook (installed at `.git/hooks/pre-commit`) so issues get caught before the network round trip.

## Test plan

- [x] Verified locally: pre-commit hook with this config **blocks** a probe commit containing `cond_agt_R3alL00k1ngT0k3nStr1ng42`
- [x] Verified locally: allowlist works — fixture/test/docs paths pass through
- [x] Doesn't false-positive on the diffs of this PR itself (own commit passed the hook)

## What's *not* in this PR

- The pre-commit hook itself lives at `.git/hooks/pre-commit` (local-only, not tracked by git). If we want team-wide local hook install, that's a separate PR (add `make install-hooks` or similar). Server-side push protection already covers everyone regardless.