### PR TITLE
fix(#1075): unlock 12 + 6 skipped tests — session_reports rewrite + z_executor pytest-forked

### DIFF
--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -18,6 +18,7 @@ paramiko>=4.0.0,<5
 click>=8.3.3
 pytest==9.1.1
 pytest-xdist==3.8.0
+pytest-forked==1.6.0  # subprocess isolation for tests with sys.modules stubs (#1075)
 pyyaml==6.0.2
 jsonschema~=4.23
 jinja2~=3.1

--- a/apps/api/scripts/check_sys_modules_ratchet.py
+++ b/apps/api/scripts/check_sys_modules_ratchet.py
@@ -60,7 +60,8 @@ ALLOWLIST = {
     "tests/test_guard_savings.py",
     "tests/test_guard_spend_month_window.py",
     "tests/test_llm_cache_integration.py",
-    "tests/test_session_reports.py",
+    # tests/test_session_reports.py — removed from allowlist 2026-08-28,
+    # rewritten to import real modules directly (env vars + skipif on DB).
     "tests/test_team_os.py",
     "tests/test_token_paths.py",
     "tests/test_workspace_seed.py",

--- a/apps/api/tests/test_session_reports.py
+++ b/apps/api/tests/test_session_reports.py
@@ -31,67 +31,27 @@ os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
 os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
 os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
 
-_STUBS = [
-    "structlog", "redis", "sentry_sdk",
-    "app.runtime.llm_client", "app.runtime.model_router",
-    # "app.routers.runs" intentionally omitted: all tests here are skipped so
-    # there is no need to stub this at collection time, and installing a
-    # MagicMock here permanently breaks every later test that imports app.main
-    # (FastAPI cannot mount a MagicMock as a router → 500 on all routes).
-    "app.core.crypto",
-]
-for _m in _STUBS:
-    sys.modules.setdefault(_m, MagicMock())
-
-# ── All tests are skipped — DB setup is deferred to avoid polluting sys.modules ──
-# importlib.reload(app.core.database) at module level during pytest collection
-# replaces app.core.database with a fresh module whose Base class differs from
-# the one models were defined against, breaking every subsequent test that uses
-# TestClient or mock DB sessions (500s, FK errors, mapper init failures).
-# The reload is now inside _setup_db() and only runs if a test actually executes.
-
-pytestmark = pytest.mark.skip(reason="Cross-test sys.modules pollution: reloading db module can't fix inconsistent Base between Workspace/SessionReport. Needs pytest-forked or refactor to not stub sys.modules elsewhere.")
-
-# Placeholders so class bodies below don't raise NameError at collection time.
-SessionLocal = None
-Workspace = None
-SessionReport = None
-_DB_OK = False
+# Real modules imported directly — env vars above are sufficient. SQLAlchemy
+# engine creation doesn't open a connection; only queries do. Tests that need
+# a live DB check _db_reachable() and skip if none.
+from app.core.database import SessionLocal
+from app.models.workspace import Workspace
+from app.models.environment import Environment  # noqa: F401 — needed for FK
+from app.modules.guard.models import SessionReport
 
 
-def _setup_db():
-    """Reload app.core.database to get the real SessionLocal.
-
-    Called lazily (only when a test actually runs, not at collection time)
-    to avoid poisoning sys.modules for the rest of the test suite.
-    """
-    import importlib
-    for _dead in ("app.core.config", "app.core.database", "app.models"):
-        if hasattr(sys.modules.get(_dead), "_mock_name"):
-            del sys.modules[_dead]
-    import app.core.config as _real_cfg
-    importlib.reload(_real_cfg)
-    import app.core.database as _real_db
-    importlib.reload(_real_db)
-    global SessionLocal, Workspace, SessionReport, _DB_OK
-    SessionLocal = _real_db.SessionLocal
-    import app.models  # noqa — registers all ORM tables
-    from app.models.environment import Environment  # noqa — needed for workflows FK
-    from app.models.workspace import Workspace as _Workspace
-    from app.modules.guard.models import SessionReport as _SessionReport
-    Workspace = _Workspace
-    SessionReport = _SessionReport
+def _db_reachable() -> bool:
+    """True iff a SELECT 1 succeeds against the configured DB."""
     from sqlalchemy import text
     try:
         with SessionLocal() as s:
             s.execute(text("SELECT 1"))
-        _DB_OK = True
+        return True
     except Exception:
-        _DB_OK = False
+        return False
 
 
-def _db_reachable() -> bool:
-    return _DB_OK
+pytestmark = pytest.mark.skipif(not _db_reachable(), reason="Postgres not reachable")
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_z_executor_lifecycle.py
+++ b/apps/api/tests/test_z_executor_lifecycle.py
@@ -12,6 +12,14 @@ from __future__ import annotations
 
 import pytest
 
+# pytest-forked: each test runs in its own subprocess so this file's module-
+# level sys.modules stubs stay isolated from other test files. Removes the
+# 6 individual skip markers below that said "passes solo". See epic #1075 —
+# proper long-term fix is to rewrite this file to not stub sys.modules
+# (needs executor dependency injection, big scope).
+pytestmark = pytest.mark.forked
+
+
 import hashlib
 import sys
 import types
@@ -534,7 +542,6 @@ def _run_execute_run(run, version, *, dag_mock=None, dag_raises=None):
     return mock_analytics, mock_eval
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_paused_is_resumable():
     run = _make_run("paused")
     version = _make_version()
@@ -546,7 +553,6 @@ def test_execute_run_paused_is_resumable():
     dag.assert_called_once()
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_happy_path_status_transitions():
     run = _make_run("pending")
     version = _make_version()
@@ -560,7 +566,6 @@ def test_execute_run_happy_path_status_transitions():
     mock_eval.assert_called()
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_crash_sets_failed_status():
     run = _make_run("pending")
     version = _make_version()
@@ -574,7 +579,6 @@ def test_execute_run_crash_sets_failed_status():
     assert len(failed_calls) >= 1
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_crash_still_emits_analytics_with_failed_outcome():
     run = _make_run("pending")
     version = _make_version()
@@ -588,7 +592,6 @@ def test_execute_run_crash_still_emits_analytics_with_failed_outcome():
     assert len(failed_calls) >= 1
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_enqueues_eval_on_success():
     run = _make_run("pending")
     version = _make_version()
@@ -598,7 +601,6 @@ def test_execute_run_enqueues_eval_on_success():
     mock_eval.assert_called_once_with(str(run.id))
 
 
-@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")
 def test_execute_run_enqueues_eval_on_failure():
     run = _make_run("pending")
     version = _make_version()


### PR DESCRIPTION
## Summary

Two files, two different fixes for the same root cause (sys.modules cross-test pollution). 18 previously-skipped tests now run in CI.

## \`test_session_reports.py\` — proper rewrite (12 tests unskipped)

**Before:** 12 tests all skipped via module-level \`pytestmark = pytest.mark.skip\` with a comment saying *"Needs pytest-forked or refactor to not stub sys.modules elsewhere"*. The file had a \`_setup_db()\` helper that reloaded \`app.core.database\` at test time to work around its own module-level stubs.

**After:** same pattern as PR #1373 — env vars at file top are sufficient for real \`app.core.config\`, \`app.core.database\`, \`app.models.workspace\`, and \`SessionReport\` to import cleanly. Per-test \`SessionLocal()\` gives real sessions. Falls back to \`pytest.mark.skipif\` if the DB isn't reachable.

**Net:** -49 lines. All 12 tests run in CI. Removed from ratchet allowlist (13 → 12).

## \`test_z_executor_lifecycle.py\` — pytest-forked (6 tests unskipped)

This file is 610 lines of intentional module mocking to unit-test \`app.runtime.executor\` in isolation. Full rewrite to use real deps would need executor dependency injection — multi-day scope, out of tonight.

**Instead:** \`pytestmark = pytest.mark.forked\` runs the file in its own subprocess. All its sys.modules mutations stay isolated — zero contamination possible.

Removed the 6 \`@pytest.mark.skip(reason="Cross-test sys.modules pollution in CI — passes solo")\` decorators since forking makes solo runs identical to combined runs.

Added \`pytest-forked==1.6.0\` to requirements.

## Verification (local)

Cross-file run before this PR: various failures + 18 skipped
Cross-file run after this PR: **67 passed / 12 skipped** (session_reports needs Postgres, only unavailable locally)

Ratchet script continues to pass (12 allowlisted files).

## Expected CI

Test count goes up by ~18 (session_reports 12 + z_executor 6). \`test_alembic_check_no_schema_drift\` and everything else stays green.

## Follow-up

- Continue removing files from the ratchet allowlist as they're rewritten
- Consider adopting \`pytestmark = pytest.mark.forked\` for other files on the allowlist that legitimately need module stubs (test_analytics_dora, test_analytics_scorecards, test_guard_events_api, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)