### PR TITLE
feat(#1347): Guard proxy tier-form model resolution (PR B.5, replaces closed #1355)

### DIFF
--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -105,6 +105,63 @@ AGENT_TOKEN_PREFIX  = "cond_agt_"  # new unified Agent ID token
 API_TOKEN_PREFIX    = "cond_api_"  # long-lived machine token — no GMC link
 
 
+# ── Tier-form model strings (PR B.5 of #1347) ─────────────────────────────────
+# Callers may send `"balanced"` or `"openai/cheap"` instead of a concrete model
+# ID. Proxy resolves via workspace primitives before the request hits Guard
+# policy or upstream. Non-tier strings pass through unchanged (backward compat).
+_TIER_FORMS = {"cheap", "balanced", "smart", "quality", "speed", "cost", "auto"}
+
+
+def _apply_tier_resolution(
+    db: Session,
+    workspace_id: str,
+    endpoint_provider: str,
+    body: dict,
+) -> tuple[str, str | None]:
+    """Rewrite body["model"] if it is a tier form. Returns (effective_model, original_tier_form).
+
+    original_tier_form is populated only when a substitution occurred (for audit
+    logging). When None, model was already concrete and body is unchanged."""
+    original = body.get("model", "unknown")
+    resolved = _resolve_tier_form(db, workspace_id, endpoint_provider, original)
+    if not resolved:
+        return original, None
+    body["model"] = resolved
+    return resolved, original if isinstance(original, str) else None
+
+
+def _resolve_tier_form(db: Session, workspace_id: str, endpoint_provider: str, model_field: object) -> str | None:
+    """If model_field is a tier name (bare or `<endpoint_provider>/<tier>`),
+    resolve via workspace primitives and return the concrete model ID.
+    Return None if it is already a concrete model (pass-through).
+
+    Cross-provider forms (e.g. `"anthropic/balanced"` sent to /openai) are
+    ignored — the endpoint provider is authoritative."""
+    if not isinstance(model_field, str) or not model_field.strip():
+        return None
+    m = model_field.strip().lower()
+    if m in _TIER_FORMS:
+        tier = m
+    elif "/" in m:
+        prefix, _, tail = m.partition("/")
+        if prefix != endpoint_provider or tail not in _TIER_FORMS:
+            return None
+        tier = tail
+    else:
+        return None
+    try:
+        from app.runtime.model_router import resolve_for_workspace
+        _, resolved, _ = resolve_for_workspace(
+            db=db,
+            workspace_id=workspace_id,
+            routing_preference=tier,
+            explicit_provider=endpoint_provider,
+        )
+        return resolved
+    except Exception:
+        return None
+
+
 def _workspace_proxy_url(db: Session, workspace_id: str) -> str:
     return settings.conduct_proxy_url
 
@@ -347,7 +404,15 @@ async def _proxy(
         except Exception:
             return _fail_closed(400, "Body must be valid JSON")
 
-        model = body.get("model", "unknown")
+        model, _tier_form_before = _apply_tier_resolution(db, workspace_id, provider, body)
+        if _tier_form_before and _tier_form_before != model:
+            log.info(
+                "proxy.tier_resolved",
+                workspace_id=workspace_id,
+                provider=provider,
+                tier_form=_tier_form_before,
+                resolved_model=model,
+            )
         ai_tool = request.headers.get("x-conduct-ai-tool") or _infer_ai_tool(request)
 
         # 4a. Resolve user email for audit rows

--- a/apps/api/scripts/proxy_smoke.sh
+++ b/apps/api/scripts/proxy_smoke.sh
@@ -161,6 +161,28 @@ run_one "perplexity" "/perplexity/chat/completions" \
   "" \
   '{"model":"sonar","max_tokens":40,"messages":[{"role":"user","content":"Reply: SMOKE_OK"}]}'
 
+# ── tier-form runs (PR B.5) ──────────────────────────────────────────────
+# Send `"balanced"` instead of a concrete model ID and verify the proxy
+# resolves via workspace primitives before forwarding upstream.
+
+echo "═══ tier-form model strings ═══════════════════════"
+
+run_one "anthropic" "/v1/messages" \
+  "-H \"x-api-key: guard-mt-$MEMBER_TOKEN\"" \
+  "-H \"anthropic-version: 2023-06-01\"" \
+  '{"model":"balanced","max_tokens":40,"messages":[{"role":"user","content":"Reply: SMOKE_OK"}]}'
+
+run_one "openai" "/openai/v1/chat/completions" \
+  "-H \"Authorization: Bearer guard-mt-$MEMBER_TOKEN\"" \
+  "" \
+  '{"model":"cheap","max_tokens":40,"messages":[{"role":"user","content":"Reply: SMOKE_OK"}]}'
+
+run_one "perplexity" "/perplexity/chat/completions" \
+  "-H \"Authorization: Bearer guard-mt-$MEMBER_TOKEN\"" \
+  "" \
+  '{"model":"balanced","max_tokens":40,"messages":[{"role":"user","content":"Reply: SMOKE_OK"}]}'
+
+
 echo "═══════════════════════════════════════════════════"
 echo "Summary: $PASS pass · $FAIL fail · $SKIP skip"
 exit $(( FAIL > 0 ? 1 : 0 ))

--- a/apps/api/tests/test_guard_proxy_tier_e2e.py
+++ b/apps/api/tests/test_guard_proxy_tier_e2e.py
@@ -1,0 +1,112 @@
+"""E2E TestClient integration for the Guard proxy tier-form path.
+
+Verifies POST /proxy/openai/v1/chat/completions with model="balanced"
+rewrites body["model"] to a concrete ID before the upstream forward.
+
+Auth, DB, policy, vault, and upstream HTTP are all patched — we\'re
+proving the flow inside _proxy(), not those dependencies.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from app.guard.policy_types import PolicyAction, PolicyDecision
+
+
+@pytest.fixture
+def client_and_capture(monkeypatch):
+    """Mount the proxy router with all external deps mocked; return a
+    (TestClient, captured_forward_calls) tuple."""
+    from app.modules.guard.routers import proxy as proxy_mod
+
+    forward_calls: list[dict] = []
+
+    async def fake_forward(**kwargs):
+        forward_calls.append(kwargs)
+        return JSONResponse({"id": "chatcmpl-mock", "model": kwargs["body"]["model"]}, status_code=200)
+
+    def fake_allow(_ctx):
+        return PolicyDecision(action=PolicyAction.ALLOW, source="test")
+
+    def fake_resolve(**kwargs):
+        # anthropic default for balanced tier — mirrors what primitives return
+        return "anthropic", "claude-sonnet-4-6", "test-resolver"
+
+    def fake_resolve_openai(**kwargs):
+        return "openai", "gpt-4.1", "test-resolver"
+
+    # DB session — nothing actually reads through it (all queries are patched)
+    monkeypatch.setattr(proxy_mod, "SessionLocal", lambda: MagicMock())
+    monkeypatch.setattr(proxy_mod, "resolve_agent_token", lambda token, db: ("00000000-0000-0000-0000-000000000001", "user-abc"))
+    monkeypatch.setattr(proxy_mod, "token_is_expired", lambda token, db: False)
+    monkeypatch.setattr(proxy_mod, "set_workspace_rls", lambda db, ws: None)
+    monkeypatch.setattr("app.guard.policy.evaluate_composed", fake_allow)
+    monkeypatch.setattr(proxy_mod, "_upstream_url", lambda db, ws, prov, env: "http://mock-upstream")
+    monkeypatch.setattr(proxy_mod, "_vault_key", lambda db, ws, prov, env: "sk-fake-vendor-key")
+    monkeypatch.setattr(proxy_mod, "_upstream_api_key", lambda db, ws, env: None)
+    monkeypatch.setattr(proxy_mod, "_forward", fake_forward)
+    monkeypatch.setattr(proxy_mod, "_infer_ai_tool", lambda req: "test-suite")
+    monkeypatch.setattr(proxy_mod, "_flatten_prompt", lambda body: "")
+    monkeypatch.setattr(proxy_mod, "_estimate_input_tokens", lambda body: 10)
+    monkeypatch.setattr("app.runtime.model_router.resolve_for_workspace", fake_resolve_openai)
+
+    app = FastAPI()
+    app.include_router(proxy_mod.router)
+    return TestClient(app), forward_calls
+
+
+def test_bare_tier_form_gets_rewritten_before_upstream(client_and_capture):
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "balanced", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    assert len(forward_calls) == 1
+    forwarded_body = forward_calls[0]["body"]
+    # The tier form must have been rewritten to a concrete model before _forward saw it.
+    assert forwarded_body["model"] == "gpt-4.1"
+    # Response mirrors the resolved model
+    assert r.json()["model"] == "gpt-4.1"
+
+
+def test_concrete_model_passes_through_untouched(client_and_capture):
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "gpt-4.1-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    forwarded_body = forward_calls[0]["body"]
+    assert forwarded_body["model"] == "gpt-4.1-mini"
+
+
+def test_provider_prefixed_tier_matching_endpoint(client_and_capture):
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "openai/smart", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    assert forward_calls[0]["body"]["model"] == "gpt-4.1"
+
+
+def test_cross_provider_prefix_forwards_raw_string(client_and_capture):
+    """Endpoint provider wins — an anthropic/ prefix sent to /openai/ is
+    passed through unchanged. Upstream (mocked here) would 400 in production."""
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "anthropic/balanced", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    assert forward_calls[0]["body"]["model"] == "anthropic/balanced"

--- a/apps/api/tests/test_guard_proxy_tier_resolution.py
+++ b/apps/api/tests/test_guard_proxy_tier_resolution.py
@@ -1,0 +1,120 @@
+"""Guard proxy tier-form model string resolution (PR B.5 of #1347).
+
+Verifies _resolve_tier_form() pass-through vs resolve behaviour; DB path
+is exercised via a monkeypatched resolve_for_workspace to keep the test
+free of a Postgres dependency.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.modules.guard.routers.proxy import _resolve_tier_form
+
+
+@pytest.fixture
+def stub_router(monkeypatch):
+    calls = []
+
+    def _fake(db, workspace_id, routing_preference, explicit_model=None, explicit_provider=None):
+        calls.append({
+            "workspace_id": workspace_id,
+            "routing_preference": routing_preference,
+            "explicit_provider": explicit_provider,
+        })
+        # emulate primitives table: cheap/balanced/smart per provider
+        table = {
+            "anthropic": {"cheap": "claude-haiku-4-5-20251001", "balanced": "claude-sonnet-4-6", "smart": "claude-opus-4-7"},
+            "openai":    {"cheap": "gpt-4.1-mini", "balanced": "gpt-4.1", "smart": "gpt-4.1"},
+        }
+        return explicit_provider, table[explicit_provider][routing_preference], "stubbed"
+
+    monkeypatch.setattr("app.runtime.model_router.resolve_for_workspace", _fake)
+    return calls
+
+
+def test_concrete_model_id_passes_through(stub_router):
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="gpt-4.1") is None
+    assert stub_router == []
+
+
+def test_bare_tier_resolves_via_endpoint_provider(stub_router):
+    out = _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="balanced")
+    assert out == "gpt-4.1"
+    assert stub_router[0]["explicit_provider"] == "openai"
+    assert stub_router[0]["routing_preference"] == "balanced"
+
+
+def test_provider_prefixed_tier_matches_endpoint(stub_router):
+    out = _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="anthropic", model_field="anthropic/smart")
+    assert out == "claude-opus-4-7"
+    assert stub_router[-1]["explicit_provider"] == "anthropic"
+    assert stub_router[-1]["routing_preference"] == "smart"
+
+
+def test_cross_provider_prefix_is_ignored(stub_router):
+    # Caller hit /openai/... but sent anthropic/balanced — endpoint provider wins,
+    # helper returns None so the raw string flows to upstream unchanged.
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="anthropic/balanced") is None
+    assert stub_router == []
+
+
+def test_bogus_tail_after_valid_provider_prefix_is_ignored(stub_router):
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="openai/foo") is None
+    assert stub_router == []
+
+
+def test_empty_or_non_string_input(stub_router):
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="") is None
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field=None) is None
+    assert _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field=42) is None
+    assert stub_router == []
+
+
+# ── _apply_tier_resolution — mirrors the _proxy() insertion point ──────────
+
+from app.modules.guard.routers.proxy import _apply_tier_resolution
+
+
+def test_apply_concrete_model_leaves_body_unchanged(stub_router):
+    body = {"model": "gpt-4.1", "messages": []}
+    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    assert model == "gpt-4.1"
+    assert tier_form is None
+    assert body["model"] == "gpt-4.1"
+    assert stub_router == []
+
+
+def test_apply_bare_tier_rewrites_body_and_returns_tier_form(stub_router):
+    body = {"model": "balanced", "messages": []}
+    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    assert model == "gpt-4.1"
+    assert tier_form == "balanced"
+    assert body["model"] == "gpt-4.1"
+    # order matters: helper must call resolver before mutating body
+    assert stub_router[0]["explicit_provider"] == "openai"
+
+
+def test_apply_provider_prefixed_tier(stub_router):
+    body = {"model": "anthropic/smart", "messages": []}
+    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="anthropic", body=body)
+    assert model == "claude-opus-4-7"
+    assert tier_form == "anthropic/smart"
+    assert body["model"] == "claude-opus-4-7"
+
+
+def test_apply_cross_provider_prefix_is_ignored(stub_router):
+    body = {"model": "anthropic/balanced", "messages": []}
+    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    # endpoint provider is authoritative; cross-provider prefix returns None
+    assert model == "anthropic/balanced"
+    assert tier_form is None
+    assert body["model"] == "anthropic/balanced"
+    assert stub_router == []
+
+
+def test_apply_missing_model_field_returns_unknown(stub_router):
+    body = {"messages": []}
+    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    assert model == "unknown"
+    assert tier_form is None
+    assert "model" not in body


### PR DESCRIPTION
Reopened from #1355 which was auto-closed when PR B (#1354) merged and deleted its base branch. Same content, rebased on main.

Callers can send model: \"balanced\" or \"anthropic/smart\" to any proxy endpoint. Proxy resolves via workspace primitives (landed in PR B), rewrites body.model to the concrete ID, forwards upstream.

## Test coverage
- 6 tests for _resolve_tier_form
- 5 tests for _apply_tier_resolution
- 4 FastAPI TestClient E2E tests
- 3 tier-form runs in scripts/proxy_smoke.sh
- 31 existing proxy tests still green

## What is NOT in this PR
- Lens still reads env vars — PR C
- Legacy env vars still defined — PR D

Refs: #1347. Follows #1354. Supersedes #1355.