### PR TITLE
refactor(auth): hexagonal split of require_permission + chore(ci): make ci-py mirror

### DIFF
--- a/apps/api/Makefile
+++ b/apps/api/Makefile
@@ -1,4 +1,4 @@
-.PHONY: schema schema-check
+.PHONY: schema schema-check ci-py ci-py-fast ci-py-help
 
 # Regenerate app/dsl/schema/v1.yaml from schema.py (source of truth)
 schema:
@@ -9,3 +9,61 @@ schema:
 schema-check:
 	python scripts/generate_schema.py --check
 	python ../../scripts/check_schema_parity.py
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Local CI mirror
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# ci-py runs the API suite the same way .github/workflows/ci.yml does:
+#   - fresh marshal_test database (isolated from your dev DB)
+#   - alembic upgrade head + up/down cycle
+#   - pytest tests/ -q --ignore=tests/test_guard.py -m 'not matrix'
+#
+# If a change passes `make ci-py` locally, it will pass the API job on CI —
+# barring pure environment differences (Vercel deploy, npm-audit, pip-audit).
+#
+# Prereqs: docker postgres container running (marshal-postgres-1), python 3.11,
+# and requirements.txt installed. Use `make ci-py-help` for a checklist.
+
+CI_DATABASE_URL := postgresql://marshal:marshal@localhost:5432/marshal_test
+CI_TEST_ENV := DATABASE_URL='$(CI_DATABASE_URL)' ANTHROPIC_API_KEY='sk-test'
+
+ci-py:
+	@docker ps --format '{{.Names}}' | grep -q '^marshal-postgres' || { \
+		echo "✗ marshal-postgres container not running."; \
+		echo "  Start it: cd .. && docker compose up -d postgres"; \
+		exit 1; \
+	}
+	@echo "→ Reset marshal_test database (drops any prior state)..."
+	@docker exec marshal-postgres-1 psql -U marshal -d postgres -c \
+		'DROP DATABASE IF EXISTS marshal_test WITH (FORCE)' >/dev/null
+	@docker exec marshal-postgres-1 psql -U marshal -d postgres -c \
+		'CREATE DATABASE marshal_test' >/dev/null
+	@echo "→ alembic upgrade head..."
+	@$(CI_TEST_ENV) alembic upgrade head
+	@echo "→ alembic downgrade -1 + upgrade head (catches broken downgrade paths)..."
+	@$(CI_TEST_ENV) alembic downgrade -1
+	@$(CI_TEST_ENV) alembic upgrade head
+	@echo "→ pytest (same flags as CI: -q --ignore=tests/test_guard.py -m 'not matrix')..."
+	@$(CI_TEST_ENV) python -m pytest tests/ -q --ignore=tests/test_guard.py -m 'not matrix'
+
+# ci-py-fast: skip DB reset + migration cycle, just re-run pytest against the
+# existing marshal_test DB. Use during iteration when schema hasn't changed.
+# Assumes `make ci-py` ran at least once to seed the DB.
+ci-py-fast:
+	@$(CI_TEST_ENV) python -m pytest tests/ -q --ignore=tests/test_guard.py -m 'not matrix'
+
+ci-py-help:
+	@echo "make ci-py       — full run (DB reset + migrations + tests). ~2-3 min."
+	@echo "make ci-py-fast  — pytest only, against existing marshal_test DB. ~30-60s."
+	@echo ""
+	@echo "Prereqs:"
+	@echo "  1. docker postgres running:  cd .. && docker compose up -d postgres"
+	@echo "  2. python 3.11 available"
+	@echo "  3. pip install -r requirements.txt"
+	@echo ""
+	@echo "Notes:"
+	@echo "  - Isolates from your dev DB (marshal) by using a separate DB (marshal_test)"
+	@echo "  - Mirrors CI's -m 'not matrix' filter (skips ~600 endpoint×role tests)"
+	@echo "  - Mirrors CI's --ignore=tests/test_guard.py (runs nightly, not per-commit)"
+	@echo "  - Full matrix + guard tests run in .github/workflows/nightly.yml"

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -671,11 +671,130 @@ def require_workspace_role(*allowed_roles: str):
     return _check
 
 
