### PR TITLE
fix(api): silence cosmetic type drift — Phase 2

### DIFF
--- a/apps/api/app/models/integration.py
+++ b/apps/api/app/models/integration.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint, Boolean
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, UniqueConstraint, Boolean
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -15,7 +15,7 @@ class Integration(Base):
     auth_method = Column(String(50), nullable=False)  # oauth/api_key/connection_string
     handle = Column(String(100), nullable=False)  # referenced in blocks as {{handle}}
     scopes = Column(ARRAY(String), nullable=True)
-    encrypted_credentials = Column(String, nullable=True)  # AES-256-GCM encrypted blob
+    encrypted_credentials = Column(Text, nullable=True)  # AES-256-GCM encrypted blob
     last_used_at = Column(DateTime(timezone=True), nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     environment_id = Column(UUID(as_uuid=True), ForeignKey("environments.id"), nullable=True)

--- a/apps/api/app/models/mcp_server.py
+++ b/apps/api/app/models/mcp_server.py
@@ -14,7 +14,7 @@ class McpServer(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
     environment_id = Column(UUID(as_uuid=True), ForeignKey("environments.id"), nullable=True)
     name = Column(String, nullable=False)
-    url = Column(String, nullable=False)
+    url = Column(Text, nullable=False)
     transport = Column(String, nullable=False, default="http")
     encrypted_auth = Column(Text, nullable=True)
     is_system = Column(Boolean, nullable=False, default=False)

--- a/apps/api/app/models/run_online_score.py
+++ b/apps/api/app/models/run_online_score.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Column, Integer, Numeric, String
+from sqlalchemy import Boolean, Column, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.core.database import Base
@@ -49,7 +49,7 @@ class RunFixtureCandidate(Base):
     anon_state            = Column(JSONB, nullable=True)
     expected_outcome_type = Column(String(255), nullable=True)
     status                = Column(String(50), nullable=False, default="pending", index=True)
-    promoted_pr_url       = Column(String, nullable=True)
+    promoted_pr_url       = Column(Text, nullable=True)
     promoted_by           = Column(String(255), nullable=True)
     created_at            = Column(
         sa.DateTime(timezone=True),

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -40,7 +40,7 @@ class GuardConfig(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id", ondelete="CASCADE"), primary_key=True)
     invite_code = Column(Text, nullable=False)
     slug = Column(Text, nullable=True)
-    alert_channel = Column(String(100), nullable=True)
+    alert_channel = Column(Text, nullable=True)
     enforcement_mode = Column(String(20), nullable=False, default="warn")
     fail_mode = Column(String(20), nullable=False, default="fail_closed")  # fail_open | fail_closed (CLI behavior on outage)
     notify_on_block = Column(Boolean, nullable=False, default=True)
@@ -170,7 +170,7 @@ class GuardAuditEvent(Base):
     tokens_saved = Column(Integer, nullable=True)
     cost_usd_before = Column(Float, nullable=True)
     cost_usd_after = Column(Float, nullable=True)
-    tool_use_id = Column(String(255), nullable=True, index=True)
+    tool_use_id = Column(Text, nullable=True, index=True)
     hook_session_id = Column(Text, nullable=True, index=True)  # raw string session_id from hook stdin
     conductai_run_id = Column(String(255), nullable=True)
     conductai_workflow = Column(String(255), nullable=True)
@@ -206,8 +206,8 @@ class GuardSavings(Base):
     __tablename__ = "guard_savings"
 
     id = Column(Integer, primary_key=True)
-    workspace_id = Column(String, nullable=False, index=True)
-    member_email = Column(String, nullable=False)
+    workspace_id = Column(Text, nullable=False, index=True)
+    member_email = Column(Text, nullable=False)
     rtk_saved_tokens = Column(BigInteger, nullable=False, default=0)
     rtk_savings_pct = Column(Float, nullable=False, default=0.0)
     rtk_total_commands = Column(Integer, nullable=False, default=0)
@@ -224,11 +224,11 @@ class GuardDeveloperTools(Base):
     __tablename__ = "guard_developer_tools"
 
     id = Column(Integer, primary_key=True)
-    workspace_id = Column(String, nullable=False, index=True)
-    user_email = Column(String, nullable=False)
-    detected_tools = Column(JSON, nullable=False, default=list)   # ["claude-code", "vscode", ...]
-    mcp_registered = Column(JSON, nullable=False, default=list)   # tools where conduct-mcp is wired
-    hook_registered = Column(JSON, nullable=False, default=list)  # tools where Guard hook is wired
+    workspace_id = Column(Text, nullable=False, index=True)
+    user_email = Column(Text, nullable=False)
+    detected_tools = Column(JSONB, nullable=False, default=list)   # ["claude-code", "vscode", ...]
+    mcp_registered = Column(JSONB, nullable=False, default=list)   # tools where conduct-mcp is wired
+    hook_registered = Column(JSONB, nullable=False, default=list)  # tools where Guard hook is wired
     reported_at = Column(DateTime(timezone=True), server_default=func.now(), nullable=False)
 
     __table_args__ = (


### PR DESCRIPTION
Phase 2 of drift cleanup. Model column types now match DB (12 columns: String→Text and JSON→JSONB in guard_developer_tools). Zero DB change.