### PR TITLE
fix(api): schema drift Session 3 PR 3d — integrations/mcp/misc indexes (12 across 7 tables)

### DIFF
--- a/apps/api/app/models/integration.py
+++ b/apps/api/app/models/integration.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, Text, DateTime, ForeignKey, UniqueConstraint, Boolean
+from sqlalchemy import Column, String, Text, DateTime, ForeignKey, Index, UniqueConstraint, Boolean
 from sqlalchemy.dialects.postgresql import UUID, ARRAY
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -21,7 +21,7 @@ class Integration(Base):
     environment_id = Column(UUID(as_uuid=True), ForeignKey("environments.id"), nullable=True)
     # Okta JWT auth (#1056). okta_issuer indexed — reverse lookup from an
     # unverified JWT `iss` to the workspace that trusts it. NULL on non-Okta rows.
-    okta_issuer = Column(String(500), nullable=True, index=True)
+    okta_issuer = Column(String(500), nullable=True)
     okta_audience = Column(String(500), nullable=True)
     okta_auth_enabled = Column(Boolean, nullable=False, default=False, server_default="false")
 
@@ -30,4 +30,7 @@ class Integration(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "handle", "environment_id", name="uq_integrations_workspace_handle_env"),
+        Index("ix_integrations_workspace_id", "workspace_id"),
+        Index("ix_integrations_workspace_environment", "workspace_id", "environment_id"),
+        Index("idx_integrations_okta_issuer", "okta_issuer"),
     )

--- a/apps/api/app/models/mcp_server.py
+++ b/apps/api/app/models/mcp_server.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text, UniqueConstraint
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -34,4 +34,6 @@ class McpServer(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "name", name="uq_mcp_server_name_per_workspace"),
+        Index("ix_mcp_servers_workspace", "workspace_id"),
+        Index("ix_mcp_servers_environment", "environment_id"),
     )

--- a/apps/api/app/models/playbook_submission.py
+++ b/apps/api/app/models/playbook_submission.py
@@ -2,7 +2,7 @@ import uuid
 from datetime import datetime, timezone
 
 import sqlalchemy as sa
-from sqlalchemy import Column, String, Integer, Text, DateTime
+from sqlalchemy import Column, DateTime, Index, Integer, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -47,4 +47,9 @@ class PlaybookSubmission(Base):
         nullable=False,
         default=lambda: datetime.now(timezone.utc),
         onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_playbook_submissions_slug", "slug"),
+        Index("ix_playbook_submissions_status", "status"),
     )

--- a/apps/api/app/models/project.py
+++ b/apps/api/app/models/project.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey, Text, UniqueConstraint
+from sqlalchemy import Column, String, DateTime, ForeignKey, Index, Text, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -19,6 +19,12 @@ class Project(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "slug", name="uq_projects_slug_workspace"),
+        Index("ix_projects_project_type", "project_type"),
+        Index(
+            "projects_workspace_security_automation_uniq", "workspace_id",
+            unique=True,
+            postgresql_where=text("project_type = 'security_automation'"),
+        ),
     )
 
     workspace = relationship("Workspace", back_populates="projects", foreign_keys=[workspace_id])

--- a/apps/api/app/models/workspace_config.py
+++ b/apps/api/app/models/workspace_config.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, String, DateTime, ForeignKey, UniqueConstraint
+from sqlalchemy import Column, String, DateTime, ForeignKey, Index, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID
 
 from app.core.database import Base
@@ -19,4 +19,5 @@ class WorkspaceConfig(Base):
 
     __table_args__ = (
         UniqueConstraint("workspace_id", "key", name="uq_workspace_config_ws_key"),
+        Index("ix_workspace_config_workspace_id", "workspace_id"),
     )

--- a/apps/api/app/modules/agent_identity/models.py
+++ b/apps/api/app/modules/agent_identity/models.py
@@ -56,4 +56,9 @@ class AgentIdentity(Base):
             unique=True,
             postgresql_where=text("source_id IS NOT NULL"),
         ),
