### PR TITLE
feat(#1347): workspace LLM Model Primitives — data + UI (PR A of 4)

### DIFF
--- a/apps/api/alembic/versions/0103_workspace_llm_primitives.py
+++ b/apps/api/alembic/versions/0103_workspace_llm_primitives.py
@@ -1,0 +1,45 @@
+"""feat(#1347): workspace_llm_primitives table
+
+One row per workspace, holds preferred_provider + tier_map for LLM routing.
+API keys stay in Vault; this is config-only. See issue #1347 for design.
+
+No consumer wiring yet — PRs B/C/D follow.
+
+Revision ID: 0103
+Revises: 0102
+Create Date: 2026-08-28
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0103"
+down_revision = "0102"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_llm_primitives",
+        sa.Column(
+            "workspace_id",
+            sa.dialects.postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("workspaces.id", ondelete="CASCADE"),
+            primary_key=True,
+        ),
+        sa.Column("preferred_provider", sa.String(length=50), nullable=False, server_default="anthropic"),
+        sa.Column("tier_map", JSONB, nullable=False, server_default=sa.text("'{}'::jsonb")),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workspace_llm_primitives")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -39,6 +39,7 @@ from app.tools import registrations as _tool_registrations  # noqa: F401  # side
 from app.modules.telemetry import routes as telemetry_routes
 from app.routers.organizations import router as organizations_router
 from app.routers.workspaces import router as workspaces_router
+from app.routers.workspace_llm_primitives import router as workspace_llm_primitives_router
 from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router, notifications_router
 from app.routers.runs import workspace_runs_router
 from app.routers.rbac import router as rbac_router, me_router as me_rbac_router
@@ -113,6 +114,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 
 app.include_router(organizations_router)
 app.include_router(workspaces_router)
+app.include_router(workspace_llm_primitives_router)
 app.include_router(workspace_projects_router)
 app.include_router(audit_log_router)
 app.include_router(workspace_preferences_router)

--- a/apps/api/app/models/workspace_llm_primitives.py
+++ b/apps/api/app/models/workspace_llm_primitives.py
@@ -1,0 +1,34 @@
+"""Workspace-scoped LLM Model Primitives — see #1347.
+
+One row per workspace. Holds routing config (preferred_provider + tier_map)
+consumed by all LLM callers (workflows, Lens, Guard). API keys stay in
+Vault (Environment); this table is config-only.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, String
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.core.database import Base
+
+
+class WorkspaceLLMPrimitives(Base):
+    __tablename__ = "workspace_llm_primitives"
+
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        primary_key=True,
+    )
+    preferred_provider = Column(String(50), nullable=False, default="anthropic")
+    # tier_map: {"cheap": "haiku-...", "balanced": "sonnet-...", "smart": "opus-..."}
+    tier_map = Column(JSONB, nullable=False, default=dict)
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )

