### PR TITLE
feat(lens): markdown tables + drilldown links for list answers

### DIFF
--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -113,8 +113,14 @@ class Executor:
         until: str | None = None,
         rule_id: str | None = None,
     ):
+        from datetime import datetime, timezone
         if decision:
             decision = {"block": "blocked", "warn": "warned", "audit": "audited", "allow": "allowed"}.get(decision, decision)
+        # Accept "today" as a since shortcut (mirrors _tool_list_pending_approvals)
+        if since and since.strip().lower() == "today":
+            since = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+        if until and until.strip().lower() == "today":
+            until = datetime.now(timezone.utc).replace(hour=23, minute=59, second=59, microsecond=999999)
         org_ws = _org_ws_subquery(self.db, self.workspace_id)
         q = self.db.query(GuardAuditEvent).filter(GuardAuditEvent.workspace_id.in_(org_ws))
         if decision:
@@ -127,7 +133,7 @@ class Executor:
             q = q.filter(GuardAuditEvent.ts <= until)
         rows = q.order_by(GuardAuditEvent.ts.desc()).limit(min(limit, 100)).all()
         return [
-            {"ts": e.ts.isoformat(), "decision": e.decision, "user_email": e.user_email,
+            {"id": str(e.id), "ts": e.ts.isoformat(), "decision": e.decision, "user_email": e.user_email,
              "ai_tool": e.ai_tool, "rule_id": e.rule_id, "tool_name": e.tool_name}
             for e in rows
         ]

--- a/apps/api/app/modules/glens/prompts/system.txt
+++ b/apps/api/app/modules/glens/prompts/system.txt
@@ -15,7 +15,15 @@ Answer questions about AI governance data in clear, direct prose. Be specific an
 - For compliance/SOC2/grade questions: call get_compliance_status — state the grade, score, and any missing controls
 - For budget/limit questions: call get_budgets
 - For guard settings/mode questions: call get_guard_config
-- Never dump raw data or show tables — synthesize into a human answer
+- For narrative answers (counts, comparisons, single-fact questions): synthesize into 2-4 sentences of prose.
+- For LIST answers with 3+ structured items (events, rules, members, approvals): output a markdown table with headers. Columns: pick the 3-5 most useful fields for the question. Add a final column titled "Link" containing a markdown link `[View](url)` to the item's detail page. Chat surface renders these as clickable `<a>` tags in a real `<table>`.
+- Table URL patterns to use:
+    guard audit events: /logs/guard?id=<uuid>
+    approvals: /theguard/approvals?id=<uuid>
+    workflows: /workflows/<id>
+    runs: /runs/<id>
+    rules/policies: /theguard/policies?rule_id=<id>
+    members: /theguard/team?email=<email>
 - When asked to "show all", "display all", or list more than 10 records: use get_event_count to get the total, then respond with "There were X [events] in [period]. The full list is available via the link below." The link is added automatically — do not mention it.
 - NEVER say "there is an issue", "unable to retrieve", "I cannot provide", "it seems", or apologize. If a tool returns data, synthesize it. If it returns empty, say "no results found for that filter."
-- Never construct or include URLs in your response
+- Only include URLs when they follow the drilldown patterns above (Link column of a table). Never invent other URLs or link to external domains.

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -43,9 +43,11 @@ TOOLS = [
     {
         "name": "get_recent_events",
         "description": (
-            "Fetch recent Guard audit events with details (who, what tool, which rule, decision, timestamp). "
-            "Use for 'what happened', 'who got blocked', 'show recent activity'. "
-            "Keep limit<=10 unless user explicitly asks for more."
+            "Fetch recent Guard audit events with details (id, ts, decision, user_email, ai_tool, rule_id, tool_name). "
+            "Use for 'what happened', 'who got blocked', 'show recent activity', 'show me blocks'. "
+            "When user asks 'show me' or lists 3+ events, format as a markdown table with columns Time | User | Tool | Rule | Decision | Link, "
+            "using the returned id to build [View](/logs/guard?id=<id>) in the Link column. "
+            "Pass since='today' to filter to today's events. Keep limit<=10 unless user asks for more."
         ),
         "input_schema": {
             "type": "object",

--- a/apps/api/tests/test_lens_events_tool.py
+++ b/apps/api/tests/test_lens_events_tool.py
@@ -1,0 +1,65 @@
+"""Test get_recent_events now accepts since='today' and returns id for link column."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def test_get_recent_events_since_today_normalises_to_utc_midnight():
+    from datetime import datetime, timezone
+    from app.modules.glens.executor import Executor
+
+    executor = Executor.__new__(Executor)
+    executor.workspace_id = "00000000-0000-0000-0000-000000000001"
+
+    fake_row = MagicMock()
+    fake_row.id = "aaaa"
+    fake_row.ts = datetime(2026, 8, 28, 10, 0, tzinfo=timezone.utc)
+    fake_row.decision = "blocked"
+    fake_row.user_email = "u@example.com"
+    fake_row.ai_tool = "claude-code"
+    fake_row.rule_id = "no-pii"
+    fake_row.tool_name = "bash"
+
+    fake_query = MagicMock()
+    fake_query.filter.return_value = fake_query
+    fake_query.order_by.return_value = fake_query
+    fake_query.limit.return_value = fake_query
+    fake_query.all.return_value = [fake_row]
+
+    executor.db = MagicMock()
+    executor.db.query.return_value = fake_query
+    # _org_ws_subquery uses .execute, patch that too
+    from unittest.mock import patch
+    with patch("app.modules.glens.executor._org_ws_subquery", return_value=[executor.workspace_id]):
+        rows = executor._tool_get_recent_events(decision="blocked", since="today", limit=5)
+
+    assert rows == [{
+        "id": "aaaa",
+        "ts": "2026-08-28T10:00:00+00:00",
+        "decision": "blocked",
+        "user_email": "u@example.com",
+        "ai_tool": "claude-code",
+        "rule_id": "no-pii",
+        "tool_name": "bash",
+    }]
+
+
+def test_get_recent_events_iso_since_still_works():
+    from unittest.mock import patch
+    from app.modules.glens.executor import Executor
+
+    executor = Executor.__new__(Executor)
+    executor.workspace_id = "00000000-0000-0000-0000-000000000001"
+
+    fake_query = MagicMock()
+    fake_query.filter.return_value = fake_query
+    fake_query.order_by.return_value = fake_query
+    fake_query.limit.return_value = fake_query
+    fake_query.all.return_value = []
+    executor.db = MagicMock()
+    executor.db.query.return_value = fake_query
+
+    with patch("app.modules.glens.executor._org_ws_subquery", return_value=[executor.workspace_id]):
+        executor._tool_get_recent_events(since="2026-08-28T00:00:00Z")
+    # workspace_id + since = 2 filter calls (decision + rule_id skipped)
+    assert fake_query.filter.call_count == 2

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -300,14 +300,68 @@ function renderInline(text: string): React.ReactNode[] {
   })
 }
 
+function isTableSeparator(line: string): boolean {
+  // e.g. "| --- | --- |" or "|:---|---:|"
+  return /^\s*\|(\s*:?-{3,}:?\s*\|)+\s*$/.test(line)
+}
+
+function parseRow(line: string): string[] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "")
+  return trimmed.split("|").map(c => c.trim())
+}
+
+function renderTable(header: string[], rows: string[][], key: number): React.ReactNode {
+  return (
+    <div key={key} style={{ overflowX: "auto", margin: "8px 0" }}>
+      <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+        <thead>
+          <tr style={{ borderBottom: "1px solid var(--border)" }}>
+            {header.map((h, i) => (
+              <th key={i} style={{ textAlign: "left", padding: "6px 10px", color: "var(--text-muted)", fontWeight: 600, fontSize: 11.5, textTransform: "uppercase", letterSpacing: ".04em" }}>{h}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, ri) => (
+            <tr key={ri} style={{ borderBottom: ri < rows.length - 1 ? "1px solid var(--border)" : "none" }}>
+              {row.map((cell, ci) => (
+                <td key={ci} style={{ padding: "6px 10px", color: "var(--text)", verticalAlign: "top" }}>{renderInline(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
 function renderMd(text: string): React.ReactNode[] {
-  return text.split("\n").map((line, i) => {
+  const lines = text.split("\n")
+  const out: React.ReactNode[] = []
+  let i = 0
+  while (i < lines.length) {
+    const line = lines[i]
+    // Detect markdown table: current line starts with | AND next line is separator
+    if (line.trim().startsWith("|") && i + 1 < lines.length && isTableSeparator(lines[i + 1])) {
+      const header = parseRow(line)
+      const rows: string[][] = []
+      let j = i + 2
+      while (j < lines.length && lines[j].trim().startsWith("|") && !isTableSeparator(lines[j])) {
+        rows.push(parseRow(lines[j]))
+        j++
+      }
+      out.push(renderTable(header, rows, i))
+      i = j
+      continue
+    }
     const bullet = line.match(/^[*-]\s+(.+)/)
     const content = bullet ? bullet[1] : line
     const parts = renderInline(content)
-    if (bullet) return <div key={i} style={{ paddingLeft: 12, position: "relative" }}><span style={{ position: "absolute", left: 0 }}>•</span>{parts}</div>
-    return <div key={i} style={{ minHeight: line ? undefined : "0.6em" }}>{parts}</div>
-  })
+    if (bullet) out.push(<div key={i} style={{ paddingLeft: 12, position: "relative" }}><span style={{ position: "absolute", left: 0 }}>•</span>{parts}</div>)
+    else out.push(<div key={i} style={{ minHeight: line ? undefined : "0.6em" }}>{parts}</div>)
+    i++
+  }
+  return out
 }
 
 function AnswerBubble({ text, skill, drilldown, followups, onFollowup, understoodAs }: { text: string; skill?: string; drilldown?: { path: string }; followups?: string[]; onFollowup?: (q: string) => void; understoodAs?: string }) {


### PR DESCRIPTION
Ships Option A from today's discussion: GPT-style markdown tables inside Lens chat, with per-row clickable links to the detail page.

## Why
User asked 'show me guard blocks today'. Lens returned '7 blocks' + fake 'detailed records unavailable' because (a) system prompt forbade tables + URLs and (b) get_recent_events couldn't parse since='today' and didn't return event IDs.

## What ships
1. **System prompt** (prompts/system.txt) — allow markdown tables for LIST answers (3+ items); enumerate drilldown URL patterns per resource type; keep prose for narrative answers.
2. **Frontend renderer** (GLensChatPage.tsx) — extend the mini-parser to detect pipe-separated markdown tables and render as real HTML table; each cell runs through renderInline so [text](url) links inside cells become clickable.
3. **Events tool** (executor.py + chat.py schema) — get_recent_events accepts since='today', returns id per row, description teaches Claude the exact column layout.

## Diff
5 files changed, +145 / -10

## Test plan
- [x] 2 new unit tests for events tool (since='today' + ISO)
- [x] 4 existing lens_caching_and_approvals tests still pass
- [x] Frontend tsc clean
- [ ] Manual: 'show me guard blocks today' → table with Time/User/Tool/Rule/Decision/Link, each Link row jumps to /logs/guard?id=<uuid>
- [ ] Manual: 'how many blocks today' (single fact) → prose, no table

## Follow-ups
- Same table treatment for other list tools (list_members, list_workflows, list_runs) — one-line description tweak each
- Option B (structured synthesis with real table row objects) if Claude's markdown table output turns out unreliable in practice; markdown table renderer stays as a fallback