-def require_permission(permission: str):
-    """
-    Dependency factory that enforces a named permission from the RBAC tables.
+def check_permission(
+    *,
+    user_id: str | None,
+    workspace_id: str,
+    credentials: HTTPAuthorizationCredentials | None,
+    db: Session,
+    permission: str,
+) -> str:
+    """Pure permission check. No FastAPI DI, no closures over factory args.
 
-    Checks: workspace_users.role → roles → role_permissions → permissions.name
+    Returns the effective role on success. Raises HTTPException(403) on failure.
+
+    Callable directly from unit tests: pass a mocked db (or a real one) and a
+    workspace/user pair; get the same behavior FastAPI routes get. Patch
+    _clerk_enabled at the module level to simulate the dev-bypass path.
+
+    See require_permission() below for the FastAPI wrapper used by routers.
+    """
+    from sqlalchemy import text as _text
+
+    if not _clerk_enabled():
+        return "admin"
+
+    import re as _re
+    if not _re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", workspace_id, _re.I):
+        raise HTTPException(status_code=403, detail="Invalid workspace ID")
+
+    # Machine tokens (cond_api_*) are workspace-scoped credentials with no
+    # user session. Treat as admin for the workspace they were minted for.
+    # Same model as AWS access keys, GitHub PATs, Stripe secret keys —
+    # the token IS the authorization.
+    if user_id is None and credentials and credentials.credentials.startswith("cond_api_"):
+        ai, _ = _resolve_agent_token(credentials.credentials, db)
+        if ai and str(getattr(ai, "workspace_id", "")) == workspace_id:
+            return "admin"
+        raise HTTPException(status_code=403, detail="API token workspace does not match request")
+
+    # Okta JWTs (#1056) are also workspace-scoped machine credentials —
+    # user_id is None because get_user_id returned None for the JWT above.
+    if user_id is None and credentials:
+        okta = _resolve_okta_jwt(credentials.credentials, db)
+        if okta is not None:
+            ai, _ = okta
+            if str(getattr(ai, "workspace_id", "")) == workspace_id:
+                return "admin"
+            raise HTTPException(status_code=403, detail="Okta JWT workspace does not match request")
+
+    row = db.execute(
+        _text("SELECT role FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),
+        {"ws": workspace_id, "uid": user_id},
+    ).fetchone()
+
+    if not row:
+        owner = db.execute(
+            _text("SELECT 1 FROM workspaces WHERE id = :ws AND owner_id = :uid"),
+            {"ws": workspace_id, "uid": user_id},
+        ).fetchone()
+        if owner:
+            return "admin"
+        # GMC fallback: cond_agt_* tokens prove authenticated workspace membership
+        gmc = db.execute(
+            _text("""
+                SELECT 1 FROM guard_member_config
+                WHERE workspace_id::text = :ws AND clerk_user_id = :uid
+                LIMIT 1
+            """),
+            {"ws": workspace_id, "uid": user_id},
+        ).fetchone()
+        if gmc:
+            return "admin"
+        raise HTTPException(status_code=403, detail="Not a member of this workspace")
+
+    user_role = row.role
+
+    has_perm = db.execute(
+        _text("""
+            SELECT 1
+            FROM roles r
+            JOIN role_permissions rp ON rp.role_id = r.id
+            JOIN permissions p ON p.id = rp.permission_id
+            WHERE r.name = :role
+              AND r.workspace_id IS NULL
+              AND p.name = :perm
+            LIMIT 1
+        """),
+        {"role": user_role, "perm": permission},
+    ).fetchone()
+
+    if not has_perm:
+        # Fallback: if the RBAC tables are unseeded (migration 0044 not yet
+        # applied), grant access based on role tier so no env gets locked out.
+        seeded = db.execute(
+            _text("SELECT 1 FROM role_permissions LIMIT 1"),
+        ).fetchone()
+        if not seeded:
+            # Tables empty — derive access from role tier (mirrors the old
+            # require_workspace_role logic): admin=all, viewer=read-only,
+            # developer+security=read+write (conservative safe default).
+            read_only_perms = {
+                "platform.workflows.view", "platform.runs.view",
+                "platform.marketplace.browse", "platform.eval.view",
+                "guard.policies.view", "guard.activity.view_own",
+                "guard.spend.view_own",
+            }
+            if user_role == "admin":
+                return user_role
+            if user_role in ("developer", "security") and permission in read_only_perms:
+                return user_role
+            if user_role == "viewer" and permission in read_only_perms:
+                return user_role
+            # Write permissions need at least developer/security
+            if user_role in ("developer", "security"):
+                return user_role
+        raise HTTPException(status_code=403, detail=f"Permission denied: {permission}")
+
+    return user_role
+
+
+def require_permission(permission: str):
+    """FastAPI dependency factory. Thin wrapper around check_permission().
+
+    The check logic lives in check_permission() (pure function, unit-testable
+    without conftest-patch acrobatics). This wrapper only binds FastAPI DI to
+    that function so routers can use ``Depends(require_permission("perm.name"))``.
 
     Seeded permissions (from migration 0044):
       platform.workflows.view       — viewer, developer, security, admin
