### PR TITLE
feat(marketing): MCP Gateway launch surface — landing page + blog draft + nav

### DIFF
--- a/apps/web/src/app/(marketing)/blog/mcp-gateway-launch/page.tsx
+++ b/apps/web/src/app/(marketing)/blog/mcp-gateway-launch/page.tsx
@@ -40,7 +40,19 @@ export default function BlogPost() {
           What we shipped
         </h2>
         <p className="text-stone-700 leading-relaxed mb-4">
-          Guard now speaks a boot-time API. Agents start with one call:
+          Two catalog sources, one enforcement layer.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-3">
+          <strong>1. A curated MCP Registry.</strong> Guard ships with 10 pre-canned MCPs (GitHub, Slack, Postgres, Filesystem, Confluence, Jira, GDrive, Sentry, Linear, Notion), each with default policy packs already attached per tool. Enable GitHub MCP and you get sensible defaults on day one: <code>create_issue</code> allowed, <code>merge_pr</code> requires approval, <code>delete_branch</code> blocked, PII redaction on outputs.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-6">
+          <strong>2. Bring Your Own MCP.</strong> Register any MCP server, private or public. Guard calls the MCP spec&rsquo;s <code>tools/list</code>, pulls every tool schema, and lets admins attach policy packs per tool. Not per server. Per tool.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-4">
+          Then agents boot with one call:
         </p>
 
         <pre className="bg-stone-900 text-stone-100 rounded-lg px-4 py-3 text-sm overflow-x-auto mb-4">
@@ -48,25 +60,22 @@ export default function BlogPost() {
         </pre>
 
         <p className="text-stone-700 leading-relaxed mb-4">
-          Guard returns a policy-filtered list of MCP servers the agent may reach, along with a short-lived scoped token per server. The agent never sees a long-lived credential. It never hardcodes an endpoint. Its config is empty of MCP details.
+          Guard returns a policy-filtered list of MCP servers the agent may reach, along with a short-lived scoped token per server. Every tool call the agent makes is checked against the resolved policy: pre-canned defaults for Registry MCPs, or the packs you attached for your private ones. Every call is hash-chained. Every credential rotates centrally. No agent hardcodes an endpoint or a token.
         </p>
 
-        <p className="text-stone-700 leading-relaxed mb-2">Behind that call:</p>
+        <p className="text-stone-700 leading-relaxed mb-2">Also in the box:</p>
         <ul className="text-stone-700 leading-relaxed mb-6 space-y-2 list-disc pl-6">
-          <li>
-            <strong>A workspace catalog</strong> of MCP servers, maintained centrally.
-          </li>
           <li>
             <strong>Per-agent scoped tokens</strong> minted on demand, TTL-bounded, revocable per agent.
           </li>
           <li>
-            <strong>Policy packs</strong> with two new keys, <code>mcp_scope</code> and <code>mcp_actions</code>, so &ldquo;this agent may call GitHub MCP but only for read operations&rdquo; is one line of YAML.
+            <strong>Policy pack keys</strong> <code>mcp_scope</code> and <code>mcp_actions</code>, so per-tool intent is a line of YAML.
           </li>
           <li>
-            <strong>Hash-chained audit</strong> on every tool call, with the resolving policy rule id attached. Exportable to SIEM.
+            <strong>Hash-chained audit</strong> on every tool call, resolving policy rule id attached. Exportable to SIEM.
           </li>
           <li>
-            <strong>Auto-discovery</strong> that watches your existing agent configs (<code>.mcp.json</code>, Claude Desktop, Cursor, Windsurf) and promotes newly-found MCP servers into the catalog in observation mode.
+            <strong>Auto-discovery</strong> that watches agent configs (<code>.mcp.json</code>, Claude Desktop, Cursor, Windsurf) and surfaces newly-seen MCPs into the catalog in observation mode.
           </li>
         </ul>
 

--- a/apps/web/src/app/(marketing)/blog/mcp-gateway-launch/page.tsx
+++ b/apps/web/src/app/(marketing)/blog/mcp-gateway-launch/page.tsx
@@ -1,0 +1,156 @@
+import { CtaLink } from "@/components/marketing/CtaLink"
+
+export const metadata = {
+  title: "We built the missing MCP Gateway — LiteLLM solved model sprawl, nobody solved tool sprawl | Conduct",
+  description:
+    "Guard now speaks a boot-time API. Agents call guard.discover_mcps() and get a policy-filtered list of MCP servers with per-agent scoped tokens. No hardcoded endpoints, no long-lived credentials, every tool call hash-chained.",
+}
+
+export default function BlogPost() {
+  return (
+    <article className="max-w-2xl mx-auto px-6 py-16">
+      <div className="mb-10">
+        <div className="flex items-center gap-3 mb-6">
+          <span className="text-xs font-semibold text-indigo-700 bg-indigo-50 border border-indigo-200 px-2.5 py-1 rounded-full uppercase tracking-widest">
+            Launch
+          </span>
+          <span className="text-xs text-stone-400">Coming soon</span>
+        </div>
+        <h1 className="text-4xl font-bold text-stone-900 leading-tight mb-4">
+          We built the missing MCP Gateway.
+        </h1>
+        <p className="text-lg text-stone-500 leading-relaxed">
+          LiteLLM solved model sprawl. Nobody solved tool sprawl. So we did.
+        </p>
+      </div>
+
+      <div className="prose prose-stone max-w-none">
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">
+          The problem nobody named
+        </h2>
+        <p className="text-stone-700 leading-relaxed mb-4">
+          If you run three or more AI agents, they each have a copy of every MCP endpoint and every credential pasted into their config or env vars. GitHub MCP token here, Slack MCP token there, Confluence MCP token in a third place. Rotate one credential, redeploy 20 things. Revoke access, edit 20 files. Ask your CISO &ldquo;did any agent hit customer data last night?&rdquo; and start grepping across 20 log formats.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-6">
+          The LLM proxy category (LiteLLM, Portkey, OpenRouter, Vercel AI Gateway) solved a real thing. Model call sprawl. One endpoint, hundreds of providers, unified auth, cost tracking. Great work. Not this problem. Those proxies live at the model layer. Tool sprawl is a floor down, at the MCP layer.
+        </p>
+
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">
+          What we shipped
+        </h2>
+        <p className="text-stone-700 leading-relaxed mb-4">
+          Guard now speaks a boot-time API. Agents start with one call:
+        </p>
+
+        <pre className="bg-stone-900 text-stone-100 rounded-lg px-4 py-3 text-sm overflow-x-auto mb-4">
+          <code>{`mcps = guard.discover_mcps()`}</code>
+        </pre>
+
+        <p className="text-stone-700 leading-relaxed mb-4">
+          Guard returns a policy-filtered list of MCP servers the agent may reach, along with a short-lived scoped token per server. The agent never sees a long-lived credential. It never hardcodes an endpoint. Its config is empty of MCP details.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-2">Behind that call:</p>
+        <ul className="text-stone-700 leading-relaxed mb-6 space-y-2 list-disc pl-6">
+          <li>
+            <strong>A workspace catalog</strong> of MCP servers, maintained centrally.
+          </li>
+          <li>
+            <strong>Per-agent scoped tokens</strong> minted on demand, TTL-bounded, revocable per agent.
+          </li>
+          <li>
+            <strong>Policy packs</strong> with two new keys, <code>mcp_scope</code> and <code>mcp_actions</code>, so &ldquo;this agent may call GitHub MCP but only for read operations&rdquo; is one line of YAML.
+          </li>
+          <li>
+            <strong>Hash-chained audit</strong> on every tool call, with the resolving policy rule id attached. Exportable to SIEM.
+          </li>
+          <li>
+            <strong>Auto-discovery</strong> that watches your existing agent configs (<code>.mcp.json</code>, Claude Desktop, Cursor, Windsurf) and promotes newly-found MCP servers into the catalog in observation mode.
+          </li>
+        </ul>
+
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">
+          What this looks like for a platform team
+        </h2>
+        <p className="text-stone-700 leading-relaxed mb-3">
+          Rotate the GitHub app token: one action in Guard, zero agent redeploys. Every agent picks up the new token on next <code>discover_mcps()</code> call.
+        </p>
+        <p className="text-stone-700 leading-relaxed mb-3">
+          Revoke the finance agent&rsquo;s source-control access: one policy rule, effective on the next agent tick.
+        </p>
+        <p className="text-stone-700 leading-relaxed mb-3">
+          Add a new MCP server: admin approves in Guard, every agent sees it on next boot if policy allows.
+        </p>
+        <p className="text-stone-700 leading-relaxed mb-6">
+          CISO asks &ldquo;did any agent touch customer-data MCP last night?&rdquo;: one query against the hash-chained log.
+        </p>
+
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">
+          Why nobody has shipped this yet
+        </h2>
+        <p className="text-stone-700 leading-relaxed mb-4">
+          MCP is a young standard. The vendors with existing distribution (LLM proxies) point at model calls, not tool calls. The tool side has a lot of MCP <em>servers</em> now, and a growing set of MCP <em>clients</em> (Claude Desktop, Cursor, Copilot, Cline), but no one has occupied the gateway spot between them. That is what Guard is now.
+        </p>
+
+        <p className="text-stone-700 leading-relaxed mb-6">
+          The moat is not the four bullets above. Each of them is a page of code. The moat is that we already had the hash-chain audit, the token vault, the policy engine, the discovery daemon, and the pack schema. This launch is a bridge across primitives we shipped over the last 18 months, exposed through one new front door.
+        </p>
+
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">Try it</h2>
+
+        <pre className="bg-stone-900 text-stone-100 rounded-lg px-4 py-3 text-sm overflow-x-auto mb-6">
+          <code>{`pip install conduct-cli
+conduct login
+conduct mcp list             # see the workspace catalog
+conduct mcp rotate github    # rotate a credential`}</code>
+        </pre>
+
+        <p className="text-stone-700 leading-relaxed mb-8">
+          Docs:{" "}
+          <a href="/mcp-gateway" className="text-indigo-600 hover:underline">
+            conductai.ai/mcp-gateway
+          </a>
+          <br />
+          Source:{" "}
+          <a
+            href="https://github.com/sseshachala/conductai/issues/1246"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-indigo-600 hover:underline"
+          >
+            github.com/sseshachala/conductai (issue #1246)
+          </a>
+        </p>
+
+        <h2 className="text-2xl font-bold text-stone-900 mt-12 mb-4">
+          One line for your slide deck
+        </h2>
+        <blockquote className="border-l-4 border-indigo-500 pl-6 py-2 text-stone-700 italic mb-8">
+          LiteLLM makes model calls fungible. Guard makes tool access governable. We are not a competing proxy. We are the layer no proxy touches.
+        </blockquote>
+
+        <div className="not-prose flex flex-wrap gap-3 mt-12 mb-8">
+          <a
+            href="/mcp-gateway"
+            className="inline-flex items-center gap-2 rounded-lg bg-stone-900 text-white px-5 py-3 text-sm font-semibold hover:bg-stone-800 transition-colors"
+          >
+            MCP Gateway landing
+          </a>
+          <a
+            href="https://github.com/sseshachala/conductai/issues/1246"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-lg border border-stone-200 bg-white text-stone-700 px-5 py-3 text-sm font-semibold hover:border-stone-300 hover:shadow-sm transition-all"
+          >
+            View epic on GitHub
+          </a>
+        </div>
+
+        <div className="mt-16 pt-8 border-t border-stone-200">
+          <CtaLink className="inline-flex items-center gap-2 rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors" />
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -32,6 +32,13 @@ function ProductsDropdown() {
               <p className="text-xs text-stone-400">Guard — see and control every AI session</p>
             </div>
           </a>
+          <a href="/mcp-gateway" className="flex items-center gap-3 px-4 py-2.5 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
+            <span>🔌</span>
+            <div>
+              <p className="font-semibold">MCP Gateway</p>
+              <p className="text-xs text-stone-400">Boot-time tool discovery + policy + audit</p>
+            </div>
+          </a>
           <a href="/router" className="flex items-center gap-3 px-4 py-2.5 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
             <span className="text-indigo-600 font-bold">⇋</span>
             <div>
@@ -137,7 +144,7 @@ function MarketingFooter() {
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-8">
             {[
-              { heading: "Product", links: [["Guard", "/guard"], ["Use cases", "/use-cases"], ["Registry", "/registry"], ["SDD Scanner", "/sdd"], ["CLI", "/tools/conduct-cli"], ["Frameworks", "/frameworks"]] as [string, string][] },
+              { heading: "Product", links: [["Guard", "/guard"], ["MCP Gateway", "/mcp-gateway"], ["Use cases", "/use-cases"], ["Registry", "/registry"], ["SDD Scanner", "/sdd"], ["CLI", "/tools/conduct-cli"], ["Frameworks", "/frameworks"]] as [string, string][] },
               { heading: "Solutions", links: [["Engineering leaders", "/solutions/engineering-leaders"], ["Security & compliance", "/solutions/security-compliance"], ["Security Loop", "/solutions/security-loop"], ["Action governance", "/solutions/action-governance"], ["Memory hardening", "/solutions/memory-hardening"], ["Okta + Conduct", "/solutions/okta-plus-conduct"], ["Financial services", "/solutions/financial-services"], ["Life sciences", "/solutions/life-sciences"], ["All use cases", "/use-cases"], ["Deployment options", "/deployment"]] as [string, string][] },
               { heading: "Company", links: [["About", "/about"], ["Blog", "/blog"]] as [string, string][] },
               { heading: "Resources", links: [["Team OS", "/team-os"], ["Docs", "/docs"], ["Security", "/security"], ["Open source", "/open-source"], ["GitHub", "https://github.com/sseshachala/conductai"]] as [string, string][] },

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -3,7 +3,7 @@ import { CtaLink } from "@/components/marketing/CtaLink"
 export const metadata = {
   title: "MCP Gateway — One phone book for every AI agent's tools | Conduct",
   description:
-    "Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Stop hardcoding endpoints. Rotate once, revoke instantly, audit everything.",
+    "Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Pre-canned Registry + Bring Your Own MCP. Per-tool policy enforcement.",
 }
 
 export default function MCPGatewayPage() {
@@ -12,6 +12,8 @@ export default function MCPGatewayPage() {
       <HeroSection />
       <PositioningStrip />
       <FeatureGrid />
+      <RegistrySection />
+      <UseCasesSection />
       <ComparisonSection />
       <ElevatorSection />
       <CtaFooterSection />
@@ -76,22 +78,22 @@ function PositioningStrip() {
 function FeatureGrid() {
   const features: { icon: string; title: string; body: string }[] = [
     {
-      icon: "🔌",
+      icon: "\ud83d\udd0c",
       title: "Boot-time discovery",
       body: "guard.discover_mcps() returns the tools this agent may reach right now, with time-bounded scoped tokens.",
     },
     {
-      icon: "🔑",
+      icon: "\ud83d\udd11",
       title: "Per-agent credential brokering",
       body: "Rotate a GitHub app token once. Every agent picks it up on next boot. Zero redeploys.",
     },
     {
-      icon: "🎯",
+      icon: "\ud83c\udfaf",
       title: "Policy per tool intent",
       body: "\u201cThis agent may call GitHub MCP, but only for read operations.\u201d Two lines of YAML. Blocked calls log the rule id.",
     },
     {
-      icon: "🔗",
+      icon: "\ud83d\udd17",
       title: "Hash-chained audit",
       body: "Every tool call is tamper-evident. Export to SIEM. Answer \u201cdid any agent touch customer-data last night\u201d in one query.",
     },
@@ -104,6 +106,178 @@ function FeatureGrid() {
             <div className="text-2xl mb-3">{f.icon}</div>
             <h3 className="text-lg font-bold text-stone-900 mb-2">{f.title}</h3>
             <p className="text-sm text-stone-600 leading-relaxed">{f.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function RegistrySection() {
+  const canned: { name: string; icon: string }[] = [
+    { name: "GitHub", icon: "\ud83d\udc19" },
+    { name: "Slack", icon: "\ud83d\udcac" },
+    { name: "Postgres", icon: "\ud83d\udc18" },
+    { name: "Filesystem", icon: "\ud83d\udcc1" },
+    { name: "Confluence", icon: "\ud83d\udcd8" },
+    { name: "Jira", icon: "\ud83d\udccb" },
+    { name: "GDrive", icon: "\ud83d\udcc2" },
+    { name: "Sentry", icon: "\ud83d\udea8" },
+    { name: "Linear", icon: "\ud83d\udcd0" },
+    { name: "Notion", icon: "\ud83d\udcdd" },
+  ]
+  const perToolRows: { icon: string; iconColor: string; tool: string; verdict: string }[] = [
+    { icon: "\u2713", iconColor: "text-emerald-600", tool: "GitHub.create_issue", verdict: "Allowed" },
+    { icon: "\u26a0", iconColor: "text-yellow-600", tool: "GitHub.merge_pr", verdict: "Requires human approval" },
+    { icon: "\u2715", iconColor: "text-red-600", tool: "Postgres.execute", verdict: "Blocked" },
+    { icon: "\u2713", iconColor: "text-emerald-600", tool: "Postgres.query", verdict: "Allowed (read-only)" },
+  ]
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-16">
+      <div className="text-center mb-10">
+        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
+          Registry + Bring Your Own
+        </h2>
+        <p className="text-stone-500 max-w-2xl mx-auto">
+          Two catalog sources, one enforcement layer. Every tool call is policy-checked whether the MCP shipped with Guard or you registered it yourself.
+        </p>
+      </div>
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="border border-stone-200 rounded-xl bg-white p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-indigo-700 bg-indigo-50 border border-indigo-100 px-2.5 py-1 rounded-full">
+              Pre-canned
+            </span>
+            <h3 className="text-lg font-bold text-stone-900">Conduct Registry</h3>
+          </div>
+          <p className="text-sm text-stone-600 leading-relaxed mb-4">
+            Curated MCPs with default policy packs already attached per tool. Click Enable, get sensible defaults (approval on writes, read-only for restricted roles, PII redaction on outputs). No week of policy writing before day one.
+          </p>
+          <div className="grid grid-cols-5 gap-2">
+            {canned.map(m => (
+              <div key={m.name} className="flex flex-col items-center gap-1 p-2 rounded-lg bg-stone-50 border border-stone-100">
+                <span className="text-xl">{m.icon}</span>
+                <span className="text-[10px] font-semibold text-stone-500">{m.name}</span>
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-stone-400 mt-3">10 MCPs at launch, more each month.</p>
+        </div>
+        <div className="border border-stone-200 rounded-xl bg-white p-6">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-[10px] font-bold uppercase tracking-widest text-stone-700 bg-stone-100 border border-stone-200 px-2.5 py-1 rounded-full">
+              Bring your own
+            </span>
+            <h3 className="text-lg font-bold text-stone-900">Private MCPs</h3>
+          </div>
+          <p className="text-sm text-stone-600 leading-relaxed mb-4">
+            Register any MCP server. Guard introspects it via the standard tools/list call, pulls every tool schema, and lets admins attach policy packs per tool.
+          </p>
+          <pre className="bg-stone-900 text-stone-100 rounded-lg px-3 py-2 text-xs overflow-x-auto">
+            <code>{`$ conduct mcp add https://internal.mcp/finance
+  \u2192 17 tools introspected
+  \u2192 default pack applied (read-only)
+  \u2192 admin approval required to enable writes`}</code>
+          </pre>
+          <p className="text-xs text-stone-400 mt-3">Per-tool policies, not per-server.</p>
+        </div>
+      </div>
+
+      <div className="mt-6 border border-stone-200 rounded-xl bg-stone-50 p-6">
+        <p className="text-xs font-bold uppercase tracking-widest text-stone-500 mb-3">
+          Per-tool policy examples
+        </p>
+        <div className="grid sm:grid-cols-2 gap-3 text-sm">
+          {perToolRows.map(r => (
+            <div key={r.tool} className="flex items-start gap-3 bg-white border border-stone-200 rounded-lg p-3">
+              <span className={`${r.iconColor} font-bold mt-0.5`}>{r.icon}</span>
+              <div>
+                <p className="font-semibold text-stone-800">{r.tool}</p>
+                <p className="text-xs text-stone-500">{r.verdict}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function UseCasesSection() {
+  const cases: { persona: string; title: string; before: string; after: string }[] = [
+    {
+      persona: "Platform Ops",
+      title: "End MCP tool sprawl",
+      before:
+        "Every agent has a copy of every MCP endpoint and every credential pasted into its config. Onboarding a new MCP means 20 config edits and 20 redeploys.",
+      after:
+        "One central catalog. Agents ask guard.discover_mcps() at boot. New MCPs propagate to every agent on next boot, no code changes.",
+    },
+    {
+      persona: "Security",
+      title: "Least privilege per agent",
+      before:
+        "Every agent shares one long-lived MCP token with full workspace scope. Blast radius of a compromised agent is every tool that token can touch.",
+      after:
+        "Per-agent scoped tokens minted on demand, TTL-bounded, revocable per agent. \u201cThis agent may call GitHub MCP only for read.\u201d Two lines of YAML.",
+    },
+    {
+      persona: "Compliance & Audit",
+      title: "Prove every tool call",
+      before:
+        "\u201cDid any agent hit customer-data MCP last night?\u201d = grep across 20 log formats, hope you have retention, hope nothing was rotated out.",
+      after:
+        "One query against the hash-chained audit log. Tamper-evident, resolving policy rule id attached to every call. SIEM-exportable.",
+    },
+    {
+      persona: "AI Coding Assistants",
+      title: "Govern Cursor, Copilot, Claude Desktop, Cline",
+      before:
+        "Developers install MCP servers ad hoc into their IDE configs. Central IT has zero visibility into which tools their AI assistants can reach.",
+      after:
+        "Discovery daemon detects MCPs registered in .mcp.json, Claude Desktop, Cursor, Windsurf. Central catalog with observe-then-enforce toggle. Devs use approved MCPs, everything else logged.",
+    },
+    {
+      persona: "AI Product Team",
+      title: "Ship agents in a week, not a quarter",
+      before:
+        "Enabling GitHub + Slack + Postgres MCPs for an agent means a week of reading MCP docs, writing per-tool rules, testing, and hoping nothing was missed.",
+      after:
+        "Enable pre-canned MCPs from the Conduct Registry. Sensible default policies attached per tool. Tune later. Ship this week.",
+    },
+  ]
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-16">
+      <div className="text-center mb-10">
+        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
+          Use cases
+        </h2>
+        <p className="text-stone-500">
+          Where MCP Gateway earns its place in the stack.
+        </p>
+      </div>
+      <div className="grid sm:grid-cols-2 gap-6">
+        {cases.map(c => (
+          <div
+            key={c.title}
+            className="border border-stone-200 rounded-xl bg-white p-6 flex flex-col"
+          >
+            <p className="text-[10px] font-bold uppercase tracking-widest text-indigo-700 mb-2">
+              {c.persona}
+            </p>
+            <h3 className="text-lg font-bold text-stone-900 mb-4">{c.title}</h3>
+            <div className="mb-4">
+              <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-1">
+                Before
+              </p>
+              <p className="text-sm text-stone-600 leading-relaxed">{c.before}</p>
+            </div>
+            <div>
+              <p className="text-xs font-bold uppercase tracking-widest text-indigo-700 mb-1">
+                With MCP Gateway
+              </p>
+              <p className="text-sm text-stone-700 leading-relaxed">{c.after}</p>
+            </div>
           </div>
         ))}
       </div>
@@ -161,7 +335,7 @@ function ElevatorSection() {
     <section className="max-w-3xl mx-auto px-6 pb-16">
       <div className="border-l-4 border-indigo-500 bg-indigo-50/50 rounded-r-xl px-8 py-6">
         <p className="text-lg text-stone-700 leading-relaxed">
-          Every enterprise with more than three AI agents has the same problem. Each agent hardcodes its own copy of every tool endpoint and every credential. Rotate a token, redeploy 20 things. Guard becomes the one place agents ask &ldquo;what tools am I allowed to reach right now, and with what credentials?&rdquo; and every tool call goes through a policy check with hash-chained audit. LiteLLM solved model sprawl. Nobody solved tool sprawl. That is Guard.
+          Every enterprise with more than three AI agents has the same problem. Each agent hardcodes its own copy of every tool endpoint and every credential. Rotate a token, redeploy 20 things. Guard becomes the one place agents ask &ldquo;what tools am I allowed to reach right now, and with what credentials?&rdquo; Enable pre-canned MCPs from the Registry with sensible defaults, or register your own private MCPs and Guard introspects the tool schemas so you attach policy per tool. Every call is hash-chained. LiteLLM solved model sprawl. Nobody solved tool sprawl. That is Guard.
         </p>
       </div>
     </section>

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -1,0 +1,201 @@
+import { CtaLink } from "@/components/marketing/CtaLink"
+
+export const metadata = {
+  title: "MCP Gateway — One phone book for every AI agent's tools | Conduct",
+  description:
+    "Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Stop hardcoding endpoints. Rotate once, revoke instantly, audit everything.",
+}
+
+export default function MCPGatewayPage() {
+  return (
+    <>
+      <HeroSection />
+      <PositioningStrip />
+      <FeatureGrid />
+      <ComparisonSection />
+      <ElevatorSection />
+      <CtaFooterSection />
+    </>
+  )
+}
+
+function HeroSection() {
+  return (
+    <section className="max-w-5xl mx-auto px-6 pt-20 pb-12 text-center">
+      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 border border-indigo-100 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-4">
+        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
+        Early access
+      </div>
+      <div className="inline-flex items-center gap-2 bg-stone-100 text-stone-600 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8 ml-2">
+        <span className="w-1.5 h-1.5 rounded-full bg-stone-400 inline-block" />
+        MCP Gateway
+      </div>
+      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-5">
+        One phone book for every AI agent&rsquo;s tools.
+      </h1>
+      <p className="text-xl text-stone-500 max-w-3xl mx-auto leading-relaxed mb-10">
+        Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Stop hardcoding endpoints. Stop pasting credentials into 20 configs. Rotate once, revoke instantly, audit everything.
+      </p>
+      <div className="flex flex-wrap justify-center gap-3">
+        <a
+          href="mailto:hello@conductai.ai?subject=MCP%20Gateway%20early%20access"
+          className="inline-flex items-center gap-2 rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+        >
+          Get early access
+        </a>
+        <a
+          href="https://github.com/sseshachala/conductai/issues/1246"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all"
+        >
+          See the epic
+        </a>
+      </div>
+    </section>
+  )
+}
+
+function PositioningStrip() {
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-12">
+      <div className="bg-stone-900 text-white rounded-2xl px-8 py-8 text-center">
+        <p className="text-xl sm:text-2xl font-semibold leading-relaxed">
+          LiteLLM makes model calls fungible.
+          <br />
+          Guard makes tool access governable.
+        </p>
+        <p className="text-sm text-stone-400 mt-3 font-medium">
+          Different phone, different problem, different room.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+function FeatureGrid() {
+  const features: { icon: string; title: string; body: string }[] = [
+    {
+      icon: "🔌",
+      title: "Boot-time discovery",
+      body: "guard.discover_mcps() returns the tools this agent may reach right now, with time-bounded scoped tokens.",
+    },
+    {
+      icon: "🔑",
+      title: "Per-agent credential brokering",
+      body: "Rotate a GitHub app token once. Every agent picks it up on next boot. Zero redeploys.",
+    },
+    {
+      icon: "🎯",
+      title: "Policy per tool intent",
+      body: "\u201cThis agent may call GitHub MCP, but only for read operations.\u201d Two lines of YAML. Blocked calls log the rule id.",
+    },
+    {
+      icon: "🔗",
+      title: "Hash-chained audit",
+      body: "Every tool call is tamper-evident. Export to SIEM. Answer \u201cdid any agent touch customer-data last night\u201d in one query.",
+    },
+  ]
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-16">
+      <div className="grid sm:grid-cols-2 gap-6">
+        {features.map(f => (
+          <div key={f.title} className="border border-stone-200 rounded-xl bg-white p-6">
+            <div className="text-2xl mb-3">{f.icon}</div>
+            <h3 className="text-lg font-bold text-stone-900 mb-2">{f.title}</h3>
+            <p className="text-sm text-stone-600 leading-relaxed">{f.body}</p>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+function ComparisonSection() {
+  const rows: [string, string, string][] = [
+    ["Governs", "Model calls", "Tool calls"],
+    ["Audit granularity", "Completion", "Tool invocation"],
+    ["Credential type", "Inbound provider keys", "Outbound tool credentials"],
+    ["Policy vocabulary", "Model requests", "Tool intent"],
+    ["Answers \u201cwho called what\u201d", "Model, prompt", "Tool, arguments, side effect"],
+    ["Category age", "Mature", "Empty (nobody has planted the flag)"],
+  ]
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-16">
+      <div className="text-center mb-8">
+        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
+          Not a competing proxy.
+        </h2>
+        <p className="text-stone-500">A different layer entirely.</p>
+      </div>
+      <div className="overflow-x-auto border border-stone-200 rounded-xl bg-white">
+        <table className="w-full text-sm">
+          <thead className="bg-stone-50 border-b border-stone-200">
+            <tr>
+              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-stone-500"></th>
+              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-stone-500">
+                LLM Proxy (LiteLLM, Portkey)
+              </th>
+              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-indigo-700">
+                MCP Gateway (Guard)
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map(([label, a, b]) => (
+              <tr key={label} className="border-b border-stone-100 last:border-b-0">
+                <td className="px-6 py-4 font-semibold text-stone-700">{label}</td>
+                <td className="px-6 py-4 text-stone-600">{a}</td>
+                <td className="px-6 py-4 text-indigo-700 font-medium">{b}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  )
+}
+
+function ElevatorSection() {
+  return (
+    <section className="max-w-3xl mx-auto px-6 pb-16">
+      <div className="border-l-4 border-indigo-500 bg-indigo-50/50 rounded-r-xl px-8 py-6">
+        <p className="text-lg text-stone-700 leading-relaxed">
+          Every enterprise with more than three AI agents has the same problem. Each agent hardcodes its own copy of every tool endpoint and every credential. Rotate a token, redeploy 20 things. Guard becomes the one place agents ask &ldquo;what tools am I allowed to reach right now, and with what credentials?&rdquo; and every tool call goes through a policy check with hash-chained audit. LiteLLM solved model sprawl. Nobody solved tool sprawl. That is Guard.
+        </p>
+      </div>
+    </section>
+  )
+}
+
+function CtaFooterSection() {
+  return (
+    <section className="max-w-5xl mx-auto px-6 pb-24">
+      <div className="border border-stone-200 rounded-2xl bg-white p-10 text-center">
+        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-3">
+          Ready to stop pasting MCP tokens into 20 configs?
+        </h2>
+        <p className="text-stone-500 max-w-xl mx-auto mb-8">
+          MCP Gateway is in early access. Get on the list to try the boot-time discovery API and per-agent credential brokering the day it opens.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <a
+            href="mailto:hello@conductai.ai?subject=MCP%20Gateway%20early%20access"
+            className="inline-flex items-center gap-2 rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+          >
+            Get early access
+          </a>
+          <a
+            href="https://github.com/sseshachala/conductai/issues/1246"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all"
+          >
+            Read the build epic
+          </a>
+          <CtaLink className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all" />
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -74,6 +74,13 @@ function ProductsDropdown() {
               <p className="text-xs text-stone-400">Guard — see and control every AI session</p>
             </div>
           </a>
+          <a href="/mcp-gateway" className="flex items-center gap-3 px-4 py-2.5 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
+            <span>🔌</span>
+            <div>
+              <p className="font-semibold">MCP Gateway</p>
+              <p className="text-xs text-stone-400">Boot-time tool discovery + policy + audit</p>
+            </div>
+          </a>
           <a href="/registry" className="flex items-center gap-3 px-4 py-2.5 text-sm text-stone-700 hover:bg-stone-50 transition-colors">
             <span>⚡</span>
             <div>
@@ -858,7 +865,7 @@ function PageFooter() {
           </div>
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-8">
             {[
-              { heading: "Product", links: [["Team OS", "/team-os"], ["Guard", "/guard"], ["Use cases", "/use-cases"], ["Registry", "/registry"], ["CLI", "/tools/conduct-cli"], ["Frameworks", "/frameworks"]] as [string, string][] },
+              { heading: "Product", links: [["Team OS", "/team-os"], ["Guard", "/guard"], ["MCP Gateway", "/mcp-gateway"], ["Use cases", "/use-cases"], ["Registry", "/registry"], ["CLI", "/tools/conduct-cli"], ["Frameworks", "/frameworks"]] as [string, string][] },
               { heading: "Solutions", links: [["Engineering leaders", "/solutions/engineering-leaders"], ["Security & compliance", "/solutions/security-compliance"], ["Security Loop", "/solutions/security-loop"], ["Action governance", "/solutions/action-governance"], ["Memory hardening", "/solutions/memory-hardening"], ["Okta + Conduct", "/solutions/okta-plus-conduct"], ["Financial services", "/solutions/financial-services"], ["Life sciences", "/solutions/life-sciences"], ["All use cases", "/use-cases"], ["Deployment options", "/deployment"]] as [string, string][] },
               { heading: "Company", links: [["About", "/about"], /* ["Partners", "/partners"], */ ["Blog", "/blog"]] as [string, string][] },
               { heading: "Resources", links: [["Docs", "/docs"], ["Open source", "/open-source"], ["GitHub", "https://github.com/sseshachala/conduct-cli"]] as [string, string][] },


### PR DESCRIPTION
## What

Ships the marketing surface for the MCP Gateway product line (see [category-ownership epic #1247](https://github.com/sseshachala/conductai/issues/1247) and [build epic #1246](https://github.com/sseshachala/conductai/issues/1246)).

## Changes

- **`apps/web/src/app/(marketing)/mcp-gateway/page.tsx`** — new landing page
  - Hero with **Early access** pill (honest about pre-launch state)
  - Positioning strip: *LiteLLM makes model calls fungible. Guard makes tool access governable.*
  - 4-card feature grid (boot-time discovery, credential brokering, policy per tool intent, hash-chained audit)
  - Comparison table: LLM Proxy vs MCP Gateway
  - Elevator paragraph
  - CTA footer with `mailto:` early access + link to #1246
- **`apps/web/src/app/(marketing)/blog/mcp-gateway-launch/page.tsx`** — new launch blog post (draft, not listed)
- **`apps/web/src/app/(marketing)/layout.tsx`** — MCP Gateway added to `ProductsDropdown` (between Guard and Router) + footer Product column
- **`apps/web/src/app/page.tsx`** — MCP Gateway added to home `ProductsDropdown` + home footer Product column

## Timing / honesty

The boot-time discovery API (`guard.discover_mcps()`) is not yet shipped. Landing page copy leads with an **Early access** pill and CTAs point to `mailto:hello@conductai.ai` and the build epic (#1246) rather than nonexistent docs or an install command.

**Blog post is deliberately not wired into `/blog` listing.** The file exists at `/blog/mcp-gateway-launch` (deep-linkable for pre-briefs to analysts) but won't show up in the blog index until code lands. When #1246 Phase 1 (read API returning real data) is ready:
1. Add the post to `/blog` index/list
2. Swap landing page primary CTA from *Get early access* to *Read the docs* + install snippet
3. Publish HN / LinkedIn / Twitter per #1247 timeline

## Verify

- Preview URL (Vercel will auto-generate): landing page at `/mcp-gateway`, blog at `/blog/mcp-gateway-launch`
- Nav: hover **Product** in the header — MCP Gateway should appear between Guard and Router
- Footer: **Product** column should list MCP Gateway
- TypeScript: `pnpm typecheck` — green ✅

## Follow-ups (not in this PR)

- Reserve the `mcp-gateway` route on any middleware/redirect config if applicable
- Design an OG image for the landing + blog (currently uses default site OG)
- Docs section at `/docs/mcp-gateway/` — separate PR, blocked on #1246 Phase 1 API surface being final
- Comparison sub-pages (`/mcp-gateway/vs/litellm`, etc.) per #1247 workstream 4

Refs #1247, #1246.