### PR TITLE
fix(ci): allowlist list_pack_catalog — intentionally public marketplace endpoint

### DIFF
--- a/apps/api/scripts/check_auth_coverage.py
+++ b/apps/api/scripts/check_auth_coverage.py
@@ -81,6 +81,9 @@ ALLOWLIST = {
     # Playbook catalog (intentionally public — no user data returned)
     "routers/playbooks.py::list_playbooks",
     "routers/playbooks.py::get_playbook",
+    # Skill pack catalog (intentionally public — marketplace browsing, no user data)
+    # Registered on two paths (/packs/available + /packs/catalog), single function
+    "routers/compliance.py::list_pack_catalog",
     # Project templates (intentionally public — no user data)
     "routers/projects.py::list_templates",
     # Admin approve (auth via X-Admin-Secret HMAC — internal ops endpoint)


### PR DESCRIPTION
## Summary

CI auth-coverage check is blocking every unrelated PR (started showing up on #1375). \`routers/compliance.py::list_pack_catalog\` is registered on two paths (\`/packs/available\` + \`/packs/catalog\`), single function with no auth dep. **Intentionally public** — same pattern as \`routers/playbooks.py::list_playbooks\` which is already allowlisted for the same reason (marketplace browsing, no user data).

## Fix

Add to ALLOWLIST with a comment explaining why:

\`\`\`python
# Skill pack catalog (intentionally public — marketplace browsing, no user data)
# Registered on two paths (/packs/available + /packs/catalog), single function
"routers/compliance.py::list_pack_catalog",
\`\`\`

## Verification

\`\`\`
$ cd apps/api && python3.11 scripts/check_auth_coverage.py
Auth coverage OK — all endpoints protected.
\`\`\`

Unblocks #1375 (docs) and any other PR currently red on the auth-coverage step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)