+        Index(
+            "ix_agent_identities_refresh_token_hash", "refresh_token_hash",
+            unique=True,
+            postgresql_where=text("refresh_token_hash IS NOT NULL"),
+        ),
     )

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -475,6 +475,10 @@ class PolicyCertification(Base):
     policy_version = Column(Text, nullable=True)    # version_hash snapshot
     certified_at   = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
+    __table_args__ = (
+        Index("ix_policy_cert_ws_pack_ts", "workspace_id", "pack_slug", sa.text("certified_at DESC")),
+    )
+
 
 class DiscoveredAgent(Base):
     __tablename__ = "discovered_agents"


### PR DESCRIPTION
## Summary

Session 3 PR 3d — **FINAL PR of the schema-drift cleanup.** Model-only, zero migration. Declares 12 orphan indexes across 7 remaining tables to match the DB, closing 12 remove_index drift ops.

| Table | Index | Cols/where | Migration |
|---|---|---|---|
| \`integrations\` | \`ix_integrations_workspace_id\` | \`(workspace_id)\` | 0001 |
| \`integrations\` | \`ix_integrations_workspace_environment\` | \`(workspace_id, environment_id)\` | 0001 |
| \`integrations\` | \`idx_integrations_okta_issuer\` | \`(okta_issuer)\` | 0091 |
| \`mcp_servers\` | \`ix_mcp_servers_workspace\` | \`(workspace_id)\` | 0018 |
| \`mcp_servers\` | \`ix_mcp_servers_environment\` | \`(environment_id)\` | 0018 |
| \`playbook_submissions\` | \`ix_playbook_submissions_slug\` | \`(slug)\` | 0001 |
| \`playbook_submissions\` | \`ix_playbook_submissions_status\` | \`(status)\` | 0001 |
| \`projects\` | \`ix_projects_project_type\` | \`(project_type)\` | 0001 |
| \`projects\` | \`projects_workspace_security_automation_uniq\` | \`UNIQUE(workspace_id) WHERE project_type = 'security_automation'\` | 0087 |
| \`agent_identities\` | \`ix_agent_identities_refresh_token_hash\` | \`UNIQUE(refresh_token_hash) WHERE NOT NULL\` | 0065 |
| \`workspace_config\` | \`ix_workspace_config_workspace_id\` | \`(workspace_id)\` | 0034 |
| \`policy_certifications\` | \`ix_policy_cert_ws_pack_ts\` | \`(workspace_id, pack_slug, certified_at DESC)\` | 0060 |

Sources verified against migrations 0001, 0018, 0034, 0060, 0065, 0087, 0091.

## Notable

For \`Integration.okta_issuer\`: dropped inline \`index=True\` on the Column and moved the declaration to \`__table_args__\` with the DB name \`idx_integrations_okta_issuer\` (matching migration 0091). SQLAlchemy's auto-generated \`ix_integrations_okta_issuer\` would mismatch.

Added Index (and \`text\` where needed) imports to 5 files.

## Verification

- Smoke-imported all 7 models — 12 indexes load with correct names
- Zero migration file added

## Big picture

This closes Session 3 of the schema-drift cleanup. Combined across all three sessions:

| Session | PRs merged | Ops cleared |
|---|---|---|
| 1 | #1337, #1363, #1364 | ~10 |
| 2 | #1365, #1366 | ~11 |
| 3 | #1367, #1369, #1370, THIS (~43) | ~43 |

After all three sessions merge, the ~50-op drift baseline should be at or near zero. \`test_alembic_check_no_schema_drift\` should finally go green.

## Test plan

- [ ] CI green (17 pre-existing failures acceptable)
- [ ] Drift op count drops by 12
- [ ] After all 4 Session 3 PRs merge: \`test_alembic_check_no_schema_drift\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)