### PR TITLE
feat(glens,mcp): add list_workflows + get_blocked_workflows on both s…

### DIFF
--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -19,6 +19,8 @@ from app.modules.guard.models import (
 )
 from app.modules.guard.routers.spend import _get_spend_summary_inner, _org_ws_subquery
 from app.modules.guard.embedding import embedding_client_for_workspace
+from app.models.workflow import Workflow
+from sqlalchemy import func as sa_func
 
 log = structlog.get_logger(__name__)
 
@@ -742,4 +744,94 @@ class Executor:
                 "user_email": e.user_email,
             }
             for e in rows
+        ]
+
+    # ── Workflow inventory + block roll-up ──────────────────────────────────
+
+    def _tool_list_workflows(self, status: str | None = None, limit: int = 20):
+        """Enumerate workflows in this workspace's org.
+
+        status: 'active' (default) | 'archived' | 'all'. Returns id/name/
+        guard_enabled/updated_at, ordered by most recently updated.
+        """
+        org_ws = _org_ws_subquery(self.db, self.workspace_id)
+        q = self.db.query(Workflow).filter(Workflow.workspace_id.in_(org_ws))
+        status = (status or "active").lower()
+        if status == "active":
+            q = q.filter(Workflow.archived_at.is_(None))
+        elif status == "archived":
+            q = q.filter(Workflow.archived_at.isnot(None))
+        # 'all' → no filter
+        rows = q.order_by(Workflow.updated_at.desc()).limit(min(limit, 100)).all()
+        return [
+            {
+                "workflow_id": str(w.id),
+                "name": w.name,
+                "guard_enabled": bool(w.guard_enabled),
+                "archived": w.archived_at is not None,
+                "updated_at": w.updated_at.isoformat() if w.updated_at else None,
+            }
+            for w in rows
+        ]
+
+    def _tool_get_blocked_workflows(
+        self,
+        since: str | None = None,
+        until: str | None = None,
+        workflow_id: str | None = None,
+        rule_id: str | None = None,
+        limit: int = 20,
+    ):
+        """Workflows that Guard has blocked, ranked by block count.
+
+        Groups guard_audit_events where decision='blocked' AND
+        conductai_workflow_id IS NOT NULL by workflow. Returns
+        [{workflow_id, name, block_count, top_rule_id, last_blocked_at}].
+        """
+        org_ws = _org_ws_subquery(self.db, self.workspace_id)
+        base = (
+            self.db.query(GuardAuditEvent)
+            .filter(GuardAuditEvent.workspace_id.in_(org_ws))
+            .filter(GuardAuditEvent.decision == "blocked")
+            .filter(GuardAuditEvent.conductai_workflow_id.isnot(None))
+        )
+        if since:
+            base = base.filter(GuardAuditEvent.ts >= since)
+        if until:
+            base = base.filter(GuardAuditEvent.ts <= until)
+        if workflow_id:
+            base = base.filter(GuardAuditEvent.conductai_workflow_id == workflow_id)
+        if rule_id:
+            base = base.filter(GuardAuditEvent.rule_id == rule_id)
+
+        # Single-query top_rule_id via Postgres MODE() WITHIN GROUP. Use MAX(name)
+        # to survive workflow renames (old events keep the old label).
+        top_rule = (
+            sa_func.mode()
+            .within_group(GuardAuditEvent.rule_id.asc())
+            .filter(GuardAuditEvent.rule_id.isnot(None))
+            .label("top_rule_id")
+        )
+        rows = (
+            base.with_entities(
+                GuardAuditEvent.conductai_workflow_id.label("workflow_id"),
+                sa_func.max(GuardAuditEvent.conductai_workflow).label("name"),
+                sa_func.count().label("block_count"),
+                sa_func.max(GuardAuditEvent.ts).label("last_blocked_at"),
+                top_rule,
+            )
+            .group_by(GuardAuditEvent.conductai_workflow_id)
+            .order_by(sa_func.count().desc())
+            .limit(min(limit, 100))
+            .all()
+        )
+        return [
+            {
+                "workflow_id": r.workflow_id,
+                "name": r.name,
+                "block_count": int(r.block_count),
+                "top_rule_id": r.top_rule_id,
+                "last_blocked_at": r.last_blocked_at.isoformat() if r.last_blocked_at else None,
+            }
+            for r in rows
         ]

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -132,6 +132,35 @@ TOOLS = [
         "description": "Get Guard configuration: enforcement mode (block/warn/advisory/off), fail mode, whether Slack notifications are on. Use for 'guard settings', 'is guard blocking', 'enforcement mode' questions.",
         "input_schema": {"type": "object", "properties": {}},
     },
