### PR TITLE
hotfix(migrations): rename glens 0090 → 0101 (prod deploy blocked)

### DIFF
--- a/apps/api/alembic/versions/0101_glens_session_agent_identity.py
+++ b/apps/api/alembic/versions/0101_glens_session_agent_identity.py
@@ -17,8 +17,8 @@ from __future__ import annotations
 import sqlalchemy as sa
 from alembic import op
 
-revision = "0090"
-down_revision = "0089"
+revision = "0101"
+down_revision = "0100"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Prod fire

Render deploy exits 255 on every restart:

\`\`\`
UserWarning: Revision 0090 is present more than once
ERROR: Multiple head revisions are present for given argument 'head'
FAILED: Multiple head revisions are present ...
\`\`\`

Cause: PR #1286 merged with alembic revision \`0090\` for the glens session agent-identity column, but \`0090_agent_identity_alignment.py\` already existed on main from an earlier merge. Two heads at 0090 → alembic can't pick a target.

## Fix

Rename the glens migration to \`0101\` on top of \`0100\`. Content is unchanged (same \`add_column\` / \`drop_column\`).

Verified locally:
\`\`\`
$ alembic heads
0101 (head)
\`\`\`

## Merge as admin

Prod is down. Admin-merge as soon as this appears.