### PR TITLE
fix(api): backfill workspace_* Index() decls — schema drift cluster 5

### DIFF
--- a/apps/api/app/models/workspace.py
+++ b/apps/api/app/models/workspace.py
@@ -22,7 +22,7 @@ class Workspace(Base):
 
     org_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True)
     # Added by revision 0066 — model was missing it (#1284).
-    clerk_org_id = sa.Column(sa.Text(), nullable=True, index=True)
+    clerk_org_id = sa.Column(sa.Text(), nullable=True)
 
     # Authoritative pointer to the Security Automation project for this workspace.
     # See conductai#1005 — replaces .first() dispatch roulette for security_loop /
@@ -45,3 +45,12 @@ class Workspace(Base):
     workflows = relationship("Workflow", back_populates="workspace")
     integrations = relationship("Integration", back_populates="workspace")
     environments = relationship("Environment", back_populates="workspace")
+
+    __table_args__ = (
+        sa.Index(
+            "ix_workspaces_clerk_org_id",
+            "clerk_org_id",
+            unique=True,
+            postgresql_where=sa.text("clerk_org_id IS NOT NULL"),
+        ),
+    )

--- a/apps/api/app/models/workspace_config.py
+++ b/apps/api/app/models/workspace_config.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, String, DateTime, ForeignKey, Index, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -19,4 +19,5 @@ class WorkspaceConfig(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "key", name="uq_workspace_config_ws_key"),
+        Index("ix_workspace_config_workspace_id", "workspace_id"),
     )

--- a/apps/api/app/models/workspace_user.py
+++ b/apps/api/app/models/workspace_user.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy import Column, String, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -18,3 +18,7 @@ class WorkspaceUser(Base):
     role_id = Column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="SET NULL"), nullable=True, index=True)
 
     workspace = relationship("Workspace", back_populates="members")
+
+    __table_args__ = (
+        Index("ix_workspace_users_clerk_user_id", "clerk_user_id"),
+    )

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -2,7 +2,7 @@ import hashlib
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Integer, LargeBinary, String, Text, UniqueConstraint, func
+from sqlalchemy import BigInteger, Boolean, Column, DateTime, Float, ForeignKey, Index, Integer, LargeBinary, String, Text, UniqueConstraint, func
 from sqlalchemy.dialects.postgresql import ARRAY, JSON, JSONB, UUID
 from pgvector.sqlalchemy import Vector
 
@@ -346,6 +346,10 @@ class WorkspaceSkillPack(Base):
     installed_by    = Column(Text, nullable=True)   # clerk_user_id
     installed_at    = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
+    __table_args__ = (
+        Index("ix_workspace_skill_packs_workspace", "workspace_id"),
+    )
+
 
 class WorkspaceCustomRule(Base):
     """Per-workspace custom guard rules. Replaces the legacy guard_policies
@@ -362,6 +366,10 @@ class WorkspaceCustomRule(Base):
     created_at   = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at   = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc),
                           onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_workspace_custom_rules_workspace", "workspace_id"),
+    )
 
 
 class GuardRuleOverride(Base):


### PR DESCRIPTION
Cluster 5 of drift cleanup (see #1325). Adds index decls across Workspace, WorkspaceUser, WorkspaceConfig, WorkspaceSkillPack, WorkspaceCustomRule matching migrations 0066, 0001, 0034, 0017, 0023. Zero DB change. WorkspaceInstructions deferred to Phase 3 (UniqueConstraint vs unique-Index naming needs semantic decision).