### PR TITLE
feat(ci): Tier 3 mutating smoke against TESTING workspace

### DIFF
--- a/.github/workflows/smoke_test.yml
+++ b/.github/workflows/smoke_test.yml
@@ -14,6 +14,10 @@ on:
       pr:
         description: 'PR number (optional)'
         default: ''
+      tier3:
+        description: 'Enable Tier 3 (mutating scratch project/env/creds — TESTING workspace only)'
+        type: boolean
+        default: true
 
 jobs:
   smoke:
@@ -25,6 +29,7 @@ jobs:
       PROJECT:  ${{ github.event.inputs.project || 'DevOps' }}
       REPO:     ${{ github.event.inputs.repo    || 'sseshachala/conductai' }}
       PR:       ${{ github.event.inputs.pr      || '' }}
+      TIER3:    ${{ github.event.inputs.tier3   || 'true' }}
 
     steps:
       - name: Checkout
@@ -54,10 +59,12 @@ jobs:
         run: |
           PR_FLAG=""
           [[ -n "$PR" ]] && PR_FLAG="--pr $PR"
+          TIER3_FLAG=""
+          [[ "$TIER3" == "true" ]] && TIER3_FLAG="--tier3"
           bash scripts/smoke_test.sh \
             --project "$PROJECT" \
             --repo    "$REPO" \
-            $PR_FLAG
+            $PR_FLAG $TIER3_FLAG
         continue-on-error: true  # upload report even on failure
 
       - name: Upload report

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -15,12 +15,14 @@ set -euo pipefail
 PROJECT=""
 REPO=""
 PR=""
+TIER3=0
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project) PROJECT="$2"; shift 2 ;;
     --repo)    REPO="$2";    shift 2 ;;
     --pr)      PR="$2";      shift 2 ;;
+    --tier3)   TIER3=1;      shift ;;
     *) echo "Unknown arg: $1"; exit 1 ;;
   esac
 done
@@ -74,8 +76,9 @@ NON_PR_AGENTS=(
 # Source of truth: `sub.add_parser("...")` in packages/conduct-cli/src/conduct_cli/main.py
 echo "── Step 0: Tier 1 — CLI --help sweep ──" | run_and_tee
 TIER1_CMDS=(
-  agents create credentials delete emit environments install install-all
-  login mcp playbooks projects reset run sessions set skill switch test token whoami
+  agents create credentials delete emit environments guard import-cedar install install-all
+  login mcp memory playbooks projects reset run session-report sessions set skill switch sync
+  test test-guard test-security test-security-verify token verify whoami
 )
 TIER1_FAILS=()
 conduct --help >/dev/null 2>&1 || { echo "conduct --help failed" | run_and_tee; exit 1; }
@@ -130,8 +133,37 @@ else
   echo "" | run_and_tee
 fi
 
+# ── Step 4: Tier 3 — mutating commands against scratch project (opt-in) ─────
+# Only run when --tier3 is passed. Nightly workflow points at the TESTING
+# workspace where scratch projects are safe to create/destroy.
+EXIT_C=0
+if [[ $TIER3 -eq 1 ]]; then
+  STAMP=$(date +%s)
+  SCRATCH_PROJECT="smoke-tier3-${STAMP}"
+  SCRATCH_ENV="smoke-tier3-env-${STAMP}"
+  cleanup_tier3() {
+    echo "── Tier 3 cleanup: removing scratch project/env ──" | run_and_tee
+    conduct delete environment "$SCRATCH_ENV" --yes 2>&1 | run_and_tee || true
+    conduct delete "$SCRATCH_PROJECT" --yes 2>&1 | run_and_tee || true
+  }
+  trap cleanup_tier3 EXIT
+
+  echo "── Step 4: Tier 3 — mutating commands (scratch: $SCRATCH_PROJECT) ──" | run_and_tee
+  {
+    conduct create "$SCRATCH_PROJECT" 2>&1 &&
+    conduct create environment "$SCRATCH_ENV" 2>&1 &&
+    conduct set credential --environment "$SCRATCH_ENV" --key SMOKE_TEST_KEY --value "smoke-value-${STAMP}" 2>&1 &&
+    conduct emit finding --severity info --type smoke-test --description "Tier 3 smoke test finding ${STAMP}" --repo "$REPO" 2>&1 &&
+    conduct session-report --developer "smoke-tier3-${STAMP}" 2>&1
+  } | run_and_tee || EXIT_C=$?
+  echo "" | run_and_tee
+else
+  echo "── Step 4: Tier 3 — SKIPPED (pass --tier3 against a scratch workspace) ──" | run_and_tee
+  echo "" | run_and_tee
+fi
+
 # ── Footer ────────────────────────────────────────────────────────────────────
-EXIT_CODE=$(( EXIT_A || EXIT_B ))
+EXIT_CODE=$(( EXIT_A || EXIT_B || EXIT_C ))
 {
   echo "================================================================"
   echo "  Finished : $(date)"


### PR DESCRIPTION
## Summary
- Adds Tier 3 to `scripts/smoke_test.sh`: opt-in via `--tier3`, exercises the mutating commands not covered by Steps 1-3 (`create`, `delete`, `set credential`, `emit finding`, `session-report`) against a scratch project scoped per run.
- Trap-based cleanup guarantees the scratch project/env are deleted even if a step mid-flow fails.
- Nightly workflow enables `--tier3` by default (dispatchable toggle exists). Points at the **TESTING** workspace via existing `CONDUCT_*` secrets.
- Also fills a Tier 1 gap: sweep now covers 30 subcommands (was 21). Added `guard`, `import-cedar`, `memory`, `session-report`, `sync`, `verify`, `test-guard`, `test-security`, `test-security-verify`.

## Why
Post-#1401 the smoke script catches CLI import breaks (Tier 1) and the install/test happy path. Tier 3 closes the gap on project/env/credential lifecycle and the two ingest paths (findings + session reports) that no other check exercises.

## Test plan
- [ ] Merge → next nightly run should show `Step 4: Tier 3 — mutating commands` succeed with scratch project deleted at end
- [ ] Verify TESTING workspace has no orphan `smoke-tier3-*` projects after the run
- [ ] Manual dispatch with `tier3: false` skips Step 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)