### PR TITLE
fix(api): schema drift Session 2 PR 2a — FK name backfill

### DIFF
--- a/apps/api/app/models/mcp_server.py
+++ b/apps/api/app/models/mcp_server.py
@@ -11,8 +11,16 @@ class McpServer(Base):
     __tablename__ = "mcp_servers"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
-    environment_id = Column(UUID(as_uuid=True), ForeignKey("environments.id"), nullable=True)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE", name="mcp_servers_workspace_id_fkey"),
+        nullable=False,
+    )
+    environment_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("environments.id", ondelete="SET NULL", name="mcp_servers_environment_id_fkey"),
+        nullable=True,
+    )
     name = Column(String, nullable=False)
     url = Column(Text, nullable=False)
     transport = Column(String, nullable=False, default="http")

--- a/apps/api/app/modules/glens/models.py
+++ b/apps/api/app/modules/glens/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from app.core.database import Base
@@ -11,7 +11,12 @@ class GlensChatSession(Base):
     __tablename__ = "glens_chat_sessions"
 
     id           = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    workspace_id = Column(PG_UUID(as_uuid=True), nullable=False, index=True)
+    workspace_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE", name="glens_chat_sessions_workspace_id_fkey"),
+        nullable=False,
+        index=True,
+    )
     title        = Column(String, nullable=False)
     messages     = Column(Text, nullable=False, default="[]")
     context_summary = Column(Text, nullable=True)

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -93,7 +93,12 @@ class GuardMemberConfig(Base):
         default=lambda: datetime.now(timezone.utc),
     )
     # Added by revision 0062 — model was missing this FK (#1284).
-    agent_identity_id = Column(String(36), ForeignKey("agent_identities.id"), nullable=True, index=True)
+    agent_identity_id = Column(
+        String(36),
+        ForeignKey("agent_identities.id", ondelete="SET NULL", name="fk_guard_member_config_agent_identity"),
+        nullable=True,
+        index=True,
+    )
 
 
 class GuardSession(Base):


### PR DESCRIPTION
## Summary

Session 2 PR 2a. **Model-only, zero migration.** Aligns 4 ForeignKey declarations with the DB names that were set by their original migrations, closing 4 remove_fk + add_fk drift pairs from alembic check.

Also adds missing \`ondelete=\` clauses that were on the DB but not in the ORM (a second latent drift the FK-name work exposes).

| Table | Column | Name (from migration) | ondelete |
|---|---|---|---|
| \`mcp_servers\` | \`workspace_id\` | \`mcp_servers_workspace_id_fkey\` | CASCADE |
| \`mcp_servers\` | \`environment_id\` | \`mcp_servers_environment_id_fkey\` | SET NULL |
| \`glens_chat_sessions\` | \`workspace_id\` | \`glens_chat_sessions_workspace_id_fkey\` | CASCADE |
| \`guard_member_config\` | \`agent_identity_id\` | \`fk_guard_member_config_agent_identity\` | SET NULL |

Sources verified against migrations 0018, 0076, 0062.

## Notable

\`glens_chat_sessions.workspace_id\` was previously declared WITHOUT a ForeignKey at all — only \`nullable=False, index=True\`. This adds the missing FK relationship to match the DB.

## Verification

- Smoke-imported 3 models → all 4 FKs load, all names + ondelete match expectation
- Zero migration file added
- \`ForeignKey\` import added to \`glens/models.py\`

## Test plan

- [ ] CI green (17 pre-existing failures acceptable; anything new = block)
- [ ] Drift op count drops by 8 (4 remove_fk + 4 add_fk pairs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)