### PR TITLE
fix(api): orphan columns + constraint style — Phase 3a+3b

### DIFF
--- a/apps/api/app/models/cred_retrieval_token.py
+++ b/apps/api/app/models/cred_retrieval_token.py
@@ -24,6 +24,9 @@ class CredRetrievalToken(Base):
     created_at = sa.Column(
         sa.DateTime(timezone=True), server_default=sa.text("now()"), nullable=False
     )
+    # Added by migration 0072 — rate limiting fields.
+    used_count = sa.Column(sa.Integer, nullable=False, server_default="0")
+    max_uses = sa.Column(sa.Integer, nullable=False, server_default="10")
 
     __table_args__ = (
         sa.Index("ix_cred_retrieval_tokens_token", "token"),

--- a/apps/api/app/models/security_policy.py
+++ b/apps/api/app/models/security_policy.py
@@ -33,7 +33,14 @@ class SecurityPolicy(Base):
     updated_at = sa.Column(
         sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")
     )
+    # Added by migration 0014 — category grouping.
+    category = sa.Column(sa.String(100), nullable=True)
+    # Added by migration 0015 — compliance pack membership.
+    pack_id = sa.Column(sa.String(100), nullable=True)
+    # Added by migration 0009 — soft delete.
+    archived_at = sa.Column(sa.DateTime(timezone=True), nullable=True)
 
     __table_args__ = (
         sa.Index("ix_security_policies_workspace", "workspace_id"),
+        sa.Index("ix_security_policies_pack_id", "pack_id"),
     )

--- a/apps/api/app/models/workspace_instructions.py
+++ b/apps/api/app/models/workspace_instructions.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -30,5 +30,5 @@ class WorkspaceInstructions(Base):
     updated_by = Column(String(255), nullable=True)  # email of admin who published
 
     __table_args__ = (
-        UniqueConstraint("workspace_id", name="uq_workspace_instructions_workspace"),
+        Index("ix_workspace_instructions_workspace_id", "workspace_id", unique=True),
     )

--- a/apps/api/app/models/workspace_invite.py
+++ b/apps/api/app/models/workspace_invite.py
@@ -29,6 +29,8 @@ class WorkspaceInvite(Base):
     accepted_at = sa.Column(sa.DateTime(timezone=True), nullable=True)
     status = sa.Column(sa.String(20), nullable=False, server_default="pending")
     expires_at = sa.Column(sa.DateTime(timezone=True), nullable=True)
+    # Added by migration 0067 — Clerk org invitation tracking (used by projects.py revoke path).
+    clerk_invitation_id = sa.Column(sa.Text, nullable=True)
 
     __table_args__ = (
         sa.UniqueConstraint("workspace_id", "invited_email", name="uq_workspace_invite_email"),


### PR DESCRIPTION
Continues drift cleanup (see #1325). Adds 5 orphan columns to models (cred_retrieval_tokens.used_count/max_uses, security_policies.category/pack_id/archived_at) and reshapes workspace_instructions UniqueConstraint→unique Index to match the DB-side naming. Zero DB change.