### PR TITLE
test(guard): FP batch 1 — 13 negatives across 6 packs (#1272)

### DIFF
--- a/apps/api/tests/fixtures/guard_packs/conduct-base.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-base.yaml
@@ -146,3 +146,35 @@ cases:
     scenario: GitHub PAT blocked
     prompt_text: "auth_token = <<CRED:GH_PAT>>"
     expected: block
+
+  # ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ───
+
+  - rule_id: proxy-audit-vision-input
+    scenario: "[E] doc listing image types without the data URI scheme"
+    prompt_text: "We support image/png, image/jpeg, image/gif, image/webp, image/bmp, image/tiff formats."
+    expected: allow
+
+  - rule_id: no-weak-crypto
+    scenario: "[A] comment describing migration away from MD5"
+    prompt_text: "# Migrated from MD5 to SHA-256 on 2024-03-01; see /docs/crypto-rotation for the audit trail."
+    expected: allow
+
+  - rule_id: no-eval
+    scenario: "[A] comment referencing eval without the call syntax"
+    prompt_text: "# We deprecated the eval function in favour of ast.literal_eval for user-supplied strings."
+    expected: allow
+
+  - rule_id: no-slack-token
+    scenario: "[E] doc describing Slack token prefix without a token value"
+    prompt_text: "Slack bot tokens start with the 'xoxb' prefix; retrieve them from your app config rather than hard-coding."
+    expected: allow
+
+  - rule_id: no-private-key
+    scenario: "[E] doc referencing SSH key file path without the header marker"
+    prompt_text: "Users store their SSH private key at ~/.ssh/id_rsa; back it up with a passphrase for offline recovery."
+    expected: allow
+
+  - rule_id: no-gh-pat-in-code
+    scenario: "[D] env-var reference replaces the literal PAT"
+    prompt_text: "token = os.environ['GITHUB_TOKEN']  # ghp-prefixed tokens are read from env, never checked in"
+    expected: allow

--- a/apps/api/tests/fixtures/guard_packs/conduct-endpoint-attacks.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-endpoint-attacks.yaml
@@ -81,3 +81,18 @@ cases:
     tool_input:
       command: "ls -la /tmp"
     expected: allow
+
+  # ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ──
+  - rule_id: endpoint-attack-private-key-read
+    scenario: "[E] warning comment mentioning SSH key path without a read verb"
+    tool_name: bash
+    tool_input:
+      command: "echo 'Never store your key at ~/.ssh/id_rsa without a passphrase — use ssh-agent instead.'"
+    expected: allow
+
+  - rule_id: endpoint-attack-cloud-cred-read
+    scenario: "[E] echo mentioning AWS credentials file location"
+    tool_name: bash
+    tool_input:
+      command: "echo 'AWS credentials live at ~/.aws/credentials — rotate them quarterly.'"
+    expected: allow

--- a/apps/api/tests/fixtures/guard_packs/conduct-irs-1075.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-irs-1075.yaml
@@ -57,3 +57,12 @@ cases:
     file_path: p.py
     content: prompt = 'summarize this article'
   expected: allow
+
+# ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ────
+- rule_id: irs1075-no-fti-plain-log
+  scenario: "[D] logger call with no PII field name"
+  tool_name: write
+  tool_input:
+    file_path: audit.py
+    content: "logger.info('processing request ' + str(request.id))"
+  expected: allow

--- a/apps/api/tests/fixtures/guard_packs/conduct-iso-42001.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-iso-42001.yaml
@@ -97,3 +97,11 @@ cases:
     file_path: cfg.py
     content: MAX_RETRIES = 3
   expected: allow
+
+# ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ────
+- rule_id: iso42001-bias-testing
+  scenario: "[E] running the pack's own bias-audit test suite (mentions bias, no deploy)"
+  tool_name: bash
+  tool_input:
+    command: "pytest tests/ -k bias"
+  expected: allow

--- a/apps/api/tests/fixtures/guard_packs/conduct-nist-ai-rmf.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-nist-ai-rmf.yaml
@@ -110,3 +110,12 @@ cases:
     file_path: cfg.py
     content: MAX_WORKERS = 4
   expected: allow
+
+# ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ────
+- rule_id: nist-manage-third-party-ai
+  scenario: "[E] docs mentioning a third-party provider without credentials context"
+  tool_name: write
+  tool_input:
+    file_path: docs/providers.md
+    content: "We evaluated third-party AI providers including perplexity.ai and groq.com; see the vendor assessment for the shortlist."
+  expected: allow

--- a/apps/api/tests/fixtures/guard_packs/conduct-owasp.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-owasp.yaml
@@ -131,3 +131,18 @@ cases:
     file_path: f.py
     content: result = calculate(x, y)
   expected: allow
+
+# ── negative canaries (#1272 batch 1 — see docs/guard-fp-strategy.md) ────
+- rule_id: owasp_crypto_guard
+  scenario: "[E] docs referencing modern hashes only"
+  tool_name: write
+  tool_input:
+    file_path: docs/crypto.md
+    content: "Approved cryptographic hashes: SHA-256, BLAKE2, Argon2. Weak legacy names have been retired."
+  expected: allow
+- rule_id: no_sensitive_data_exfil
+  scenario: "[E] health check curl with no auth term"
+  tool_name: bash
+  tool_input:
+    command: "curl -f https://api.example.com/healthz"
+  expected: allow

--- a/apps/api/tests/test_guard_pack_coverage.py
+++ b/apps/api/tests/test_guard_pack_coverage.py
@@ -38,7 +38,7 @@ COVERAGE_ALLOWANCE = 66
 # case (expected: allow). Every rule that fires needs at least one
 # adjacent-but-benign fixture case so we catch false positives before
 # they ship. Lower as negative cases are added.
-NEGATIVE_CASE_ALLOWANCE = 95
+NEGATIVE_CASE_ALLOWANCE = 82
 
 
 def _load_seeded_rules() -> dict[str, set[str]]:


### PR DESCRIPTION
Batch 1 of #1272. Follows docs/guard-fp-strategy.md.

**Ratchet drop:** NEGATIVE_CASE_ALLOWANCE 95 → 82. All 198 pack matrix cases pass.

**Coverage added (13 rules, tagged by archetype)**

conduct-base (6): proxy-audit-vision-input [E], no-weak-crypto [A], no-eval [A], no-slack-token [E], no-private-key [E], no-gh-pat-in-code [D]

conduct-owasp (2): owasp_crypto_guard [E], no_sensitive_data_exfil [E]

conduct-irs-1075 (1): irs1075-no-fti-plain-log [D]

conduct-iso-42001 (1): iso42001-bias-testing [E]

conduct-nist-ai-rmf (1): nist-manage-third-party-ai [E]

conduct-endpoint-attacks (2): endpoint-attack-private-key-read [E], endpoint-attack-cloud-cred-read [E]

**Archetype tags** — Every scenario name starts with [A-E] so the FP class is visible at a glance. A=comment, B=import, C=test, D=env-var, E=doc.

**One iterative correction during authoring**

Original iso42001-bias-testing candidate (deploy-model command with bias-audit gate) accidentally matched iso42001-impact-assessment via the deploy verb. Retargeted to 'pytest tests/ -k bias' — hits zero iso rules. Documents the 'watch sibling rules in the same pack' anti-pattern the wholistic strategy targets.

**Test plan**

- [ ] test_pack_rule_coverage_does_not_regress passes at allowance 82
- [ ] test_covered_rules_have_negative_case passes
- [ ] 198 pack_matrix cases pass (was 185, +13 new)

**Not covered**

- 82 rules still need negatives — see #1272 ledger
- Next batch: top-10 prompt-injection detectors