### PR TITLE
feat(glens): 8 read-domain tool sets (#1287-#1294)

### DIFF
--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -20,7 +20,14 @@ from app.modules.guard.models import (
 from app.modules.guard.routers.spend import _get_spend_summary_inner, _org_ws_subquery
 from app.modules.guard.embedding import embedding_client_for_workspace
 from app.models.workflow import Workflow
-from sqlalchemy import func as sa_func
+from app.models.integration import Integration
+from app.models.workspace_user import WorkspaceUser
+from app.models.audit_log import AuditLog
+from app.models.project import Project
+from app.models.watchdog_event import WatchdogEvent
+from app.models.run import RunEvent
+from app.modules.guard.models import GuardApprovalRequest
+from sqlalchemy import func as sa_func, or_ as sa_or
 
 log = structlog.get_logger(__name__)
 
@@ -832,6 +839,416 @@ class Executor:
                 "block_count": int(r.block_count),
                 "top_rule_id": r.top_rule_id,
                 "last_blocked_at": r.last_blocked_at.isoformat() if r.last_blocked_at else None,
+            }
+            for r in rows
+        ]
+
+    # ── Approvals (#1287) ─────────────────────────────────────────────────────
+
+    def _tool_list_pending_approvals(self, status: str = "pending", limit: int = 20):
+        """List HITL approval requests. status: pending | approved | rejected | timed_out | all."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        q = self.db.query(GuardApprovalRequest).filter(GuardApprovalRequest.workspace_id == ws_uuid)
+        status = (status or "pending").lower()
+        if status != "all":
+            q = q.filter(GuardApprovalRequest.status == status)
+        rows = q.order_by(GuardApprovalRequest.created_at.desc()).limit(min(limit, 100)).all()
+        return [
+            {
+                "id": str(r.id),
+                "status": r.status,
+                "rule_id": r.rule_id,
+                "tool_name": r.tool_name,
+                "requester_email": r.requester_email,
+                "decided_by_email": r.decided_by_email,
+                "decided_at": r.decided_at.isoformat() if r.decided_at else None,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "timeout_at": r.timeout_at.isoformat() if r.timeout_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_get_approval(self, id: str):
+        """One approval request with full tool_input payload."""
+        try:
+            rid = uuid.UUID(id)
+        except ValueError:
+            return {"error": "id must be a UUID"}
+        ws_uuid = uuid.UUID(self.workspace_id)
+        r = (
+            self.db.query(GuardApprovalRequest)
+            .filter(GuardApprovalRequest.id == rid, GuardApprovalRequest.workspace_id == ws_uuid)
+            .first()
+        )
+        if not r:
+            return {"error": "Approval not found"}
+        return {
+            "id": str(r.id),
+            "status": r.status,
+            "rule_id": r.rule_id,
+            "tool_name": r.tool_name,
+            "tool_input": r.tool_input,
+            "requester_email": r.requester_email,
+            "decided_by_email": r.decided_by_email,
+            "decided_at": r.decided_at.isoformat() if r.decided_at else None,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "timeout_at": r.timeout_at.isoformat() if r.timeout_at else None,
+        }
+
+    # ── Packs (#1288) ─────────────────────────────────────────────────────────
+
+    def _tool_list_installed_packs(self):
+        """Installed skill packs for this workspace's org."""
+        org_ws = _org_ws_subquery(self.db, self.workspace_id)
+        rows = (
+            self.db.query(WorkspaceSkillPack)
+            .filter(WorkspaceSkillPack.workspace_id.in_(org_ws))
+            .order_by(WorkspaceSkillPack.installed_at.desc())
+            .all()
+        )
+        return [
+            {
+                "pack_slug": r.pack_slug,
+                "pinned_version": r.pinned_version,
+                "installed_by": r.installed_by,
+                "installed_at": r.installed_at.isoformat() if r.installed_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_browse_marketplace(self, query: str | None = None, limit: int = 30):
+        """Available skill packs in the catalog. Latest version per slug."""
+        q = self.db.query(SkillPack)
+        if query:
+            like = f"%{query.lower()}%"
+            q = q.filter(sa_or(
+                sa_func.lower(SkillPack.slug).like(like),
+                sa_func.lower(SkillPack.name).like(like),
+                sa_func.lower(SkillPack.description).like(like),
+            ))
+        rows = q.order_by(SkillPack.slug.asc(), SkillPack.version.desc()).limit(min(limit * 3, 200)).all()
+        seen: set[str] = set()
+        out: list[dict] = []
+        for r in rows:
+            if r.slug in seen:
+                continue
+            seen.add(r.slug)
+            rules = r.rules if isinstance(r.rules, list) else []
+            out.append({
+                "slug": r.slug,
+                "version": r.version,
+                "name": r.name,
+                "description": r.description,
+                "tier": r.tier,
+                "rules_count": len(rules),
+                "published_at": r.published_at.isoformat() if r.published_at else None,
+            })
+            if len(out) >= limit:
+                break
+        return out
+
+    def _tool_get_pack_details(self, slug: str):
+        """One skill pack's latest version with full rule list."""
+        r = (
+            self.db.query(SkillPack)
+            .filter(SkillPack.slug == slug)
+            .order_by(SkillPack.version.desc())
+            .first()
+        )
+        if not r:
+            return {"error": f"Pack '{slug}' not found"}
+        rules = r.rules if isinstance(r.rules, list) else []
+        return {
+            "slug": r.slug,
+            "version": r.version,
+            "name": r.name,
+            "description": r.description,
+            "tier": r.tier,
+            "rules_count": len(rules),
+            "rules": rules,
+            "published_at": r.published_at.isoformat() if r.published_at else None,
+        }
+
+    # ── Integrations (#1289) ──────────────────────────────────────────────────
+
+    def _tool_list_integrations(self):
+        """List all integrations (Slack, GitHub, Okta, Vercel, ...) for this workspace."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        rows = self.db.query(Integration).filter(Integration.workspace_id == ws_uuid).all()
+        return [
+            {
+                "id": str(r.id),
+                "service": r.service,
+                "auth_method": r.auth_method,
+                "handle": r.handle,
+                "scopes": list(r.scopes) if r.scopes else [],
+                "last_used_at": r.last_used_at.isoformat() if r.last_used_at else None,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_get_integration_status(self, service: str):
+        """One integration by service (github/slack/okta/...) — status + handle + last used."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        r = (
+            self.db.query(Integration)
+            .filter(Integration.workspace_id == ws_uuid, Integration.service == service.lower())
+            .first()
+        )
+        if not r:
+            return {"service": service, "configured": False}
+        return {
+            "service": r.service,
+            "configured": True,
+            "auth_method": r.auth_method,
+            "handle": r.handle,
+            "scopes": list(r.scopes) if r.scopes else [],
+            "last_used_at": r.last_used_at.isoformat() if r.last_used_at else None,
+        }
+
+    # ── Team members (#1290) ──────────────────────────────────────────────────
+
+    def _tool_list_members(self, role: str | None = None, limit: int = 50):
+        """List workspace members. Optional role filter."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        q = self.db.query(WorkspaceUser).filter(WorkspaceUser.workspace_id == ws_uuid)
+        if role:
+            q = q.filter(WorkspaceUser.role == role.lower())
+        rows = q.order_by(WorkspaceUser.joined_at.desc()).limit(min(limit, 200)).all()
+        return [
+            {
+                "clerk_user_id": r.clerk_user_id,
+                "role": r.role,
+                "invited_by": r.invited_by,
+                "joined_at": r.joined_at.isoformat() if r.joined_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_get_member(self, clerk_user_id: str):
+        """One member's workspace record."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        r = (
+            self.db.query(WorkspaceUser)
+            .filter(WorkspaceUser.workspace_id == ws_uuid, WorkspaceUser.clerk_user_id == clerk_user_id)
+            .first()
+        )
+        if not r:
+            return {"error": "Member not found"}
+        return {
+            "clerk_user_id": r.clerk_user_id,
+            "role": r.role,
+            "role_id": str(r.role_id) if r.role_id else None,
+            "invited_by": r.invited_by,
+            "joined_at": r.joined_at.isoformat() if r.joined_at else None,
+        }
+
+    # ── Platform audit log (#1291) ────────────────────────────────────────────
+
+    def _tool_get_audit_events(
+        self,
+        actor_email: str | None = None,
+        action: str | None = None,
+        resource_type: str | None = None,
+        since: str | None = None,
+        until: str | None = None,
+        limit: int = 25,
+    ):
+        """Platform audit events (invites, role changes, run triggers, credential
+        edits, etc). Separate from Guard audit — this is org-wide platform activity."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        q = self.db.query(AuditLog).filter(AuditLog.workspace_id == ws_uuid)
+        if actor_email:
+            q = q.filter(AuditLog.actor_email == actor_email)
+        if action:
+            q = q.filter(AuditLog.action == action)
+        if resource_type:
+            q = q.filter(AuditLog.resource_type == resource_type)
+        if since:
+            q = q.filter(AuditLog.created_at >= since)
+        if until:
+            q = q.filter(AuditLog.created_at <= until)
+        rows = q.order_by(AuditLog.created_at.desc()).limit(min(limit, 100)).all()
+        return [
+            {
+                "id": str(r.id),
+                "actor_email": r.actor_email,
+                "actor_role": r.actor_role,
+                "action": r.action,
+                "resource_type": r.resource_type,
+                "resource_id": r.resource_id,
+                "metadata": r.meta,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_search_audit_log(self, q: str, limit: int = 25):
+        """Substring search across audit action, actor_email, resource_type, resource_id."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        like = f"%{q.lower()}%"
+        rows = (
+            self.db.query(AuditLog)
+            .filter(
+                AuditLog.workspace_id == ws_uuid,
+                sa_or(
+                    sa_func.lower(AuditLog.action).like(like),
+                    sa_func.lower(AuditLog.actor_email).like(like),
+                    sa_func.lower(AuditLog.resource_type).like(like),
+                    sa_func.lower(AuditLog.resource_id).like(like),
+                ),
+            )
+            .order_by(AuditLog.created_at.desc())
+            .limit(min(limit, 100))
+            .all()
+        )
+        return [
+            {
+                "id": str(r.id),
+                "actor_email": r.actor_email,
+                "action": r.action,
+                "resource_type": r.resource_type,
+                "resource_id": r.resource_id,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ]
+
+    # ── Projects (#1292) ──────────────────────────────────────────────────────
+
+    def _tool_list_projects(self, limit: int = 50):
+        """List projects in this workspace."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        rows = (
+            self.db.query(Project)
+            .filter(Project.workspace_id == ws_uuid)
+            .order_by(Project.created_at.desc())
+            .limit(min(limit, 200))
+            .all()
+        )
+        return [
+            {
+                "id": str(r.id),
+                "name": r.name,
+                "slug": r.slug,
+                "project_type": r.project_type,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_get_project(self, id_or_slug: str):
+        """One project by UUID or slug."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        q = self.db.query(Project).filter(Project.workspace_id == ws_uuid)
+        try:
+            r = q.filter(Project.id == uuid.UUID(id_or_slug)).first()
+        except ValueError:
+            r = q.filter(Project.slug == id_or_slug).first()
+        if not r:
+            return {"error": "Project not found"}
+        return {
+            "id": str(r.id),
+            "name": r.name,
+            "slug": r.slug,
+            "project_type": r.project_type,
+            "security_finding_id": r.security_finding_id,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+        }
+
+    # ── Observability alerts (#1293) ──────────────────────────────────────────
+
+    def _tool_list_alerts(
+        self,
+        severity: str | None = None,
+        event_type: str | None = None,
+        include_resolved: bool = False,
+        since: str | None = None,
+        limit: int = 25,
+    ):
+        """Watchdog alerts (stale worker, credential expiry, silent playbook, etc)."""
+        ws_uuid = uuid.UUID(self.workspace_id)
+        q = self.db.query(WatchdogEvent).filter(WatchdogEvent.workspace_id == ws_uuid)
+        if severity:
+            q = q.filter(WatchdogEvent.severity == severity.lower())
+        if event_type:
+            q = q.filter(WatchdogEvent.event_type == event_type)
+        if not include_resolved:
+            q = q.filter(WatchdogEvent.resolved_at.is_(None))
+        if since:
+            q = q.filter(WatchdogEvent.created_at >= since)
+        rows = q.order_by(WatchdogEvent.created_at.desc()).limit(min(limit, 100)).all()
+        return [
+            {
+                "id": str(r.id),
+                "event_type": r.event_type,
+                "severity": r.severity,
+                "run_id": str(r.run_id) if r.run_id else None,
+                "workflow_id": str(r.workflow_id) if r.workflow_id else None,
+                "payload": r.payload,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
+            }
+            for r in rows
+        ]
+
+    def _tool_get_alert(self, id: str):
+        """One watchdog alert with full payload."""
+        try:
+            aid = uuid.UUID(id)
+        except ValueError:
+            return {"error": "id must be a UUID"}
+        ws_uuid = uuid.UUID(self.workspace_id)
+        r = (
+            self.db.query(WatchdogEvent)
+            .filter(WatchdogEvent.id == aid, WatchdogEvent.workspace_id == ws_uuid)
+            .first()
+        )
+        if not r:
+            return {"error": "Alert not found"}
+        return {
+            "id": str(r.id),
+            "event_type": r.event_type,
+            "severity": r.severity,
+            "run_id": str(r.run_id) if r.run_id else None,
+            "workflow_id": str(r.workflow_id) if r.workflow_id else None,
+            "payload": r.payload,
+            "created_at": r.created_at.isoformat() if r.created_at else None,
+            "resolved_at": r.resolved_at.isoformat() if r.resolved_at else None,
+        }
+
+    # ── Run logs (#1294) ──────────────────────────────────────────────────────
+
+    def _tool_list_run_events(self, run_id: str, kind: str | None = None, limit: int = 100):
+        """Events emitted during a workflow run — block_started/completed/failed/
+        approval_requested/etc. Use when the user wants to see 'what happened
+        during run X'."""
+        try:
+            rid = uuid.UUID(run_id)
+        except ValueError:
+            return {"error": "run_id must be a UUID"}
+        # Scope check — only return events for runs in this workspace's org.
+        from app.models.run import Run
+        org_ws = _org_ws_subquery(self.db, self.workspace_id)
+        run = (
+            self.db.query(Run)
+            .filter(Run.id == rid, Run.workspace_id.in_(org_ws))
+            .first()
+        )
+        if not run:
+            return {"error": "Run not found"}
+        q = self.db.query(RunEvent).filter(RunEvent.run_id == rid)
+        if kind:
+            q = q.filter(RunEvent.kind == kind)
+        rows = q.order_by(RunEvent.created_at.asc()).limit(min(limit, 500)).all()
+        return [
+            {
+                "id": str(r.id),
+                "block_id": r.block_id,
+                "kind": r.kind,
+                "payload": r.payload,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
             }
             for r in rows
         ]

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -144,6 +144,177 @@ TOOLS = [
         },
     },
     {
+        "name": "list_pending_approvals",
+        "description": "HITL approval queue. Use for 'what needs my approval', 'pending requests'. status defaults to 'pending'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["pending", "approved", "rejected", "timed_out", "all"]},
+                "limit": {"type": "integer", "default": 20},
+            },
+        },
+    },
+    {
+        "name": "get_approval",
+        "description": "One approval request by id with the full tool_input payload.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"id": {"type": "string", "description": "Approval UUID"}},
+            "required": ["id"],
+        },
+    },
+    {
+        "name": "list_installed_packs",
+        "description": "Installed skill packs for this workspace. Use for 'what packs are installed', 'do we have SOC2 pack'.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "browse_marketplace",
+        "description": "Available skill packs in the marketplace. Substring search on slug/name/description. Use for 'what packs are available', 'find a pack for HIPAA'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Substring search"},
+                "limit": {"type": "integer", "default": 20},
+            },
+        },
+    },
+    {
+        "name": "get_pack_details",
+        "description": "One skill pack's rules and metadata.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"slug": {"type": "string"}},
+            "required": ["slug"],
+        },
+    },
+    {
+        "name": "list_integrations",
+        "description": "Configured integrations (Slack, GitHub, Okta, ...). Use for 'what integrations are set up'.",
+        "input_schema": {"type": "object", "properties": {}},
+    },
+    {
+        "name": "get_integration_status",
+        "description": "Status of one integration by service name. Use for 'is Slack connected', 'when did GitHub last sync'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"service": {"type": "string", "description": "e.g. github, slack, okta, vercel"}},
+            "required": ["service"],
+        },
+    },
+    {
+        "name": "list_members",
+        "description": "Workspace members with role. Optional role filter. Use for 'who is on the team', 'who are the admins'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "role": {"type": "string", "enum": ["admin", "developer", "security", "viewer"]},
+                "limit": {"type": "integer", "default": 50},
+            },
+        },
+    },
+    {
+        "name": "get_member",
+        "description": "One workspace member's role + join info.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"clerk_user_id": {"type": "string"}},
+            "required": ["clerk_user_id"],
+        },
+    },
+    {
+        "name": "get_audit_events",
+        "description": (
+            "Platform audit log — invites, role changes, credential edits, run triggers. "
+            "Separate from Guard events; this is org-wide platform activity. Filter by "
+            "actor_email/action/resource_type/time range."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "actor_email": {"type": "string"},
+                "action": {"type": "string", "description": "e.g. run.triggered, invite.sent, role.changed"},
+                "resource_type": {"type": "string"},
+                "since": {"type": "string", "description": "ISO date start"},
+                "until": {"type": "string", "description": "ISO date end"},
+                "limit": {"type": "integer", "default": 25},
+            },
+        },
+    },
+    {
+        "name": "search_audit_log",
+        "description": "Substring search across audit action, actor_email, resource_type, resource_id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "q": {"type": "string"},
+                "limit": {"type": "integer", "default": 25},
+            },
+            "required": ["q"],
+        },
+    },
+    {
+        "name": "list_projects",
+        "description": "Projects in this workspace. Use for 'what projects do we have'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"limit": {"type": "integer", "default": 50}},
+        },
+    },
+    {
+        "name": "get_project",
+        "description": "One project by UUID or slug.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"id_or_slug": {"type": "string"}},
+            "required": ["id_or_slug"],
+        },
+    },
+    {
+        "name": "list_alerts",
+        "description": (
+            "Watchdog alerts — stale worker, credential expiry, silent playbook, "
+            "repeated failures. Use for 'what alerts are firing', 'unresolved warnings'. "
+            "Excludes resolved unless include_resolved=true."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "severity": {"type": "string", "enum": ["info", "warning", "error"]},
+                "event_type": {"type": "string"},
+                "include_resolved": {"type": "boolean"},
+                "since": {"type": "string", "description": "ISO date start"},
+                "limit": {"type": "integer", "default": 25},
+            },
+        },
+    },
+    {
+        "name": "get_alert",
+        "description": "One watchdog alert by id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"id": {"type": "string", "description": "Alert UUID"}},
+            "required": ["id"],
+        },
+    },
+    {
+        "name": "list_run_events",
+        "description": (
+            "Events emitted during one workflow run. Use when the user asks "
+            "'what happened during run X', 'which blocks failed in this run', "
+            "'walk me through this run'."
+        ),
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "Run UUID"},
+                "kind": {"type": "string", "description": "Filter to one event kind"},
+                "limit": {"type": "integer", "default": 100},
+            },
+            "required": ["run_id"],
+        },
+    },
+    {
         "name": "get_blocked_workflows",
         "description": (
             "Workflows Guard has blocked, ranked by block count. Use for 'which workflow triggered a block', "
@@ -258,6 +429,37 @@ def _build_drilldown(tool_calls: list[tuple[str, dict]]) -> str | None:
             page = "/theguard/discovery"
         elif name in ("get_compliance_status", "get_framework_coverage"):
             page = "/theguard/compliance"
+        elif name in ("list_pending_approvals", "get_approval"):
+            page = "/theguard/approvals"
+            if args.get("status") and args["status"] != "all":
+                filters["status"] = args["status"]
+        elif name in ("list_installed_packs", "browse_marketplace", "get_pack_details"):
+            slug = args.get("slug")
+            page = f"/packs/{slug}" if slug else "/packs"
+        elif name in ("list_integrations", "get_integration_status"):
+            page = "/integrations"
+        elif name in ("list_members", "get_member"):
+            page = "/theguard/team"
+            if args.get("role"):
+                filters["role"] = args["role"]
+        elif name in ("get_audit_events", "search_audit_log"):
+            page = "/audit"
+            if args.get("actor_email"):   filters["actor"] = args["actor_email"]
+            if args.get("action"):        filters["action"] = args["action"]
+            if args.get("resource_type"): filters["resource_type"] = args["resource_type"]
+            if args.get("since"):         filters["since"] = args["since"]
+            if args.get("until"):         filters["until"] = args["until"]
+        elif name == "list_projects":
+            page = "/projects"
+        elif name == "get_project":
+            page = f"/projects/{args.get('id_or_slug')}" if args.get("id_or_slug") else "/projects"
+        elif name in ("list_alerts", "get_alert"):
+            page = "/observability/alerts"
+            if args.get("severity"):   filters["severity"] = args["severity"]
+            if args.get("event_type"): filters["event_type"] = args["event_type"]
+        elif name == "list_run_events":
+            rid = args.get("run_id")
+            page = f"/runs/{rid}" if rid else "/runs"
 
     if not filters and page == "/logs/guard":
         return None

--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -296,6 +296,235 @@ _TOOLS: list[ToolDef] = [
         annotations=_READ_ONLY,
         tags=_LENS_TAGS,
     ),
+    # ── Approvals (#1287) ─────────────────────────────────────────────────
+    ToolDef(
+        name="list_pending_approvals",
+        description="HITL approval queue. status = pending (default) | approved | rejected | timed_out | all.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "status": {"type": "string", "enum": ["pending", "approved", "rejected", "timed_out", "all"]},
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("list_pending_approvals"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_approval",
+        description="One approval request with full tool_input payload.",
+        input_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string", "description": "Approval UUID"}},
+            "required": ["id"],
+        },
+        impl=_impl("get_approval"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Packs (#1288) ─────────────────────────────────────────────────────
+    ToolDef(
+        name="list_installed_packs",
+        description="List installed skill packs for this workspace's org.",
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=_impl("list_installed_packs"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="browse_marketplace",
+        description="Available skill packs in the catalog (latest version per slug). Optional query for substring match on slug/name/description.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Substring search"},
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("browse_marketplace"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_pack_details",
+        description="One skill pack's latest version with the full rule list.",
+        input_schema={
+            "type": "object",
+            "properties": {"slug": {"type": "string", "description": "Pack slug"}},
+            "required": ["slug"],
+        },
+        impl=_impl("get_pack_details"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Integrations (#1289) ──────────────────────────────────────────────
+    ToolDef(
+        name="list_integrations",
+        description="All integrations (Slack, GitHub, Okta, Vercel, ...) configured for this workspace.",
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=_impl("list_integrations"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_integration_status",
+        description="One integration by service. Returns configured=false if none.",
+        input_schema={
+            "type": "object",
+            "properties": {"service": {"type": "string", "description": "e.g. github, slack, okta, vercel"}},
+            "required": ["service"],
+        },
+        impl=_impl("get_integration_status"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Team members (#1290) ──────────────────────────────────────────────
+    ToolDef(
+        name="list_members",
+        description="Workspace members with role. Optional role filter (admin/developer/security/viewer).",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "role": {"type": "string", "enum": ["admin", "developer", "security", "viewer"]},
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("list_members"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_member",
+        description="One workspace member's role + join info by Clerk user id.",
+        input_schema={
+            "type": "object",
+            "properties": {"clerk_user_id": {"type": "string"}},
+            "required": ["clerk_user_id"],
+        },
+        impl=_impl("get_member"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Platform audit log (#1291) ────────────────────────────────────────
+    ToolDef(
+        name="get_audit_events",
+        description=(
+            "Platform audit events (invites, role changes, credential edits, run triggers). "
+            "Separate from Guard events — this is org-wide platform activity."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "actor_email": {"type": "string"},
+                "action": {"type": "string", "description": "e.g. run.triggered, invite.sent"},
+                "resource_type": {"type": "string"},
+                "since": _TS_SINCE, "until": _TS_UNTIL,
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("get_audit_events"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="search_audit_log",
+        description="Substring search across audit action, actor_email, resource_type, resource_id.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "q": {"type": "string", "description": "Search query"},
+                "limit": _LIMIT,
+            },
+            "required": ["q"],
+        },
+        impl=_impl("search_audit_log"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Projects (#1292) ──────────────────────────────────────────────────
+    ToolDef(
+        name="list_projects",
+        description="Projects in this workspace.",
+        input_schema={
+            "type": "object",
+            "properties": {"limit": _LIMIT},
+            "required": [],
+        },
+        impl=_impl("list_projects"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_project",
+        description="One project by UUID or slug.",
+        input_schema={
+            "type": "object",
+            "properties": {"id_or_slug": {"type": "string"}},
+            "required": ["id_or_slug"],
+        },
+        impl=_impl("get_project"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Observability alerts (#1293) ──────────────────────────────────────
+    ToolDef(
+        name="list_alerts",
+        description=(
+            "Watchdog alerts (stale worker, credential expiry, silent playbook, "
+            "repeated failures). Excludes resolved unless include_resolved=true."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "severity": {"type": "string", "enum": ["info", "warning", "error"]},
+                "event_type": {"type": "string"},
+                "include_resolved": {"type": "boolean"},
+                "since": _TS_SINCE,
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=_impl("list_alerts"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_alert",
+        description="One watchdog alert with full payload.",
+        input_schema={
+            "type": "object",
+            "properties": {"id": {"type": "string", "description": "Alert UUID"}},
+            "required": ["id"],
+        },
+        impl=_impl("get_alert"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    # ── Run logs (#1294) ──────────────────────────────────────────────────
+    ToolDef(
+        name="list_run_events",
+        description=(
+            "Events emitted during one workflow run — block_started/completed/failed, "
+            "approval_requested, etc. Use when the user asks 'what happened during run X'."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "run_id": {"type": "string", "description": "Run UUID"},
+                "kind": {"type": "string", "description": "Filter to one event kind"},
+                "limit": _LIMIT,
+            },
+            "required": ["run_id"],
+        },
+        impl=_impl("list_run_events"),
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
     ToolDef(
         name="get_blocked_workflows",
         description=(

--- a/apps/api/tests/fixtures/guard_packs/conduct-prompt-injection.yaml
+++ b/apps/api/tests/fixtures/guard_packs/conduct-prompt-injection.yaml
@@ -150,3 +150,87 @@ cases:
     file_path: p.py
     content: prompt = 'summarize this article in three bullet points'
   expected: allow
+
+# ── negative canaries (#1272 batch 2 — see docs/guard-fp-strategy.md) ────
+# All cases tagged [E] (docs/research writing) — the archetype most
+# common for FP on prompt-injection detectors: legitimate discussion of
+# the very attacks these rules exist to catch.
+- rule_id: prompt-inject-system-prompt-reveal
+  scenario: "[E] docs referencing prompt redaction without the reveal verb form"
+  tool_name: write
+  tool_input:
+    file_path: docs/security.md
+    content: "The developer redacted the model configuration from their debug logs before publishing the demo."
+  expected: allow
+
+- rule_id: prompt-inject-role-hijack
+  scenario: "[E] RBAC prose without role-play triggers"
+  tool_name: write
+  tool_input:
+    file_path: docs/rbac.md
+    content: "Role-based access control assigns permissions per group; changes go through code review."
+  expected: allow
+
+- rule_id: prompt-inject-jailbreak-personas
+  scenario: "[E] research prose about model safety without persona names"
+  tool_name: write
+  tool_input:
+    file_path: docs/safety.md
+    content: "Anthropic's constitutional AI research covers how models resist unsafe requests."
+  expected: allow
+
+- rule_id: prompt-inject-hypothetical-framing
+  scenario: "[E] paper prose about threat models"
+  tool_name: write
+  tool_input:
+    file_path: docs/threat-model.md
+    content: "The paper discusses privacy under different threat models observed in production."
+  expected: allow
+
+- rule_id: prompt-inject-authority-spoof
+  scenario: "[E] meeting notes mentioning administrator role"
+  tool_name: write
+  tool_input:
+    file_path: docs/notes.md
+    content: "The team lead met the administrator yesterday to review the quarterly access controls."
+  expected: allow
+
+- rule_id: prompt-inject-tool-disable
+  scenario: "[E] product copy about enabling moderation"
+  tool_name: write
+  tool_input:
+    file_path: docs/product.md
+    content: "User experience improves when we enable helpful moderation instead of blocking outright."
+  expected: allow
+
+- rule_id: prompt-inject-emotional-coercion
+  scenario: "[E] support training material"
+  tool_name: write
+  tool_input:
+    file_path: docs/support.md
+    content: "Customer support agents undergo training to recognize distress cues and route calls appropriately."
+  expected: allow
+
+- rule_id: prompt-inject-encoded-payload-marker
+  scenario: "[E] MIME docs mentioning base64 without decode verb"
+  tool_name: write
+  tool_input:
+    file_path: docs/mime.md
+    content: "The MIME standard specifies base64 encoding for binary email attachments."
+  expected: allow
+
+- rule_id: prompt-inject-refusal-suppress
+  scenario: "[E] style guide about saying 'no' clearly"
+  tool_name: write
+  tool_input:
+    file_path: docs/style.md
+    content: "The style guide asks writers to say 'no' clearly when they mean it, without hedging."
+  expected: allow
+
+- rule_id: prompt-inject-code-block-instruction
+  scenario: "[E] docs describing plain markdown fenced blocks"
+  tool_name: write
+  tool_input:
+    file_path: docs/markdown.md
+    content: "Documentation code blocks use fenced markdown without special labels for language hints."
+  expected: allow

--- a/apps/api/tests/glens/test_read_tools_batch1.py
+++ b/apps/api/tests/glens/test_read_tools_batch1.py
@@ -1,0 +1,85 @@
+"""Parity + drilldown checks for the batch-1 read tools (8 domains, 16 tools).
+
+Guards against drift between:
+- Executor `_tool_*` methods
+- `ToolDef` registrations in `app/tools/registrations/lens.py`
+- `TOOLS` schema list seen by the LLM
+- `_build_drilldown` routes seen by the UI
+
+Isolated (no DB) — behavior tests live under each domain's owned suite.
+"""
+from __future__ import annotations
+
+BATCH1_TOOLS = (
+    # #1287 approvals
+    "list_pending_approvals",
+    "get_approval",
+    # #1288 packs
+    "list_installed_packs",
+    "browse_marketplace",
+    "get_pack_details",
+    # #1289 integrations
+    "list_integrations",
+    "get_integration_status",
+    # #1290 team
+    "list_members",
+    "get_member",
+    # #1291 audit
+    "get_audit_events",
+    "search_audit_log",
+    # #1292 projects
+    "list_projects",
+    "get_project",
+    # #1293 alerts
+    "list_alerts",
+    "get_alert",
+    # #1294 logs
+    "list_run_events",
+)
+
+
+def test_registrations_expose_all_batch1_tools():
+    from app.tools.registrations import lens
+    from app.tools.registry import default_registry
+    lens.register(replace=True)
+    names = {t.name for t in default_registry._tools.values() if "lens" in t.tags}
+    missing = [n for n in BATCH1_TOOLS if n not in names]
+    assert not missing, f"Not registered: {missing}"
+
+
+def test_chat_TOOLS_exposes_all_batch1_tools():
+    from app.modules.glens.routers import chat
+    names = {t["name"] for t in chat.TOOLS}
+    missing = [n for n in BATCH1_TOOLS if n not in names]
+    assert not missing, f"Not in chat.TOOLS: {missing}"
+
+
+def test_executor_has_all_tool_methods():
+    from app.modules.glens.executor import Executor
+    missing = [n for n in BATCH1_TOOLS if not hasattr(Executor, f"_tool_{n}")]
+    assert not missing, f"Executor missing _tool_ methods: {missing}"
+
+
+def test_drilldown_routes_per_domain():
+    from app.modules.glens.routers import chat
+    cases = [
+        # (tool_name, args, expected_url_or_prefix)
+        (("list_pending_approvals", {}), "/theguard/approvals"),
+        (("list_pending_approvals", {"status": "approved"}), "/theguard/approvals?status=approved"),
+        (("get_approval", {"id": "abc"}), "/theguard/approvals"),
+        (("list_installed_packs", {}), "/packs"),
+        (("get_pack_details", {"slug": "soc2"}), "/packs/soc2"),
+        (("list_integrations", {}), "/integrations"),
+        (("list_members", {}), "/theguard/team"),
+        (("list_members", {"role": "admin"}), "/theguard/team?role=admin"),
+        (("get_audit_events", {}), "/audit"),
+        (("search_audit_log", {"q": "invite"}), "/audit"),
+        (("list_projects", {}), "/projects"),
+        (("get_project", {"id_or_slug": "foo"}), "/projects/foo"),
+        (("list_alerts", {}), "/observability/alerts"),
+        (("list_alerts", {"severity": "error"}), "/observability/alerts?severity=error"),
+        (("list_run_events", {"run_id": "r1"}), "/runs/r1"),
+    ]
+    for call, expected in cases:
+        got = chat._build_drilldown([call])
+        assert got == expected, f"{call} → expected {expected}, got {got}"

--- a/apps/api/tests/test_guard_pack_coverage.py
+++ b/apps/api/tests/test_guard_pack_coverage.py
@@ -38,7 +38,7 @@ COVERAGE_ALLOWANCE = 66
 # case (expected: allow). Every rule that fires needs at least one
 # adjacent-but-benign fixture case so we catch false positives before
 # they ship. Lower as negative cases are added.
-NEGATIVE_CASE_ALLOWANCE = 82
+NEGATIVE_CASE_ALLOWANCE = 73
 
 
 def _load_seeded_rules() -> dict[str, set[str]]:


### PR DESCRIPTION
Batch 1 of the epic #1281 (Lens = universal read surface). Closes #1287, #1288, #1289, #1290, #1291, #1292, #1293, #1294.

## Summary

16 new Lens tools across 8 read domains. Same wiring pattern as PR #1286 (Executor `_tool_*` → `lens.py` registration → `chat.py` TOOLS → drilldown route), all read-only, scoped to workspace/org.

## Tools per domain

| Domain | Tools | Drilldown |
|---|---|---|
| #1287 approvals | `list_pending_approvals`, `get_approval` | `/theguard/approvals` |
| #1288 packs | `list_installed_packs`, `browse_marketplace`, `get_pack_details` | `/packs`, `/packs/{slug}` |
| #1289 integrations | `list_integrations`, `get_integration_status` | `/integrations` |
| #1290 team | `list_members`, `get_member` | `/theguard/team` |
| #1291 audit | `get_audit_events`, `search_audit_log` | `/audit` |
| #1292 projects | `list_projects`, `get_project` | `/projects`, `/projects/{id}` |
| #1293 alerts | `list_alerts`, `get_alert` | `/observability/alerts` |
| #1294 logs | `list_run_events` | `/runs/{run_id}` |

## Test plan

- [x] 4 parity tests pass locally — registration ↔ chat.TOOLS ↔ Executor methods ↔ drilldown routes.
- [ ] Live: create a Lens session, ask "what approvals are pending" — expect a real list + drilldown to `/theguard/approvals`.
- [ ] Live: ask "is Slack connected" — expect `get_integration_status` call + drilldown to `/integrations`.
- [ ] Live: ask "show me watchdog alerts" — expect `list_alerts` + drilldown to `/observability/alerts`.

## Parked from this batch

- **#1295 reports** — SOC2 is computed inline in `governance.py`; needs a persisted `compliance_reports` table or a stable helper first. Comment posted.
- **#1296 autopilot activity** — no dedicated activity table; needs a design decision (synthesise vs materialise). Comment posted.

## Depends on

- PR #1286 (agent-identity + workflow-details + list_runs + get_run + session-scoped tokens) — needs to merge first; this branch is based on main so it'll rebase cleanly after #1286 lands.