### PR TITLE
ci: align codeql-action init + autobuild to v4.37.8 (supersedes #1208)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,6 +52,6 @@ jobs:
         uses: github/codeql-action/autobuild@d6317709a54fd87078d323eeb0e48ec331c8e621 # v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@f3712979fa5f215279b101dd0a2e3bdfb4353324 # v3
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@d6317709a54fd87078d323eeb0e48ec331c8e621 # v3
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: ${{ matrix.language }}
           # security-extended pulls in more queries than the default suite
@@ -49,9 +49,9 @@ jobs:
           queries: security-extended
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@d6317709a54fd87078d323eeb0e48ec331c8e621 # v3
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v3
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: /language:${{ matrix.language }}


### PR DESCRIPTION
## Summary

Supersedes #1208. Dependabot's original PR bumped only \`codeql-action/analyze\` from v3.37.7 → v4.37.8 but left \`init\` and \`autobuild\` pinned at v3. CodeQL requires \`init\` and \`analyze\` to be the same major version — mixed would break the analysis job.

This PR bumps all three subactions to the same v4.37.8 SHA (\`db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28\`), keeping the workflow internally consistent. Same commit SHA works for all three because they live in the same \`github/codeql-action\` repo.

Also fixes the stale \`# v3\` comment Dependabot left next to the analyze SHA (the SHA itself was already v4).

## Diff

\`\`\`
.github/workflows/codeql.yml | 6 +++---
1 file changed, 3 insertions(+), 3 deletions(-)
\`\`\`

## v4 breaking changes (context)

- Removed \`add-snippets\` input (default now \`true\`, was \`false\`)
- Requires Node 20+ (satisfied — runners on Node 24)
- No effect on \`security-extended\` queries or the current permission model

## Test plan

- [x] Verified v4.37.8 SHA resolves to \`db488ddef3...\` via \`gh api /repos/github/codeql-action/tags\`
- [ ] CI runs cleanly on this PR
- [ ] Post-merge: close #1208 as superseded (my auto-close won't fire because it's a Dependabot PR)