### PR TITLE
fix(ci): nightly installs webkit for smoke-mobile-iphone

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -173,7 +173,8 @@ jobs:
         # apps/web is an npm workspace — install at repo root.
         run: npm ci
       - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium firefox
+        # webkit required by smoke-mobile-iphone (iPhone 14 device uses WebKit engine).
+        run: npx playwright install --with-deps chromium firefox webkit
         working-directory: apps/web
       - name: Run Playwright
         run: npm run test:e2e


### PR DESCRIPTION
## Summary
- Adds `webkit` to nightly's `npx playwright install` list. The `smoke-mobile-iphone` project uses the iPhone 14 device, which runs on WebKit — without it, every mobile smoke test failed with `browserType.launch: Executable doesn't exist at .../webkit-2287/pw_run.sh`.
- `web-smoke.yml` already installs all three browsers; nightly was the outlier.

## Why
Fix #3 of 3 identified from run [33238091177](https://github.com/sseshachala/conductai/actions/runs/33238091177). Should clear ~30-40 of the 129 failures.

## Test plan
- [ ] Manual `workflow_dispatch` on `nightly.yml` — verify `smoke-mobile-iphone` tests actually run (pass or fail on real assertions, not browser-missing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)