### PR TITLE
fix(web): pre-empt TS7006 implicit-any errors from Next 15.5.21 (unblocks #1196)

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useEffect, useCallback } from "react"
+import { useState, useRef, useEffect, useCallback, type MouseEvent as ReactMouseEvent } from "react"
 import Link from "next/link"
 import { usePathname, useRouter } from "next/navigation"
 import { useAuth, useUser, useClerk } from "@clerk/nextjs"
@@ -1416,8 +1416,8 @@ function SideNavItem({
         marginBottom: 1,
         transition: "background 120ms, color 120ms",
       }}
-      onMouseEnter={e => { if (!active) { (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--text)" } }}
-      onMouseLeave={e => { if (!active) { (e.currentTarget as HTMLAnchorElement).style.background = "transparent"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--text-2)" } }}
+      onMouseEnter={(e: ReactMouseEvent<HTMLAnchorElement>) => { if (!active) { e.currentTarget.style.background = "var(--surface-2)"; e.currentTarget.style.color = "var(--text)" } }}
+      onMouseLeave={(e: ReactMouseEvent<HTMLAnchorElement>) => { if (!active) { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--text-2)" } }}
     >
       <span style={{ flexShrink: 0, display: "flex", alignItems: "center", color: "inherit" }}>{icon}</span>
       {!collapsed && (
@@ -1532,8 +1532,8 @@ function UserChipInner({ collapsed, userRole, topbar }: { collapsed: boolean; us
             href="/settings"
             onClick={() => setMenuOpen(false)}
             style={{ display: "block", padding: "8px 12px", fontSize: 13, color: "var(--text-2)", textDecoration: "none" }}
-            onMouseEnter={e => { (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--text)" }}
-            onMouseLeave={e => { (e.currentTarget as HTMLAnchorElement).style.background = "transparent"; (e.currentTarget as HTMLAnchorElement).style.color = "var(--text-2)" }}
+            onMouseEnter={(e: ReactMouseEvent<HTMLAnchorElement>) => { e.currentTarget.style.background = "var(--surface-2)"; e.currentTarget.style.color = "var(--text)" }}
+            onMouseLeave={(e: ReactMouseEvent<HTMLAnchorElement>) => { e.currentTarget.style.background = "transparent"; e.currentTarget.style.color = "var(--text-2)" }}
           >
             Settings
           </Link>

--- a/apps/web/src/components/guard/ActivityRow.tsx
+++ b/apps/web/src/components/guard/ActivityRow.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { useState, type MouseEvent as ReactMouseEvent } from "react"
 import { timeAgo } from "@/lib/runUtils"
 import { DecisionBadge } from "./DecisionBadge"
 
@@ -332,7 +332,7 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
           {ev.source === "brain_block" && ev.conductai_workflow ? (
             ev.conductai_run_id ? (
               <Link href={`/workflows/${ev.conductai_workflow_id}/runs/${ev.conductai_run_id}`}
-                onClick={(e) => e.stopPropagation()}
+                onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
                 style={{ textDecoration: "none", fontSize: 11.5, fontFamily: "var(--font-mono, monospace)", color: "var(--accent-text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", display: "block", maxWidth: "100%" }}>
                 {ev.conductai_workflow}
               </Link>
@@ -341,7 +341,7 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
             )
           ) : (
             ev.conductai_run_id ? (
-              <Link href={`/workflows/${ev.conductai_workflow_id}/runs/${ev.conductai_run_id}`} onClick={(e) => e.stopPropagation()} style={{ textDecoration: "none" }}>
+              <Link href={`/workflows/${ev.conductai_workflow_id}/runs/${ev.conductai_run_id}`} onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()} style={{ textDecoration: "none" }}>
                 <ToolBadge tool={ev.ai_tool} />
               </Link>
             ) : (
@@ -373,7 +373,7 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
       </div>
       <div>
         {ev.conductai_run_id ? (
-          <Link href={`/workflows/${ev.conductai_workflow_id}/runs/${ev.conductai_run_id}`} onClick={(e) => e.stopPropagation()} style={{ display: "inline-flex", alignItems: "center", gap: 3, textDecoration: "none" }}>
+          <Link href={`/workflows/${ev.conductai_workflow_id}/runs/${ev.conductai_run_id}`} onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()} style={{ display: "inline-flex", alignItems: "center", gap: 3, textDecoration: "none" }}>
             <DecisionBadge decision={ev.decision} />
             <span style={{ fontSize: 11, color: "var(--accent-text)" }}>→</span>
           </Link>


### PR DESCRIPTION
## Summary

7 event handlers in \`AppShell.tsx\` (4) and \`guard/ActivityRow.tsx\` (3) relied on TypeScript inferring the event parameter type from JSX. Next 15.5.21 (pending in Dependabot #1196) tightens this inference and reports TS7006 (\`Parameter 'e' implicitly has an 'any' type\`) on each site.

This PR adds explicit type annotations using React's \`MouseEvent\`, aliased as \`ReactMouseEvent\` to avoid shadowing the DOM \`MouseEvent\` already used elsewhere via \`addEventListener\` signatures.

Also drops the now-redundant \`(e.currentTarget as HTMLAnchorElement)\` casts inside \`AppShell\` handlers — the parameter type provides the narrowing.

## Impact

- \`tsc --noEmit\` passes on current Next 15.5.18 (verified locally)
- When #1196 lands (15.5.18 → 15.5.21), the Web typecheck lane in that PR turns green without further changes
- Zero runtime impact — type-only diff

## Diff

\`\`\`
apps/web/src/components/AppShell.tsx           | 5 +++--
apps/web/src/components/guard/ActivityRow.tsx  | 5 +++--
2 files changed, 9 insertions(+), 9 deletions(-)
\`\`\`

## Test plan

- [x] \`tsc --noEmit\` passes locally
- [ ] CI Web typecheck lane passes on this PR
- [ ] After merge: Dependabot rebases #1196 → Web typecheck should be GREEN there