@@ -700,119 +819,22 @@ def require_permission(permission: str):
       guard.settings.edit           — admin
 
     Usage:
-        from app.core.auth import require_permission
-
         @router.get("/scorecards")
         def get_scorecards(_: str = Depends(require_permission("platform.eval.view")), ...):
-
-        @router.post("/workflows/{id}/runs")
-        def trigger_run(_: str = Depends(require_permission("platform.workflows.run")), ...):
     """
-    from sqlalchemy import text as _text
-
     def _check(
         user_id: Annotated[str | None, Depends(get_user_id)],
         workspace_id: Annotated[str, Depends(get_workspace_id)],
         credentials: Annotated[HTTPAuthorizationCredentials | None, Depends(_bearer)] = None,
         db: Session = Depends(get_db),
     ) -> str:
-        if not _clerk_enabled():
-            return "admin"
-
-        import re as _re
-        if not _re.match(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", workspace_id, _re.I):
-            raise HTTPException(status_code=403, detail="Invalid workspace ID")
-
-        # Machine tokens (cond_api_*) are workspace-scoped credentials with no
-        # user session. Treat as admin for the workspace they were minted for.
-        # Same model as AWS access keys, GitHub PATs, Stripe secret keys —
-        # the token IS the authorization.
-        if user_id is None and credentials and credentials.credentials.startswith("cond_api_"):
-            ai, _ = _resolve_agent_token(credentials.credentials, db)
-            if ai and str(getattr(ai, "workspace_id", "")) == workspace_id:
-                return "admin"
-            raise HTTPException(status_code=403, detail="API token workspace does not match request")
-
-        # Okta JWTs (#1056) are also workspace-scoped machine credentials —
-        # user_id is None because get_user_id returned None for the JWT above.
-        if user_id is None and credentials:
-            okta = _resolve_okta_jwt(credentials.credentials, db)
-            if okta is not None:
-                ai, _ = okta
-                if str(getattr(ai, "workspace_id", "")) == workspace_id:
-                    return "admin"
-                raise HTTPException(status_code=403, detail="Okta JWT workspace does not match request")
-
-        row = db.execute(
-            _text("SELECT role FROM workspace_users WHERE workspace_id = :ws AND clerk_user_id = :uid"),
-            {"ws": workspace_id, "uid": user_id},
-        ).fetchone()
-
-        if not row:
-            owner = db.execute(
-                _text("SELECT 1 FROM workspaces WHERE id = :ws AND owner_id = :uid"),
-                {"ws": workspace_id, "uid": user_id},
-            ).fetchone()
-            if owner:
-                return "admin"
-            # GMC fallback: cond_agt_* tokens prove authenticated workspace membership
-            gmc = db.execute(
-                _text("""
-                    SELECT 1 FROM guard_member_config
-                    WHERE workspace_id::text = :ws AND clerk_user_id = :uid
-                    LIMIT 1
-                """),
-                {"ws": workspace_id, "uid": user_id},
-            ).fetchone()
-            if gmc:
-                return "admin"
-            raise HTTPException(status_code=403, detail="Not a member of this workspace")
-
-        user_role = row.role
-
-        has_perm = db.execute(
-            _text("""
-                SELECT 1
-                FROM roles r
-                JOIN role_permissions rp ON rp.role_id = r.id
-                JOIN permissions p ON p.id = rp.permission_id
-                WHERE r.name = :role
-                  AND r.workspace_id IS NULL
-                  AND p.name = :perm
-                LIMIT 1
-            """),
-            {"role": user_role, "perm": permission},
-        ).fetchone()
-
-        if not has_perm:
-            # Fallback: if the RBAC tables are unseeded (migration 0044 not yet
-            # applied), grant access based on role tier so no env gets locked out.
-            seeded = db.execute(
-                _text("SELECT 1 FROM role_permissions LIMIT 1"),
-            ).fetchone()
-            if not seeded:
-                # Tables empty — derive access from role tier (mirrors the old
-                # require_workspace_role logic): admin=all, viewer=read-only,
-                # developer+security=read+write (conservative safe default).
-                read_only_perms = {
-                    "platform.workflows.view", "platform.runs.view",
-                    "platform.marketplace.browse", "platform.eval.view",
-                    "guard.policies.view", "guard.activity.view_own",
-                    "guard.spend.view_own",
-                }
-                if user_role == "admin":
-                    return user_role
-                if user_role in ("developer", "security") and permission in read_only_perms:
-                    return user_role
-                if user_role == "viewer" and permission in read_only_perms:
-                    return user_role
-                # Write permissions need at least developer/security
-                if user_role in ("developer", "security"):
-                    return user_role
-            raise HTTPException(status_code=403, detail=f"Permission denied: {permission}")
-
-        return user_role
-
+        return check_permission(
+            user_id=user_id,
+            workspace_id=workspace_id,
+            credentials=credentials,
+            db=db,
+            permission=permission,
+        )
     return _check
 
 

--- a/apps/api/tests/test_require_permission.py
+++ b/apps/api/tests/test_require_permission.py
@@ -1,62 +1,28 @@
-"""
-Unit tests for require_permission in app.core.auth.
+"""Unit tests for check_permission in app.core.auth.
 
-No real DB, no network. Uses the same module-stub pattern as test_guard_savings.py.
+Tests target `check_permission` directly — the pure function extracted from
+what used to be the `require_permission._check` closure. No FastAPI DI, no
+sys.modules manipulation, no fixture acrobatics to bypass conftest's patch
+of `require_permission`. The pure function doesn't touch the wrapper that
+conftest patches, so tests run reliably regardless of order, autouse
+fixtures, or which other tests ran first.
 
-require_permission(perm) returns a _check closure. We test _check directly,
-injecting a mock user_id, workspace_id, and db rather than going through
-FastAPI Depends resolution.
+The db is injected directly; imports are safe because SQLAlchemy is lazy
+about connecting.
+
+See app.core.auth.require_permission for the FastAPI wrapper used by routers.
 """
 from __future__ import annotations
 
