### PR TITLE
fix(api): schema drift Session 3 PR 3b — guard module indexes (12 across 6 tables)

### DIFF
--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -153,6 +153,11 @@ class GuardNotificationChannel(Base):
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
+    __table_args__ = (
+        Index("idx_guard_notif_workspace_action", "workspace_id", "action"),
+        Index("idx_guard_notif_workspace_enabled", "workspace_id", "enabled"),
+    )
+
 
 class GuardAuditEvent(Base):
     __tablename__ = "guard_audit_events"
@@ -294,6 +299,19 @@ class GuardSpendBudget(Base):
         onupdate=lambda: datetime.now(timezone.utc),
     )
 
+    __table_args__ = (
+        Index(
+            "uq_guard_spend_workspace_default", "workspace_id",
+            unique=True,
+            postgresql_where=sa.text("clerk_user_id IS NULL"),
+        ),
+        Index(
+            "uq_guard_spend_workspace_member", "workspace_id", "clerk_user_id",
+            unique=True,
+            postgresql_where=sa.text("clerk_user_id IS NOT NULL"),
+        ),
+    )
+
 
 class GuardRateLimit(Base):
     """Per-workspace / per-agent-identity RPM+TPM caps (#980).
@@ -321,6 +339,7 @@ class GuardRateLimit(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "agent_identity_id", name="uq_guard_rate_limits_scope"),
+        Index("idx_guard_rate_limits_ws", "workspace_id"),
     )
 
 
@@ -416,6 +435,10 @@ class GuardRuleOverride(Base):
     expires_at       = Column(DateTime(timezone=True), nullable=True)
     use_audited_at    = Column(DateTime(timezone=True), nullable=True)
     expiry_audited_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (
+        Index("ix_guard_rule_overrides_workspace", "workspace_id"),
+    )
 
 
 class GuardPolicyCache(Base):
@@ -538,6 +561,13 @@ class GuardKnowledgeIndex(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "source_kind", "source_id", name="guard_knowledge_index_workspace_id_source_kind_source_id_key"),
+        Index("guard_knowledge_index_workspace_id_source_kind_idx", "workspace_id", "source_kind"),
+        Index(
+            "guard_knowledge_index_embedding_idx", "embedding",
+            postgresql_using="ivfflat",
+            postgresql_ops={"embedding": "vector_cosine_ops"},
+            postgresql_with={"lists": "100"},
+        ),
     )
 
 
@@ -568,6 +598,19 @@ class GuardApprovalRequest(Base):
 
     surface    = Column(String(50), nullable=False, default="unknown")
     session_id = Column(String(255), nullable=True)
+
+    __table_args__ = (
+        Index("idx_guard_approvals_ws_status", "workspace_id", "status", "created_at"),
+        Index("idx_guard_approvals_ws_requester", "workspace_id", "requester_email"),
+        Index(
+            "idx_guard_approvals_source_run", "source_run_id",
+            postgresql_where=sa.text("source_run_id IS NOT NULL"),
+        ),
+        Index(
+            "idx_guard_approvals_pending_timeout", "timeout_at",
+            postgresql_where=sa.text("status = 'pending'"),
+        ),
+    )
 
     source_run_id   = Column(UUID(as_uuid=True), ForeignKey("runs.id", ondelete="SET NULL"), nullable=True)
     source_block_id = Column(String(255), nullable=True)


### PR DESCRIPTION
## Summary

Session 3 PR 3b. **Model-only, zero migration.** Declares 12 orphan indexes across 6 Guard tables to match the DB, closing 12 remove_index drift ops.

| Table | Index | Cols/where | Migration |
|---|---|---|---|
| \`guard_approval_requests\` | \`idx_guard_approvals_ws_status\` | \`(workspace_id, status, created_at)\` | 0093 |
| \`guard_approval_requests\` | \`idx_guard_approvals_ws_requester\` | \`(workspace_id, requester_email)\` | 0093 |
| \`guard_approval_requests\` | \`idx_guard_approvals_source_run\` | \`(source_run_id) WHERE source_run_id IS NOT NULL\` | 0093 |
| \`guard_approval_requests\` | \`idx_guard_approvals_pending_timeout\` | \`(timeout_at) WHERE status = 'pending'\` | 0093 |
| \`guard_notification_channels\` | \`idx_guard_notif_workspace_action\` | \`(workspace_id, action)\` | 0092 |
| \`guard_notification_channels\` | \`idx_guard_notif_workspace_enabled\` | \`(workspace_id, enabled)\` | 0092 |
| \`guard_spend_budgets\` | \`uq_guard_spend_workspace_default\` | \`UNIQUE(workspace_id) WHERE clerk_user_id IS NULL\` | 0001 |
| \`guard_spend_budgets\` | \`uq_guard_spend_workspace_member\` | \`UNIQUE(workspace_id, clerk_user_id) WHERE NOT NULL\` | 0001 |
| \`guard_rate_limits\` | \`idx_guard_rate_limits_ws\` | \`(workspace_id)\` | 0096 |
| \`guard_rule_overrides\` | \`ix_guard_rule_overrides_workspace\` | \`(workspace_id)\` | 0017 |
| \`guard_knowledge_index\` | \`guard_knowledge_index_workspace_id_source_kind_idx\` | \`(workspace_id, source_kind)\` | 0079 |
| \`guard_knowledge_index\` | \`guard_knowledge_index_embedding_idx\` | \`ivfflat(embedding) WITH (lists=100), cosine\` | 0079 |

Sources verified against migrations 0001, 0017, 0079, 0092, 0093, 0096.

Partial indexes (\`postgresql_where\`) preserve the exact WHERE clauses. The pgvector ivfflat index uses \`postgresql_using + postgresql_ops + postgresql_with\` to match the CREATE INDEX USING ivfflat declared in raw SQL in migration 0079.

## Verification

- Smoke-imported 6 models — all 12 indexes load with correct names

## Test plan

- [ ] CI green (17 pre-existing failures acceptable)
- [ ] Drift op count drops by 12

🤖 Generated with [Claude Code](https://claude.com/claude-code)