### PR TITLE
fix(api): add 5 drifted columns to models (#1284 follow-up)

### DIFF
--- a/apps/api/app/models/workspace.py
+++ b/apps/api/app/models/workspace.py
@@ -21,6 +21,8 @@ class Workspace(Base):
     updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc), onupdate=lambda: datetime.now(timezone.utc))
 
     org_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True)
+    # Added by revision 0066 — model was missing it (#1284).
+    clerk_org_id = sa.Column(sa.Text(), nullable=True, index=True)
 
     # Authoritative pointer to the Security Automation project for this workspace.
     # See conductai#1005 — replaces .first() dispatch roulette for security_loop /

--- a/apps/api/app/models/workspace_user.py
+++ b/apps/api/app/models/workspace_user.py
@@ -14,5 +14,7 @@ class WorkspaceUser(Base):
     role = Column(String(50), nullable=False, default="developer")  # admin / developer / security / viewer
     invited_by = Column(String(255), nullable=True)
     joined_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    # DB has this FK to roles.id (baseline); model was missing it (#1284).
+    role_id = Column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="SET NULL"), nullable=True, index=True)
 
     workspace = relationship("Workspace", back_populates="members")

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -91,6 +91,8 @@ class GuardMemberConfig(Base):
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
     )
+    # Added by revision 0062 — model was missing this FK (#1284).
+    agent_identity_id = Column(String(36), ForeignKey("agent_identities.id"), nullable=True, index=True)
 
 
 class GuardSession(Base):
@@ -174,6 +176,9 @@ class GuardAuditEvent(Base):
     conductai_workflow = Column(String(255), nullable=True)
     conductai_workflow_id = Column(String(255), nullable=True)
     blast_radius = Column(JSONB, nullable=True)
+    # Added by revision 0056 — model was missing these columns (#1284).
+    os_info = Column(String(128), nullable=True)
+    hostname = Column(String(255), nullable=True)
     ts = Column(
         DateTime(timezone=True),
         nullable=False,


### PR DESCRIPTION
Follow-up to #1285. The alembic check probe was still failing on 5 column-level drift entries.

**Root cause**

DB has columns that model classes did not declare. Metadata was incomplete.

**Columns added**

- guard_audit_events.hostname (from revision 0056) — String(255)
- guard_audit_events.os_info (from revision 0056) — String(128)
- guard_member_config.agent_identity_id (from revision 0062) — String(36) FK
- workspace_users.role_id (from baseline 0001) — UUID FK to roles.id
- workspaces.clerk_org_id (from revision 0066) — Text

All 5 are nullable. Model addition is pure metadata catch-up — no write-path behavior change.

**Verified**

Base.metadata.tables now includes all 5 columns. Combined with #1285, this closes the remaining table + column drift entries surfaced by test_alembic_check_no_schema_drift.

**Not covered**

Index and constraint drift is still open. DB has autogenerated indexes on the new FKs that models don't spell out in __table_args__. Lower priority — safe to defer.

**Test plan**

- [ ] CI green on API job
- [ ] test_alembic_check_no_schema_drift makes further progress
- [ ] Existing tests unaffected (columns are nullable, purely additive)