-import os
-import sys
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 
-HERE = Path(__file__).resolve()
-APPS_API = HERE.parent.parent
-if str(APPS_API) not in sys.path:
-    sys.path.insert(0, str(APPS_API))
+from app.core.auth import check_permission
 
-os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
-os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
-os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
-os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
 
-_log_mock = MagicMock()
-_log_mock.get_logger = MagicMock(return_value=MagicMock())
-sys.modules["structlog"] = _log_mock
-sys.modules.setdefault("redis", MagicMock())
-sys.modules.setdefault("sentry_sdk", MagicMock())
-
-_cfg_stub = MagicMock()
-_cfg_stub.settings = MagicMock(
-    sentry_dsn=None,
-    sqlalchemy_database_url="sqlite:///:memory:",
-    encryption_key="test-key-32-bytes-long-xxxxxxxx!",
-    allowed_egress_hosts=[],
-    clerk_secret_key = "REDACTED",
-    clerk_frontend_api="clerk.example.com",
-    environment="test",
-    log_level="INFO",
-)
-sys.modules["app.core.config"] = _cfg_stub
-sys.modules["app.core.database"] = MagicMock()
-
-_venv_site = APPS_API / ".venv" / "lib"
-for _p in _venv_site.glob("python*/site-packages"):
-    if str(_p) not in sys.path:
-        sys.path.insert(0, str(_p))
-
-sys.modules.pop("app.core.auth", None)
-
-from fastapi import HTTPException  # noqa: E402
-from app.core.auth import require_permission  # noqa: E402
-
-# A valid UUID-format workspace_id (the regex in require_permission enforces this)
+# A valid UUID-format workspace_id (the regex in check_permission enforces this)
 _WS = "00000000-0000-0000-0000-000000000001"
 _UID = "user_abc123"
 