--- a/apps/api/app/routers/workspace_llm_primitives.py
+++ b/apps/api/app/routers/workspace_llm_primitives.py
@@ -1,0 +1,113 @@
+"""Workspace LLM Model Primitives — GET/PUT config for one workspace.
+
+See #1347. Config-only; API keys stay in Vault.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.database import get_db
+from app.models.workspace_llm_primitives import WorkspaceLLMPrimitives
+
+router = APIRouter(prefix="/workspaces", tags=["workspace-llm-primitives"])
+
+# Defaults returned when a workspace has no row yet. Kept in sync with
+# app.runtime.model_router canonical model constants.
+DEFAULT_PREFERRED_PROVIDER = "anthropic"
+DEFAULT_TIER_MAP: dict[str, str] = {
+    "cheap":    "claude-haiku-4-5-20251001",
+    "balanced": "claude-sonnet-4-6",
+    "smart":    "claude-opus-4-7",
+}
+SUPPORTED_PROVIDERS = {"anthropic", "openai", "perplexity", "together"}
+SUPPORTED_TIERS = {"cheap", "balanced", "smart"}
+
+
+class LLMPrimitivesOut(BaseModel):
+    preferred_provider: str
+    tier_map: dict[str, str]
+    updated_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class LLMPrimitivesUpdate(BaseModel):
+    preferred_provider: str = Field(..., min_length=1)
+    tier_map: dict[str, str] = Field(default_factory=dict)
+
+
+def _defaults() -> LLMPrimitivesOut:
+    return LLMPrimitivesOut(
+        preferred_provider=DEFAULT_PREFERRED_PROVIDER,
+        tier_map=dict(DEFAULT_TIER_MAP),
+        updated_at=None,
+    )
+
+
+@router.get("/{workspace_id}/llm-primitives", response_model=LLMPrimitivesOut)
+def get_llm_primitives(
+    workspace_id: str,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workflows.view")),
+):
+    if str(workspace_id) != str(scoped_ws_id):
+        raise HTTPException(status_code=403, detail="Workspace mismatch")
+    row = db.get(WorkspaceLLMPrimitives, scoped_ws_id)
+    if row is None:
+        return _defaults()
+    return LLMPrimitivesOut(
+        preferred_provider=row.preferred_provider,
+        tier_map=row.tier_map or {},
+        updated_at=row.updated_at,
+    )
+
+
+@router.put("/{workspace_id}/llm-primitives", response_model=LLMPrimitivesOut)
+def put_llm_primitives(
+    workspace_id: str,
+    body: LLMPrimitivesUpdate,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workspace.edit")),
+):
+    if str(workspace_id) != str(scoped_ws_id):
+        raise HTTPException(status_code=403, detail="Workspace mismatch")
+
+    provider = body.preferred_provider.strip().lower()
+    if provider not in SUPPORTED_PROVIDERS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"preferred_provider must be one of {sorted(SUPPORTED_PROVIDERS)}",
+        )
+
+    tier_map = {k: v for k, v in body.tier_map.items() if k and v}
+    for tier in tier_map:
+        if tier not in SUPPORTED_TIERS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"tier_map key {tier!r} must be one of {sorted(SUPPORTED_TIERS)}",
+            )
+
+    row = db.get(WorkspaceLLMPrimitives, scoped_ws_id)
+    if row is None:
+        row = WorkspaceLLMPrimitives(
+            workspace_id=scoped_ws_id,
+            preferred_provider=provider,
+            tier_map=tier_map,
+        )
+        db.add(row)
+    else:
+        row.preferred_provider = provider
+        row.tier_map = tier_map
+    db.commit()
+    db.refresh(row)
+    return LLMPrimitivesOut(
+        preferred_provider=row.preferred_provider,
+        tier_map=row.tier_map or {},
+        updated_at=row.updated_at,
+    )

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -11,11 +11,13 @@ import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
 import PreferencesPanel from "@/components/settings/PreferencesPanel"
 import ProxySettings from "@/components/settings/ProxySettings"
+import LLMPrimitivesPanel from "@/components/settings/LLMPrimitivesPanel"
 
-type Tab = "credentials" | "members" | "preferences" | "proxy"
+type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "proxy"
 
 const TAB_LABELS: Record<Tab, string> = {
   credentials: "Vault",
+  llm_primitives: "LLM Model Primitives",
   preferences: "Appearance",
   members: "Members & roles",
   proxy: "Proxy",
@@ -162,7 +164,7 @@ function OrgNameEditor({ getToken }: { getToken: (() => Promise<string | null>) 
 // ── Main settings page ────────────────────────────────────────────────────────
 
 function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
-  const tabs = (["credentials", "preferences", "proxy", ...(isAdmin ? ["members"] : [])] as Tab[])
+  const tabs = (["credentials", "llm_primitives", "preferences", "proxy", ...(isAdmin ? ["members"] : [])] as Tab[])
   const [activeTab, setActiveTab] = useState<Tab>("credentials")
   const [showTip, setShowTip] = useState(false)
 
@@ -217,6 +219,9 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
 
         <div role="tabpanel" id="tabpanel-credentials" aria-labelledby="tab-credentials" hidden={activeTab !== "credentials"}>
           <EnvironmentsManager isAdmin={isAdmin} />
+        </div>
+        <div role="tabpanel" id="tabpanel-llm_primitives" aria-labelledby="tab-llm_primitives" hidden={activeTab !== "llm_primitives"}>
+          <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />
         </div>
         <div role="tabpanel" id="tabpanel-preferences" aria-labelledby="tab-preferences" hidden={activeTab !== "preferences"}>
           <PreferencesPanel />

--- a/apps/web/src/components/settings/LLMPrimitivesPanel.tsx
+++ b/apps/web/src/components/settings/LLMPrimitivesPanel.tsx
@@ -1,0 +1,184 @@
+"use client"
+
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { API } from "@/lib/api"
+
+interface LLMPrimitives {
+  preferred_provider: string
+  tier_map: Record<string, string>
+  updated_at: string | null
+}
+
+const PROVIDERS = ["anthropic", "openai", "perplexity", "together"] as const
+const TIERS = ["cheap", "balanced", "smart"] as const
+
+const PROVIDER_HINTS: Record<(typeof PROVIDERS)[number], string> = {
+  anthropic:  "Claude models — Opus / Sonnet / Haiku",
+  openai:     "GPT models — 4.1 / 4o / o-series",
+  perplexity: "Sonar reasoning / search models",
+  together:   "Together AI hosted OSS models",
+}
+
+export default function LLMPrimitivesPanel({
+  workspaceId,
+  isAdmin,
+}: {
+  workspaceId: string
+  isAdmin: boolean
+}) {
+  const { authFetch } = useAuthFetch()
+  const [primitives, setPrimitives] = useState<LLMPrimitives | null>(null)
+  const [tierMapText, setTierMapText] = useState("")
+  const [loading, setLoading] = useState(true)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [error, setError] = useState("")
+
+  const load = useCallback(async () => {
+    if (!workspaceId) return
+    setLoading(true)
+    try {
+      const res = await authFetch(`${API}/workspaces/${workspaceId}/llm-primitives`)
+      if (!res.ok) throw new Error(`Load failed (${res.status})`)
+      const data = (await res.json()) as LLMPrimitives
+      setPrimitives(data)
+      setTierMapText(JSON.stringify(data.tier_map ?? {}, null, 2))
+      setError("")
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Load failed")
+    } finally {
+      setLoading(false)
+    }
+  }, [authFetch, workspaceId])
+
+  useEffect(() => { load() }, [load])
+
+  const parseError = useMemo(() => {
+    if (!tierMapText.trim()) return null
+    try {
+      const parsed = JSON.parse(tierMapText)
+      if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+        return "tier_map must be a JSON object"
+      }
+      for (const [k, v] of Object.entries(parsed)) {
+        if (!(TIERS as readonly string[]).includes(k)) {
+          return `Unknown tier ${JSON.stringify(k)} — must be one of ${TIERS.join(", ")}`
+        }
+        if (typeof v !== "string" || !v.trim()) {
+          return `Model for tier ${JSON.stringify(k)} must be a non-empty string`
+        }
+      }
+      return null
+    } catch (e) {
+      return e instanceof Error ? e.message : "Invalid JSON"
+    }
+  }, [tierMapText])
+
+  async function save() {
+    if (!primitives || parseError) return
+    setSaving(true); setError(""); setSaved(false)
+    try {
+      const tier_map = tierMapText.trim() ? JSON.parse(tierMapText) : {}
+      const res = await authFetch(`${API}/workspaces/${workspaceId}/llm-primitives`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          preferred_provider: primitives.preferred_provider,
+          tier_map,
+        }),
+      })
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}))
+        throw new Error(body?.detail ?? `Save failed (${res.status})`)
+      }
+      const data = (await res.json()) as LLMPrimitives
+      setPrimitives(data)
+      setTierMapText(JSON.stringify(data.tier_map ?? {}, null, 2))
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (loading) {
+    return <div style={{ height: 120, borderRadius: 12, background: "var(--surface-2)", border: "1px solid var(--border)", opacity: 0.7 }} />
+  }
+
+  if (!primitives) {
+    return <p style={{ fontSize: 13, color: "var(--text-muted)" }}>{error || "Unable to load LLM Model Primitives."}</p>
+  }
+
+  const canSave = isAdmin && !saving && !parseError
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <div>
+        <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--text)", margin: 0 }}>LLM Model Primitives</h2>
+        <p style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 4, lineHeight: 1.5 }}>
+          Workspace-scoped routing config for every LLM caller — Lens, workflows, brain blocks. API keys stay in Vault; this tab only decides which provider and model tier is used.
+        </p>
+      </div>
+
+      <div className="card" style={{ padding: "16px 18px", display: "flex", flexDirection: "column", gap: 14 }}>
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <label style={{ fontSize: 12.5, fontWeight: 600, color: "var(--text)" }}>Preferred provider</label>
+          <select
+            value={primitives.preferred_provider}
+            onChange={e => setPrimitives({ ...primitives, preferred_provider: e.target.value })}
+            disabled={!isAdmin}
+            style={{ fontSize: 13, padding: "8px 10px", border: "1px solid var(--border)", borderRadius: 8, background: "var(--surface)", color: "var(--text)", outline: "none", maxWidth: 320 }}
+          >
+            {PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
+          </select>
+          <p style={{ fontSize: 11.5, color: "var(--text-muted)", margin: 0 }}>
+            {PROVIDER_HINTS[primitives.preferred_provider as (typeof PROVIDERS)[number]] ?? "Custom provider"}
+          </p>
+        </div>
+
+        <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+          <label style={{ fontSize: 12.5, fontWeight: 600, color: "var(--text)" }}>Tier map (JSON)</label>
+          <textarea
+            value={tierMapText}
+            onChange={e => setTierMapText(e.target.value)}
+            disabled={!isAdmin}
+            rows={7}
+            spellCheck={false}
+            className="mono"
+            style={{ fontSize: 12, padding: "10px 12px", border: `1px solid ${parseError ? "var(--err-bd)" : "var(--border)"}`, borderRadius: 8, background: "var(--surface)", color: "var(--text)", outline: "none", resize: "vertical" }}
+          />
+          <p style={{ fontSize: 11.5, color: parseError ? "var(--err)" : "var(--text-muted)", margin: 0 }}>
+            {parseError ?? `Keys: ${TIERS.join(" / ")}. Values are model IDs (e.g. claude-sonnet-4-6, gpt-4.1-mini).`}
+          </p>
+        </div>
+
+        {error && <p style={{ fontSize: 12, color: "var(--err)", margin: 0 }}>{error}</p>}
+
+        {isAdmin && (
+          <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+            <button
+              onClick={save}
+              disabled={!canSave}
+              className="btn btn-primary btn-sm"
+              style={{ opacity: canSave ? 1 : 0.5 }}
+            >
+              {saving ? "Saving…" : saved ? "Saved ✓" : "Save"}
+            </button>
+            {primitives.updated_at && (
+              <span style={{ fontSize: 11.5, color: "var(--text-muted)" }}>
+                Last updated {new Date(primitives.updated_at).toLocaleString()}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      <p style={{ fontSize: 11.5, color: "var(--text-muted)", margin: 0 }}>
+        Consumer wiring (Lens, workflows, Guard) lands in follow-up PRs — see issue #1347.
+      </p>
+    </div>
+  )
+}


### PR DESCRIPTION
First of four PRs for #1347 (workspace-scoped LLM primitives).

**Scope: data + UI only, zero consumer wiring.** PRs B/C/D follow.

## What this ships
- New table `workspace_llm_primitives` (workspace_id PK, preferred_provider, tier_map JSONB, updated_at)
- Hand-written schema revision `0103`
- `GET/PUT /workspaces/{id}/llm-primitives` guarded by `require_permission` (view / workspace.edit)
- Defaults on first GET: `anthropic` + tier map (haiku / sonnet / opus). First PUT persists the row.
- Provider whitelist + tier key whitelist enforced at the router
- New Settings tab **LLM Model Primitives** between Vault and Appearance
- Provider dropdown + JSON textarea with client-side validation, save button, last-updated stamp

## Design lock (2026-08-28)
- Workspace-scoped, one config per workspace, no per-vault override
- API keys stay in Vault; this table is config only
- Consumer-layer overrides (Lens session, Guard rule, Canvas block) deferred

## What is NOT in this PR
- Lens still reads env vars — PR C
- ModelRouter still takes `playbook_slug` — PR B
- Legacy env vars still defined — PR D

Setting values today has no runtime effect. Plumbing only.

## Test plan
- [x] Backend imports cleanly (routes register)
- [x] Schema revision loads (0103 -> 0102)
- [x] Frontend `tsc --noEmit` clean
- [ ] Manual: run schema upgrade to head on a scratch DB
- [ ] Manual: Settings > LLM Model Primitives — see defaults, edit + save, refresh persists
- [ ] Manual: non-admin sees inputs disabled
- [ ] Manual: bad tier key in JSON = red error, save disabled

Refs: #1347