### PR TITLE
fix(ci): scan-web docker build context → repo root (unblocks Container Security)

### DIFF
--- a/.github/workflows/container-security.yml
+++ b/.github/workflows/container-security.yml
@@ -45,7 +45,11 @@ jobs:
       matrix:
         image:
           - { name: "api", dockerfile: "apps/api/Dockerfile", context: "apps/api" }
-          - { name: "web", dockerfile: "apps/web/Dockerfile", context: "apps/web" }
+          # context is repo root because apps/web/src/app/(marketing)/docs/page.tsx
+          # imports docs/reference/*.md via a ../../../../../../docs/... webpack
+          # asset/source import — that path only resolves when the build context
+          # includes the repo-root docs/ dir.
+          - { name: "web", dockerfile: "apps/web/Dockerfile", context: "." }
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,14 +1,19 @@
+# Build context is REPO ROOT (see .github/workflows/container-security.yml).
+# apps/web/src/app/(marketing)/docs/page.tsx imports docs/reference/*.md via
+# ../../../../../../docs/... — needs the repo-root docs/ dir in the build tree.
 FROM node:20-alpine AS base
 WORKDIR /app
-COPY package*.json ./
+COPY apps/web/package*.json ./
 RUN npm install
 
 FROM base AS dev
-COPY . .
+COPY apps/web/ .
+COPY docs/ /docs/
 CMD ["npm", "run", "dev"]
 
 FROM base AS builder
-COPY . .
+COPY apps/web/ .
+COPY docs/ /docs/
 RUN npm run build
 
 FROM node:20-alpine AS prod


### PR DESCRIPTION
## Summary

Pre-existing failure on every PR's \`Scan web\` check:

\`\`\`
./src/app/(marketing)/docs/page.tsx
Module not found: Can't resolve '../../../../../../docs/reference/okta-tracking.md'
\`\`\`

**Root cause:** \`apps/web/src/app/(marketing)/docs/page.tsx\` imports the \`.md\` via a webpack \`asset/source\` loader with a \`../../../../../../docs/...\` path that resolves to \`<repo-root>/docs/reference/okta-tracking.md\`. The container-security workflow built with \`context: apps/web\`, so the parent \`docs/\` directory wasn't in the build context and the resolve failed.

Confirmed pre-existing (fails on #1237 with the same error, has been red for weeks).

## Fix — 2 files, ~10 lines total

**\`.github/workflows/container-security.yml\`** — change web image context from \`apps/web\` to \`.\` (repo root).

**\`apps/web/Dockerfile\`** — update \`COPY\` paths for the new context:
- \`COPY apps/web/package*.json ./\` (was \`COPY package*.json ./\`)
- \`COPY apps/web/ .\` (was \`COPY . .\`)
- **\`COPY docs/ /docs/\`** (NEW — .md import resolves to \`/docs/\`)

The \`.md\` path resolution from \`/app/src/app/(marketing)/docs/page.tsx\` going up 6 levels lands at \`/\` — then \`docs/reference/okta-tracking.md\` is \`/docs/reference/okta-tracking.md\`. Matches what the webpack build expects.

## Verification

Locally: \`docker build --file apps/web/Dockerfile .\` from repo root → build succeeds.

## Unblocks

- PR #1396 (18 tests unlocked, blocked only by this)
- PR #1237 (bandit)
- Any future PR that would have been red on Container Security → Scan web

🤖 Generated with [Claude Code](https://claude.com/claude-code)