### PR TITLE
feat(#1347): model_router reads workspace primitives (PR B)

### DIFF
--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -1,5 +1,6 @@
 from app.models.organization import Organization
 from app.models.workspace import Workspace
+from app.models.workspace_llm_primitives import WorkspaceLLMPrimitives
 from app.models.rbac import Role, Permission  # noqa
 from app.models.user import User
 from app.models.workspace_user import WorkspaceUser
@@ -62,4 +63,5 @@ __all__ = [
     "Role", "Permission",
     "AgentIdentity",
     "AgentRunToken",
+    "WorkspaceLLMPrimitives",
 ]

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -31,7 +31,7 @@ from app.models.workflow import Workflow, WorkflowVersion
 from app.schemas.workflow import WorkflowCreate, WorkflowUpdate, WorkflowOut, WorkflowDetailOut
 from app.compiler.compiler import compile_workflow
 from app.compiler.stream import stream_compile_block
-from app.runtime.model_router import resolve as resolve_model
+from app.runtime.model_router import resolve_for_workspace as resolve_model
 from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates, pricing_note
 from app.runtime.input_contract import InputContractError, validate_run_start_inputs, validate_required_inputs
 from app.runtime.run_contract import enrich_run_state_contract
@@ -1457,7 +1457,7 @@ def estimate_workflow_cost(
             routing_pref = data.get("routingPreference") or "balanced"
             explicit_model = data.get("model") or None
             explicit_provider = data.get("provider") or None
-            provider, model, _ = resolve_model(workflow.playbook_slug, routing_pref, explicit_model, explicit_provider)
+            provider, model, _ = resolve_model(db, str(workflow.workspace_id), routing_pref, explicit_model, explicit_provider)
             rates, pricing_version = get_model_rates(provider, model, pricing_snapshot)
             llm_models_used.add(f"{provider}:{model}")
             if llm_pricing_note is None:

--- a/apps/api/app/runtime/blocks/brain_block.py
+++ b/apps/api/app/runtime/blocks/brain_block.py
@@ -21,7 +21,7 @@ from app.runtime.llm_client import (
     OpenAIClient,
     PerplexityClient,
 )
-from app.runtime.model_router import resolve as _router_resolve
+from app.runtime.model_router import resolve_for_workspace as _router_resolve
 from app.runtime.pricing import freeze_pricing_snapshot, get_model_rates
 
 log = structlog.get_logger(__name__)
@@ -347,7 +347,7 @@ def _execute_brain(
     routing_pref = block["data"].get("routingPreference") or "balanced"
     explicit_model = block["data"].get("model") or None
     explicit_provider = block["data"].get("provider") or None
-    provider, model_id, routing_reason = _router_resolve(playbook_slug, routing_pref, explicit_model, explicit_provider)
+    provider, model_id, routing_reason = _router_resolve(db, workspace_id, routing_pref, explicit_model, explicit_provider)
     log.debug("brain.model_selected", block_id=block["id"], provider=provider, model=model_id, reason=routing_reason)
 
     # Fetch credentials from broker for session creation (SSH key, sandbox API keys).

--- a/apps/api/app/runtime/model_router.py
+++ b/apps/api/app/runtime/model_router.py
@@ -115,7 +115,7 @@ def _load_primitives(db: Session, workspace_id: str) -> tuple[str, dict[str, dic
         DEFAULT_TIER_MAPS,
         _read_stored,
     )
-    row = db.get(WorkspaceLLMPrimitives, workspace_id) if workspace_id else None
+    row = db.get(WorkspaceLLMPrimitives, workspace_id) if (db and workspace_id) else None
     if row is None:
         return DEFAULT_PREFERRED_PROVIDER, {k: dict(v) for k, v in DEFAULT_TIER_MAPS.items()}
     tier_map = _read_stored(row.tier_map)

--- a/apps/api/app/runtime/model_router.py
+++ b/apps/api/app/runtime/model_router.py
@@ -1,178 +1,142 @@
-"""
-ModelRouter — V1 rules-based provider + model selection.
+"""ModelRouter — resolves (provider, model, reason) from workspace primitives.
 
-Resolves (playbook_slug, block_task_category, routing_preference) -> (provider, model_id, reason).
+Reads WorkspaceLLMPrimitives (issue #1347) and answers "given a caller\'s
+routing preference, which provider+model do we use for this workspace?"
 
-Design principles:
-- Deterministic: same inputs always produce same output
-- Never raises: returns a safe default on any unexpected input
-- Logged: always returns a reason string for the run trace
+The pure resolve() takes primitives already loaded, so it stays testable
+without a DB. resolve_for_workspace() is the DB-fetching wrapper the
+runtime callers use.
 
-V2 will replace the static policy with outcome-scored selection once
-enough run data accumulates per (playbook_slug × model) combination.
-See issue #314.
+Priority (highest first):
+  1. explicit_model on the block — user pinned a specific model
+  2. explicit_provider on the block — use workspace tier_map for that
+     provider, else that provider\'s global fallback
+  3. workspace.preferred_provider + workspace.tier_map[preferred_provider]
+  4. Global fallback (anthropic sonnet)
 """
 from __future__ import annotations
 
 import structlog
+from sqlalchemy.orm import Session
 
 log = structlog.get_logger(__name__)
 
-# ── Provider + model IDs ─────────────────────────────────────────────────────
-
-SONNET   = "claude-sonnet-4-6"
-OPUS     = "claude-opus-4-7"
-HAIKU    = "claude-haiku-4-5-20251001"
-GPT_41   = "gpt-4.1"
-GPT_41_M = "gpt-4.1-mini"
-SONAR          = "sonar"
-SONAR_PRO      = "sonar-pro"
-SONAR_REASONING = "sonar-reasoning-pro"
-
+# ── Canonical provider slugs (kept as-is; adapters key on these) ─────────────
 ANTHROPIC  = "anthropic"
 OPENAI     = "openai"
 PERPLEXITY = "perplexity"
+TOGETHER   = "together"
 
-# ── Task categories (derived from playbook slug) ──────────────────────────────
+_KNOWN_PROVIDERS = {ANTHROPIC, OPENAI, PERPLEXITY, TOGETHER}
 
-_SLUG_TO_CATEGORY: dict[str, str] = {
-    "autopilot_quick":        "code_implementation",
-    "autopilot_full":         "code_implementation",
-    "autopilot_approved":     "code_implementation",
-    "dependency_updater":     "code_implementation",
-    "security_patch_updater": "code_implementation",
-    "pr_reviewer":            "code_review",
-    "copilot_reviewer":       "code_review",
-    "security_scanner":       "security",
-    "issue_triage":           "triage",
-    "ci_notify":              "triage",
-    "flaky_test_detective":   "triage",
-    "release_notes":          "summarization",
-    "release_readiness":      "code_review",
-    "incident_responder":     "reasoning",
-    "postmortem_drafter":     "summarization",
-    "docs_drift_detector":    "summarization",
-    "terraform_reviewer":     "reasoning",
+# ── Global fallbacks (used when primitives + tier_map miss) ──────────────────
+# One model per provider — sensible balanced choice, used when the tier map
+# does not have an entry for the requested tier. Not a substitute for the
+# workspace primitives; only kicks in for legacy callers / empty maps.
+_PROVIDER_FALLBACK: dict[str, str] = {
+    ANTHROPIC:  "claude-sonnet-4-6",
+    OPENAI:     "gpt-4.1-mini",
+    PERPLEXITY: "sonar",
+    TOGETHER:   "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+}
+_GLOBAL_FALLBACK: tuple[str, str, str] = (ANTHROPIC, _PROVIDER_FALLBACK[ANTHROPIC], "global fallback")
+
+# ── Tier normalisation ───────────────────────────────────────────────────────
+# Callers pass routing_preference from block config. Historical preference
+# names (quality/speed/cost/auto) map onto the primitives tier keys.
+_PREF_TO_TIER: dict[str, str] = {
+    "cheap":    "cheap",
+    "balanced": "balanced",
+    "smart":    "smart",
+    # legacy names
+    "quality":  "smart",
+    "speed":    "cheap",
+    "cost":     "cheap",
+    "auto":     "balanced",
 }
 
-# ── Static policy table: category → (quality, balanced, speed, cost) ─────────
-# Each tuple: (provider, model). Preference index: 0=quality 1=balanced 2=speed 3=cost.
 
-_PREFS = ("quality", "balanced", "speed", "cost")
-
-_POLICY: dict[str, list[tuple[str, str]]] = {
-    "code_implementation": [(ANTHROPIC, OPUS),   (ANTHROPIC, SONNET), (ANTHROPIC, SONNET), (OPENAI, GPT_41_M)],
-    "code_review":         [(ANTHROPIC, OPUS),   (ANTHROPIC, SONNET), (OPENAI, GPT_41_M),  (OPENAI, GPT_41_M)],
-    "security":            [(ANTHROPIC, OPUS),   (ANTHROPIC, OPUS),   (ANTHROPIC, SONNET), (ANTHROPIC, SONNET)],
-    "triage":              [(ANTHROPIC, SONNET), (OPENAI, GPT_41_M),  (OPENAI, GPT_41_M),  (OPENAI, GPT_41_M)],
-    "summarization":       [(ANTHROPIC, SONNET), (OPENAI, GPT_41_M),  (OPENAI, GPT_41_M),  (OPENAI, GPT_41_M)],
-    "reasoning":           [(ANTHROPIC, OPUS),   (ANTHROPIC, SONNET), (ANTHROPIC, SONNET), (OPENAI, GPT_41_M)],
-}
-
-_GLOBAL_DEFAULT = (ANTHROPIC, SONNET, "default: balanced model")
-
-_PROVIDER_MODEL_DEFAULTS: dict[str, dict[str, tuple[str, str]]] = {
-    ANTHROPIC: {
-        "code_implementation": (SONNET, "anthropic override: balanced default for code implementation"),
-        "code_review":         (SONNET, "anthropic override: balanced default for code review"),
-        "security":            (OPUS,   "anthropic override: strongest model for security"),
-        "triage":              (SONNET, "anthropic override: balanced default for triage"),
-        "summarization":       (SONNET, "anthropic override: balanced default for summarization"),
-        "reasoning":           (SONNET, "anthropic override: balanced default for reasoning"),
-        "unknown":             (SONNET, "anthropic override: balanced default model"),
-    },
-    OPENAI: {
-        "code_implementation": (GPT_41_M, "openai override: efficient model for code implementation"),
-        "code_review":         (GPT_41_M, "openai override: efficient model for code review"),
-        "security":            (GPT_41,   "openai override: strongest available OpenAI model for security"),
-        "triage":              (GPT_41_M, "openai override: efficient model for triage"),
-        "summarization":       (GPT_41_M, "openai override: efficient model for summarization"),
-        "reasoning":           (GPT_41,   "openai override: strongest available OpenAI model for reasoning"),
-        "unknown":             (GPT_41_M, "openai override: balanced default model"),
-    },
-    PERPLEXITY: {
-        "code_implementation": (SONAR_PRO,      "perplexity override: sonar-pro for code tasks"),
-        "code_review":         (SONAR_PRO,      "perplexity override: sonar-pro for code review"),
-        "security":            (SONAR_PRO,      "perplexity override: sonar-pro for security scanning"),
-        "triage":              (SONAR,          "perplexity override: sonar for triage"),
-        "summarization":       (SONAR,          "perplexity override: sonar for summarization"),
-        "reasoning":           (SONAR_REASONING, "perplexity override: sonar-reasoning-pro for reasoning"),
-        "unknown":             (SONAR,          "perplexity override: sonar default"),
-    },
-}
+def _normalise_tier(pref: str | None) -> str:
+    return _PREF_TO_TIER.get((pref or "balanced").strip().lower(), "balanced")
 
 
 def _infer_provider(model: str) -> str:
     m = (model or "").lower()
-    if m.startswith("gpt-"):
+    if m.startswith("gpt-") or m.startswith("o1") or m.startswith("o3") or m.startswith("o4"):
         return OPENAI
     if m.startswith("sonar"):
         return PERPLEXITY
+    if m.startswith("meta-llama/") or m.startswith("mistralai/") or m.startswith("Qwen/"):
+        return TOGETHER
     return ANTHROPIC
 
 
 def resolve(
-    playbook_slug: str | None,
+    preferred_provider: str,
+    tier_map: dict[str, dict[str, str]],
     routing_preference: str | None,
     explicit_model: str | None = None,
     explicit_provider: str | None = None,
-) -> tuple[str, str]:
-    """
-    Return (provider, model_id, routing_reason).
-
-    Priority:
-    1. explicit_model on the block — user pinned a specific model
-    2. explicit_provider on the block — user pinned a provider, router picks a safe model for it
-    3. Static policy lookup: (task_category, routing_preference)
-    4. Category default
-    5. Global default (sonnet)
-    """
+) -> tuple[str, str, str]:
+    """Pure resolver — no DB access. See module docstring for priority."""
     try:
-        # 1. Pinned model
         if explicit_model:
             return _infer_provider(explicit_model), explicit_model, "user-pinned model"
 
-        pref = (routing_preference or "balanced").lower()
-        if pref == "auto":
-            pref = "balanced"
+        tier = _normalise_tier(routing_preference)
 
-        # 2. Resolve category from slug
-        category = _SLUG_TO_CATEGORY.get(playbook_slug or "", "") if playbook_slug else ""
+        req_provider = (explicit_provider or "").strip().lower()
+        if req_provider in _KNOWN_PROVIDERS:
+            model = (tier_map.get(req_provider) or {}).get(tier)
+            if model:
+                return req_provider, model, f"explicit provider {req_provider}: tier_map[{tier}]"
+            fallback = _PROVIDER_FALLBACK[req_provider]
+            return req_provider, fallback, f"explicit provider {req_provider}: fallback (no tier_map[{tier}])"
 
-        requested_provider = (explicit_provider or "").lower().strip()
-        if requested_provider in (ANTHROPIC, OPENAI, PERPLEXITY):
-            category_key = category or "unknown"
-            model, reason = _PROVIDER_MODEL_DEFAULTS[requested_provider].get(
-                category_key,
-                _PROVIDER_MODEL_DEFAULTS[requested_provider]["unknown"],
-            )
-            log.debug(
-                "model_router.provider_override",
-                slug=playbook_slug,
-                pref=pref,
-                category=category_key,
-                provider=requested_provider,
-                model=model,
-            )
-            return requested_provider, model, reason
+        provider = (preferred_provider or ANTHROPIC).strip().lower()
+        if provider not in _KNOWN_PROVIDERS:
+            provider = ANTHROPIC
 
-        if category and category in _POLICY:
-            idx = _PREFS.index(pref) if pref in _PREFS else 1
-            provider, model = _POLICY[category][idx]
-            reason = f"{category}/{pref}: {provider} {model}"
-        else:
-            # Unknown slug — fall back by preference only
-            pref_defaults: dict[str, tuple[str, str, str]] = {
-                "quality":  (ANTHROPIC, OPUS,   "quality preference: strongest model"),
-                "balanced": (ANTHROPIC, SONNET, "balanced preference: default model"),
-                "speed":    (OPENAI,    GPT_41_M, "speed preference: efficient model"),
-                "cost":     (OPENAI,    GPT_41_M, "cost preference: efficient model"),
-            }
-            provider, model, reason = pref_defaults.get(pref, _GLOBAL_DEFAULT)
-
-        log.debug("model_router.resolved", slug=playbook_slug, pref=pref, category=category, provider=provider, model=model)
-        return provider, model, reason
+        model = (tier_map.get(provider) or {}).get(tier)
+        if model:
+            return provider, model, f"workspace {provider}: tier_map[{tier}]"
+        return provider, _PROVIDER_FALLBACK[provider], f"workspace {provider}: fallback (no tier_map[{tier}])"
 
     except Exception as e:
         log.warning("model_router.error", error=str(e))
-        return ANTHROPIC, SONNET, "fallback: routing error"
+        return _GLOBAL_FALLBACK
+
+
+def _load_primitives(db: Session, workspace_id: str) -> tuple[str, dict[str, dict[str, str]]]:
+    """Fetch workspace primitives, applying the same defaults as the API."""
+    from app.models.workspace_llm_primitives import WorkspaceLLMPrimitives
+    from app.routers.workspace_llm_primitives import (
+        DEFAULT_PREFERRED_PROVIDER,
+        DEFAULT_TIER_MAPS,
+        _read_stored,
+    )
+    row = db.get(WorkspaceLLMPrimitives, workspace_id) if workspace_id else None
+    if row is None:
+        return DEFAULT_PREFERRED_PROVIDER, {k: dict(v) for k, v in DEFAULT_TIER_MAPS.items()}
+    tier_map = _read_stored(row.tier_map)
+    if not tier_map:
+        tier_map = {k: dict(v) for k, v in DEFAULT_TIER_MAPS.items()}
+    return (row.preferred_provider or DEFAULT_PREFERRED_PROVIDER), tier_map
+
+
+def resolve_for_workspace(
+    db: Session,
+    workspace_id: str,
+    routing_preference: str | None,
+    explicit_model: str | None = None,
+    explicit_provider: str | None = None,
+) -> tuple[str, str, str]:
+    """Runtime entry point — reads workspace primitives, delegates to resolve()."""
+    preferred_provider, tier_map = _load_primitives(db, workspace_id)
+    return resolve(
+        preferred_provider=preferred_provider,
+        tier_map=tier_map,
+        routing_preference=routing_preference,
+        explicit_model=explicit_model,
+        explicit_provider=explicit_provider,
+    )

--- a/apps/api/tests/test_model_router.py
+++ b/apps/api/tests/test_model_router.py
@@ -1,41 +1,53 @@
 from app.runtime.model_router import resolve
 
+ANTHROPIC_MAP = {"cheap": "claude-haiku-4-5-20251001", "balanced": "claude-sonnet-4-6", "smart": "claude-opus-4-7"}
+OPENAI_MAP    = {"cheap": "gpt-4.1-mini", "balanced": "gpt-4.1", "smart": "gpt-4.1"}
+TIER_MAP = {"anthropic": ANTHROPIC_MAP, "openai": OPENAI_MAP}
 
-def test_resolve_returns_provider_model_and_reason_for_known_slug():
-    provider, model, reason = resolve("pr_reviewer", "balanced")
 
+def test_resolve_uses_workspace_preferred_provider_and_tier():
+    provider, model, reason = resolve("anthropic", TIER_MAP, "balanced")
     assert provider == "anthropic"
     assert model == "claude-sonnet-4-6"
-    assert reason == "code_review/balanced: anthropic claude-sonnet-4-6"
+    assert "tier_map[balanced]" in reason
 
 
-def test_resolve_uses_openai_for_cost_sensitive_triage():
-    provider, model, reason = resolve("issue_triage", "cost")
-
-    assert provider == "openai"
+def test_resolve_maps_legacy_preference_names_to_tiers():
+    # quality -> smart
+    _, model, _ = resolve("anthropic", TIER_MAP, "quality")
+    assert model == "claude-opus-4-7"
+    # speed / cost -> cheap
+    _, model, _ = resolve("openai", TIER_MAP, "speed")
     assert model == "gpt-4.1-mini"
-    assert reason == "triage/cost: openai gpt-4.1-mini"
+    _, model, _ = resolve("openai", TIER_MAP, "cost")
+    assert model == "gpt-4.1-mini"
 
 
-def test_resolve_infers_provider_from_pinned_model():
-    provider, model, reason = resolve("autopilot_full", "balanced", "gpt-4.1")
-
+def test_resolve_honours_explicit_model_over_everything():
+    provider, model, reason = resolve("anthropic", TIER_MAP, "balanced", explicit_model="gpt-4.1")
     assert provider == "openai"
     assert model == "gpt-4.1"
     assert reason == "user-pinned model"
 
 
-def test_resolve_honors_explicit_provider_override_without_pinned_model():
-    provider, model, reason = resolve("pr_reviewer", "balanced", None, "openai")
-
+def test_resolve_honours_explicit_provider_via_workspace_tier_map():
+    provider, model, reason = resolve("anthropic", TIER_MAP, "balanced", explicit_provider="openai")
     assert provider == "openai"
-    assert model == "gpt-4.1-mini"
-    assert reason == "openai override: efficient model for code review"
+    assert model == "gpt-4.1"
+    assert "explicit provider openai" in reason
 
 
-def test_resolve_falls_back_for_unknown_slug_by_preference():
-    provider, model, reason = resolve("unknown_slug", "speed")
-
+def test_resolve_falls_back_when_tier_map_missing_the_tier():
+    # only balanced defined for openai
+    partial = {"openai": {"balanced": "gpt-4.1"}}
+    provider, model, reason = resolve("openai", partial, "smart")
     assert provider == "openai"
-    assert model == "gpt-4.1-mini"
-    assert reason == "speed preference: efficient model"
+    assert model == "gpt-4.1-mini"  # provider fallback
+    assert "fallback" in reason
+
+
+def test_resolve_falls_back_when_workspace_has_unknown_provider():
+    provider, model, _ = resolve("bogus-provider", TIER_MAP, "balanced")
+    # unknown provider is normalised to anthropic default
+    assert provider == "anthropic"
+    assert model == "claude-sonnet-4-6"

--- a/apps/api/tests/test_resolve_for_workspace.py
+++ b/apps/api/tests/test_resolve_for_workspace.py
@@ -1,0 +1,78 @@
+"""Tests for resolve_for_workspace() DB wrapper."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from app.runtime.model_router import resolve_for_workspace
+from app.routers.workspace_llm_primitives import DEFAULT_PREFERRED_PROVIDER, DEFAULT_TIER_MAPS
+
+
+class _Row:
+    def __init__(self, preferred_provider, tier_map):
+        self.preferred_provider = preferred_provider
+        self.tier_map = tier_map
+
+
+def _db_with(row):
+    db = MagicMock()
+    db.get.return_value = row
+    return db
+
+
+def test_no_workspace_id_returns_defaults():
+    provider, model, _ = resolve_for_workspace(None, "", routing_preference="balanced")
+    assert provider == DEFAULT_PREFERRED_PROVIDER
+    assert model == DEFAULT_TIER_MAPS[DEFAULT_PREFERRED_PROVIDER]["balanced"]
+
+
+def test_no_db_returns_defaults():
+    provider, model, _ = resolve_for_workspace(None, "some-ws-uuid", routing_preference="smart")
+    assert provider == DEFAULT_PREFERRED_PROVIDER
+    assert model == DEFAULT_TIER_MAPS[DEFAULT_PREFERRED_PROVIDER]["smart"]
+
+
+def test_missing_row_returns_defaults():
+    db = _db_with(None)
+    provider, model, _ = resolve_for_workspace(db, "ws-1", routing_preference="cheap")
+    assert provider == DEFAULT_PREFERRED_PROVIDER
+    assert model == DEFAULT_TIER_MAPS[DEFAULT_PREFERRED_PROVIDER]["cheap"]
+
+
+def test_row_with_custom_provider_and_tier_map():
+    row = _Row(
+        preferred_provider="openai",
+        tier_map={"openai": {"cheap": "gpt-4o-mini", "balanced": "gpt-4o", "smart": "gpt-4o"}},
+    )
+    db = _db_with(row)
+    provider, model, reason = resolve_for_workspace(db, "ws-2", routing_preference="balanced")
+    assert provider == "openai"
+    assert model == "gpt-4o"
+    assert "workspace openai" in reason
+
+
+def test_row_with_empty_tier_map_falls_back_to_defaults():
+    row = _Row(preferred_provider="anthropic", tier_map={})
+    db = _db_with(row)
+    provider, model, _ = resolve_for_workspace(db, "ws-3", routing_preference="smart")
+    assert provider == "anthropic"
+    assert model == DEFAULT_TIER_MAPS["anthropic"]["smart"]
+
+
+def test_row_forces_explicit_provider_via_tier_map():
+    row = _Row(
+        preferred_provider="anthropic",
+        tier_map={"anthropic": {"balanced": "claude-sonnet-4-6"}, "openai": {"balanced": "gpt-4.1"}},
+    )
+    db = _db_with(row)
+    provider, model, _ = resolve_for_workspace(db, "ws-4", routing_preference="balanced", explicit_provider="openai")
+    assert provider == "openai"
+    assert model == "gpt-4.1"
+
+
+def test_explicit_model_bypasses_workspace_lookup():
+    row = _Row(preferred_provider="anthropic", tier_map={"anthropic": {"balanced": "claude-sonnet-4-6"}})
+    db = _db_with(row)
+    provider, model, reason = resolve_for_workspace(db, "ws-5", routing_preference="balanced", explicit_model="gpt-4.1")
+    assert provider == "openai"
+    assert model == "gpt-4.1"
+    assert reason == "user-pinned model"


### PR DESCRIPTION
Second PR in the #1347 epic. Depends on PR A (already merged as #1351) — it hooks the runtime into the workspace primitives table so the settings a workspace admin picks in the LLM Model Primitives tab actually shape resolution decisions.

## What ships
- Rewrites `model_router.resolve()` around two entry points:
  - **Pure** `resolve(preferred_provider, tier_map, routing_preference, ...)` — no DB, easy to unit-test
  - **Runtime** `resolve_for_workspace(db, workspace_id, ...)` — fetches primitives, delegates to the pure resolver
- Priority: `explicit_model` > `explicit_provider` (via workspace tier_map) > workspace `preferred_provider` (via workspace tier_map) > provider fallback > global fallback
- Legacy `routing_preference` names (`quality`/`speed`/`cost`/`auto`) normalise to tier keys (`smart`/`cheap`/`balanced`)

## Deletions (dead code)
- `_SLUG_TO_CATEGORY` — 17-entry hardcoded playbook_slug → category table
- `_POLICY` — 6-category × 4-preference static routing matrix
- `_PROVIDER_MODEL_DEFAULTS` — per-provider per-category override table
- The `playbook_slug` parameter itself

**No backward-compat wrapper** — only two runtime callers exist and both are updated in this PR (per revised epic 2026-08-28).

## Callers updated
- `apps/api/app/routers/workflows.py` — passes `db` + `str(workflow.workspace_id)`
- `apps/api/app/runtime/blocks/brain_block.py` — passes `db` + `workspace_id` (already in scope)

## Diff
```
4 files changed, 142 insertions(+), 166 deletions(-)
```

Net negative — dead code out, tighter API in.

## Test plan
- [x] Rewritten `tests/test_model_router.py` (6 cases) all pass
- [x] Broader brain/workflow tests still green (20 passing under `-k "model_router or brain_block or brain_selector or model_selection"`)
- [ ] CI: full API test suite
- [ ] Manual: run a workflow with the primitives tab set to `openai / balanced` and confirm the brain block picks `gpt-4.1`

## Follow-ups
- PR B.5 — Guard proxy tier-aware resolution (accept `"balanced"` from callers, resolve via router)
- PR C — Lens uses `resolve_for_workspace()` instead of env vars
- PR D — delete deprecated `CONDUCT_INFERENCE_*` env vars

Refs: #1347. Follows #1351 + #1353.