### PR TITLE
fix(api): remaining check_permission + onboarding test failures

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -377,7 +377,7 @@ def get_user_id(
     db: Session = Depends(get_db),
 ) -> str | None:
     """Returns the Clerk user_id (sub claim), 'dev' in local dev mode, or None for machine API tokens."""
-    if not _clerk_enabled():
+    if not globals()["_clerk_enabled"]():
         return DEV_USER_ID
 
     if not credentials:
@@ -444,7 +444,7 @@ def get_workspace_id(
     4. Dev workspace (when Clerk is not configured)
     """
     explicit_ws = ws_id or x_workspace_id
-    if not _clerk_enabled():
+    if not globals()["_clerk_enabled"]():
         return explicit_ws or DEV_WORKSPACE_ID
 
     if not credentials:
@@ -508,7 +508,7 @@ def get_user_workspace_role(
     Returns the authenticated user's role in the requested workspace.
     Raises 403 if the user is not a member. Skips check in dev mode.
     """
-    if not _clerk_enabled():
+    if not globals()["_clerk_enabled"]():
         return "admin"
 
     # workspace_id must be a valid UUID — Clerk user_ids (user_xxx) are not.
@@ -583,7 +583,7 @@ def get_guard_org_id(
 
     Accepts: Clerk Bearer JWT — returns org_id or sub claim.
     """
-    if not _clerk_enabled():
+    if not globals()["_clerk_enabled"]():
         return "dev-org"
 
     if not credentials:
@@ -602,7 +602,7 @@ def get_guard_hook_auth(
     db: Session = Depends(get_db),
 ) -> str:
     """Auth for hook/CLI endpoints. Accepts cond_agt_* agent token or Clerk JWT."""
-    if not _clerk_enabled():
+    if not globals()["_clerk_enabled"]():
         return "dev-org"
 
     if not credentials:

--- a/apps/api/tests/test_onboarding_flow.py
+++ b/apps/api/tests/test_onboarding_flow.py
@@ -307,7 +307,7 @@ def test_full_onboarding_flow(db):
             admin_client = _client_for(ADMIN_ID, workspace_id, role="admin", email=ADMIN_EMAIL)
 
             invites_to_create = [
-                (DEV_EMAIL,      "editor"),
+                (DEV_EMAIL,      "developer"),
                 (VIEWER_EMAIL,   "viewer"),
                 (SECURITY_EMAIL, "security"),
             ]
@@ -338,7 +338,7 @@ def test_full_onboarding_flow(db):
             # invite matching works correctly.
 
             invited_users = [
-                (DEV_ID,      DEV_EMAIL,      "editor"),
+                (DEV_ID,      DEV_EMAIL,      "developer"),
                 (VIEWER_ID,   VIEWER_EMAIL,   "viewer"),
                 (SECURITY_ID, SECURITY_EMAIL, "security"),
             ]
@@ -362,7 +362,7 @@ def test_full_onboarding_flow(db):
             assert SECURITY_ID in member_map, f"Security user {SECURITY_ID!r} missing — members: {list(member_map)}"
 
             assert member_map[ADMIN_ID]    == "admin",    f"Admin role mismatch: {member_map[ADMIN_ID]!r}"
-            assert member_map[DEV_ID]      == "editor",   f"Dev role mismatch: {member_map[DEV_ID]!r}"
+            assert member_map[DEV_ID]      == "developer",   f"Dev role mismatch: {member_map[DEV_ID]!r}"
             assert member_map[VIEWER_ID]   == "viewer",   f"Viewer role mismatch: {member_map[VIEWER_ID]!r}"
             assert member_map[SECURITY_ID] == "security", f"Security role mismatch: {member_map[SECURITY_ID]!r}"
 
@@ -417,7 +417,7 @@ def test_full_onboarding_flow(db):
             # 4d. Editor (dev): GET policies → 200 (reads succeed)
             # In dev mode, get_guard_org_id returns "dev-org" regardless of role,
             # so Guard read access is always granted.  We confirm reads work for non-admin.
-            dev_client = _client_for(DEV_ID, workspace_id, role="editor", email=DEV_EMAIL)
+            dev_client = _client_for(DEV_ID, workspace_id, role="developer", email=DEV_EMAIL)
             resp = dev_client.get(f"/guard/policies{team_id_param}")
             assert resp.status_code == 200, (
                 f"Editor GET /guard/policies expected 200, got {resp.status_code}: {resp.text}"
@@ -441,7 +441,7 @@ def test_full_onboarding_flow(db):
 
             # 4g. Workspace RBAC: editor/viewer blocked from workspace-admin actions
             # POST /projects/{id}/members requires admin role — test it with editor
-            dev_client_admin_test = _client_for(DEV_ID, workspace_id, role="editor", email=DEV_EMAIL)
+            dev_client_admin_test = _client_for(DEV_ID, workspace_id, role="developer", email=DEV_EMAIL)
             resp = dev_client_admin_test.post(
                 f"/projects/{workspace_id}/members",
                 json={"email": "blocked@acme-test.com", "role": "viewer"},


### PR DESCRIPTION
Follow-up to #1279 + #1278. Two small, independent fixes:

**1. Six _clerk_enabled() call sites in auth.py, not just one**

#1279 patched only line 698. Five direct-dispatch calls remained on lines 380, 447, 511, 586, 605 — still hitting Python 3.11's LOAD_GLOBAL inline-cache bug when unittest.mock.patch swaps the module dict.

Fix: apply the globals()[...] dispatch pattern at every call site (5 more replacements). Resolves 10 test_require_permission failures.

**2. test_onboarding_flow sends role='editor' but backend accepts admin/security/developer/viewer**

#1278 fixed the guard_teams → guard_config schema reference but not this. 'editor' had the same intent as 'developer' (write access, not admin). Renamed all 5 occurrences.

**Not covered here (separate follow-up)**

test_z_migration_round_trip::test_alembic_check_no_schema_drift is a real schema drift — SQLAlchemy metadata has a column that the alembic revisions don't. Filing separately since it requires identifying which column and adding a revision.

**Test plan**

- [ ] CI green on API job
- [ ] test_require_permission suite passes (10 tests)
- [ ] test_onboarding_flow.test_full_onboarding_flow passes
- [ ] test_z_migration_round_trip.test_alembic_check_no_schema_drift STILL fails (expected — separate PR)

**Files**

- apps/api/app/core/auth.py (5 lines changed)
- apps/api/tests/test_onboarding_flow.py (5 lines changed)