### PR TITLE
fix(lens): get_recent_events attribute crash + open chat links in new tab

### DIFF
--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -134,7 +134,7 @@ class Executor:
         rows = q.order_by(GuardAuditEvent.ts.desc()).limit(min(limit, 100)).all()
         return [
             {"id": str(e.id), "ts": e.ts.isoformat(), "decision": e.decision, "user_email": e.user_email,
-             "ai_tool": e.ai_tool, "rule_id": e.rule_id, "tool_name": e.tool_name}
+             "ai_tool": e.ai_tool, "rule_id": e.rule_id, "tool_call": e.tool_call}
             for e in rows
         ]
 

--- a/apps/api/tests/test_lens_events_tool.py
+++ b/apps/api/tests/test_lens_events_tool.py
@@ -18,7 +18,7 @@ def test_get_recent_events_since_today_normalises_to_utc_midnight():
     fake_row.user_email = "u@example.com"
     fake_row.ai_tool = "claude-code"
     fake_row.rule_id = "no-pii"
-    fake_row.tool_name = "bash"
+    fake_row.tool_call = "bash"
 
     fake_query = MagicMock()
     fake_query.filter.return_value = fake_query
@@ -40,7 +40,7 @@ def test_get_recent_events_since_today_normalises_to_utc_midnight():
         "user_email": "u@example.com",
         "ai_tool": "claude-code",
         "rule_id": "no-pii",
-        "tool_name": "bash",
+        "tool_call": "bash",
     }]
 
 

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -295,7 +295,7 @@ function renderInline(text: string): React.ReactNode[] {
   return text.split(/(\*\*[^*]+\*\*|\[[^\]]+\]\([^)]+\))/).map((p, j) => {
     if (p.startsWith("**")) return <strong key={j}>{p.slice(2, -2)}</strong>
     const link = p.match(/^\[([^\]]+)\]\(([^)]+)\)$/)
-    if (link) return <a key={j} href={link[2]} style={{ color: "var(--accent, #6366f1)", textDecoration: "underline" }}>{link[1]}</a>
+    if (link) return <a key={j} href={link[2]} target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent, #6366f1)", textDecoration: "underline" }}>{link[1]}</a>
     return p
   })
 }


### PR DESCRIPTION
Two follow-up fixes after PR #1362:

1. **Table not rendering** — worker logs show every get_recent_events call raised AttributeError: 'GuardAuditEvent' object has no attribute 'tool_name'. Real column is tool_call. Claude got the error, fell back to prose 'detailed event list is currently unavailable due to a data issue'. Pre-existing bug; surfaced now because the new system prompt tells Claude to call this tool for 'show me' queries.

2. **Chat links open in new tab** — user asked for target=_blank so drilldowns don't navigate away from the live Lens session. Added rel=noopener noreferrer for safety.

3 files, +4 / -4. 6 tests pass, tsc clean.