+    {
+        "name": "list_workflows",
+        "description": "List workflows in this workspace's org. Use for 'what workflows do we have', 'show all workflows', 'archived workflows'. status defaults to 'active'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["active", "archived", "all"]},
+                "limit": {"type": "integer", "default": 20, "description": "Max rows (max 100)"},
+            },
+        },
+    },
+    {
+        "name": "get_blocked_workflows",
+        "description": (
+            "Workflows Guard has blocked, ranked by block count. Use for 'which workflow triggered a block', "
+            "'which workflows are being blocked', 'top blocked workflows'. Filter by workflow_id or rule_id "
+            "to drill in. since/until narrow the window."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "since": {"type": "string", "description": "ISO date start"},
+                "until": {"type": "string", "description": "ISO date end"},
+                "workflow_id": {"type": "string", "description": "Filter to one workflow"},
+                "rule_id": {"type": "string", "description": "Filter to one rule"},
+                "limit": {"type": "integer", "default": 20},
+            },
+        },
+    },
 ]
 
 def _load_system_prompt() -> str:
@@ -212,17 +241,28 @@ def _build_drilldown(tool_calls: list[tuple[str, dict]]) -> str | None:
                 filters["until"] = args["until"]
             if args.get("rule_id"):
                 filters["rule_id"] = args["rule_id"]
+        elif name == "get_blocked_workflows":
+            page = "/theguard/activity"
+            filters["decision"] = "blocked"
+            if args.get("since"):    filters["since"] = args["since"]
+            if args.get("until"):    filters["until"] = args["until"]
+            if args.get("workflow_id"): filters["workflow_id"] = args["workflow_id"]
+            if args.get("rule_id"):  filters["rule_id"] = args["rule_id"]
+        elif name == "list_workflows":
+            page = "/workflows"
         elif name in ("get_spend_summary", "get_savings_summary", "get_budgets"):
-            page = "/guard/spend"
+            page = "/theguard/spend"
         elif name in ("list_policies", "get_guard_config"):
-            page = "/guard/policies"
+            page = "/theguard/policies"
         elif name in ("get_discovery_summary",):
-            page = "/guard/discovery"
+            page = "/theguard/discovery"
         elif name in ("get_compliance_status", "get_framework_coverage"):
-            page = "/guard/compliance"
+            page = "/theguard/compliance"
 
     if not filters and page == "/logs/guard":
         return None
+    if "since" in filters and "until" not in filters:
+        filters["until"] = datetime.now(timezone.utc).strftime("%Y-%m-%d")
     if filters:
         qs = "&".join(f"{k}={v}" for k, v in filters.items())
         return f"{page}?{qs}"

--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -281,6 +281,42 @@ _TOOLS: list[ToolDef] = [
         annotations=_READ_ONLY,
         tags=_LENS_TAGS,
     ),
