### PR TITLE
fix(api): schema drift — final 3 workspace_* orphan indexes (supersedes #1331)

### DIFF
--- a/apps/api/app/models/workspace_user.py
+++ b/apps/api/app/models/workspace_user.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy import Column, String, DateTime, ForeignKey, Index
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from app.core.database import Base
@@ -18,3 +18,7 @@ class WorkspaceUser(Base):
     role_id = Column(UUID(as_uuid=True), ForeignKey("roles.id", ondelete="SET NULL"), nullable=True, index=True)
 
     workspace = relationship("Workspace", back_populates="members")
+
+    __table_args__ = (
+        Index("ix_workspace_users_clerk_user_id", "clerk_user_id"),
+    )

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -405,6 +405,10 @@ class WorkspaceSkillPack(Base):
     installed_by    = Column(Text, nullable=True)   # clerk_user_id
     installed_at    = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
 
+    __table_args__ = (
+        Index("ix_workspace_skill_packs_workspace", "workspace_id"),
+    )
+
 
 class WorkspaceCustomRule(Base):
     """Per-workspace custom guard rules. Replaces the legacy guard_policies
@@ -421,6 +425,10 @@ class WorkspaceCustomRule(Base):
     created_at   = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
     updated_at   = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc),
                           onupdate=lambda: datetime.now(timezone.utc))
+
+    __table_args__ = (
+        Index("ix_workspace_custom_rules_workspace", "workspace_id"),
+    )
 
 
 class GuardRuleOverride(Base):


### PR DESCRIPTION
## Summary

Closes the last drift ops that survived Sessions 1-3 of the schema-drift cleanup. This **replaces #1331** (closed as partially superseded — 2 of its 5 changes had already landed via #1363 and #1371). The remaining 3 unique changes are here as a fresh, conflict-free PR.

| Table | Index | Cols | Migration |
|---|---|---|---|
| \`workspace_users\` | \`ix_workspace_users_clerk_user_id\` | \`(clerk_user_id)\` | 0001 |
| \`workspace_skill_packs\` | \`ix_workspace_skill_packs_workspace\` | \`(workspace_id)\` | 0017 |
| \`workspace_custom_rules\` | \`ix_workspace_custom_rules_workspace\` | \`(workspace_id)\` | 0017 |

## Verification

- Smoke-imported 3 models — all 3 indexes load with correct names
- Zero migration file added

## Big picture — schema drift cleanup complete

After this merges (10th and final drift PR):

| Session | PRs | Ops cleared |
|---|---|---|
| 1 | #1337, #1363, #1364 | ~10 |
| 2 | #1365, #1366 | ~11 |
| 3 | #1367, #1369, #1370, #1371 | ~43 |
| **Final** | **THIS** | 3 |

**Total: ~67 drift ops eliminated across 10 PRs.** After this merges, \`test_alembic_check_no_schema_drift\` should finally go green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)