### PR TITLE
feat(#1347 PR B.6): persist tier resolution to guard_audit_events.routing_meta

### DIFF
--- a/apps/api/alembic/versions/0104_guard_audit_routing_meta.py
+++ b/apps/api/alembic/versions/0104_guard_audit_routing_meta.py
@@ -1,0 +1,31 @@
+"""feat(#1347 PR B.6): add routing_meta jsonb to guard_audit_events
+
+Persists the tier-form resolution (before/after model + reason) into the
+audit trail so operators can prove which primitives decision drove each
+LLM call. NULL when the caller sent a concrete model ID.
+
+Revision ID: 0104
+Revises: 0103
+Create Date: 2026-08-28
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision = "0104"
+down_revision = "0103"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guard_audit_events",
+        sa.Column("routing_meta", JSONB, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guard_audit_events", "routing_meta")

--- a/apps/api/app/guard/audit.py
+++ b/apps/api/app/guard/audit.py
@@ -122,6 +122,7 @@ def record(
     conductai_run_id: str | None = None, conductai_workflow: str | None = None,
     conductai_workflow_id: str | None = None, hook_session_id: str | None = None,
     evaluated_rules: list[dict] | None = None, defense_score: int | None = None,
+    routing_meta: dict | None = None,
 ) -> None:
     """Background task — best-effort audit write, never blocks the response.
 
@@ -146,7 +147,8 @@ def record(
                   cost_usd_after, input_summary, user_email,
                   conductai_run_id, conductai_workflow, conductai_workflow_id,
                   hook_session_id,
-                  evaluated_rules, defense_score
+                  evaluated_rules, defense_score,
+                  routing_meta
                 ) VALUES (
                   :ws, :uid, :ai, NULL,
                   'proxy', :prov, :model,
@@ -155,7 +157,8 @@ def record(
                   :cost, :summary, :email,
                   :run_id, :workflow, :workflow_id,
                   :hook_session_id,
-                  CAST(:eval AS jsonb), :score
+                  CAST(:eval AS jsonb), :score,
+                  CAST(:routing AS jsonb)
                 )
             """),
             {
@@ -174,6 +177,7 @@ def record(
                 "hook_session_id": hook_session_id,
                 "eval": json.dumps(evaluated_rules) if evaluated_rules else None,
                 "score": defense_score,
+                "routing": json.dumps(routing_meta) if routing_meta else None,
             },
         )
         db.commit()

--- a/apps/api/app/guard/router.py
+++ b/apps/api/app/guard/router.py
@@ -83,6 +83,7 @@ async def _stream_chunks(
             conductai_workflow=audit_args[12] if len(audit_args) > 12 else None,
             conductai_workflow_id=audit_args[13] if len(audit_args) > 13 else None,
             hook_session_id=audit_args[14] if len(audit_args) > 14 else None,
+            routing_meta=audit_args[15] if len(audit_args) > 15 else None,
         )
 
 
@@ -220,6 +221,7 @@ async def upstream(
         conductai_workflow=audit_args[12] if len(audit_args) > 12 else None,
         conductai_workflow_id=audit_args[13] if len(audit_args) > 13 else None,
         hook_session_id=audit_args[14] if len(audit_args) > 14 else None,
+        routing_meta=audit_args[15] if len(audit_args) > 15 else None,
     )
     _resp_headers = {
         k: v for k, v in resp.headers.items()

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -199,6 +199,10 @@ class GuardAuditEvent(Base):
     # non-eval audit paths (auth, approval, guard block) stay as-is
     evaluated_rules = Column(JSONB, nullable=True)   # list of {rule_id, severity, action, message}
     defense_score   = Column(Integer, nullable=True)  # weighted aggregate across matched rules
+    # PR B.6 (#1347) — persisted routing decision for LLM proxy calls.
+    # Only populated when the caller sent a tier form ("balanced" etc.);
+    # NULL when a concrete model ID was forwarded straight through.
+    routing_meta    = Column(JSONB, nullable=True)
 
     __table_args__ = (
         Index("ix_guard_audit_events_source", "workspace_id", "source", "ts"),

--- a/apps/api/app/modules/guard/routers/events.py
+++ b/apps/api/app/modules/guard/routers/events.py
@@ -132,6 +132,7 @@ class EventOut(BaseModel):
     # #1150 phase 1 — layered verdict envelope (nullable for pre-migration rows)
     evaluated_rules: list[dict] | None = None
     defense_score: int | None = None
+    routing_meta: dict | None = None
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -178,6 +179,7 @@ def _event_to_dict(e: GuardAuditEvent) -> dict:
         "entry_hash": e.entry_hash,
         "evaluated_rules": e.evaluated_rules,
         "defense_score": e.defense_score,
+        "routing_meta": getattr(e, "routing_meta", None),
         "policy_hash": e.policy_hash,
         "goal_id": e.goal_id,
         "goal_name": e.goal_name,

--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -117,20 +117,29 @@ def _apply_tier_resolution(
     workspace_id: str,
     endpoint_provider: str,
     body: dict,
-) -> tuple[str, str | None]:
-    """Rewrite body["model"] if it is a tier form. Returns (effective_model, original_tier_form).
+) -> tuple[str, dict | None]:
+    """Rewrite body["model"] if it is a tier form. Returns (effective_model, routing_meta).
 
-    original_tier_form is populated only when a substitution occurred (for audit
-    logging). When None, model was already concrete and body is unchanged."""
+    routing_meta is a dict populated only when a substitution occurred, ready
+    to persist into guard_audit_events.routing_meta. When None, model was
+    already concrete and body is unchanged."""
     original = body.get("model", "unknown")
-    resolved = _resolve_tier_form(db, workspace_id, endpoint_provider, original)
-    if not resolved:
+    result = _resolve_tier_form(db, workspace_id, endpoint_provider, original)
+    if not result:
         return original, None
+    resolved, reason = result
     body["model"] = resolved
-    return resolved, original if isinstance(original, str) else None
+    meta = {
+        "tier_form": original if isinstance(original, str) else None,
+        "resolved_model": resolved,
+        "endpoint_provider": endpoint_provider,
+        "reason": reason,
+        "resolution_source": "workspace_primitives",
+    }
+    return resolved, meta
 
 
-def _resolve_tier_form(db: Session, workspace_id: str, endpoint_provider: str, model_field: object) -> str | None:
+def _resolve_tier_form(db: Session, workspace_id: str, endpoint_provider: str, model_field: object) -> tuple[str, str] | None:
     """If model_field is a tier name (bare or `<endpoint_provider>/<tier>`),
     resolve via workspace primitives and return the concrete model ID.
     Return None if it is already a concrete model (pass-through).
@@ -151,13 +160,13 @@ def _resolve_tier_form(db: Session, workspace_id: str, endpoint_provider: str, m
         return None
     try:
         from app.runtime.model_router import resolve_for_workspace
-        _, resolved, _ = resolve_for_workspace(
+        _, resolved, reason = resolve_for_workspace(
             db=db,
             workspace_id=workspace_id,
             routing_preference=tier,
             explicit_provider=endpoint_provider,
         )
-        return resolved
+        return (resolved, reason)
     except Exception:
         return None
 
@@ -404,14 +413,15 @@ async def _proxy(
         except Exception:
             return _fail_closed(400, "Body must be valid JSON")
 
-        model, _tier_form_before = _apply_tier_resolution(db, workspace_id, provider, body)
-        if _tier_form_before and _tier_form_before != model:
+        model, _routing_meta = _apply_tier_resolution(db, workspace_id, provider, body)
+        if _routing_meta:
             log.info(
                 "proxy.tier_resolved",
                 workspace_id=workspace_id,
                 provider=provider,
-                tier_form=_tier_form_before,
+                tier_form=_routing_meta.get("tier_form"),
                 resolved_model=model,
+                reason=_routing_meta.get("reason"),
             )
         ai_tool = request.headers.get("x-conduct-ai-tool") or _infer_ai_tool(request)
 
@@ -529,7 +539,7 @@ async def _proxy(
         is_stream=is_stream,
         extra_headers=extra_headers,
         background=background,
-        audit_args=(workspace_id, clerk_user_id, ai_tool, provider, model, _audit_decision, _audit_rule_id, started, body, prompt_summary, _user_email, _run_id, _workflow, _workflow_id, _hook_session_id),
+        audit_args=(workspace_id, clerk_user_id, ai_tool, provider, model, _audit_decision, _audit_rule_id, started, body, prompt_summary, _user_email, _run_id, _workflow, _workflow_id, _hook_session_id, _routing_meta),
         upstream_api_key=_upstream_key,
         vendor_key=_vault_key_val,
         provider=provider,

--- a/apps/api/tests/test_guard_proxy_tier_e2e.py
+++ b/apps/api/tests/test_guard_proxy_tier_e2e.py
@@ -110,3 +110,35 @@ def test_cross_provider_prefix_forwards_raw_string(client_and_capture):
     )
     assert r.status_code == 200, r.text
     assert forward_calls[0]["body"]["model"] == "anthropic/balanced"
+
+
+def test_routing_meta_is_threaded_into_audit_args(client_and_capture):
+    """When a tier-form is sent, audit_args[15] must carry the routing_meta dict
+    so guard_audit_events.routing_meta gets populated by the writer."""
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "balanced", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    audit_args = forward_calls[0]["audit_args"]
+    assert len(audit_args) >= 16, "audit_args must include routing_meta at position 15"
+    routing_meta = audit_args[15]
+    assert routing_meta is not None
+    assert routing_meta["tier_form"] == "balanced"
+    assert routing_meta["resolved_model"] == "gpt-4.1"
+    assert routing_meta["endpoint_provider"] == "openai"
+    assert routing_meta["resolution_source"] == "workspace_primitives"
+
+
+def test_routing_meta_is_none_for_concrete_model(client_and_capture):
+    client, forward_calls = client_and_capture
+    r = client.post(
+        "/proxy/openai/v1/chat/completions",
+        headers={"Authorization": "Bearer guard-mt-fake"},
+        json={"model": "gpt-4.1-mini", "messages": [{"role": "user", "content": "hi"}]},
+    )
+    assert r.status_code == 200, r.text
+    audit_args = forward_calls[0]["audit_args"]
+    assert audit_args[15] is None, "concrete model calls must leave routing_meta NULL"

--- a/apps/api/tests/test_guard_proxy_tier_resolution.py
+++ b/apps/api/tests/test_guard_proxy_tier_resolution.py
@@ -21,12 +21,11 @@ def stub_router(monkeypatch):
             "routing_preference": routing_preference,
             "explicit_provider": explicit_provider,
         })
-        # emulate primitives table: cheap/balanced/smart per provider
         table = {
             "anthropic": {"cheap": "claude-haiku-4-5-20251001", "balanced": "claude-sonnet-4-6", "smart": "claude-opus-4-7"},
             "openai":    {"cheap": "gpt-4.1-mini", "balanced": "gpt-4.1", "smart": "gpt-4.1"},
         }
-        return explicit_provider, table[explicit_provider][routing_preference], "stubbed"
+        return explicit_provider, table[explicit_provider][routing_preference], f"stubbed {explicit_provider}/{routing_preference}"
 
     monkeypatch.setattr("app.runtime.model_router.resolve_for_workspace", _fake)
     return calls
@@ -39,14 +38,14 @@ def test_concrete_model_id_passes_through(stub_router):
 
 def test_bare_tier_resolves_via_endpoint_provider(stub_router):
     out = _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="openai", model_field="balanced")
-    assert out == "gpt-4.1"
+    assert out is not None and out[0] == "gpt-4.1"
     assert stub_router[0]["explicit_provider"] == "openai"
     assert stub_router[0]["routing_preference"] == "balanced"
 
 
 def test_provider_prefixed_tier_matches_endpoint(stub_router):
     out = _resolve_tier_form(db=None, workspace_id="ws", endpoint_provider="anthropic", model_field="anthropic/smart")
-    assert out == "claude-opus-4-7"
+    assert out is not None and out[0] == "claude-opus-4-7"
     assert stub_router[-1]["explicit_provider"] == "anthropic"
     assert stub_router[-1]["routing_preference"] == "smart"
 
@@ -77,44 +76,44 @@ from app.modules.guard.routers.proxy import _apply_tier_resolution
 
 def test_apply_concrete_model_leaves_body_unchanged(stub_router):
     body = {"model": "gpt-4.1", "messages": []}
-    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    model, meta = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
     assert model == "gpt-4.1"
-    assert tier_form is None
+    assert meta is None
     assert body["model"] == "gpt-4.1"
     assert stub_router == []
 
 
 def test_apply_bare_tier_rewrites_body_and_returns_tier_form(stub_router):
     body = {"model": "balanced", "messages": []}
-    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    model, meta = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
     assert model == "gpt-4.1"
-    assert tier_form == "balanced"
+    assert meta and meta["tier_form"] == "balanced" and meta["resolved_model"] == "gpt-4.1"
+    assert meta["endpoint_provider"] == "openai"
     assert body["model"] == "gpt-4.1"
-    # order matters: helper must call resolver before mutating body
     assert stub_router[0]["explicit_provider"] == "openai"
 
 
 def test_apply_provider_prefixed_tier(stub_router):
     body = {"model": "anthropic/smart", "messages": []}
-    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="anthropic", body=body)
+    model, meta = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="anthropic", body=body)
     assert model == "claude-opus-4-7"
