### PR TITLE
fix(api): backfill AgentMemory Index() decls — schema drift cluster 3

### DIFF
--- a/apps/api/app/models/agent_memory.py
+++ b/apps/api/app/models/agent_memory.py
@@ -1,6 +1,7 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey
+import sqlalchemy as sa
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID
 from pgvector.sqlalchemy import Vector
 from app.core.database import Base
@@ -18,3 +19,23 @@ class AgentMemory(Base):
     embedding = Column(Vector(1536), nullable=True)  # native pgvector; 1536d = OpenAI text-embedding-3-small
     run_id = Column(UUID(as_uuid=True), ForeignKey("runs.id", ondelete="SET NULL"), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_agent_memory_lookup", "workspace_id", "playbook_slug", "scope", "key"),
+        Index(
+            "ix_agent_memory_created",
+            "workspace_id", "playbook_slug", "scope", "key", "created_at",
+        ),
+        Index(
+            "ix_agent_memory_search",
+            "workspace_id", "playbook_slug", "scope", "key",
+            postgresql_where=sa.text("embedding IS NOT NULL"),
+        ),
+        Index(
+            "ix_agent_memory_hnsw",
+            "embedding",
+            postgresql_using="hnsw",
+            postgresql_ops={"embedding": "vector_cosine_ops"},
+            postgresql_with={"m": 16, "ef_construction": 64},
+        ),
+    )


### PR DESCRIPTION
Cluster 3 of drift cleanup (see #1325). Adds 4 index decls on AgentMemory (lookup / created / search / hnsw) matching baseline 0001. Zero DB change.