### PR TITLE
test(guard): FP batch 3 — finish prompt-injection (10 negatives, #1272)

### DIFF
--- a/apps/api/tests/fixtures/guard_packs/conduct-prompt-injection.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-prompt-injection.yaml
@@ -234,3 +234,85 @@ cases:
     file_path: docs/markdown.md
     content: "Documentation code blocks use fenced markdown without special labels for language hints."
   expected: allow
+
+# ── negative canaries (#1272 batch 3 — see docs/guard-fp-strategy.md) ────
+# Finishes prompt-injection coverage. All [E] docs archetype.
+- rule_id: prompt-inject-grandma-exploit
+  scenario: "[E] family memoir without the recipe-bedtime-story trigger"
+  tool_name: write
+  tool_input:
+    file_path: docs/memoir.md
+    content: "The great-aunt shared her recipe cards during the family reunion last summer."
+  expected: allow
+
+- rule_id: prompt-inject-suffix-attack
+  scenario: "[E] style guide about sentence-ending punctuation"
+  tool_name: write
+  tool_input:
+    file_path: docs/style.md
+    content: "The style guide asks writers to end sentences with periods, question marks, or exclamation points."
+  expected: allow
+
+- rule_id: prompt-inject-delimiter-escape
+  scenario: "[E] markdown docs about horizontal rules"
+  tool_name: write
+  tool_input:
+    file_path: docs/markdown.md
+    content: "Markdown parsers treat three consecutive dashes as a horizontal rule element."
+  expected: allow
+
+- rule_id: prompt-inject-indirect-tool-output
+  scenario: "[E] audit trail docs mentioning rule decisions"
+  tool_name: write
+  tool_input:
+    file_path: docs/audit.md
+    content: "The compliance report mentions that the audit trail includes every rule decision."
+  expected: allow
+
+- rule_id: prompt-inject-encoded-canary-b64-ignore
+  scenario: "[E] base64 spec docs about padding"
+  tool_name: write
+  tool_input:
+    file_path: docs/base64.md
+    content: "Standard base64 encoding padding uses equals signs at the end of the encoded string."
+  expected: allow
+
+- rule_id: prompt-inject-fake-conversation
+  scenario: "[E] transcript description without user/assistant labels"
+  tool_name: write
+  tool_input:
+    file_path: docs/standup.md
+    content: "The transcript documented conversation flow between different team members during standup."
+  expected: allow
+
+- rule_id: prompt-inject-tool-name-spoof
+  scenario: "[E] invoice text mentioning tools without JSON structure"
+  tool_name: write
+  tool_input:
+    file_path: docs/invoice.md
+    content: "The invoice details listed the tool used for each item in the workshop repair estimate."
+  expected: allow
+
+- rule_id: prompt-inject-credentials-exfil-instruction
+  scenario: "[E] platform docs about credential vault workflow"
+  tool_name: write
+  tool_input:
+    file_path: docs/creds.md
+    content: "Environment configuration files are managed via the platform team's shared vault workflow."
+  expected: allow
+
+- rule_id: prompt-inject-persistence-write
+  scenario: "[E] docs about caching persistence"
+  tool_name: write
+  tool_input:
+    file_path: docs/cache.md
+    content: "The article covered how caching layers persist frequently accessed keys across service restarts."
+  expected: allow
+
+- rule_id: prompt-inject-language-switch-attack
+  scenario: "[E] i18n release notes about glossaries"
+  tool_name: write
+  tool_input:
+    file_path: docs/i18n.md
+    content: "The translation team ships glossaries in Spanish, French, and German for each release milestone."
+  expected: allow

--- a/apps/api/tests/test_guard_pack_coverage.py
+++ b/apps/api/tests/test_guard_pack_coverage.py
@@ -38,7 +38,7 @@ COVERAGE_ALLOWANCE = 66
 # case (expected: allow). Every rule that fires needs at least one
 # adjacent-but-benign fixture case so we catch false positives before
 # they ship. Lower as negative cases are added.
-NEGATIVE_CASE_ALLOWANCE = 73
+NEGATIVE_CASE_ALLOWANCE = 63
 
 
 def _load_seeded_rules() -> dict[str, set[str]]:


### PR DESCRIPTION
Batch 3 of #1272. Completes prompt-injection pack coverage — all 30 rules now have negatives.

**Ratchet drop:** NEGATIVE_CASE_ALLOWANCE 73 → 63. All 221 pack + coverage tests pass on first try (zero cross-rule triggers during dry-run).

**Coverage added — 10 rules, all archetype [E] (docs/prose)**

- prompt-inject-grandma-exploit — family memoir
- prompt-inject-suffix-attack — style guide about punctuation
- prompt-inject-delimiter-escape — markdown horizontal rules
- prompt-inject-indirect-tool-output — audit trail docs
- prompt-inject-encoded-canary-b64-ignore — base64 padding spec
- prompt-inject-fake-conversation — standup transcript description
- prompt-inject-tool-name-spoof — invoice text mentioning tools
- prompt-inject-credentials-exfil-instruction — platform vault workflow
- prompt-inject-persistence-write — cache persistence docs
- prompt-inject-language-switch-attack — i18n release notes

**Pack status after this batch**

conduct-prompt-injection: **30 / 30 rules covered (100% negative-case coverage)**

**Remaining backlog**

63 rules across the other 10 packs still need negatives. Next batches target OWASP (15 remaining) and endpoint-attacks (7 remaining) — the next-highest-exposure clusters.

**Method**

Each candidate content was dry-run against ALL 30 prompt-injection rule patterns to confirm zero cross-rule triggers before landing in the fixture. First-try success this batch (no rewrites needed).

**Test plan**

- [ ] CI green
- [ ] Full pack matrix passes (221 → 221 with 10 new negatives + baseline)
- [ ] Ratchet 63 is the new floor