### PR TITLE
feat(#1347): per-provider tier_map + defaults cleanup (PR A follow-up)

### DIFF
--- a/apps/api/app/routers/workspace_llm_primitives.py
+++ b/apps/api/app/routers/workspace_llm_primitives.py
@@ -69,14 +69,10 @@ class LLMPrimitivesUpdate(BaseModel):
     tier_map: dict[str, dict[str, str]] = Field(default_factory=dict)
 
 
-def _normalise_stored(raw: Any) -> dict[str, dict[str, str]]:
-    """Accept either the nested schema or the legacy flat one for a smooth
-    transition; return the nested form."""
-    if not isinstance(raw, dict) or not raw:
+def _read_stored(raw: Any) -> dict[str, dict[str, str]]:
+    """Coerce the JSONB payload back into {provider: {tier: model}}."""
+    if not isinstance(raw, dict):
         return {}
-    # legacy flat: {"cheap": "...", "balanced": "...", "smart": "..."}
-    if all(isinstance(v, str) for v in raw.values()):
-        return {"anthropic": {k: v for k, v in raw.items() if isinstance(v, str)}}
     out: dict[str, dict[str, str]] = {}
     for provider, tiers in raw.items():
         if not isinstance(tiers, dict):
@@ -109,7 +105,7 @@ def get_llm_primitives(
         return _defaults()
     return LLMPrimitivesOut(
         preferred_provider=row.preferred_provider,
-        tier_map=_normalise_stored(row.tier_map),
+        tier_map=_read_stored(row.tier_map),
         updated_at=row.updated_at,
     )
 
@@ -168,6 +164,6 @@ def put_llm_primitives(
     db.refresh(row)
     return LLMPrimitivesOut(
         preferred_provider=row.preferred_provider,
-        tier_map=_normalise_stored(row.tier_map),
+        tier_map=_read_stored(row.tier_map),
         updated_at=row.updated_at,
     )

--- a/apps/api/app/routers/workspace_llm_primitives.py
+++ b/apps/api/app/routers/workspace_llm_primitives.py
@@ -1,10 +1,20 @@
 """Workspace LLM Model Primitives — GET/PUT config for one workspace.
 
 See #1347. Config-only; API keys stay in Vault.
+
+tier_map is nested by provider so switching preferred_provider does not
+overwrite the other providers\' tier configs:
+
+    {
+      "anthropic": {"cheap": "...", "balanced": "...", "smart": "..."},
+      "openai":    {"cheap": "...", "balanced": "...", "smart": "..."},
+      ...
+    }
 """
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
@@ -16,34 +26,71 @@ from app.models.workspace_llm_primitives import WorkspaceLLMPrimitives
 
 router = APIRouter(prefix="/workspaces", tags=["workspace-llm-primitives"])
 
-# Defaults returned when a workspace has no row yet. Kept in sync with
-# app.runtime.model_router canonical model constants.
 DEFAULT_PREFERRED_PROVIDER = "anthropic"
-DEFAULT_TIER_MAP: dict[str, str] = {
+SUPPORTED_PROVIDERS = {"anthropic", "openai", "perplexity", "together"}
+SUPPORTED_TIERS = {"cheap", "balanced", "smart"}
+
+# Anthropic uses native Claude models. Everything else speaks OpenAI protocol
+# (openai, perplexity, together via OpenAI-compat) so the same GPT tier map
+# is a sensible starting default; users tune from there.
+ANTHROPIC_TIER_MAP: dict[str, str] = {
     "cheap":    "claude-haiku-4-5-20251001",
     "balanced": "claude-sonnet-4-6",
     "smart":    "claude-opus-4-7",
 }
-SUPPORTED_PROVIDERS = {"anthropic", "openai", "perplexity", "together"}
-SUPPORTED_TIERS = {"cheap", "balanced", "smart"}
+OPENAI_COMPAT_TIER_MAP: dict[str, str] = {
+    "cheap":    "gpt-4.1-mini",
+    "balanced": "gpt-4.1",
+    "smart":    "gpt-4.1",
+}
+
+DEFAULT_TIER_MAPS: dict[str, dict[str, str]] = {
+    "anthropic": dict(ANTHROPIC_TIER_MAP),
+    "openai":    dict(OPENAI_COMPAT_TIER_MAP),
+}
+
+
+def tier_map_defaults_for(provider: str) -> dict[str, str]:
+    """Return the seed tier map for a provider we have not seen yet."""
+    if provider == "anthropic":
+        return dict(ANTHROPIC_TIER_MAP)
+    return dict(OPENAI_COMPAT_TIER_MAP)
 
 
 class LLMPrimitivesOut(BaseModel):
     preferred_provider: str
-    tier_map: dict[str, str]
+    tier_map: dict[str, dict[str, str]]
     updated_at: datetime | None = None
     model_config = ConfigDict(from_attributes=True)
 
 
 class LLMPrimitivesUpdate(BaseModel):
     preferred_provider: str = Field(..., min_length=1)
-    tier_map: dict[str, str] = Field(default_factory=dict)
+    tier_map: dict[str, dict[str, str]] = Field(default_factory=dict)
+
+
+def _normalise_stored(raw: Any) -> dict[str, dict[str, str]]:
+    """Accept either the nested schema or the legacy flat one for a smooth
+    transition; return the nested form."""
+    if not isinstance(raw, dict) or not raw:
+        return {}
+    # legacy flat: {"cheap": "...", "balanced": "...", "smart": "..."}
+    if all(isinstance(v, str) for v in raw.values()):
+        return {"anthropic": {k: v for k, v in raw.items() if isinstance(v, str)}}
+    out: dict[str, dict[str, str]] = {}
+    for provider, tiers in raw.items():
+        if not isinstance(tiers, dict):
+            continue
+        cleaned = {k: v for k, v in tiers.items() if isinstance(v, str) and v.strip()}
+        if cleaned:
+            out[provider] = cleaned
+    return out
 
 
 def _defaults() -> LLMPrimitivesOut:
     return LLMPrimitivesOut(
         preferred_provider=DEFAULT_PREFERRED_PROVIDER,
-        tier_map=dict(DEFAULT_TIER_MAP),
+        tier_map={k: dict(v) for k, v in DEFAULT_TIER_MAPS.items()},
         updated_at=None,
     )
 
@@ -62,7 +109,7 @@ def get_llm_primitives(
         return _defaults()
     return LLMPrimitivesOut(
         preferred_provider=row.preferred_provider,
-        tier_map=row.tier_map or {},
+        tier_map=_normalise_stored(row.tier_map),
         updated_at=row.updated_at,
     )
 
@@ -85,29 +132,42 @@ def put_llm_primitives(
             detail=f"preferred_provider must be one of {sorted(SUPPORTED_PROVIDERS)}",
         )
 
-    tier_map = {k: v for k, v in body.tier_map.items() if k and v}
-    for tier in tier_map:
-        if tier not in SUPPORTED_TIERS:
+    cleaned: dict[str, dict[str, str]] = {}
+    for prov, tiers in body.tier_map.items():
+        prov_key = str(prov).strip().lower()
+        if prov_key not in SUPPORTED_PROVIDERS:
             raise HTTPException(
                 status_code=422,
-                detail=f"tier_map key {tier!r} must be one of {sorted(SUPPORTED_TIERS)}",
+                detail=f"tier_map provider {prov_key!r} must be one of {sorted(SUPPORTED_PROVIDERS)}",
             )
+        prov_tiers: dict[str, str] = {}
+        for tier, model in (tiers or {}).items():
+            if tier not in SUPPORTED_TIERS:
+                raise HTTPException(
+                    status_code=422,
+                    detail=f"tier_map[{prov_key}] key {tier!r} must be one of {sorted(SUPPORTED_TIERS)}",
+                )
+            if not isinstance(model, str) or not model.strip():
+                continue
+            prov_tiers[tier] = model.strip()
+        if prov_tiers:
+            cleaned[prov_key] = prov_tiers
 
     row = db.get(WorkspaceLLMPrimitives, scoped_ws_id)
     if row is None:
         row = WorkspaceLLMPrimitives(
             workspace_id=scoped_ws_id,
             preferred_provider=provider,
-            tier_map=tier_map,
+            tier_map=cleaned,
         )
         db.add(row)
     else:
         row.preferred_provider = provider
-        row.tier_map = tier_map
+        row.tier_map = cleaned
     db.commit()
     db.refresh(row)
     return LLMPrimitivesOut(
         preferred_provider=row.preferred_provider,
-        tier_map=row.tier_map or {},
+        tier_map=_normalise_stored(row.tier_map),
         updated_at=row.updated_at,
     )

--- a/apps/web/src/components/settings/LLMPrimitivesPanel.tsx
+++ b/apps/web/src/components/settings/LLMPrimitivesPanel.tsx
@@ -4,20 +4,39 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api"
 
+type TierMap = Record<string, Record<string, string>>
+
 interface LLMPrimitives {
   preferred_provider: string
-  tier_map: Record<string, string>
+  tier_map: TierMap
   updated_at: string | null
 }
 
 const PROVIDERS = ["anthropic", "openai", "perplexity", "together"] as const
 const TIERS = ["cheap", "balanced", "smart"] as const
 
-const PROVIDER_HINTS: Record<(typeof PROVIDERS)[number], string> = {
-  anthropic:  "Claude models — Opus / Sonnet / Haiku",
-  openai:     "GPT models — 4.1 / 4o / o-series",
-  perplexity: "Sonar reasoning / search models",
-  together:   "Together AI hosted OSS models",
+type Provider = (typeof PROVIDERS)[number]
+
+const PROVIDER_HINTS: Record<Provider, string> = {
+  anthropic:  "Claude models — native SDK",
+  openai:     "GPT models — native OpenAI protocol",
+  perplexity: "Perplexity Sonar — OpenAI-compatible endpoint",
+  together:   "Together AI hosted OSS models — OpenAI-compatible endpoint",
+}
+
+const ANTHROPIC_DEFAULTS: Record<string, string> = {
+  cheap:    "claude-haiku-4-5-20251001",
+  balanced: "claude-sonnet-4-6",
+  smart:    "claude-opus-4-7",
+}
+const OPENAI_COMPAT_DEFAULTS: Record<string, string> = {
+  cheap:    "gpt-4.1-mini",
+  balanced: "gpt-4.1",
+  smart:    "gpt-4.1",
+}
+
+function defaultsFor(provider: string): Record<string, string> {
+  return provider === "anthropic" ? { ...ANTHROPIC_DEFAULTS } : { ...OPENAI_COMPAT_DEFAULTS }
 }
 
 export default function LLMPrimitivesPanel({
@@ -29,7 +48,7 @@ export default function LLMPrimitivesPanel({
 }) {
   const { authFetch } = useAuthFetch()
   const [primitives, setPrimitives] = useState<LLMPrimitives | null>(null)
-  const [tierMapText, setTierMapText] = useState("")
+  const [sliceText, setSliceText] = useState("")
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [saved, setSaved] = useState(false)
@@ -43,7 +62,8 @@ export default function LLMPrimitivesPanel({
       if (!res.ok) throw new Error(`Load failed (${res.status})`)
       const data = (await res.json()) as LLMPrimitives
       setPrimitives(data)
-      setTierMapText(JSON.stringify(data.tier_map ?? {}, null, 2))
+      const slice = data.tier_map?.[data.preferred_provider] ?? defaultsFor(data.preferred_provider)
+      setSliceText(JSON.stringify(slice, null, 2))
       setError("")
     } catch (e) {
       setError(e instanceof Error ? e.message : "Load failed")
@@ -54,12 +74,29 @@ export default function LLMPrimitivesPanel({
 
   useEffect(() => { load() }, [load])
 
-  const parseError = useMemo(() => {
-    if (!tierMapText.trim()) return null
+  function switchProvider(next: string) {
+    if (!primitives) return
+    const merged: TierMap = { ...primitives.tier_map }
+    // Preserve edits the user just made for the outgoing provider.
     try {
-      const parsed = JSON.parse(tierMapText)
+      const parsed = JSON.parse(sliceText)
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        merged[primitives.preferred_provider] = parsed as Record<string, string>
+      }
+    } catch {
+      // ignore parse errors on switch; user sees them again when they return
+    }
+    const nextSlice = merged[next] ?? defaultsFor(next)
+    setPrimitives({ ...primitives, preferred_provider: next, tier_map: merged })
+    setSliceText(JSON.stringify(nextSlice, null, 2))
+  }
+
+  const parseError = useMemo(() => {
+    if (!sliceText.trim()) return null
+    try {
+      const parsed = JSON.parse(sliceText)
       if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
-        return "tier_map must be a JSON object"
+        return "tier map must be a JSON object"
       }
       for (const [k, v] of Object.entries(parsed)) {
         if (!(TIERS as readonly string[]).includes(k)) {
@@ -73,19 +110,20 @@ export default function LLMPrimitivesPanel({
     } catch (e) {
       return e instanceof Error ? e.message : "Invalid JSON"
     }
-  }, [tierMapText])
+  }, [sliceText])
 
   async function save() {
     if (!primitives || parseError) return
     setSaving(true); setError(""); setSaved(false)
     try {
-      const tier_map = tierMapText.trim() ? JSON.parse(tierMapText) : {}
+      const slice = sliceText.trim() ? JSON.parse(sliceText) : {}
+      const merged: TierMap = { ...primitives.tier_map, [primitives.preferred_provider]: slice }
       const res = await authFetch(`${API}/workspaces/${workspaceId}/llm-primitives`, {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           preferred_provider: primitives.preferred_provider,
-          tier_map,
+          tier_map: merged,
         }),
       })
       if (!res.ok) {
@@ -94,7 +132,8 @@ export default function LLMPrimitivesPanel({
       }
       const data = (await res.json()) as LLMPrimitives
       setPrimitives(data)
-      setTierMapText(JSON.stringify(data.tier_map ?? {}, null, 2))
+      const nextSlice = data.tier_map?.[data.preferred_provider] ?? defaultsFor(data.preferred_provider)
+      setSliceText(JSON.stringify(nextSlice, null, 2))
       setSaved(true)
       setTimeout(() => setSaved(false), 2000)
     } catch (e) {
@@ -113,6 +152,7 @@ export default function LLMPrimitivesPanel({
   }
 
   const canSave = isAdmin && !saving && !parseError
+  const currentProvider = primitives.preferred_provider
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
@@ -127,23 +167,25 @@ export default function LLMPrimitivesPanel({
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
           <label style={{ fontSize: 12.5, fontWeight: 600, color: "var(--text)" }}>Preferred provider</label>
           <select
-            value={primitives.preferred_provider}
-            onChange={e => setPrimitives({ ...primitives, preferred_provider: e.target.value })}
+            value={currentProvider}
+            onChange={e => switchProvider(e.target.value)}
             disabled={!isAdmin}
             style={{ fontSize: 13, padding: "8px 10px", border: "1px solid var(--border)", borderRadius: 8, background: "var(--surface)", color: "var(--text)", outline: "none", maxWidth: 320 }}
           >
             {PROVIDERS.map(p => <option key={p} value={p}>{p}</option>)}
           </select>
           <p style={{ fontSize: 11.5, color: "var(--text-muted)", margin: 0 }}>
-            {PROVIDER_HINTS[primitives.preferred_provider as (typeof PROVIDERS)[number]] ?? "Custom provider"}
+            {PROVIDER_HINTS[currentProvider as Provider] ?? "Custom provider"}
           </p>
         </div>
 
         <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-          <label style={{ fontSize: 12.5, fontWeight: 600, color: "var(--text)" }}>Tier map (JSON)</label>
+          <label style={{ fontSize: 12.5, fontWeight: 600, color: "var(--text)" }}>
+            Tier map for <span className="mono">{currentProvider}</span>
+          </label>
           <textarea
-            value={tierMapText}
-            onChange={e => setTierMapText(e.target.value)}
+            value={sliceText}
+            onChange={e => setSliceText(e.target.value)}
             disabled={!isAdmin}
             rows={7}
             spellCheck={false}
@@ -151,7 +193,7 @@ export default function LLMPrimitivesPanel({
             style={{ fontSize: 12, padding: "10px 12px", border: `1px solid ${parseError ? "var(--err-bd)" : "var(--border)"}`, borderRadius: 8, background: "var(--surface)", color: "var(--text)", outline: "none", resize: "vertical" }}
           />
           <p style={{ fontSize: 11.5, color: parseError ? "var(--err)" : "var(--text-muted)", margin: 0 }}>
-            {parseError ?? `Keys: ${TIERS.join(" / ")}. Values are model IDs (e.g. claude-sonnet-4-6, gpt-4.1-mini).`}
+            {parseError ?? `Keys: ${TIERS.join(" / ")}. Values are model IDs for ${currentProvider}. Other providers keep their own tier maps.`}
           </p>
         </div>
 


### PR DESCRIPTION
Follow-up to merged #1351. Same design lock (#1347), splits the tier map by provider so switching providers doesn't clobber the others' configs.

## What changed vs #1351
- Storage schema is nested: \`{provider: {tier: model}}\`
- Provider dropdown swaps the textarea to that provider's slice; unsaved edits are folded back in on switch so nothing is lost
- Seed defaults: \`anthropic\` gets Claude models, \`openai\` / \`perplexity\` / \`together\` all get the OpenAI-compat tier map (perplexity + together speak OpenAI protocol)
- Reader coerces \`{provider: {tier: model}}\` and drops garbage — no legacy flat-form fallback (PR A hadn't shipped when we made the change; zero rows exist in prod under the old shape)

## Test plan
- [x] Frontend \`tsc --noEmit\` clean
- [x] Backend imports cleanly
- [ ] Manual: Settings > LLM Model Primitives — switch providers, see each provider's tier map, edit + save + refresh persists per-provider
- [ ] Manual: paste a garbage JSON value into an unused provider slot; save; reload — reader drops it silently

## Why a new PR / branch
Original branch (\`feat/llm-primitives-workspace\`) was squash-merged into main as PR #1351. The two follow-up commits stayed on that branch, which then conflicted against squashed-main. Guard blocks force-push (correct). New branch off main with a clean cherry-pick of the two commits is the safest path.

Refs: #1347, follow-up to #1351