### PR TITLE
fix(api): schema drift Session 3 PR 3a — audit/discovery/watchdog indexes

### DIFF
--- a/apps/api/app/models/audit_log.py
+++ b/apps/api/app/models/audit_log.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 import sqlalchemy as sa
-from sqlalchemy import Column, String, DateTime, Text
+from sqlalchemy import Column, String, DateTime, Index, Text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from app.core.database import Base
 
@@ -19,3 +19,8 @@ class AuditLog(Base):
     resource_id = Column(String(255), nullable=True)
     meta = Column("metadata", JSONB, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_audit_log_workspace_created", "workspace_id", "created_at"),
+        Index("ix_audit_log_workspace_action", "workspace_id", "action"),
+    )

--- a/apps/api/app/models/watchdog_event.py
+++ b/apps/api/app/models/watchdog_event.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, CheckConstraint, event
+from sqlalchemy import Column, String, DateTime, CheckConstraint, Index, event
 from sqlalchemy.orm import validates
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from app.core.database import Base
@@ -34,6 +34,8 @@ class WatchdogEvent(Base):
             f"severity IN ({', '.join(repr(s) for s in WATCHDOG_SEVERITIES)})",
             name="ck_watchdog_events_severity",
         ),
+        Index("ix_watchdog_events_workspace_id", "workspace_id"),
+        Index("ix_watchdog_events_created_at", "created_at"),
     )
 
     @validates("event_type")

--- a/apps/api/app/modules/glens/models.py
+++ b/apps/api/app/modules/glens/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, String, Text
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Text
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from app.core.database import Base
@@ -31,3 +31,7 @@ class GlensChatSession(Base):
     created_at   = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc))
     updated_at   = Column(DateTime(timezone=True), default=lambda: datetime.now(timezone.utc),
                           onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_glens_chat_sessions_updated_at", "updated_at"),
+    )

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -464,6 +464,10 @@ class DiscoveryScan(Base):
     started_at     = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     completed_at   = Column(DateTime(timezone=True), nullable=True)
 
+    __table_args__ = (
+        Index("ix_discovery_scans_workspace", "workspace_id"),
+    )
+
 
 class PolicyCertification(Base):
     __tablename__ = "policy_certifications"
@@ -498,6 +502,8 @@ class DiscoveredAgent(Base):
             "workspace_id", "framework", "source",
             name="uq_discovered_agents_workspace_framework_source",
         ),
+        Index("ix_discovered_agents_workspace", "workspace_id"),
+        Index("ix_discovered_agents_scan", "scan_id"),
     )
 
 


### PR DESCRIPTION
## Summary

Session 3 PR 3a. **Model-only, zero migration.** Declares 8 orphan indexes across 5 tables to match the DB (all from original migrations), closing 8 \`remove_index\` drift ops.

| Table | Index | Columns | Migration |
|---|---|---|---|
| \`audit_log\` | \`ix_audit_log_workspace_created\` | \`(workspace_id, created_at)\` | 0001 |
| \`audit_log\` | \`ix_audit_log_workspace_action\` | \`(workspace_id, action)\` | 0001 |
| \`watchdog_events\` | \`ix_watchdog_events_workspace_id\` | \`(workspace_id)\` | 0001 |
| \`watchdog_events\` | \`ix_watchdog_events_created_at\` | \`(created_at)\` | 0001 |
| \`discovery_scans\` | \`ix_discovery_scans_workspace\` | \`(workspace_id)\` | 0044 |
| \`discovered_agents\` | \`ix_discovered_agents_workspace\` | \`(workspace_id)\` | 0044 |
| \`discovered_agents\` | \`ix_discovered_agents_scan\` | \`(scan_id)\` | 0044 |
| \`glens_chat_sessions\` | \`ix_glens_chat_sessions_updated_at\` | \`(updated_at)\` | 0076 |

Also adds \`Index\` import to 3 files that didn't previously import it.

## Verification

- Smoke-imported 5 models — all 8 indexes load with expected names
- Zero migration file added

## Test plan

- [ ] CI green (17 pre-existing failures acceptable; anything new = block)
- [ ] Drift op count drops by 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)