### PR TITLE
fix(api): schema drift Session 2 PR 2b — UniqueConstraint name backfill

### DIFF
--- a/apps/api/app/models/mcp_server.py
+++ b/apps/api/app/models/mcp_server.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -22,4 +22,8 @@ class McpServer(Base):
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "name", name="uq_mcp_server_name_per_workspace"),
     )

--- a/apps/api/app/models/model_routing_policy.py
+++ b/apps/api/app/models/model_routing_policy.py
@@ -20,3 +20,7 @@ class ModelRoutingPolicy(Base):
     model_id = sa.Column(sa.Text(), nullable=False)
     reason = sa.Column(sa.Text(), nullable=False, server_default="")
     enabled = sa.Column(sa.Boolean(), nullable=False, server_default="true")
+
+    __table_args__ = (
+        sa.UniqueConstraint("category", "preference", name="uq_routing_category_preference"),
+    )

--- a/apps/api/app/models/project.py
+++ b/apps/api/app/models/project.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey, Text
+from sqlalchemy import Column, String, DateTime, ForeignKey, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -16,6 +16,10 @@ class Project(Base):
     project_type = Column(String(32), nullable=False, default="user")
     security_finding_id = Column(String(36), nullable=True, index=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        UniqueConstraint("workspace_id", "slug", name="uq_projects_slug_workspace"),
+    )
 
     workspace = relationship("Workspace", back_populates="projects", foreign_keys=[workspace_id])
     workflows = relationship("Workflow", back_populates="project")

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -488,6 +488,13 @@ class DiscoveredAgent(Base):
     first_seen_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     last_seen_at  = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id", "framework", "source",
+            name="uq_discovered_agents_workspace_framework_source",
+        ),
+    )
+
 
 class GuardVerifyRun(Base):
     """Persisted result of a Guard Verify adversarial test battery execution."""
@@ -525,7 +532,7 @@ class GuardKnowledgeIndex(Base):
     )
 
     __table_args__ = (
-        UniqueConstraint("workspace_id", "source_kind", "source_id", name="uq_guard_knowledge_source"),
+        UniqueConstraint("workspace_id", "source_kind", "source_id", name="guard_knowledge_index_workspace_id_source_kind_source_id_key"),
     )
 
 


### PR DESCRIPTION
## Summary

Session 2 PR 2b. **Model-only, zero migration.** Declares 5 UniqueConstraints in the ORM to match the names already set by their original migrations, closing ~6 drift ops (5 remove_constraint + 1 add_constraint name mismatch).

| Table | Columns | Name (from migration) |
|---|---|---|
| \`mcp_servers\` | \`(workspace_id, name)\` | \`uq_mcp_server_name_per_workspace\` |
| \`model_routing_policies\` | \`(category, preference)\` | \`uq_routing_category_preference\` |
| \`projects\` | \`(workspace_id, slug)\` | \`uq_projects_slug_workspace\` |
| \`discovered_agents\` | \`(workspace_id, framework, source)\` | \`uq_discovered_agents_workspace_framework_source\` |
| \`guard_knowledge_index\` | \`(workspace_id, source_kind, source_id)\` | \`guard_knowledge_index_workspace_id_source_kind_source_id_key\` |

Sources verified against migrations 0001, 0007, 0018, 0051, 0079.

## Notable

4 of 5 models were missing \`__table_args__\` entirely. \`GuardKnowledgeIndex\` had the constraint declared but with an ORM-invented name (\`uq_guard_knowledge_source\`); DB uses the Postgres-auto name from raw SQL \`CREATE TABLE\`. Renamed to match.

## Verification

- Smoke-imported all 5 models — UniqueConstraints load with expected names
- Zero migration file added
- \`UniqueConstraint\` imports added to \`mcp_server.py\` and \`project.py\`

## Test plan

- [ ] CI green (17 pre-existing failures acceptable; anything new = block)
- [ ] Drift op count drops by ~6

🤖 Generated with [Claude Code](https://claude.com/claude-code)