@@ -99,6 +65,7 @@ def _make_db_no_member(owner_match: bool = False):
     """
     First db.execute call → no workspace_users row.
     Second db.execute call → owner row if owner_match else None.
+    Third db.execute call → None (GMC fallback).
     """
     db = MagicMock()
     owner_row = MagicMock() if owner_match else None
@@ -110,9 +77,15 @@ def _make_db_no_member(owner_match: bool = False):
     return db
 
 
-def _call_check(checker, db, user_id=_UID, workspace_id=_WS):
-    """Call the _check closure returned by require_permission directly."""
-    return checker(user_id=user_id, workspace_id=workspace_id, db=db)
+def _call(db, permission, user_id=_UID, workspace_id=_WS, credentials=None):
+    """Call check_permission with test defaults."""
+    return check_permission(
+        user_id=user_id,
+        workspace_id=workspace_id,
+        credentials=credentials,
+        db=db,
+        permission=permission,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -121,100 +94,88 @@ def _call_check(checker, db, user_id=_UID, workspace_id=_WS):
 
 class TestValidPermission:
     def test_valid_permission_returns_role(self):
-        checker = require_permission("platform.eval.view")
         db = _make_db_with_role_and_perm("developer", has_perm=True)
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "platform.eval.view")
         assert result == "developer"
 
     def test_valid_permission_admin_role(self):
-        checker = require_permission("platform.workspace.edit")
         db = _make_db_with_role_and_perm("admin", has_perm=True)
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "platform.workspace.edit")
         assert result == "admin"
 
 
 class TestMissingPermission:
     def test_missing_permission_raises_403(self):
-        checker = require_permission("guard.policies.edit")
         db = _make_db_with_role_and_perm("developer", has_perm=False)
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db)
+                _call(db, "guard.policies.edit")
         assert exc_info.value.status_code == 403
 
     def test_missing_permission_detail_mentions_permission(self):
-        checker = require_permission("guard.policies.edit")
         db = _make_db_with_role_and_perm("developer", has_perm=False)
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db)
+                _call(db, "guard.policies.edit")
         assert "guard.policies.edit" in exc_info.value.detail
 
 
 class TestNonMember:
     def test_non_member_raises_403(self):
-        checker = require_permission("platform.eval.view")
         db = _make_db_no_member(owner_match=False)
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db)
+                _call(db, "platform.eval.view")
         assert exc_info.value.status_code == 403
 
     def test_non_member_detail(self):
-        checker = require_permission("platform.eval.view")
         db = _make_db_no_member(owner_match=False)
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db)
+                _call(db, "platform.eval.view")
         assert "member" in exc_info.value.detail.lower() or exc_info.value.status_code == 403
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution: patch on _clerk_enabled doesn't reach the reloaded auth module in CI order")
 class TestDevMode:
     def test_dev_mode_skips_check(self):
-        checker = require_permission("guard.settings.edit")
         db = MagicMock()
         db.execute.side_effect = RuntimeError("DB should not be called in dev mode")
         with patch("app.core.auth._clerk_enabled", return_value=False):
-            result = _call_check(checker, db)
+            result = _call(db, "guard.settings.edit")
         assert result == "admin"
 
     def test_dev_mode_never_hits_db(self):
-        checker = require_permission("platform.eval.view")
         db = MagicMock()
         with patch("app.core.auth._clerk_enabled", return_value=False):
-            _call_check(checker, db)
+            _call(db, "platform.eval.view")
         db.execute.assert_not_called()
 
 
 class TestOwnerFallback:
     def test_owner_fallback_grants_admin(self):
         """Not in workspace_users, but IS the workspace owner → returns 'admin'."""
-        checker = require_permission("platform.eval.view")
         db = _make_db_no_member(owner_match=True)
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "platform.eval.view")
         assert result == "admin"
 
     def test_owner_fallback_does_not_check_permission_table(self):
         """Owner path returns immediately — no third DB call for role_permissions."""
-        checker = require_permission("platform.eval.view")
         db = _make_db_no_member(owner_match=True)
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            _call_check(checker, db)
+            _call(db, "platform.eval.view")
         # Only two db.execute calls: workspace_users check + owner check
         assert db.execute.call_count == 2
 
 
 class TestInvalidWorkspaceId:
     def test_non_uuid_workspace_id_raises_403(self):
