### PR TITLE
fix(api): schema drift Phase 3d — model-only (D1 + D2)

### DIFF
--- a/apps/api/app/models/workspace.py
+++ b/apps/api/app/models/workspace.py
@@ -22,7 +22,9 @@ class Workspace(Base):
 
     org_id = Column(UUID(as_uuid=True), ForeignKey("organizations.id", ondelete="SET NULL"), nullable=True)
     # Added by revision 0066 — model was missing it (#1284).
-    clerk_org_id = sa.Column(sa.Text(), nullable=True, index=True)
+    # Partial unique index (see __table_args__): one Clerk org ↔ one workspace,
+    # NULLs allowed for workspaces not yet linked to Clerk.
+    clerk_org_id = sa.Column(sa.Text(), nullable=True)
 
     # Authoritative pointer to the Security Automation project for this workspace.
     # See conductai#1005 — replaces .first() dispatch roulette for security_loop /
@@ -31,6 +33,15 @@ class Workspace(Base):
         UUID(as_uuid=True),
         ForeignKey("projects.id", ondelete="SET NULL"),
         nullable=True,
+    )
+
+    __table_args__ = (
+        sa.Index(
+            "ix_workspaces_clerk_org_id",
+            "clerk_org_id",
+            unique=True,
+            postgresql_where=sa.text("clerk_org_id IS NOT NULL"),
+        ),
     )
 
     organization = relationship("Organization", back_populates="workspaces")

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -203,6 +203,14 @@ class GuardAuditEvent(Base):
     # Only populated when the caller sent a tier form ("balanced" etc.);
     # NULL when a concrete model ID was forwarded straight through.
     routing_meta    = Column(JSONB, nullable=True)
+    # Added by revision 0102 (#1340) — was already read by _event_to_dict via
+    # getattr hotfix (#1338). Declaring on ORM closes schema drift.
+    # ondelete=SET NULL: audit history must survive identity deletion.
+    agent_identity_id = Column(
+        String(36),
+        ForeignKey("agent_identities.id", ondelete="SET NULL"),
+        nullable=True,
+    )
 
     __table_args__ = (
         Index("ix_guard_audit_events_source", "workspace_id", "source", "ts"),
@@ -218,6 +226,7 @@ class GuardAuditEvent(Base):
             postgresql_using="gin",
         ),
         Index("ix_guard_audit_events_ws_ts", "workspace_id", sa.text("ts DESC")),
+        Index("ix_guard_audit_events_agent_identity_id", "agent_identity_id"),
     )
 
 


### PR DESCRIPTION
## Summary

Session 1, PR B of the schema-drift cleanup plan. **Model-only, zero migration.** Closes 2 real-drift decisions:

- **D1** — `GuardAuditEvent.agent_identity_id` Column + Index added to ORM. DB already has both (migration 0102 / #1340). Code was reading via `getattr` hotfix (#1338); this closes the drift properly.
- **D2** — `workspaces.clerk_org_id` moved from plain `index=True` on Column to `__table_args__` partial unique Index matching the DB (`unique=True, postgresql_where=... IS NOT NULL`).

**D3** (`workspace_instructions` constraint→index rename) deferred to the migration PR that follows, because it needs a `DROP CONSTRAINT ... RENAME TO` and I can't introspect the DB constraint name without a running instance.

## Verification

- Smoke-imported both models under py3.11 — `agent_identity_id` present + nullable, `ix_guard_audit_events_agent_identity_id` index present, `ix_workspaces_clerk_org_id` present + unique.
- Zero migration file added.
- Zero business logic changed.

## Test plan

- [ ] CI green (17 pre-existing failures acceptable; anything new = block)
- [ ] `test_alembic_check_no_schema_drift` op count drops (D1 + D2 = ~4 fewer ops)
- [ ] Merge order: this after #1331, before PR C (migration 0106)

🤖 Generated with [Claude Code](https://claude.com/claude-code)