### PR TITLE
fix(#1317): remove sys.modules stubbing in test files + defensive _clerk_enabled dispatch

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -123,6 +123,21 @@ def _clerk_enabled() -> bool:
     return bool(settings.clerk_secret_key and settings.clerk_frontend_api)
 
 
+def _clerk_enabled_dispatch() -> bool:
+    """Dispatched form of ``_clerk_enabled`` for auth dependencies.
+
+    Looks up ``_clerk_enabled`` through ``sys.modules`` so ``mock.patch.object``
+    on the module attribute is respected inside test bodies. Falls back to the
+    local closure when the module has been evicted from ``sys.modules`` (some
+    tests evict app.core.auth to force re-import — see #1317). Without the
+    fallback the sys.modules lookup raises ``KeyError``.
+    """
+    mod = sys.modules.get(__name__)
+    if mod is None:
+        return _clerk_enabled()
+    return mod._clerk_enabled()
+
+
 @lru_cache(maxsize=512)
 def get_clerk_user_email(user_id: str) -> str | None:
     """Fetch the primary email address for a Clerk user via the Clerk REST API.
@@ -378,7 +393,7 @@ def get_user_id(
     db: Session = Depends(get_db),
 ) -> str | None:
     """Returns the Clerk user_id (sub claim), 'dev' in local dev mode, or None for machine API tokens."""
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return DEV_USER_ID
 
     if not credentials:
@@ -445,7 +460,7 @@ def get_workspace_id(
     4. Dev workspace (when Clerk is not configured)
     """
     explicit_ws = ws_id or x_workspace_id
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return explicit_ws or DEV_WORKSPACE_ID
 
     if not credentials:
@@ -509,7 +524,7 @@ def get_user_workspace_role(
     Returns the authenticated user's role in the requested workspace.
     Raises 403 if the user is not a member. Skips check in dev mode.
     """
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return "admin"
 
     # workspace_id must be a valid UUID — Clerk user_ids (user_xxx) are not.
@@ -584,7 +599,7 @@ def get_guard_org_id(
 
     Accepts: Clerk Bearer JWT — returns org_id or sub claim.
     """
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return "dev-org"
 
     if not credentials:
@@ -603,7 +618,7 @@ def get_guard_hook_auth(
     db: Session = Depends(get_db),
 ) -> str:
     """Auth for hook/CLI endpoints. Accepts cond_agt_* agent token or Clerk JWT."""
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return "dev-org"
 
     if not credentials:
@@ -696,7 +711,7 @@ def check_permission(
     # _clerk_enabled at test time.  Python 3.11's LOAD_GLOBAL inline cache can
     # serve a stale pointer to the original function even after setattr() updates
     # the module __dict__; going through globals() forces a fresh dict read.
-    if not sys.modules[__name__]._clerk_enabled():
+    if not _clerk_enabled_dispatch():
         return "admin"
 
     import re as _re

--- a/apps/api/tests/test_agent_identity_auth.py
+++ b/apps/api/tests/test_agent_identity_auth.py
@@ -34,30 +34,6 @@ os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
 os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
 os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
 
-# ── Stub noisy infrastructure before any app import ─────────────────────────
-
-_log_mock = MagicMock()
-_log_mock.get_logger = MagicMock(return_value=MagicMock())
-_log_mock.contextvars = MagicMock()
-sys.modules["structlog"] = _log_mock
-sys.modules.setdefault("redis", MagicMock())
-sys.modules.setdefault("sentry_sdk", MagicMock())
-
-_cfg_stub = MagicMock()
-_cfg_stub.settings = MagicMock(
-    sentry_dsn=None,
-    sqlalchemy_database_url="sqlite:///:memory:",
-    encryption_key="test-key-32-bytes-long-xxxxxxxx!",
-    allowed_egress_hosts=[],
-    clerk_secret_key = "REDACTED",
-    clerk_frontend_api="clerk.example.com",
-    environment="test",
-    log_level="INFO",
-)
-sys.modules.setdefault("app.core.config", _cfg_stub)
-_db_stub = MagicMock()
-sys.modules.setdefault("app.core.database", _db_stub)
-
 # Add venv site-packages so SQLAlchemy / cryptography are importable
 _venv_site = APPS_API / ".venv" / "lib"
 _venv_paths_added: list[str] = []
@@ -65,11 +41,6 @@ for _p in _venv_site.glob("python*/site-packages"):
     if str(_p) not in sys.path:
         sys.path.insert(0, str(_p))
         _venv_paths_added.append(str(_p))
-
-# Evict any cached module copies so the real source is loaded fresh
-for _mod in list(sys.modules.keys()):
-    if _mod.startswith("app.core.auth") or _mod.startswith("app.core.crypto"):
-        del sys.modules[_mod]
 
 # ── Constants shared across tests ────────────────────────────────────────────
 
@@ -918,64 +889,9 @@ class TestTokenValid:
         mock_db.close.assert_called_once()
 
 
-# ── Module-level cleanup — restore sys.modules so later test files are not
-# contaminated by the stubs set above. This runs at collection time, after all
-# classes in this file are defined but before other test files are collected.
-# Tests in THIS file use _restore_stubs_fixture (autouse) to re-add stubs at
-# test execution time. ─────────────────────────────────────────────────────────
-
-# Only evict the app modules that were stub-imported during setup, not all app.*
-# (evicting all app.* causes mapper-configuration failures when they're re-imported
-# in a partial order that doesn't include all referenced models).
-# Evict config, database, and ALL app.models/app.modules modules so subsequent
-# test files re-import them with a clean (real) database.Base. We must evict
-# models together with the database module to avoid mapper-registry mismatches.
-_EVICT_PREFIXES = (
-    "app.core.config",
-    "app.core.database",
-    "app.core.auth",
-    "app.core.crypto",
-    "app.models",
-    "app.modules",
-    "app.runtime",
-    "app.routers",
-)
-for _mod in list(sys.modules.keys()):
-    if _mod.startswith(_EVICT_PREFIXES):
-        del sys.modules[_mod]
-
 # Remove the venv paths we added so subsequent tests resolve from normal paths.
 for _venv_p in _venv_paths_added:
     try:
         sys.path.remove(_venv_p)
     except ValueError:
         pass
-
-
-@pytest.fixture(autouse=True)
-def _restore_stubs_fixture():
-    """Re-inject config/db stubs before each test in this file and evict auth
-    so it re-imports fresh with the stub settings. On teardown, restore the
-    previous values so subsequent test files start clean."""
-    _prev_config = sys.modules.get("app.core.config")
-    _prev_db = sys.modules.get("app.core.database")
-
-    sys.modules["app.core.config"] = _cfg_stub
-    sys.modules["app.core.database"] = _db_stub
-    for _m in list(sys.modules.keys()):
-        if _m.startswith("app.core.auth") or _m.startswith("app.core.crypto"):
-            del sys.modules[_m]
-    yield
-    # Restore original config/db or evict if there was none before.
-    if _prev_config is not None:
-        sys.modules["app.core.config"] = _prev_config
-    else:
-        sys.modules.pop("app.core.config", None)
-    if _prev_db is not None:
-        sys.modules["app.core.database"] = _prev_db
-    else:
-        sys.modules.pop("app.core.database", None)
-    # Evict auth/crypto so next test re-imports fresh.
-    for _m in list(sys.modules.keys()):
-        if _m.startswith("app.core.auth") or _m.startswith("app.core.crypto"):
-            del sys.modules[_m]

--- a/apps/api/tests/test_token_paths.py
+++ b/apps/api/tests/test_token_paths.py
@@ -31,37 +31,6 @@ os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
 os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
 os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
 
-_log_mock = MagicMock()
-_log_mock.get_logger = MagicMock(return_value=MagicMock())
-_log_mock.contextvars = MagicMock()
-sys.modules["structlog"] = _log_mock
-sys.modules.setdefault("redis", MagicMock())
-sys.modules.setdefault("sentry_sdk", MagicMock())
-
-_cfg_stub = MagicMock()
-_cfg_stub.settings = MagicMock(
-    sentry_dsn=None,
-    sqlalchemy_database_url="sqlite:///:memory:",
-    encryption_key="test-key-32-bytes-long-xxxxxxxx!",
-    allowed_egress_hosts=[],
-    clerk_secret_key = "REDACTED",
-    clerk_frontend_api="clerk.example.com",
-    environment="test",
-    log_level="INFO",
-    api_base_url="https://api.conductai.ai",
-    conduct_proxy_url="",
-    cli_api_key="",
-    cli_workspace_id="",
-    redis_url="redis://localhost:6379",
-    default_max_cost_usd=5.0,
-)
-# Use setdefault so we don't overwrite modules already imported by conftest.py
-# (conftest imports app.core.auth which pulls in app.core.config and
-# app.core.database; replacing them permanently at collection time corrupts every
-# test that runs after this file is collected, even tests in other files).
-sys.modules.setdefault("app.core.config", _cfg_stub)
-sys.modules.setdefault("app.core.database", MagicMock())
-
 _venv_site = APPS_API / ".venv" / "lib"
 for _p in _venv_site.glob("python*/site-packages"):
     if str(_p) not in sys.path:


### PR DESCRIPTION
## Summary

Root-causes 13 pre-existing CI failures (attack_surface × 8, agent_token_endpoints × 2, token_paths × 3, chaos × 1) that manifest as opaque 500s with \"internal error occurred\" — all downstream fallout from two test files replacing \`app.core.config\`, \`app.core.database\`, \`structlog\`, \`redis\`, \`sentry_sdk\` in \`sys.modules\` at collection time, then evicting broad \`app.*\` prefixes at teardown.

## Fix 1 — \`test_agent_identity_auth.py\` (net -85 lines)

Env vars set at file top are sufficient for real \`app.core.config\` + \`app.core.database\` to import cleanly. Removed top-of-file MagicMock stubs, module-level teardown (evicted 8 prefixes), and the \`_restore_stubs_fixture\` autouse. **All 36 tests still pass with real modules loaded.**

## Fix 2 — \`test_token_paths.py\` (net -31 lines)

Same treatment. Inline \`_evict()\` calls inside \`TestGetWorkspaceIdRunToken\` remain — Fix 3 makes them safe. **All 14 tests still pass.**

## Fix 3 — \`app.core.auth._clerk_enabled_dispatch\` helper (+16 lines, replaces 6 call sites)

\`sys.modules[__name__]._clerk_enabled()\` (added for \`mock.patch.object\` to work) crashed with \`KeyError: 'app.core.auth'\` when tests evicted the module. Added defensive dispatch with fallback to local closure. \`mock.patch\` still works; evictions no longer crash.

## Verification

Local (no Postgres, so \`test_attack_surface\` can't fully exercise route handlers):
- \`test_agent_identity_auth.py\`: 36 pass alone → 36 pass combined
- \`test_agent_token_endpoints.py\`: 2 previously-failing tests **PASS**
- \`test_token_paths.py\`: 3 previously-failing \`TestGetWorkspaceIdRunToken\` tests **PASS**
- Combined 5-file run: 59 pass / 7 fail (down from 13), remaining 7 need real Postgres — CI will verify

## Test plan

- [ ] CI green — expected to drop from 17 → **4** pre-existing failures (only Cluster D/E/F/G remain)
- [ ] \`test_alembic_check_no_schema_drift\` finally goes green (all Session 1-3 drift PRs merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)