### PR TITLE
ci: run api RBAC matrix on PR, not just nightly (#1265)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,10 +56,11 @@ jobs:
         run: make schema-check
         working-directory: apps/api
       - name: Test
-        # `-m 'not matrix'` skips the full endpoint×role runtime probe
-        # (~600 tests). Static layers of test_endpoint_matrix still run here.
-        # Full matrix runs nightly — see .github/workflows/nightly.yml.
-        run: python -m pytest tests/ -q --ignore=tests/test_guard.py -m 'not matrix'
+        # #1265 — matrix marker no longer excluded, so the RBAC route×role
+        # runtime probe runs on every PR (catches auth regressions same-day
+        # instead of the 24h nightly window). Nightly still runs the full
+        # matrix as belt-and-suspenders — see .github/workflows/nightly.yml.
+        run: python -m pytest tests/ -q --ignore=tests/test_guard.py
         working-directory: apps/api
         env:
           DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test


### PR DESCRIPTION
Closes #1265.

**Summary**

Drops the '-m not matrix' filter on the api job pytest step so the RBAC route × role runtime probe now runs on every PR that touches apps/api. Catches auth regressions same-day instead of the 24 h nightly window.

**Delta**

- 5 lines in .github/workflows/ci.yml
- No test code changes — leverages the pre-existing apps/api/tests/test_endpoint_matrix.py (397 lines, 5 tests)
- Nightly api-matrix job stays as belt-and-suspenders full run

**Test plan**

- [ ] CI on this PR runs the matrix and passes (~1–2 min added to api job)
- [ ] Merge, then verify next PR touching apps/api runs the probe automatically
- [ ] If a future PR breaks auth, matrix step turns red pre-merge

**Notes**

- No new job, no new dep, no new fixtures — the matrix step reuses the Postgres service and migrations already in the api job