### PR TITLE
fix(api): schema drift Session 3 PR 3c — runtime/analytics indexes (11 across 6 tables)

### DIFF
--- a/apps/api/app/models/run_analytics_event.py
+++ b/apps/api/app/models/run_analytics_event.py
@@ -10,7 +10,7 @@ import uuid
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Column, Integer, Numeric, String, Text
+from sqlalchemy import Column, Index, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -40,4 +40,9 @@ class RunAnalyticsEvent(Base):
         sa.DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_run_analytics_events_playbook_slug_created_at", "playbook_slug", "created_at"),
+        Index("ix_run_analytics_events_workspace_id_created_at", "workspace_id", "created_at"),
     )

--- a/apps/api/app/models/run_block_state.py
+++ b/apps/api/app/models/run_block_state.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Column, String, Boolean, Integer, DateTime, ForeignKey
+from sqlalchemy import Column, String, Boolean, Integer, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 from app.core.database import Base
@@ -36,4 +36,8 @@ class RunBlockState(Base):
         DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_run_block_states_run_id", "run_id"),
     )

--- a/apps/api/app/models/run_online_score.py
+++ b/apps/api/app/models/run_online_score.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Boolean, Column, Integer, Numeric, String, Text
+from sqlalchemy import Boolean, Column, Index, Integer, Numeric, String, Text
 from sqlalchemy.dialects.postgresql import JSONB, UUID
 
 from app.core.database import Base
@@ -32,6 +32,11 @@ class RunOnlineScore(Base):
         sa.DateTime(timezone=True),
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_run_online_scores_grade", "grade"),
+        Index("ix_run_online_scores_scored_at", "scored_at"),
     )
 
 

--- a/apps/api/app/models/run_trace.py
+++ b/apps/api/app/models/run_trace.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 import sqlalchemy as sa
-from sqlalchemy import Column, String, DateTime, Integer, Text, ForeignKey
+from sqlalchemy import Column, String, DateTime, Integer, Text, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -23,5 +23,10 @@ class RunTrace(Base):
     output_tokens = Column(Integer, nullable=True)
     duration_ms = Column(Integer, nullable=True)
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_run_traces_run_id", "run_id"),
+        Index("ix_run_traces_run_id_block_turn", "run_id", "block_id", "turn"),
+    )
 
     run = relationship("Run", backref="traces")

--- a/apps/api/app/models/team_session_memory.py
+++ b/apps/api/app/models/team_session_memory.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, Text, Float, DateTime, ForeignKey
+from sqlalchemy import Column, String, Text, Float, DateTime, ForeignKey, Index, text
 from sqlalchemy.dialects.postgresql import UUID, ARRAY, JSONB
 from pgvector.sqlalchemy import Vector
 from app.core.database import Base
@@ -25,3 +25,14 @@ class TeamSessionMemory(Base):
     confidence = Column(Float, nullable=False, default=0.5)
     visibility = Column(String(20), nullable=False, default="team")
     created_at = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_tsm_workspace_repo", "workspace_id", "repo_full_name"),
+        Index(
+            "ix_tsm_hnsw", "embedding",
+            postgresql_using="hnsw",
+            postgresql_ops={"embedding": "vector_cosine_ops"},
+            postgresql_with={"m": "16", "ef_construction": "64"},
+            postgresql_where=text("embedding IS NOT NULL"),
+        ),
+    )

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -352,6 +352,11 @@ class SessionReport(Base):
         default=lambda: datetime.now(timezone.utc),
     )
 
+    __table_args__ = (
+        Index("ix_session_reports_workspace", "workspace_id"),
+        Index("ix_session_reports_email", "developer_email"),
+    )
+
 
 # ── Skill Pack Model ───────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Session 3 PR 3c. **Model-only, zero migration.** Declares 11 orphan indexes across 6 runtime/analytics tables to match the DB, closing 11 remove_index drift ops.

| Table | Index | Cols/where | Migration |
|---|---|---|---|
| \`run_analytics_events\` | \`ix_run_analytics_events_playbook_slug_created_at\` | \`(playbook_slug, created_at)\` | 0001 |
| \`run_analytics_events\` | \`ix_run_analytics_events_workspace_id_created_at\` | \`(workspace_id, created_at)\` | 0001 |
| \`run_block_states\` | \`ix_run_block_states_run_id\` | \`(run_id)\` | 0078 |
| \`run_online_scores\` | \`ix_run_online_scores_grade\` | \`(grade)\` | 0001 |
| \`run_online_scores\` | \`ix_run_online_scores_scored_at\` | \`(scored_at)\` | 0001 |
| \`run_traces\` | \`ix_run_traces_run_id\` | \`(run_id)\` | 0001 |
| \`run_traces\` | \`ix_run_traces_run_id_block_turn\` | \`(run_id, block_id, turn)\` | 0001 |
| \`team_session_memory\` | \`ix_tsm_workspace_repo\` | \`(workspace_id, repo_full_name)\` | 0001 |
| \`team_session_memory\` | \`ix_tsm_hnsw\` | \`hnsw(embedding) WITH (m=16, ef=64), cosine, WHERE NOT NULL\` | 0001 |
| \`session_reports\` | \`ix_session_reports_workspace\` | \`(workspace_id)\` | 0001 |
| \`session_reports\` | \`ix_session_reports_email\` | \`(developer_email)\` | 0001 |

Sources verified against migrations 0001 and 0078. pgvector HNSW index preserved with \`postgresql_using + postgresql_ops + postgresql_with + postgresql_where\` matching the raw SQL.

## Verification

- Smoke-imported 6 models — all 11 indexes load with correct names
- Zero migration file added

## Test plan

- [ ] CI green (17 pre-existing failures acceptable)
- [ ] Drift op count drops by 11

🤖 Generated with [Claude Code](https://claude.com/claude-code)