### PR TITLE
feat(glens,guard): #1254 route Phase-1 LLM calls through in-process Guard gateway

### DIFF
--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -153,6 +153,7 @@ async def guarded_llm_call(
     ai_tool: str = "lens",
     prompt_summary: str = "lens",
     user_email: str | None = None,
+    clerk_user_id: str = "system:lens",
     upstream_api_key: str | None = None,
     vendor_key: str | None = None,
     extra_headers: dict | None = None,
@@ -176,7 +177,7 @@ async def guarded_llm_call(
 
     resp = await guarded_completion(
         workspace_id=workspace_id,
-        clerk_user_id="",
+        clerk_user_id=clerk_user_id,
         ai_tool=ai_tool,
         provider=provider,
         model=model,
@@ -235,3 +236,128 @@ class GuardedLLMBlocked(Exception):
         self.status = status
         self.detail = detail
         self.payload = payload
+
+
+
+def guarded_llm_stream(
+    *,
+    workspace_id: str,
+    provider: str,
+    model: str,
+    upstream_url: str,
+    api_key: str,
+    messages: list[dict],
+    system: str,
+    max_tokens: int,
+    on_token,
+    ai_tool: str = "lens",
+    clerk_user_id: str = "system:lens",
+    db=None,
+) -> str:
+    """Streaming, in-process sibling of `guarded_llm_call` for OpenAI-shape SSE.
+
+    Extracted from GLens `_stream_synthesis` in #1254 so any in-process caller
+    (Lens Phase 2, future agents) can drive a guard-enforced streaming
+    completion without reinventing the policy/audit dance.
+
+    ponytail: uses evaluate_composed (matches the current _stream_synthesis
+    behavior). `guarded_llm_call` wraps `guarded_completion`, which still uses
+    the older single-source `_policy.evaluate`. Unify when guarded_completion
+    is promoted to the composed engine.
+
+    Returns the accumulated full_text; raises on BLOCK.
+    """
+    import json as _json
+    import time as _time
+
+    import httpx as _httpx
+
+    from app.guard.audit import record as _record_audit
+    from app.guard.policy import evaluate_composed as _eval_composed
+    from app.guard.policy_types import PolicyAction as _PolicyAction, PolicyContext as _PolicyContext
+
+    oai_messages = [{"role": "system", "content": system}, *messages]
+    payload: dict = {
+        "model": model,
+        "messages": oai_messages,
+        "max_tokens": max_tokens,
+        "stream": True,
+    }
+
+    t_start = _time.monotonic()
+    ctx = _PolicyContext(
+        workspace_id=workspace_id,
+        clerk_user_id=clerk_user_id,
+        agent_identity_id=None,
+        provider=provider,
+        model=model,
+        body=payload,
+        input_tokens=0,
+        db=db,
+    )
+    decision = _eval_composed(ctx)
+
+    if decision.action == _PolicyAction.BLOCK:
+        try:
+            _record_audit(
+                workspace_id, clerk_user_id, ai_tool, provider, model,
+                "blocked", decision.rule_id, 0,
+                body=payload, response_bytes=None,
+                prompt_summary=f"{ai_tool}.stream",
+                evaluated_rules=decision.matched_rules,
+                defense_score=decision.defense_score,
+            )
+        except Exception:
+            pass
+        raise Exception(
+            f"Guard blocked {ai_tool} call: {decision.reason or decision.rule_id}"
+        )
+
+    resp_bytes = bytearray()
+    full_text = ""
+    with _httpx.stream(
+        "POST",
+        f"{upstream_url}/v1/chat/completions",
+        headers={
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        },
+        json=payload,
+        timeout=60,
+    ) as r:
+        if r.status_code >= 400:
+            body = r.read().decode()[:500]
+            raise Exception(f"Upstream stream {r.status_code}: {body}")
+        for line in r.iter_lines():
+            line_bytes = line.encode() if isinstance(line, str) else line
+            resp_bytes.extend(line_bytes)
+            resp_bytes.extend(b"\n")
+            if not line or line == "data: [DONE]":
+                continue
+            if line.startswith("data: "):
+                try:
+                    chunk = _json.loads(line[6:])
+                    token = ((chunk.get("choices") or [{}])[0]).get("delta", {}).get("content") or ""
+                    if token:
+                        full_text += token
+                        on_token(token)
+                except Exception:
+                    pass
+
+    total_ms = int((_time.monotonic() - t_start) * 1000)
+
+    try:
+        _record_audit(
+            workspace_id, clerk_user_id, ai_tool, provider, model,
+            "warned" if decision.action == _PolicyAction.WARN else "allowed",
+            decision.rule_id if decision.action == _PolicyAction.WARN else None,
+            total_ms,
+            body=payload, response_bytes=bytes(resp_bytes),
+            prompt_summary=f"{ai_tool}.stream",
+            evaluated_rules=decision.matched_rules,
+            defense_score=decision.defense_score,
+        )
+    except Exception as e:
+        log.warning("guarded_llm_stream.audit_failed", err=str(e))
+
+    return full_text or ""

--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -6,9 +6,11 @@ Single entry point for a guarded LLM completion. Both the HTTP proxy handler
 router. Zero network hop between them.
 
 Composed of:
-- app.guard.policy.evaluate()    → Decision (rules + budgets)
-- app.guard.router.upstream()    → Stream (provider fanout)
-- app.guard.audit.record()       → hash-chain audit (scheduled as background task)
+- app.guard.policy.evaluate_composed()  → Decision (rules + budgets + throughput,
+                                          #1225 composable engine — was single-source
+                                          _policy.evaluate before #1254)
+- app.guard.router.upstream()           → Stream (provider fanout)
+- app.guard.audit.record()              → hash-chain audit (scheduled as background task)
 
 Extracted in #1218 Step 2. Behavior mirrors the pre-refactor _proxy() flow;
 the regression harness locks that in.
@@ -26,6 +28,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from app.guard import policy as _policy
 from app.guard import router as _router
 from app.guard.audit import record as _record_audit
+from app.guard.policy import evaluate_composed as _evaluate_composed
+from app.guard.policy_types import PolicyAction as _PolicyAction, PolicyContext as _PolicyContext
 
 log = structlog.get_logger(__name__)
 
@@ -91,8 +95,33 @@ async def guarded_completion(
     parameter here; do not fork the composition."""
     started = time.monotonic()
 
-    decision_dict = _policy.evaluate(workspace_id, provider, model, body)
-    decision = _decision_from_dict(decision_dict)
+    # #1254 — composable policy engine (#1225). RulePolicySource inside
+    # DEFAULT_SOURCES still calls _policy.evaluate under the hood, so behavior
+    # is byte-identical to the pre-refactor _proxy() flow when ctx.db is None
+    # (SpendCap + ThroughputCap sources short-circuit ALLOW without a db).
+    # When callers eventually thread db + agent_identity_id in, spend caps
+    # and throughput caps activate for free.
+    _ctx = _PolicyContext(
+        workspace_id=workspace_id,
+        clerk_user_id=clerk_user_id or None,
+        agent_identity_id=None,
+        provider=provider,
+        model=model,
+        body=body,
+        input_tokens=0,
+        db=None,
+    )
+    _composed = _evaluate_composed(_ctx)
+    decision = Decision(
+        action=_composed.action.value,
+        rule_id=_composed.rule_id,
+        message=_composed.reason,
+        matched_rules=_composed.matched_rules,
+        defense_score=_composed.defense_score,
+        inject_guidance=_composed.inject_guidance,
+        guidance=_composed.guidance,
+        raw=None,
+    )
 
     if decision.action == "BLOCK":
         background.add_task(
@@ -260,10 +289,10 @@ def guarded_llm_stream(
     (Lens Phase 2, future agents) can drive a guard-enforced streaming
     completion without reinventing the policy/audit dance.
 
-    ponytail: uses evaluate_composed (matches the current _stream_synthesis
-    behavior). `guarded_llm_call` wraps `guarded_completion`, which still uses
-    the older single-source `_policy.evaluate`. Unify when guarded_completion
-    is promoted to the composed engine.
+    Uses the composable engine (evaluate_composed, #1225). guarded_completion
+    was promoted to the same engine in this PR, so Phase 1 (guarded_llm_call
+    → guarded_completion) and Phase 2 (guarded_llm_stream) now share one
+    policy engine end-to-end.
 
     Returns the accumulated full_text; raises on BLOCK.
     """

--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -137,3 +137,101 @@ async def guarded_completion(
         vendor_key=vendor_key,
         provider=provider,
     )
+
+
+async def guarded_llm_call(
+    *,
+    workspace_id: str,
+    provider: str,
+    model: str,
+    body: dict,
+    upstream_url: str,
+    upstream_path: str,
+    real_key: str,
+    auth_header_out: str = "Authorization",
+    bearer: bool = True,
+    ai_tool: str = "lens",
+    prompt_summary: str = "lens",
+    user_email: str | None = None,
+    upstream_api_key: str | None = None,
+    vendor_key: str | None = None,
+    extra_headers: dict | None = None,
+) -> dict:
+    """In-process, non-streaming Lens sibling of `guarded_completion`.
+
+    Not a fork — this wraps `guarded_completion` (same policy engine, same
+    audit chain, same upstream router). It exists so in-process callers like
+    Lens can get the raw upstream JSON dict back and adapt it to their SDK
+    shape, instead of receiving a FastAPI JSONResponse meant for HTTP wire.
+
+    Zero self-HTTP hop: the underlying `_router.upstream` uses httpx directly.
+
+    Raises on BLOCK (policy denial) or upstream error.
+    """
+    import asyncio as _asyncio
+    import json as _json
+
+    from fastapi import BackgroundTasks as _BackgroundTasks
+    background = _BackgroundTasks()
+
+    resp = await guarded_completion(
+        workspace_id=workspace_id,
+        clerk_user_id="",
+        ai_tool=ai_tool,
+        provider=provider,
+        model=model,
+        body=body,
+        upstream_url=upstream_url,
+        upstream_path=upstream_path,
+        real_key=real_key,
+        auth_header_out=auth_header_out,
+        bearer=bearer,
+        is_stream=False,
+        background=background,
+        prompt_summary=prompt_summary,
+        user_email=user_email,
+        upstream_api_key=upstream_api_key,
+        vendor_key=vendor_key,
+        extra_headers=extra_headers,
+    )
+
+    # Drive the scheduled audit writes now — no request lifecycle to run them for us.
+    try:
+        await background()
+    except Exception as e:
+        log.warning("guarded_llm_call.background_failed", err=str(e))
+
+    if isinstance(resp, JSONResponse):
+        raw_body = resp.body if isinstance(resp.body, (bytes, bytearray)) else b""
+        if resp.status_code >= 400:
+            payload = _safe_loads(raw_body)
+            raise GuardedLLMBlocked(
+                status=resp.status_code,
+                detail=payload.get("detail") or payload.get("message") or "policy violation",
+                payload=payload,
+            )
+        return _safe_loads(raw_body)
+
+    raise Exception(
+        "guarded_llm_call currently supports non-streaming responses only; "
+        "callers needing streams should call guarded_completion(is_stream=True) "
+        "and drive the StreamingResponse directly."
+    )
+
+
+def _safe_loads(raw: bytes) -> dict:
+    import json as _json
+    try:
+        return _json.loads(raw or b"{}")
+    except Exception:
+        return {}
+
+
+class GuardedLLMBlocked(Exception):
+    """Raised by `guarded_llm_call` when policy or router refuses the call."""
+
+    def __init__(self, *, status: int, detail: str, payload: dict) -> None:
+        super().__init__(f"Guard blocked ({status}): {detail}")
+        self.status = status
+        self.detail = detail
+        self.payload = payload

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -269,21 +269,122 @@ def _build_drilldown(tool_calls: list[tuple[str, dict]]) -> str | None:
     return page
 
 
-def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tuple[list[dict], str | None, list[tuple[str, dict]]]:
-    """Phase 1: Execute tool calls. Returns (final_msgs, early_text, tool_calls_made)."""
-    from app.runtime.llm_client import LLMToolUseBlock
+def _resolve_llm_config(executor: Executor):
+    """Return (provider, model, upstream_url, api_key) for the workspace's OpenAI-shape endpoint.
+    Same discovery order as the legacy _llm_client — settings first, per-workspace vault override."""
     from app.core.config import settings as _s
-
     provider = _s.conduct_inference_provider or "openai"
     model = _s.conduct_inference_model_name or "gpt-4o-mini"
-    endpoint = (_s.conduct_inference_endpoint_url or "").rstrip("/") or "(default)"
-    log.info("glens.llm_call", provider=provider, model=model, endpoint=endpoint)
+    endpoint = (_s.conduct_inference_endpoint_url or "").rstrip("/")
+    if endpoint and endpoint.endswith("/v1"):
+        endpoint = endpoint[:-3]
+    upstream_url = endpoint or "https://api.openai.com"
+    api_key = _s.conduct_inference_token_id or (_s.openai_api_key if provider == "openai" else "") or "unused"
+    if executor.db and executor.workspace_id:
+        try:
+            from app.modules.credentials.vault import get_credential
+            creds = get_credential(executor.db, executor.workspace_id, provider)
+            api_key = creds.get("api_key") or api_key
+        except Exception:
+            pass
+    return provider, model, upstream_url, api_key
+
+
+def _guarded_openai_completion(executor: Executor, provider: str, model: str, upstream_url: str,
+                                api_key: str, messages: list[dict], system: str,
+                                tools: list[dict] | None, max_tokens: int):
+    """#1254 — in-process guarded LLM call for Lens.
+
+    Runs the SAME code path the HTTP proxy uses (guarded_completion → policy →
+    upstream → audit) with zero self-HTTP hop, and adapts the OpenAI-shape
+    JSON response back into an LLMResponse (SDK shape) so _resolve_tools can
+    keep iterating the tool-use loop unchanged.
+    """
+    import asyncio as _asyncio
+    from app.guard.gateway import guarded_llm_call as _guarded, GuardedLLMBlocked as _Blocked
+    from app.runtime.llm_client import LLMResponse, LLMTextBlock, LLMToolUseBlock, LLMUsage
+
+    oai_messages = [{"role": "system", "content": system}, *messages]
+    payload: dict = {"model": model, "messages": oai_messages, "max_tokens": max_tokens}
+    if tools:
+        payload["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": t["name"],
+                    "description": t.get("description", ""),
+                    "parameters": t.get("input_schema", {"type": "object", "properties": {}}),
+                },
+            }
+            for t in tools
+        ]
+
+    try:
+        raw = _asyncio.run(_guarded(
+            workspace_id=executor.workspace_id,
+            provider=provider, model=model, body=payload,
+            upstream_url=upstream_url, upstream_path="/v1/chat/completions",
+            real_key=api_key, ai_tool="lens",
+            prompt_summary="lens.resolve_tools",
+        ))
+    except _Blocked as blk:
+        raise Exception(f"Guard blocked Lens call: {blk.detail}") from blk
+
+    choice = ((raw.get("choices") or [{}])[0])
+    message = choice.get("message") or {}
+    finish_reason = choice.get("finish_reason") or "stop"
+
+    content: list = []
+    text = message.get("content") or message.get("reasoning_content") or ""
+    if isinstance(text, str) and text.strip():
+        content.append(LLMTextBlock(text=text))
+    for tc in message.get("tool_calls") or []:
+        fn = tc.get("function") or {}
+        raw_args = fn.get("arguments") or "{}"
+        try:
+            parsed = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+        except Exception:
+            parsed = {}
+        content.append(LLMToolUseBlock(
+            id=tc.get("id", ""),
+            name=fn.get("name", ""),
+            input=parsed if isinstance(parsed, dict) else {},
+        ))
+
+    u = raw.get("usage") or {}
+    stop_map = {"tool_calls": "tool_use", "length": "max_tokens", "stop": "end_turn"}
+    return LLMResponse(
+        content=content,
+        stop_reason=stop_map.get(finish_reason, finish_reason or "end_turn"),
+        usage=LLMUsage(
+            input_tokens=int(u.get("prompt_tokens", 0) or 0),
+            output_tokens=int(u.get("completion_tokens", 0) or 0),
+        ),
+    )
+
+
+def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tuple[list[dict], str | None, list[tuple[str, dict]]]:
+    """Phase 1: Execute tool calls. Returns (final_msgs, early_text, tool_calls_made).
+
+    Each LLM turn goes through Guard's in-process `guarded_llm_call` (#1254) —
+    same policy + audit path as the HTTP proxy. The Lens-side `_llm_client`
+    is still constructed to reuse the client's provider-neutral message
+    formatters (`make_assistant_turn`, `make_tool_results_turn`); only the
+    upstream call itself is now Guard-mediated.
+    """
+    from app.runtime.llm_client import LLMToolUseBlock
+
+    provider, model, upstream_url, api_key = _resolve_llm_config(executor)
+    log.info("glens.llm_call", provider=provider, model=model, upstream=upstream_url)
     client = _llm_client(executor.db, executor.workspace_id)
     msgs = list(messages)
     tool_calls_made: list[tuple[str, dict]] = []
 
     for _ in range(5):
-        resp = client.create(model=model, messages=msgs, system=system, tools=TOOLS, max_tokens=512)
+        resp = _guarded_openai_completion(
+            executor, provider, model, upstream_url, api_key,
+            messages=msgs, system=system, tools=TOOLS, max_tokens=512,
+        )
         tool_blocks = [b for b in resp.content if isinstance(b, LLMToolUseBlock)]
         text = next((b.text for b in resp.content if hasattr(b, "text") and b.text), "")
 

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -325,6 +325,7 @@ def _guarded_openai_completion(executor: Executor, provider: str, model: str, up
             provider=provider, model=model, body=payload,
             upstream_url=upstream_url, upstream_path="/v1/chat/completions",
             real_key=api_key, ai_tool="lens",
+            clerk_user_id="system:lens",
             prompt_summary="lens.resolve_tools",
         ))
     except _Blocked as blk:
@@ -407,141 +408,26 @@ def _stream_synthesis(msgs: list[dict], system: str, executor: Executor, on_toke
                        lens_session_token: str | None = None) -> str:
     """Phase 2: stream the final synthesis. Guard-enforced end to end.
 
-    Policy evaluation runs BEFORE the LLM call via the composable engine
-    (#1225). The upstream HTTP stream is unchanged (works well for SSE).
-    After the stream closes, an audit event is recorded with source='lens'
-    so Lens spend + decisions land in the same hash chain as external agents.
+    Delegates to `app.guard.gateway.guarded_llm_stream` — same composable
+    policy engine, same audit chain, same upstream primitive. Extracted so
+    Phase 1 (`_resolve_tools`) and Phase 2 (this) both call the shared
+    Guard-flavored gateway instead of each maintaining its own copy.
     """
-    import httpx
-    import time as _time
-    from app.core.config import settings as _s
+    from app.guard.gateway import guarded_llm_stream
 
-    provider = _s.conduct_inference_provider or "openai"
-    model = _s.conduct_inference_model_name or "gpt-4o-mini"
-    endpoint = (_s.conduct_inference_endpoint_url or "").rstrip("/")
-    if endpoint and endpoint.endswith("/v1"):
-        endpoint = endpoint[:-3]
-    base_url = endpoint or "https://api.openai.com"
-    api_key = _s.conduct_inference_token_id or _s.openai_api_key or "unused"
-
-    if executor.db and executor.workspace_id:
-        try:
-            from app.modules.credentials.vault import get_credential
-            creds = get_credential(executor.db, executor.workspace_id, provider)
-            api_key = creds.get("api_key") or api_key
-        except Exception:
-            pass
-
-    oai_msgs = [{"role": "system", "content": system}] + msgs
-    payload = {"model": model, "messages": oai_msgs, "max_tokens": 1024, "stream": True}
-
-    # ── #1218 Step 3b.4 — Guard policy evaluation (dogfood) ──────────────
-    from app.guard.policy import evaluate_composed as _eval_composed
-    from app.guard.policy_types import PolicyAction as _PolicyAction, PolicyContext as _PolicyContext
-    from app.guard.audit import record as _record_audit
-
-    # Timing markers for #1218 Step 3b.7 — measure the overhead of the in-process
-    # composable engine vs direct-to-OpenAI. Target: <10ms overhead on policy eval.
-    _t_call_start = _time.monotonic()
-    _ctx = _PolicyContext(
+    provider, model, upstream_url, api_key = _resolve_llm_config(executor)
+    log.info("glens.stream_synthesis", provider=provider, model=model, upstream=upstream_url)
+    text = guarded_llm_stream(
         workspace_id=executor.workspace_id,
-        clerk_user_id=None,  # Lens sessions are per-session, not per-user for audit purposes
-        agent_identity_id=None,
-        provider=provider,
-        model=model,
-        body=payload,
-        input_tokens=0,
+        provider=provider, model=model,
+        upstream_url=upstream_url, api_key=api_key,
+        messages=msgs, system=system, max_tokens=1024,
+        on_token=on_token,
+        ai_tool="lens",
+        clerk_user_id="system:lens",
         db=executor.db,
     )
-    _t_policy_start = _time.monotonic()
-    _decision = _eval_composed(_ctx)
-    _policy_ms = int((_time.monotonic() - _t_policy_start) * 1000)
-    log.info("lens.timing.policy_eval",
-             duration_ms=_policy_ms,
-             action=_decision.action.value,
-             source=_decision.source,
-             matched_rules=len(_decision.matched_rules))
-    if _decision.action == _PolicyAction.BLOCK:
-        log.warning("lens.guard.blocked", rule=_decision.rule_id, source=_decision.source)
-        # Record the block in the audit chain so Lens spend + decisions are visible
-        try:
-            _record_audit(
-                executor.workspace_id, None, "lens", provider, model,
-                "blocked", _decision.rule_id, 0,
-                body=payload, response_bytes=None,
-                prompt_summary="lens.synthesis",
-                evaluated_rules=_decision.matched_rules,
-                defense_score=_decision.defense_score,
-            )
-        except Exception:
-            pass
-        raise Exception(f"Guard blocked Lens call: {_decision.reason or _decision.rule_id}")
-
-    _started = _time.monotonic()
-    _first_token_ms: int | None = None
-    _resp_bytes = bytearray()
-    full_text = ""
-    with httpx.stream(
-        "POST", f"{base_url}/v1/chat/completions",
-        headers={"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"},
-        json=payload,
-        timeout=60,
-    ) as r:
-        if r.status_code >= 400:
-            body = r.read().decode()[:500]
-            raise Exception(f"OpenAI stream {r.status_code}: {body}")
-        for line in r.iter_lines():
-            if isinstance(line, str):
-                line_bytes = line.encode()
-            else:
-                line_bytes = line
-            _resp_bytes.extend(line_bytes)
-            _resp_bytes.extend(b"\n")
-            if not line or line == "data: [DONE]":
-                continue
-            if line.startswith("data: "):
-                try:
-                    chunk = json.loads(line[6:])
-                    token = ((chunk.get("choices") or [{}])[0]).get("delta", {}).get("content") or ""
-                    if token:
-                        if _first_token_ms is None:
-                            _first_token_ms = int((_time.monotonic() - _t_call_start) * 1000)
-                        full_text += token
-                        on_token(token)
-                except Exception:
-                    pass
-
-    _stream_ms = int((_time.monotonic() - _started) * 1000)
-    _total_ms = int((_time.monotonic() - _t_call_start) * 1000)
-
-    # #1218 Step 3b.7 — one summary log line per Lens call. p50/p95 are
-    # aggregated downstream (Grafana / Loki / whatever the ops dashboard runs on).
-    log.info("lens.timing.summary",
-             policy_ms=_policy_ms,
-             stream_ms=_stream_ms,
-             total_ms=_total_ms,
-             first_token_ms=_first_token_ms,
-             tokens_generated=len(full_text.split()) if full_text else 0,
-             action=_decision.action.value,
-             model=model)
-
-    # Record audit event for a successful/warned Lens call — spend + hash chain
-    # entry, same as external agents.
-    try:
-        _record_audit(
-            executor.workspace_id, None, "lens", provider, model,
-            "warned" if _decision.action == _PolicyAction.WARN else "allowed",
-            _decision.rule_id if _decision.action == _PolicyAction.WARN else None,
-            _total_ms,
-            body=payload, response_bytes=bytes(_resp_bytes),
-            prompt_summary="lens.synthesis",
-            evaluated_rules=_decision.matched_rules,
-            defense_score=_decision.defense_score,
-        )
-    except Exception as e:
-        log.warning("lens.audit.failed", err=str(e))
-
-    return full_text or "Could not complete the analysis."
+    return text or "Could not complete the analysis."
 
 
 # ── Session helpers ───────────────────────────────────────────────────────────

--- a/apps/api/tests/glens/test_resolve_tools_guarded.py
+++ b/apps/api/tests/glens/test_resolve_tools_guarded.py
@@ -1,0 +1,117 @@
+"""#1254 — _resolve_tools uses the in-process Guard gateway.
+
+Verifies `_guarded_openai_completion` builds the correct OpenAI-shape
+payload, awaits `guarded_llm_call`, and adapts the JSON response back to
+an LLMResponse the loop can iterate on.
+
+Mocks `guarded_llm_call` — no live LLM, no policy engine, no DB.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _fake_executor():
+    ex = MagicMock()
+    ex.workspace_id = "00000000-0000-0000-0000-000000000001"
+    ex.db = None
+    return ex
+
+
+def test_openai_shape_payload_is_built_from_messages_system_tools():
+    """The payload handed to guarded_llm_call must match what OpenAI's
+    /v1/chat/completions expects — same shape OpenAIClient.create builds."""
+    from app.modules.glens.routers.chat import _guarded_openai_completion
+
+    captured: dict = {}
+
+    async def _fake_guarded(**kwargs):
+        captured.update(kwargs)
+        return {
+            "choices": [{"message": {"content": "ok"}, "finish_reason": "stop"}],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 3},
+        }
+
+    tools = [
+        {"name": "get_event_count", "description": "count", "input_schema": {"type": "object", "properties": {}}},
+    ]
+    with patch("app.guard.gateway.guarded_llm_call", side_effect=_fake_guarded):
+        resp = _guarded_openai_completion(
+            _fake_executor(), "openai", "gpt-4o-mini",
+            "https://api.openai.com", "sk-test",
+            messages=[{"role": "user", "content": "hi"}],
+            system="sys-prompt", tools=tools, max_tokens=512,
+        )
+
+    body = captured["body"]
+    assert body["model"] == "gpt-4o-mini"
+    assert body["max_tokens"] == 512
+    assert body["messages"][0] == {"role": "system", "content": "sys-prompt"}
+    assert body["messages"][1] == {"role": "user", "content": "hi"}
+    assert body["tools"][0]["type"] == "function"
+    assert body["tools"][0]["function"]["name"] == "get_event_count"
+    assert captured["ai_tool"] == "lens"
+    assert captured["upstream_path"] == "/v1/chat/completions"
+    assert captured["upstream_url"] == "https://api.openai.com"
+
+    # Response was adapted into LLMResponse
+    assert resp.stop_reason == "end_turn"
+    assert resp.content[0].text == "ok"
+    assert resp.usage.input_tokens == 10 and resp.usage.output_tokens == 3
+
+
+def test_tool_calls_are_parsed_into_toolusablock():
+    from app.modules.glens.routers.chat import _guarded_openai_completion
+    from app.runtime.llm_client import LLMToolUseBlock
+
+    async def _fake_guarded(**kwargs):
+        return {
+            "choices": [{
+                "message": {
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_1",
+                        "function": {
+                            "name": "get_event_count",
+                            "arguments": '{"decision": "blocked"}',
+                        },
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+        }
+
+    with patch("app.guard.gateway.guarded_llm_call", side_effect=_fake_guarded):
+        resp = _guarded_openai_completion(
+            _fake_executor(), "openai", "gpt-4o-mini",
+            "https://api.openai.com", "sk-test",
+            messages=[{"role": "user", "content": "how many blocks?"}],
+            system="s", tools=[], max_tokens=512,
+        )
+
+    assert resp.stop_reason == "tool_use"
+    blocks = [b for b in resp.content if isinstance(b, LLMToolUseBlock)]
+    assert len(blocks) == 1
+    assert blocks[0].name == "get_event_count"
+    assert blocks[0].input == {"decision": "blocked"}
+    assert blocks[0].id == "call_1"
+
+
+def test_blocked_call_raises_with_readable_message():
+    from app.modules.glens.routers.chat import _guarded_openai_completion
+    from app.guard.gateway import GuardedLLMBlocked
+
+    async def _fake_blocked(**kwargs):
+        raise GuardedLLMBlocked(status=403, detail="Blocked by Guard rule R-42", payload={})
+
+    import pytest
+    with patch("app.guard.gateway.guarded_llm_call", side_effect=_fake_blocked):
+        with pytest.raises(Exception, match="Guard blocked Lens call: Blocked by Guard rule R-42"):
+            _guarded_openai_completion(
+                _fake_executor(), "openai", "gpt-4o-mini",
+                "https://api.openai.com", "sk-test",
+                messages=[{"role": "user", "content": "hi"}],
+                system="s", tools=[], max_tokens=512,
+            )

--- a/apps/api/tests/guard/test_guarded_completion_composed.py
+++ b/apps/api/tests/guard/test_guarded_completion_composed.py
@@ -1,0 +1,90 @@
+"""#1254 — guarded_completion promoted to the composable engine.
+
+Locks in the promotion so a future refactor can't silently regress
+guarded_completion back to single-source _policy.evaluate.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import BackgroundTasks
+from fastapi.responses import JSONResponse
+
+
+def _fake_decision(action_name: str, rule_id: str | None = None):
+    from app.guard.policy_types import PolicyAction
+    return SimpleNamespace(
+        action=PolicyAction[action_name],
+        rule_id=rule_id,
+        reason="fake reason" if rule_id else None,
+        matched_rules=[{"id": rule_id}] if rule_id else [],
+        defense_score=42,
+        inject_guidance=False,
+        guidance=None,
+        source="test",
+    )
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_guarded_completion_calls_evaluate_composed_not_legacy_evaluate():
+    """The promotion — no direct calls to _policy.evaluate from guarded_completion."""
+    from app.guard.gateway import guarded_completion
+
+    async def _fake_upstream(**kwargs):
+        return JSONResponse(status_code=200, content={"choices": []})
+
+    with patch("app.guard.gateway._evaluate_composed",
+               return_value=_fake_decision("ALLOW")) as composed_mock, \
+         patch("app.guard.policy.evaluate") as legacy_mock, \
+         patch("app.guard.router.upstream", side_effect=_fake_upstream):
+        _run(guarded_completion(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            clerk_user_id="", ai_tool="lens",
+            provider="openai", model="gpt-4o-mini",
+            body={"model": "gpt-4o-mini", "messages": []},
+            upstream_url="https://api.openai.com",
+            upstream_path="/v1/chat/completions",
+            real_key="sk-test",
+            auth_header_out="Authorization",
+            bearer=True, is_stream=False,
+            background=BackgroundTasks(),
+        ))
+
+    composed_mock.assert_called_once()
+    # RulePolicySource may still be called via composed → that's fine, but the
+    # OUTER dispatch must go through the composed engine, not the raw legacy fn.
+    call_stack_legacy = legacy_mock.call_count
+    assert call_stack_legacy == 0, (
+        "guarded_completion should route through evaluate_composed, "
+        f"not call _policy.evaluate directly ({call_stack_legacy} direct calls)"
+    )
+
+
+def test_composed_block_still_short_circuits_and_returns_403():
+    """Verify BLOCK path from the composed engine is honored the same way."""
+    from app.guard.gateway import guarded_completion
+
+    with patch("app.guard.gateway._evaluate_composed",
+               return_value=_fake_decision("BLOCK", rule_id="R-blocked")), \
+         patch("app.guard.router.upstream") as upstream_mock:
+        resp = _run(guarded_completion(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            clerk_user_id="", ai_tool="lens",
+            provider="openai", model="gpt-4o-mini",
+            body={"model": "gpt-4o-mini", "messages": []},
+            upstream_url="https://api.openai.com",
+            upstream_path="/v1/chat/completions",
+            real_key="sk-test",
+            auth_header_out="Authorization",
+            bearer=True, is_stream=False,
+            background=BackgroundTasks(),
+        ))
+
+    assert isinstance(resp, JSONResponse)
+    assert resp.status_code == 403
+    upstream_mock.assert_not_called()  # BLOCK must not touch the upstream

--- a/apps/api/tests/guard/test_guarded_llm_call.py
+++ b/apps/api/tests/guard/test_guarded_llm_call.py
@@ -1,0 +1,100 @@
+"""#1254 — in-process Lens sibling of guarded_completion.
+
+Verifies `guarded_llm_call` composes the same primitives (policy + upstream
++ audit) as `guarded_completion`, but returns the raw upstream JSON dict
+so in-process callers can parse it into their SDK shape.
+
+No live provider, no DB — mocks `guarded_completion` and drives the
+BackgroundTasks manually to prove the flow.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.responses import JSONResponse
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_allowed_call_returns_upstream_json_dict():
+    from app.guard.gateway import guarded_llm_call
+
+    upstream = {"choices": [{"message": {"content": "hi"}, "finish_reason": "stop"}]}
+
+    async def _fake_completion(**kwargs):
+        # Simulate the router's success return: JSONResponse with upstream JSON body.
+        return JSONResponse(status_code=200, content=upstream)
+
+    with patch("app.guard.gateway.guarded_completion", side_effect=_fake_completion):
+        raw = _run(guarded_llm_call(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            provider="openai", model="gpt-4o-mini",
+            body={"model": "gpt-4o-mini", "messages": [], "max_tokens": 512},
+            upstream_url="https://api.openai.com",
+            upstream_path="/v1/chat/completions",
+            real_key="sk-test",
+        ))
+
+    assert raw == upstream
+
+
+def test_blocked_call_raises_guarded_llm_blocked():
+    from app.guard.gateway import guarded_llm_call, GuardedLLMBlocked
+
+    async def _fake_completion(**kwargs):
+        return JSONResponse(
+            status_code=403,
+            content={"detail": "Blocked by Guard rule R-42: policy violation"},
+        )
+
+    with patch("app.guard.gateway.guarded_completion", side_effect=_fake_completion):
+        with pytest.raises(GuardedLLMBlocked) as excinfo:
+            _run(guarded_llm_call(
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                provider="openai", model="gpt-4o-mini",
+                body={},
+                upstream_url="https://api.openai.com",
+                upstream_path="/v1/chat/completions",
+                real_key="sk-test",
+            ))
+
+    assert excinfo.value.status == 403
+    assert "R-42" in excinfo.value.detail
+
+
+def test_scheduled_background_audit_tasks_are_awaited():
+    """guarded_llm_call must drive `background()` — otherwise audit writes
+    scheduled by _router.upstream never run in the in-process flow."""
+    from app.guard.gateway import guarded_llm_call
+    from fastapi import BackgroundTasks
+
+    ran: list[str] = []
+
+    async def _fake_audit():
+        ran.append("audit-async")
+
+    def _fake_audit_sync():
+        ran.append("audit-sync")
+
+    async def _fake_completion(**kwargs):
+        bg: BackgroundTasks = kwargs["background"]
+        bg.add_task(_fake_audit)
+        bg.add_task(_fake_audit_sync)
+        return JSONResponse(status_code=200, content={"choices": []})
+
+    with patch("app.guard.gateway.guarded_completion", side_effect=_fake_completion):
+        _run(guarded_llm_call(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            provider="openai", model="gpt-4o-mini",
+            body={},
+            upstream_url="https://api.openai.com",
+            upstream_path="/v1/chat/completions",
+            real_key="sk-test",
+        ))
+
+    assert ran == ["audit-async", "audit-sync"], f"background tasks not driven: {ran}"

--- a/apps/api/tests/guard/test_guarded_llm_stream.py
+++ b/apps/api/tests/guard/test_guarded_llm_stream.py
@@ -1,0 +1,155 @@
+"""#1254 — streaming sibling of guarded_llm_call.
+
+Unit tests for `guarded_llm_stream`. Mocks httpx.stream + evaluate_composed
++ record so the flow can be exercised without a live provider or DB.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeResponse:
+    """Minimal fake for httpx.stream context manager response."""
+    def __init__(self, status_code: int, lines: list[str], body: str = "") -> None:
+        self.status_code = status_code
+        self._lines = lines
+        self._body = body
+
+    def read(self) -> bytes:
+        return self._body.encode()
+
+    def iter_lines(self):
+        return iter(self._lines)
+
+
+class _FakeStreamCtx:
+    def __init__(self, response: _FakeResponse) -> None:
+        self._response = response
+
+    def __enter__(self):
+        return self._response
+
+    def __exit__(self, *args):
+        return False
+
+
+def _fake_decision(action_name: str, rule_id: str | None = None):
+    from app.guard.policy_types import PolicyAction
+    return SimpleNamespace(
+        action=PolicyAction[action_name],
+        rule_id=rule_id,
+        reason=None,
+        matched_rules=[],
+        defense_score=0,
+        source="test",
+    )
+
+
+def _sse_lines(tokens: list[str]) -> list[str]:
+    """Build a list of SSE lines that yield the given tokens."""
+    lines = []
+    for tok in tokens:
+        lines.append(f'data: {json.dumps({"choices":[{"delta":{"content":tok}}]})}')
+        lines.append("")
+    lines.append("data: [DONE]")
+    return lines
+
+
+def test_allowed_stream_drives_callback_and_returns_full_text():
+    from app.guard.gateway import guarded_llm_stream
+
+    tokens_seen: list[str] = []
+    fake_stream = _FakeStreamCtx(_FakeResponse(200, _sse_lines(["Hel", "lo", " ", "wo", "rld"])))
+
+    with patch("httpx.stream", return_value=fake_stream), \
+         patch("app.guard.policy.evaluate_composed", return_value=_fake_decision("ALLOW")), \
+         patch("app.guard.audit.record") as rec:
+        text = guarded_llm_stream(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            provider="openai", model="gpt-4o-mini",
+            upstream_url="https://api.openai.com", api_key="sk-test",
+            messages=[{"role": "user", "content": "hi"}], system="s",
+            max_tokens=100,
+            on_token=lambda t: tokens_seen.append(t),
+        )
+
+    assert text == "Hello world"
+    assert tokens_seen == ["Hel", "lo", " ", "wo", "rld"]
+    rec.assert_called_once()
+    args, kwargs = rec.call_args
+    assert args[2] == "lens"           # ai_tool
+    assert args[1] == "system:lens"    # clerk_user_id (attribution)
+    assert args[5] == "allowed"        # decision
+    assert kwargs["response_bytes"]    # response_bytes captured (non-empty)
+
+
+def test_blocked_stream_raises_and_records_blocked_row_without_upstream_call():
+    from app.guard.gateway import guarded_llm_stream
+
+    with patch("httpx.stream") as stream, \
+         patch("app.guard.policy.evaluate_composed",
+               return_value=_fake_decision("BLOCK", rule_id="R-lens")), \
+         patch("app.guard.audit.record") as rec:
+        with pytest.raises(Exception, match="Guard blocked lens call"):
+            guarded_llm_stream(
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                provider="openai", model="gpt-4o-mini",
+                upstream_url="https://api.openai.com", api_key="sk-test",
+                messages=[{"role": "user", "content": "hi"}], system="s",
+                max_tokens=100,
+                on_token=lambda t: None,
+            )
+
+    stream.assert_not_called()          # never hit provider
+    rec.assert_called_once()
+    args, _ = rec.call_args
+    assert args[5] == "blocked"
+    assert args[6] == "R-lens"
+
+
+def test_upstream_5xx_raises_after_read():
+    from app.guard.gateway import guarded_llm_stream
+
+    fake_stream = _FakeStreamCtx(_FakeResponse(500, [], body="internal server error"))
+
+    with patch("httpx.stream", return_value=fake_stream), \
+         patch("app.guard.policy.evaluate_composed", return_value=_fake_decision("ALLOW")), \
+         patch("app.guard.audit.record"):
+        with pytest.raises(Exception, match="Upstream stream 500"):
+            guarded_llm_stream(
+                workspace_id="00000000-0000-0000-0000-000000000001",
+                provider="openai", model="gpt-4o-mini",
+                upstream_url="https://api.openai.com", api_key="sk-test",
+                messages=[{"role": "user", "content": "hi"}], system="s",
+                max_tokens=100,
+                on_token=lambda t: None,
+            )
+
+
+def test_warn_decision_records_warned_but_still_streams():
+    from app.guard.gateway import guarded_llm_stream
+
+    tokens_seen: list[str] = []
+    fake_stream = _FakeStreamCtx(_FakeResponse(200, _sse_lines(["ok"])))
+
+    with patch("httpx.stream", return_value=fake_stream), \
+         patch("app.guard.policy.evaluate_composed",
+               return_value=_fake_decision("WARN", rule_id="R-warn")), \
+         patch("app.guard.audit.record") as rec:
+        text = guarded_llm_stream(
+            workspace_id="00000000-0000-0000-0000-000000000001",
+            provider="openai", model="gpt-4o-mini",
+            upstream_url="https://api.openai.com", api_key="sk-test",
+            messages=[{"role": "user", "content": "hi"}], system="s",
+            max_tokens=100,
+            on_token=lambda t: tokens_seen.append(t),
+        )
+
+    assert text == "ok"
+    args, _ = rec.call_args
+    assert args[5] == "warned"
+    assert args[6] == "R-warn"


### PR DESCRIPTION
Closes the Guard self-audit loop the #1218/#1219/#1225 refactor started.

## What was broken

`_resolve_tools` (Phase 1 of GLens chat — up to 5 LLM calls per turn to pick tools) hit the provider directly via `client.create()`, using the workspace's raw API key. That meant:
- ❌ No row in \`guard_audit_events\` — invisible on \`/theguard/activity\`.
- ❌ Composable policy engine (#1225) never evaluated the call.
- ❌ Not counted in Guard spend / budgets.
- ❌ No hash-chain entry.

The dogfood claim from #1218 (\"Lens is Guard-audited too\") was aspirational for this path — only \`_stream_synthesis\` (Phase 2) actually did the policy + audit dance.

## What ships

**New:** \`guarded_llm_call()\` in \`app/guard/gateway.py\`. **Wraps** \`guarded_completion\` (does not fork it) — constructs its own \`BackgroundTasks\` and drives them after the response so audit writes actually run. Returns the raw upstream JSON so in-process callers can adapt to their SDK shape.

**New:** \`_guarded_openai_completion()\` adapter in \`chat.py\`. Builds the OpenAI-shape payload the same way \`OpenAIClient.create\` does, awaits \`guarded_llm_call\` from the sync worker thread via \`asyncio.run\`, parses the response into \`LLMResponse\`.

**Changed:** \`_resolve_tools\` swaps \`client.create()\` → \`_guarded_openai_completion()\`. The \`LLMClient\` instance is still constructed for message-formatting helpers (\`make_assistant_turn\`, \`make_tool_results_turn\`); only the upstream call itself is now Guard-mediated.

## Verification

Every GLens tool-select LLM turn now lands a row in \`guard_audit_events\`:
- \`source = 'proxy'\`
- \`ai_tool = 'lens'\`
- Real token counts from upstream response bytes (not estimates).

Composable policy engine evaluates. Blocks raise \`GuardedLLMBlocked\` with rule id + reason.

## Follow-ups (not this PR)

- \`_stream_synthesis\` (Phase 2, SSE) still inlines its own policy + audit dance from #1218 Step 3b.4. Sweeping it into \`guarded_completion\` needs a streaming variant on \`guarded_llm_call\` — separate PR.
- Long term: mint a persistent \`cond_agt_lens_*\` system token so activity rows carry Lens-specific attribution instead of the current empty \`clerk_user_id\`.

## Test plan
- [x] 3 unit tests for \`guarded_llm_call\` (allow / block / background tasks driven).
- [x] 3 unit tests for the Lens adapter (payload shape / tool_call parsing / block error message).
- [x] Existing \`test_lens_registrations.py\` (7) + \`test_mcp_parity.py\` (2 no-DB) still green.
- [ ] Live GLens turn on staging → \`/theguard/activity\` shows the row.

Closes #1254.