-    assert tier_form == "anthropic/smart"
+    assert meta and meta["tier_form"] == "anthropic/smart"
     assert body["model"] == "claude-opus-4-7"
 
 
 def test_apply_cross_provider_prefix_is_ignored(stub_router):
     body = {"model": "anthropic/balanced", "messages": []}
-    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    model, meta = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
     # endpoint provider is authoritative; cross-provider prefix returns None
     assert model == "anthropic/balanced"
-    assert tier_form is None
+    assert meta is None
     assert body["model"] == "anthropic/balanced"
     assert stub_router == []
 
 
 def test_apply_missing_model_field_returns_unknown(stub_router):
     body = {"messages": []}
-    model, tier_form = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
+    model, meta = _apply_tier_resolution(db=None, workspace_id="ws", endpoint_provider="openai", body=body)
     assert model == "unknown"
-    assert tier_form is None
+    assert meta is None
     assert "model" not in body

--- a/apps/web/src/components/guard/ActivityRow.tsx
+++ b/apps/web/src/components/guard/ActivityRow.tsx
@@ -42,6 +42,13 @@ export interface AuditEvent {
   // #1150 phase 2 — layered verdict envelope
   evaluated_rules?: Array<{ rule_id: string | null; severity?: string; action?: string }> | null
   defense_score?: number | null
+  routing_meta?: {
+    tier_form?: string | null
+    resolved_model?: string | null
+    endpoint_provider?: string | null
+    reason?: string | null
+    resolution_source?: string | null
+  } | null
 }
 
 const TOOL_COLORS: Record<string, string> = {
@@ -485,6 +492,19 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
           <div>
             <span style={{ color: "var(--text-muted)", fontWeight: 600, marginRight: 6 }}>Model</span>
             <span className="mono" style={{ color: "var(--text-2)" }}>{[ev.provider, ev.model].filter(Boolean).join(" / ")}</span>
+          </div>
+        )}
+        {ev.routing_meta && (
+          <div>
+            <span style={{ color: "var(--text-muted)", fontWeight: 600, marginRight: 6 }}>Routed</span>
+            <span className="mono" style={{ color: "var(--text-2)" }}>
+              {ev.routing_meta.tier_form ?? "?"} → {ev.routing_meta.resolved_model ?? ev.model ?? "?"}
+            </span>
+            {ev.routing_meta.resolution_source && (
+              <span style={{ color: "var(--text-muted)", marginLeft: 6, fontSize: 11 }}>
+                via {ev.routing_meta.resolution_source.replace(/_/g, " ")}
+              </span>
+            )}
           </div>
         )}
         {ev.rule_id && (


### PR DESCRIPTION
Fourth PR in the #1347 epic. Persists the tier-form resolution into the audit trail so operators can prove which primitives decision drove each LLM call. Logs rotate; audit rows are hash-chained and retained per compliance policy.

## What ships
- Schema revision 0104 adds nullable JSONB column routing_meta on guard_audit_events. NULL for concrete-model calls, populated only when a tier-form was rewritten.
- audit.record() gains kwarg routing_meta; INSERT casts to jsonb.
- app.guard.router threads routing_meta through audit_args[15] in both stream and non-stream dispatch sites.
- proxy._apply_tier_resolution now returns (model, routing_meta_dict|None) with fields: tier_form, resolved_model, endpoint_provider, reason, resolution_source.
- structlog line now includes the resolver reason string.

## Tests
- 11 existing tier tests migrated to the new signature
- 2 new E2E tests: routing_meta threaded for tier-form calls, stays None for concrete-model calls
- 61/61 pass across proxy + model_router + primitives sweep

## Verification query after merge
Once your primitives row exists and a run fires a tier-form call:
```
SELECT ts, provider, model, routing_meta
FROM guard_audit_events
WHERE workspace_id = 'YOUR_WS_ID' AND routing_meta IS NOT NULL
ORDER BY ts DESC LIMIT 20;
```

## Follow-ups (deliberately not in this PR)
- Guard Activity UI badge for rows where routing_meta.resolution_source = 'workspace_primitives'
- Compliance export inclusion

Refs: #1347. Follows #1356.