### PR TITLE
fix(ci): set ALLOWED_ORIGINS for web-smoke + nightly (CORS fix, clears 16 failures)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -123,6 +123,9 @@ jobs:
       DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test
       REDIS_URL: redis://localhost:6379
       ENCRYPTION_KEY: test-key-32-bytes-long-xxxxxxxx!
+      # Next dev on :3000 fetches API on :8000 → different origin. Without this,
+      # CORSMiddleware rejects every browser fetch and pages render "Failed to fetch".
+      ALLOWED_ORIGINS: http://localhost:3000
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_TEST_PUBLISHABLE_KEY }}
       CLERK_SECRET_KEY: ${{ secrets.CLERK_TEST_SECRET_KEY }}
       CLERK_FRONTEND_API: ${{ secrets.CLERK_TEST_FRONTEND_API }}

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -37,6 +37,9 @@ jobs:
       DATABASE_URL: postgresql://marshal:marshal@localhost:5432/marshal_test
       REDIS_URL: redis://localhost:6379
       ENCRYPTION_KEY: test-key-32-bytes-long-xxxxxxxx!
+      # Next dev on :3000 fetches API on :8000 → different origin. Without this,
+      # CORSMiddleware rejects every browser fetch and pages render "Failed to fetch".
+      ALLOWED_ORIGINS: http://localhost:3000
       # Clerk sandbox — role projects only run when all four are present.
       # Add missing secrets in Settings → Secrets and variables → Actions.
       NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ secrets.CLERK_TEST_PUBLISHABLE_KEY }}


### PR DESCRIPTION
## Root cause
\`apps/api/app/main.py:95\` — CORSMiddleware uses \`allow_origins=_origins\`, derived from the \`ALLOWED_ORIGINS\` env var. Neither \`web-smoke.yml\` nor \`nightly.yml\` sets it → \`_origins\` is empty → API rejects **every** cross-origin request from Next dev server on :3000.

## Evidence from run [33243625078](https://github.com/sseshachala/conductai/actions/runs/33243625078)
Per-role trace shows page rendered "Failed to fetch" (\`error-context.md\` line 74), sidebar shows placeholder \`"ORGANISATION"\` — that's \`AppShell.tsx:473\` fallback when \`WorkspaceContext.activeWorkspace\` is null, because \`/projects\` fetch was CORS-blocked too.

## Impact
Clears all 16 remaining bucket-#1 failures:
- \`flows/approvals-reject-reason\` — 2 tests × chromium + firefox
- \`flows-per-role/agents-list-shows-workflow\` — 4 roles
- \`flows-per-role/integrations-list-shows-mcp\` — 4 roles
- \`flows-per-role/policies-list-shows-custom-rule\` — 4 roles

## Diff
6 lines total. One \`ALLOWED_ORIGINS: http://localhost:3000\` in each of the two workflow env blocks, plus a comment noting why.

## Test plan
- [ ] Merge → re-dispatch \`nightly.yml\` → expect 0 failures across web-smoke
- [ ] Confirm bucket #1 tracking is no longer needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)