-        checker = require_permission("platform.eval.view")
         db = MagicMock()
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db, workspace_id="not-a-uuid")
+                _call(db, "platform.eval.view", workspace_id="not-a-uuid")
         assert exc_info.value.status_code == 403
 
 
@@ -239,37 +200,32 @@ def _make_db_unseeded(role: str):
 
 class TestUnseedledRbacFallback:
     def test_admin_gets_through_unseeded(self):
-        checker = require_permission("guard.settings.edit")
         db = _make_db_unseeded("admin")
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "guard.settings.edit")
         assert result == "admin"
 
     def test_developer_read_perm_unseeded(self):
-        checker = require_permission("platform.eval.view")
         db = _make_db_unseeded("developer")
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "platform.eval.view")
         assert result == "developer"
 
     def test_developer_write_perm_unseeded(self):
-        checker = require_permission("guard.policies.edit")
         db = _make_db_unseeded("developer")
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "guard.policies.edit")
         assert result == "developer"
 
     def test_viewer_read_perm_unseeded(self):
-        checker = require_permission("platform.workflows.view")
         db = _make_db_unseeded("viewer")
         with patch("app.core.auth._clerk_enabled", return_value=True):
-            result = _call_check(checker, db)
+            result = _call(db, "platform.workflows.view")
         assert result == "viewer"
 
     def test_viewer_write_perm_unseeded_raises_403(self):
-        checker = require_permission("guard.policies.edit")
         db = _make_db_unseeded("viewer")
         with patch("app.core.auth._clerk_enabled", return_value=True):
             with pytest.raises(HTTPException) as exc_info:
-                _call_check(checker, db)
+                _call(db, "guard.policies.edit")
         assert exc_info.value.status_code == 403


### PR DESCRIPTION
## Honest scope

**Code cleanup + local CI mirror. NOT the sys.modules pollution fix I originally claimed.**

Running locally (via the new \`make ci-py\` target this PR adds) revealed the pollution has 10 sources across the test suite, not the 1 in \`test_require_permission.py\`. Fixing that one file's usage of the anti-pattern helps future maintainability but does not close the ~24 CI failures I originally claimed. Those need a systematic pass on all 10 files (tracked separately).

## What this PR actually does

1. **Splits \`require_permission\` into a pure \`check_permission\` function + thin FastAPI wrapper** (\`apps/api/app/core/auth.py\`).
   - The pure function is trivially unit-testable — no FastAPI DI, no closure state, no conftest patch to work around.
   - \`test_require_permission.py\` rewritten to import \`check_permission\` directly. No \`sys.modules\` hackery, no autouse fixtures, no \`real_require_permission\` chain. Cleaner code.
   - This is a legit architectural improvement even without the CI win.

2. **Adds \`make ci-py\` target** (\`apps/api/Makefile\`) that mirrors CI's API job exactly:
   - Isolated \`marshal_test\` database (separate from dev DB — prevents pollution)
   - Same alembic sequence CI runs (up + up/down cycle)
   - Same pytest flags CI uses (\`-q --ignore=tests/test_guard.py -m 'not matrix'\`)
   - This is what let me discover the systemic sys.modules issue in the first place. Genuinely valuable for future development.

## What this PR does NOT do

- **Does not reduce CI failure count.** Main is at ~30 failures from sys.modules pollution across 10 test files. This PR doesn't touch 9 of them. CI on main after this merges = still ~30 failures.
- **Does not fix the workspace-isolation regression** (\`test_user_a_cannot_list_workspace_b_workflows\`). That test still fails in CI because other polluting tests run before it.

## Follow-up needed (separate PR)

Apply either \`pytestmark = pytest.mark.forked\` OR the same hexagonal treatment to the remaining 9 files that mangle \`sys.modules\`:
\`\`\`
test_agent_identity_auth.py, test_analytics_dora.py, test_analytics_scorecards.py,
test_guard_mcp_auth.py, test_guard_savings.py, test_guard_spend_month_window.py,
test_guard.py, test_token_paths.py, test_workspace_seed.py, test_z_executor_lifecycle.py
\`\`\`

That's the real CI unblocker. ~30 min of mechanical work with pytest-forked.