+    ToolDef(
+        name="list_workflows",
+        description="Enumerate workflows in this workspace's org. status = active (default) | archived | all.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["active", "archived", "all"]},
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("list_workflows"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_blocked_workflows",
+        description=(
+            "Workflows Guard has blocked, ranked by block count. Returns "
+            "[{workflow_id, name, block_count, top_rule_id, last_blocked_at}]. "
+            "Optional filters: since/until (ISO ts), workflow_id, rule_id."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "since": _TS_SINCE, "until": _TS_UNTIL,
+                "workflow_id": {"type": "string", "description": "Filter to one workflow"},
+                "rule_id": _RULE_ID,
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("get_blocked_workflows"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
 ]
 
 

--- a/apps/api/tests/glens/test_workflow_tools.py
+++ b/apps/api/tests/glens/test_workflow_tools.py
@@ -1,0 +1,182 @@
+"""Direct DB tests for the two workflow tools on GLens Executor.
+
+Exercises:
+- `_tool_list_workflows` — active/archived/all filter, org-scoped
+- `_tool_get_blocked_workflows` — group-by workflow_id, block_count rank,
+  top_rule_id via Postgres MODE() WITHIN GROUP, workflow_id + rule_id filters
+
+Requires a real Postgres (uses the same `requires_db` marker as the
+regression suite). Follows the `seeded_workspace` pattern: create a fresh
+workspace + insert test rows in setup, tear everything down in teardown.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from tests.regression.conftest import requires_db
+
+
+def _now():
+    return datetime.now(timezone.utc)
+
+
+@pytest.fixture
+def ws_and_executor():
+    """Fresh workspace + bound Executor. Cleans up all seeded rows on teardown."""
+    from app.core.database import SessionLocal
+    from app.models.workspace import Workspace
+    from app.modules.glens.executor import Executor
+
+    ws_id = uuid.uuid4()
+    tag = ws_id.hex[:8]
+    with SessionLocal() as db:
+        db.add(Workspace(
+            id=ws_id,
+            name="glens-wf-" + tag,
+            owner_id="user_test_glens_wf_" + tag,
+            plan="free",
+            is_approved=True,
+            created_at=_now(),
+            updated_at=_now(),
+        ))
+        db.commit()
+
+    db = SessionLocal()
+    try:
+        yield db, str(ws_id), Executor(db, str(ws_id))
+    finally:
+        db.close()
+        with SessionLocal() as db2:
+            from app.modules.guard.models import GuardAuditEvent
+            from app.models.workflow import Workflow
+            db2.query(GuardAuditEvent).filter(GuardAuditEvent.workspace_id == ws_id).delete()
+            db2.query(Workflow).filter(Workflow.workspace_id == ws_id).delete()
+            ws = db2.get(Workspace, ws_id)
+            if ws is not None:
+                db2.delete(ws)
+            db2.commit()
+
+
+def _seed_workflow(db, workspace_id, name, archived=False):
+    from app.models.workflow import Workflow
+    wf = Workflow(
+        id=uuid.uuid4(),
+        workspace_id=uuid.UUID(workspace_id),
+        name=name,
+        default_mode="dag",
+        guard_enabled=True,
+        agent_identity_required=True,
+        created_at=_now(),
+        updated_at=_now(),
+        archived_at=_now() if archived else None,
+    )
+    db.add(wf)
+    db.commit()
+    return str(wf.id)
+
+
+def _seed_event(db, workspace_id, workflow_id, workflow_name, rule_id, decision="blocked", when=None):
+    """Insert with an explicit column list so the test is immune to future
+    guard_audit_events column additions (ORM insert would name every column)."""
+    from sqlalchemy import text as sa_text
+    db.execute(
+        sa_text(
+            "INSERT INTO guard_audit_events "
+            "(id, workspace_id, ai_tool, source, decision, rule_id, "
+            " conductai_workflow_id, conductai_workflow, ts) "
+            "VALUES (:id, :ws, 'test_agent', 'hook', :dec, :rule, :wfid, :wfname, :ts)"
+        ),
+        {
+            "id": uuid.uuid4(),
+            "ws": uuid.UUID(workspace_id),
+            "dec": decision,
+            "rule": rule_id,
+            "wfid": workflow_id,
+            "wfname": workflow_name,
+            "ts": when or _now(),
+        },
+    )
+    db.commit()
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# list_workflows
+# ─────────────────────────────────────────────────────────────────────────────
+
+@requires_db
+def test_list_workflows_active_by_default(ws_and_executor):
+    db, ws_id, ex = ws_and_executor
+    _seed_workflow(db, ws_id, "alpha")
+    _seed_workflow(db, ws_id, "beta")
+    _seed_workflow(db, ws_id, "gamma", archived=True)
+
+    rows = ex._tool_list_workflows()
+    names = {r["name"] for r in rows}
+    assert names == {"alpha", "beta"}, names
+    assert all(r["archived"] is False for r in rows)
+
+
+@requires_db
+def test_list_workflows_status_archived_and_all(ws_and_executor):
+    db, ws_id, ex = ws_and_executor
+    _seed_workflow(db, ws_id, "active-1")
+    _seed_workflow(db, ws_id, "archived-1", archived=True)
+
+    assert {r["name"] for r in ex._tool_list_workflows(status="archived")} == {"archived-1"}
+    assert {r["name"] for r in ex._tool_list_workflows(status="all")} == {"active-1", "archived-1"}
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# get_blocked_workflows — the interesting one (MODE() WITHIN GROUP)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@requires_db
+def test_get_blocked_workflows_ranks_by_count_and_picks_top_rule(ws_and_executor):
+    """A has 3 blocks (R1×2, R2×1) → top R1. B has 5 blocks (R2×3, R3×2) → top R2.
+    C has 1 allowed event only → must NOT appear. Order = B, A."""
+    db, ws_id, ex = ws_and_executor
+    wf_a, wf_b, wf_c = "wf-a", "wf-b", "wf-c"
+
+    for rule in ("R1", "R1", "R2"):
+        _seed_event(db, ws_id, wf_a, "Alpha", rule)
+    for rule in ("R2", "R2", "R2", "R3", "R3"):
+        _seed_event(db, ws_id, wf_b, "Bravo", rule)
+    _seed_event(db, ws_id, wf_c, "Charlie", "R1", decision="allowed")
+
+    rows = ex._tool_get_blocked_workflows()
+
+    assert [r["workflow_id"] for r in rows] == [wf_b, wf_a], rows
+    assert rows[0]["name"] == "Bravo" and rows[0]["block_count"] == 5 and rows[0]["top_rule_id"] == "R2"
+    assert rows[1]["name"] == "Alpha" and rows[1]["block_count"] == 3 and rows[1]["top_rule_id"] == "R1"
+    assert all(r["workflow_id"] != wf_c for r in rows), "allowed-only workflow leaked in"
+
+
+@requires_db
+def test_get_blocked_workflows_filters_by_workflow_and_rule(ws_and_executor):
+    db, ws_id, ex = ws_and_executor
+    _seed_event(db, ws_id, "wf-a", "Alpha", "R1")
+    _seed_event(db, ws_id, "wf-a", "Alpha", "R2")
+    _seed_event(db, ws_id, "wf-b", "Bravo", "R1")
+
+    only_a = ex._tool_get_blocked_workflows(workflow_id="wf-a")
+    assert len(only_a) == 1 and only_a[0]["workflow_id"] == "wf-a" and only_a[0]["block_count"] == 2
+
+    only_r1 = ex._tool_get_blocked_workflows(rule_id="R1")
+    assert {r["workflow_id"] for r in only_r1} == {"wf-a", "wf-b"}
+    assert all(r["block_count"] == 1 for r in only_r1)
+
+
+@requires_db
+def test_get_blocked_workflows_bounded_by_since_until(ws_and_executor):
+    db, ws_id, ex = ws_and_executor
+    old = _now() - timedelta(days=10)
+    recent = _now() - timedelta(hours=1)
+    _seed_event(db, ws_id, "wf-a", "Alpha", "R1", when=old)
+    _seed_event(db, ws_id, "wf-a", "Alpha", "R1", when=recent)
+
+    since = (_now() - timedelta(days=1)).isoformat()
+    rows = ex._tool_get_blocked_workflows(since=since)
+    assert len(rows) == 1 and rows[0]["block_count"] == 1

--- a/apps/api/tests/regression/fixtures/mcp_new_lens_get_blocked_workflows.json
+++ b/apps/api/tests/regression/fixtures/mcp_new_lens_get_blocked_workflows.json
@@ -1,0 +1,35 @@
+{
+  "name": "mcp_new_lens_get_blocked_workflows",
+  "description": "New /mcp tools/call for get_blocked_workflows on an empty workspace \u2014 proves the tool is wired and returns a text-content result.",
+  "requires_db": true,
+  "request": {
+    "method": "POST",
+    "path": "/mcp",
+    "headers": {
+      "Content-Type": "application/json",
+      "Authorization": "Bearer {token}"
+    },
+    "body": {
+      "jsonrpc": "2.0",
+      "id": 41,
+      "method": "tools/call",
+      "params": {
+        "name": "get_blocked_workflows",
+        "arguments": {}
+      }
+    }
+  },
+  "expected_response": {
+    "status": 200,
+    "body_match": {
+      "jsonrpc": "2.0",
+      "id": 41
+    },
+    "custom_assertions": [
+      {
+        "kind": "result_has_content_type",
+        "type": "text"
+      }
+    ]
+  }
+}

--- a/apps/api/tests/regression/fixtures/mcp_new_lens_tools_list.json
+++ b/apps/api/tests/regression/fixtures/mcp_new_lens_tools_list.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp_new_lens_tools_list",
-  "description": "New /mcp tools/list surfaces registered Lens Executor tools via ToolRegistry — proves Phase 3b lens registrations are wired.",
+  "description": "New /mcp tools/list surfaces registered Lens Executor tools via ToolRegistry \u2014 proves Phase 3b lens registrations are wired.",
   "requires_db": true,
   "request": {
     "method": "POST",
@@ -23,7 +23,18 @@
       "id": 21
     },
     "custom_assertions": [
-      {"kind": "tools_include", "names": ["get_recent_events", "get_governance_kpis", "get_compliance_status", "list_policies", "search_knowledge"]}
+      {
+        "kind": "tools_include",
+        "names": [
+          "get_recent_events",
+          "get_governance_kpis",
+          "get_compliance_status",
+          "list_policies",
+          "search_knowledge",
+          "list_workflows",
+          "get_blocked_workflows"
+        ]
+      }
     ]
   }
 }

--- a/apps/api/tests/regression/test_mcp_parity.py
+++ b/apps/api/tests/regression/test_mcp_parity.py
@@ -38,6 +38,8 @@ MCP_FIXTURES_DB = [
     "mcp_new_guard_tools_list",
     "mcp_new_guard_status",
     "mcp_new_conduct_list_projects",
+    # Workflow tools — list_workflows + get_blocked_workflows reachable via /mcp
+    "mcp_new_lens_get_blocked_workflows",
 ]
 
 


### PR DESCRIPTION
…urfaces

Two workflow tools on the Conduct MCP registry and GLens chat:
- list_workflows(status?, limit?) — enumerate workflows in this workspace's org
- get_blocked_workflows(since?, until?, workflow_id?, rule_id?, limit?) — workflows ranked by Guard block count with top_rule_id and last_blocked_at

get_blocked_workflows uses a single-query Postgres MODE() WITHIN GROUP for top_rule_id (no N+1). MAX(name) handles workflow renames.

Also fixes the GLens governance drilldown URLs (/guard/* -> /theguard/*) and caps open-ended date ranges by adding until=<today> when only since is set.

Tests: 5 new DB tests + 1 new MCP fixture + tools/list assertion updated.

## What this PR does

One or two sentences on the change and the reason for it. Link the
issue if there is one (`fixes #123`).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor / internal change (no user-visible behaviour change)
- [ ] Docs
- [ ] Playbook / pack

## Checklist

- [ ] Tests added or updated (or explicit note why not).
- [ ] `pytest` (API) and `pnpm typecheck` (web) pass locally.
- [ ] No secrets, no personal data, no customer names in the diff.
- [ ] Commit messages describe the **why**.
- [ ] Docs updated if behaviour changed.

## How to test

Steps a reviewer can follow to see the change working.

## Screenshots or output

If UI or CLI output changed, paste before/after.
