### PR TITLE
fix(lens): populate _raw_content + separate upstream errors from Guard blocks

### DIFF
--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -249,7 +249,17 @@ async def guarded_llm_call(
                 or _err.get("type")
                 or "policy violation"
             )
-            raise GuardedLLMBlocked(
+            # Guard's own fail_closed uses error.type == "conduct_guard_proxy".
+            # Any other 4xx/5xx from upstream is a provider error, not a Guard
+            # block — must not be labelled as such (misleads users + audit).
+            _is_guard_block = _err.get("type") == "conduct_guard_proxy"
+            if _is_guard_block:
+                raise GuardedLLMBlocked(
+                    status=resp.status_code,
+                    detail=detail,
+                    payload=payload,
+                )
+            raise LensUpstreamError(
                 status=resp.status_code,
                 detail=detail,
                 payload=payload,
@@ -269,6 +279,21 @@ def _safe_loads(raw: bytes) -> dict:
         return _json.loads(raw or b"{}")
     except Exception:
         return {}
+
+
+class LensUpstreamError(Exception):
+    """Upstream provider (OpenAI/Anthropic/etc) returned a non-2xx.
+
+    Semantically distinct from GuardedLLMBlocked — this is a provider
+    error, not a policy denial. Callers should surface it as such and
+    NOT prefix it with 'Guard blocked'.
+    """
+
+    def __init__(self, *, status: int, detail: str, payload: dict | None = None) -> None:
+        self.status = status
+        self.detail = detail
+        self.payload = payload or {}
+        super().__init__(f"upstream HTTP {status}: {detail}")
 
 
 class GuardedLLMBlocked(Exception):

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -465,7 +465,7 @@ def _guarded_openai_completion(executor: Executor, provider: str, model: str, up
     keep iterating the tool-use loop unchanged.
     """
     import asyncio as _asyncio
-    from app.guard.gateway import guarded_llm_call as _guarded, GuardedLLMBlocked as _Blocked
+    from app.guard.gateway import guarded_llm_call as _guarded, GuardedLLMBlocked as _Blocked, LensUpstreamError as _Upstream
     from app.runtime.llm_client import LLMResponse, LLMTextBlock, LLMToolUseBlock, LLMUsage
 
     oai_messages = [{"role": "system", "content": system}, *messages]
@@ -495,6 +495,8 @@ def _guarded_openai_completion(executor: Executor, provider: str, model: str, up
         ))
     except _Blocked as blk:
         raise Exception(f"Guard blocked Lens call: {blk.detail}") from blk
+    except _Upstream as up:
+        raise Exception(f"LLM upstream error ({up.status}): {up.detail}") from up
 
     choice = ((raw.get("choices") or [{}])[0])
     message = choice.get("message") or {}
@@ -526,6 +528,10 @@ def _guarded_openai_completion(executor: Executor, provider: str, model: str, up
             input_tokens=int(u.get("prompt_tokens", 0) or 0),
             output_tokens=int(u.get("completion_tokens", 0) or 0),
         ),
+        # ponytail: OpenAIClient.make_assistant_turn reads _raw_content to
+        # emit the assistant message with paired `tool_calls`. Without this
+        # the next turn's role:tool messages have no parent → OpenAI 400.
+        _raw_content=message,
     )
 
 
@@ -780,7 +786,8 @@ async def glens_chat_stream(
                 error_type=_err_type,
                 exc_info=True,
             )
-            await event_q.put({"type": "error", "message": "Something went wrong. Please try again."})
+            _short = _err_detail if len(_err_detail) <= 200 else _err_detail[:200] + "…"
+            await event_q.put({"type": "error", "message": f"{_err_type}: {_short}"})
 
     async def generate():
         task = asyncio.create_task(_run_work())

--- a/apps/api/tests/glens/test_resolve_tools_guarded.py
+++ b/apps/api/tests/glens/test_resolve_tools_guarded.py
@@ -115,3 +115,79 @@ def test_blocked_call_raises_with_readable_message():
                 messages=[{"role": "user", "content": "hi"}],
                 system="s", tools=[], max_tokens=512,
             )
+
+
+def test_raw_content_populated_so_make_assistant_turn_emits_tool_calls():
+    """#1342 regression — _guarded_openai_completion must populate _raw_content
+    on the returned LLMResponse. Without it, OpenAIClient.make_assistant_turn
+    reads an empty dict and emits an assistant message with no tool_calls —
+    the next turn's role:tool messages then fail OpenAI's pairing check
+    with a 400.
+    """
+    from app.modules.glens.routers.chat import _guarded_openai_completion
+    from app.runtime.adapters.openai import OpenAIClient
+
+    async def _fake_guarded(**kwargs):
+        return {
+            "choices": [{
+                "message": {
+                    "content": None,
+                    "tool_calls": [{
+                        "id": "call_abc",
+                        "function": {"name": "get_event_count", "arguments": "{}"},
+                    }],
+                },
+                "finish_reason": "tool_calls",
+            }],
+            "usage": {"prompt_tokens": 5, "completion_tokens": 2},
+        }
+
+    with patch("app.guard.gateway.guarded_llm_call", side_effect=_fake_guarded):
+        resp = _guarded_openai_completion(
+            _fake_executor(), "openai", "gpt-4o-mini",
+            "https://api.openai.com", "sk-test",
+            messages=[{"role": "user", "content": "hi"}],
+            system="s", tools=[], max_tokens=512,
+        )
+
+    # _raw_content must be the raw provider message (not None, not empty)
+    assert resp._raw_content is not None
+    assert resp._raw_content.get("tool_calls"), "_raw_content missing tool_calls — pairing will break"
+
+    # Round-trip through OpenAIClient.make_assistant_turn — the assistant
+    # message MUST carry tool_calls so subsequent role:tool messages pair.
+    client = OpenAIClient(api_key="sk-x")
+    turn = client.make_assistant_turn(resp)
+    assert turn[0]["role"] == "assistant"
+    assert "tool_calls" in turn[0]
+    assert turn[0]["tool_calls"][0]["id"] == "call_abc"
+
+
+def test_upstream_error_is_distinct_from_guard_block():
+    """#1342 — an OpenAI 400 must NOT be relabeled as 'Guard blocked'.
+    LensUpstreamError is a separate exception class; the chat handler
+    surfaces it with an upstream-error prefix, not the Guard-block prefix.
+    """
+    from app.modules.glens.routers.chat import _guarded_openai_completion
+    from app.guard.gateway import LensUpstreamError
+
+    async def _fake_upstream_err(**kwargs):
+        raise LensUpstreamError(
+            status=400,
+            detail="Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.",
+            payload={"error": {"type": "invalid_request_error"}},
+        )
+
+    import pytest
+    with patch("app.guard.gateway.guarded_llm_call", side_effect=_fake_upstream_err):
+        with pytest.raises(Exception) as exc_info:
+            _guarded_openai_completion(
+                _fake_executor(), "openai", "gpt-4o-mini",
+                "https://api.openai.com", "sk-test",
+                messages=[{"role": "user", "content": "hi"}],
+                system="s", tools=[], max_tokens=512,
+            )
+    msg = str(exc_info.value)
+    assert "Guard blocked" not in msg, f"upstream error mislabeled as Guard block: {msg}"
+    assert "upstream" in msg.lower()
+    assert "400" in msg


### PR DESCRIPTION
Fixes **#1342** — Lens chat 100% broken in prod.

## Root cause

Every message trigged an OpenAI 400:
> Invalid parameter: messages with role 'tool' must be a response to a preceeding message with 'tool_calls'.

Traced to `apps/api/app/modules/glens/routers/chat.py::_guarded_openai_completion`: the manually-constructed `LLMResponse` never populated `_raw_content`. `OpenAIClient.make_assistant_turn` reads `_raw_content` to emit the assistant message with paired `tool_calls`. With it missing, the assistant turn went out empty → the next turn's `role: tool` messages had no parent → 400.

## Three fixes in one PR

**1. `_raw_content` populated** (the actual bug — 1 line + comment)
Now the OpenAI adapter can emit `{role: assistant, content: ..., tool_calls: [...]}` and the next `role: tool` messages pair correctly.

**2. Gateway error mapping**
`guarded_llm_call` used to raise `GuardedLLMBlocked` on any non-2xx from upstream — mislabeling every OpenAI 4xx/5xx as a Guard policy denial. Introduced `LensUpstreamError`; only `GuardedLLMBlocked` when the response has `error.type == "conduct_guard_proxy"` (Guard's own fail_closed shape).

**3. SSE error surface**
`chat.py::_run_work` swallowed the actual error as `"Something went wrong. Please try again."`. Now emits `{error_type}: {detail[:200]}` so users see the real cause without SSH-ing to prod.

## Tests

Added 2 regression tests to `tests/glens/test_resolve_tools_guarded.py`:
- `test_raw_content_populated_so_make_assistant_turn_emits_tool_calls` — round-trips through the real OpenAI adapter; asserts assistant turn carries `tool_calls`
- `test_upstream_error_is_distinct_from_guard_block` — asserts an OpenAI 400 does NOT surface with a Guard-block label

Full test run: 25 passed, 22 skipped (unchanged from pre-PR baseline).

## Test plan

- [ ] Preview build passes
- [ ] After merge → Render deploy → open `/lens` in prod → send any query → get a real answer (not "Something went wrong")
- [ ] Server logs show `glens.stream.failed` events (if any) with distinct error types (`LensUpstreamError` vs `GuardedLLMBlocked` vs others)
- [ ] Guard-blocked requests still surface with the `"Guard blocked Lens call: ..."` prefix (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)