### PR TITLE
feat(ux): shared <SettingsShell> for workspace + Guard (#1359)

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -4,8 +4,7 @@ import { useState, useEffect, useRef } from "react"
 import { useAuth } from "@clerk/nextjs"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api"
-import AppShell from "@/components/AppShell"
-import { TabBar } from "@/components/TabBar"
+import { SettingsShell, type SettingsTab } from "@/components/SettingsShell"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
@@ -15,13 +14,13 @@ import LLMPrimitivesPanel from "@/components/settings/LLMPrimitivesPanel"
 
 type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "proxy"
 
-const TAB_LABELS: Record<Tab, string> = {
-  credentials: "Vault",
-  llm_primitives: "LLM Model Primitives",
-  preferences: "Appearance",
-  members: "Members & roles",
-  proxy: "Proxy",
-}
+const TABS: readonly SettingsTab<Tab>[] = [
+  { key: "credentials",    label: "Vault" },
+  { key: "llm_primitives", label: "LLM Model Primitives" },
+  { key: "preferences",    label: "Appearance" },
+  { key: "proxy",          label: "Proxy" },
+  { key: "members",        label: "Members & roles", adminOnly: true },
+]
 
 export default function SettingsPage() {
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
@@ -164,11 +163,8 @@ function OrgNameEditor({ getToken }: { getToken: (() => Promise<string | null>) 
 // ── Main settings page ────────────────────────────────────────────────────────
 
 function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
-  const tabs = (["credentials", "llm_primitives", "preferences", "proxy", ...(isAdmin ? ["members"] : [])] as Tab[])
-  const [activeTab, setActiveTab] = useState<Tab>("credentials")
   const [showTip, setShowTip] = useState(false)
 
-  // Only show tip if user hasn't dismissed it before
   useEffect(() => {
     if (typeof window !== "undefined") {
       setShowTip(localStorage.getItem("conduct_settings_tip_dismissed") !== "1")
@@ -182,8 +178,23 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
     setShowTip(false)
   }
 
+  const panels: Partial<Record<Tab, React.ReactNode>> = {
+    credentials:    <EnvironmentsManager isAdmin={isAdmin} />,
+    llm_primitives: <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />,
+    preferences:    <PreferencesPanel />,
+    proxy:          <ProxySettings workspaceId={workspaceId} getToken={getToken} />,
+    members:        <MembersManager />,
+  }
+
   return (
-    <AppShell>
+    <SettingsShell<Tab>
+      title="Settings"
+      description="Connect tools, manage environments, members, appearance, and API access."
+      tabs={TABS}
+      isAdmin={isAdmin}
+      panels={panels}
+      initialTab="credentials"
+    >
       {showTip && (
         <div style={{ position: "fixed", bottom: 24, right: 24, zIndex: 50, maxWidth: 380, width: "100%", borderRadius: 12, background: "var(--warn-bg)", border: "1px solid var(--warn-bd)", padding: "12px 16px", display: "flex", alignItems: "flex-start", gap: 12 }}>
           <span style={{ color: "var(--warn)", flexShrink: 0 }}>⚠</span>
@@ -201,40 +212,7 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
           </button>
         </div>
       )}
-      <div style={{ maxWidth: 960, margin: "0 auto", padding: "40px 24px" }}>
-        <div style={{ marginBottom: 20 }}>
-          <h1 style={{ fontSize: 25, fontWeight: 680, letterSpacing: "-.02em", color: "var(--text)", margin: 0 }}>
-            Settings
-          </h1>
-          <p style={{ fontSize: 14, color: "var(--text-3)", marginTop: 5, margin: "5px 0 0" }}>
-            Connect tools, manage environments, members, appearance, and API access.
-          </p>
-        </div>
-
-        {isAdmin && <OrgNameEditor getToken={getToken} />}
-
-        <div style={{ marginBottom: 24 }}>
-          <TabBar tabs={tabs} labels={TAB_LABELS} activeTab={activeTab} onSelect={setActiveTab} />
-        </div>
-
-        <div role="tabpanel" id="tabpanel-credentials" aria-labelledby="tab-credentials" hidden={activeTab !== "credentials"}>
-          <EnvironmentsManager isAdmin={isAdmin} />
-        </div>
-        <div role="tabpanel" id="tabpanel-llm_primitives" aria-labelledby="tab-llm_primitives" hidden={activeTab !== "llm_primitives"}>
-          <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />
-        </div>
-        <div role="tabpanel" id="tabpanel-preferences" aria-labelledby="tab-preferences" hidden={activeTab !== "preferences"}>
-          <PreferencesPanel />
-        </div>
-        {isAdmin && (
-          <div role="tabpanel" id="tabpanel-members" aria-labelledby="tab-members" hidden={activeTab !== "members"}>
-            <MembersManager />
-          </div>
-        )}
-        <div role="tabpanel" id="tabpanel-proxy" aria-labelledby="tab-proxy" hidden={activeTab !== "proxy"}>
-          <ProxySettings workspaceId={workspaceId} getToken={getToken} />
-        </div>
-      </div>
-    </AppShell>
+      {isAdmin && <OrgNameEditor getToken={getToken} />}
+    </SettingsShell>
   )
 }

--- a/apps/web/src/app/(app)/theguard/settings/page.tsx
+++ b/apps/web/src/app/(app)/theguard/settings/page.tsx
@@ -12,6 +12,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import { useTokenGuardrails, patchTokenGuardrails } from "@/hooks/useTokenGuardrails"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import { SettingsShell, type SettingsTab } from "@/components/SettingsShell"
 import { SlackIntegrationPicker } from "@/components/SlackIntegrationPicker"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
@@ -27,19 +28,24 @@ interface TeamPrefs {
   advisory_mode: boolean
 }
 
+// ─── Tab shape — mirrors workspace /settings via <SettingsShell> (issue #1359) ─
 
-// ─── Section header (reused across all groupings) ─────────────────────────────
+type GuardSettingsTab =
+  | "enforcement"
+  | "notifications"
+  | "guardrails"
+  | "rate_limits"
+  | "connections"
+  | "sync"
 
-function SectionHeader({ title, hint }: { title: string; hint?: string }) {
-  return (
-    <div style={{ margin: "28px 0 12px" }}>
-      <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".08em" }}>
-        {title}
-      </div>
-      {hint && <div style={{ fontSize: 12, color: "var(--text-3)", marginTop: 2 }}>{hint}</div>}
-    </div>
-  )
-}
+const GUARD_SETTINGS_TABS: readonly SettingsTab<GuardSettingsTab>[] = [
+  { key: "enforcement",   label: "Enforcement" },
+  { key: "notifications", label: "Notifications" },
+  { key: "guardrails",    label: "Cost & performance" },
+  { key: "rate_limits",   label: "Rate limits", adminOnly: true },
+  { key: "connections",   label: "Connections" },
+  { key: "sync",          label: "Sync status" },
+]
 
 
 
@@ -753,24 +759,14 @@ function SettingsContent() {
           {error}
         </div>
       ) : (
-        <>
-          {/* View-only notice */}
-          {!isAdmin && resolvedRole !== null && (
-            <div style={{
-              borderRadius: 8,
-              border: "1px solid var(--border)",
-              background: "var(--surface-2)",
-              padding: "10px 16px",
-              fontSize: 12,
-              color: "var(--text-3)",
-              marginBottom: 24,
-            }}>
-              View only — contact your admin to make changes.
-            </div>
-          )}
-
-          {/* Status ribbon — sync + resync side by side */}
-          <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20 }}>
+        <SettingsShell<GuardSettingsTab>
+          wrapInAppShell={false}
+          tabs={GUARD_SETTINGS_TABS}
+          isAdmin={isAdmin}
+          initialTab="enforcement"
+          panels={{
+            sync: (
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20 }}>
               <div className="card" style={{ padding: "18px 20px", minWidth: 0 }}>
                 <div className="eyebrow" style={{ marginBottom: 12 }}>Sync status</div>
                 {toolCoverage === null ? (
@@ -820,10 +816,10 @@ function SettingsContent() {
                   {resyncing ? "Syncing…" : resyncDone ? "Synced" : "Re-sync"}
                 </button>
               </div>
-          </div>
-
-          <SectionHeader title="Enforcement" hint="How Guard decides and when it fails safely" />
-          <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 20, alignItems: "stretch" }}>
+              </div>
+            ),
+            enforcement: (
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 20, alignItems: "stretch" }}>
               <div className="card" style={{ padding: "18px 20px", minWidth: 0 }}>
                 <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 4, gap: 8 }}>
                   <div className="eyebrow">Agent guard <span style={{ color: "var(--text-muted)", fontWeight: 400, textTransform: "none", letterSpacing: 0 }}>· workspace default</span></div>
@@ -966,10 +962,10 @@ function SettingsContent() {
                   </div>
                 </label>
               </div>
-          </div>
-
-          <SectionHeader title="Notifications" hint="Route policy events per action tier. Add multiple Slack channels — each one gets pinged whenever a rule with that action fires." />
-          <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+              </div>
+            ),
+            notifications: (
+              <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
             <NotificationsCard workspaceId={wsId ?? null} isAdmin={isAdmin} />
             <div style={{ background: "var(--info-bg)", border: "1px solid var(--info-bd)", borderRadius: 12, padding: "14px 18px" }}>
               <p style={{ fontSize: 12, fontWeight: 600, color: "var(--info)", marginBottom: 6 }}>Setup checklist</p>
@@ -987,10 +983,10 @@ function SettingsContent() {
                 .
               </p>
             </div>
-          </div>
-
-          <SectionHeader title="Cost & performance" hint="Token guardrails detected and enforced across your workspace" />
-          <div className="card" style={{ overflow: "hidden", marginTop: 20 }}>
+              </div>
+            ),
+            guardrails: (
+              <div className="card" style={{ overflow: "hidden" }}>
             <div style={{ padding: "15px 20px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", gap: 10 }}>
               <span style={{ width: 30, height: 30, borderRadius: 8, background: "var(--accent)", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
                 <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
@@ -1065,18 +1061,12 @@ function SettingsContent() {
                   />
                 </div>
               ))}
-            </div>
-          </div>
-
-          {isAdmin && (
-            <>
-              <SectionHeader title="Rate Limits" hint="Requests-per-minute and tokens-per-minute caps on proxy traffic. Blocks return 429 with x-guard reason." />
-              <RateLimitsCard isAdmin={isAdmin} />
-            </>
-          )}
-
-          <SectionHeader title="Connections" hint="MCP servers and integrations" />
-          <div className="card" style={{ marginTop: 20, padding: "14px 20px", display: "flex", alignItems: "center", gap: 12 }}>
+              </div>
+              </div>
+            ),
+            rate_limits: <RateLimitsCard isAdmin={isAdmin} />,
+            connections: (
+              <div className="card" style={{ padding: "14px 20px", display: "flex", alignItems: "center", gap: 12 }}>
             <span style={{ width: 30, height: 30, borderRadius: 8, background: "var(--accent)", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
                 <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
@@ -1089,10 +1079,24 @@ function SettingsContent() {
             <a href="/integrations" className="btn btn-ghost btn-sm" style={{ textDecoration: "none" }}>
               Manage MCP →
             </a>
-          </div>
-
-          {/* Automation — hidden until operation cleanup complete */}
-        </>
+              </div>
+            ),
+          }}
+        >
+          {!isAdmin && resolvedRole !== null && (
+            <div style={{
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "var(--surface-2)",
+              padding: "10px 16px",
+              fontSize: 12,
+              color: "var(--text-3)",
+              marginBottom: 24,
+            }}>
+              View only — contact your admin to make changes.
+            </div>
+          )}
+        </SettingsShell>
       )}
     </GuardShell>
   )

--- a/apps/web/src/components/SettingsShell.tsx
+++ b/apps/web/src/components/SettingsShell.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+/**
+ * Shared settings surface — header + TabBar + tabpanels, wrapped in AppShell.
+ *
+ * Used by /settings (workspace), /theguard/settings (Guard), and workflow
+ * settings so every settings page has the same shape. See issue #1359.
+ *
+ * When embedding inside another page shell (e.g. GuardShell already owns
+ * AppShell + h1 + top-level nav), pass wrapInAppShell={false} and omit
+ * title — SettingsShell then renders only the TabBar + panels.
+ */
+
+import { useState, type ReactNode } from "react"
+import AppShell from "@/components/AppShell"
+import { TabBar } from "@/components/TabBar"
+
+export interface SettingsTab<K extends string> {
+  key: K
+  label: string
+  adminOnly?: boolean
+}
+
+export function SettingsShell<K extends string>({
+  title,
+  description,
+  tabs,
+  isAdmin,
+  panels,
+  initialTab,
+  rightSlot,
+  wrapInAppShell = true,
+  children,
+}: {
+  title?: string
+  description?: string
+  tabs: readonly SettingsTab<K>[]
+  isAdmin: boolean
+  panels: Partial<Record<K, ReactNode>>
+  initialTab?: K
+  rightSlot?: ReactNode
+  wrapInAppShell?: boolean
+  children?: ReactNode
+}) {
+  const visibleTabs = tabs.filter(t => !t.adminOnly || isAdmin)
+  const firstKey = visibleTabs[0]?.key as K
+  const [activeTab, setActiveTab] = useState<K>(initialTab ?? firstKey)
+  const labels = Object.fromEntries(visibleTabs.map(t => [t.key, t.label])) as Record<K, string>
+  const tabKeys = visibleTabs.map(t => t.key) as readonly K[]
+
+  const body = (
+    <>
+      {title && (
+        <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 16, marginBottom: 20 }}>
+          <div>
+            <h1 style={{ fontSize: 25, fontWeight: 680, letterSpacing: "-.02em", color: "var(--text)", margin: 0 }}>
+              {title}
+            </h1>
+            {description && (
+              <p style={{ fontSize: 14, color: "var(--text-3)", margin: "5px 0 0" }}>
+                {description}
+              </p>
+            )}
+          </div>
+          {rightSlot && <div style={{ flexShrink: 0 }}>{rightSlot}</div>}
+        </div>
+      )}
+
+      {children}
+
+      <div style={{ marginBottom: 24 }}>
+        <TabBar tabs={tabKeys} labels={labels} activeTab={activeTab} onSelect={setActiveTab} />
+      </div>
+
+      {visibleTabs.map(t => (
+        <div
+          key={t.key}
+          role="tabpanel"
+          id={`tabpanel-${t.key}`}
+          aria-labelledby={`tab-${t.key}`}
+          hidden={activeTab !== t.key}
+        >
+          {panels[t.key]}
+        </div>
+      ))}
+    </>
+  )
+
+  if (!wrapInAppShell) return <>{body}</>
+
+  return (
+    <AppShell>
+      <div style={{ maxWidth: 960, margin: "0 auto", padding: "40px 24px" }}>
+        {body}
+      </div>
+    </AppShell>
+  )
+}


### PR DESCRIPTION
## Summary

Standardises the settings UI shape across the platform per epic #1359.

- Extracts a shared `<SettingsShell>` primitive (`apps/web/src/components/SettingsShell.tsx`) — header + `TabBar` + tabpanels, wraps `AppShell` by default, opt-out via `wrapInAppShell={false}` for embedding inside another shell.
- Migrates workspace `/settings` (`apps/web/src/app/(app)/settings/page.tsx`) as the reference consumer — drop-in refactor, no visible change (net −19 lines).
- Adopts `<SettingsShell>` inside Guard `/theguard/settings` (`apps/web/src/app/(app)/theguard/settings/page.tsx`) — six stacked `SectionHeader` blocks become six tabs: Enforcement / Notifications / Cost & performance / Rate limits (admin-only) / Connections / Sync status. `GuardShell` (Guard's top-level nav) is preserved; `SettingsShell` sits inside it. Dead `SectionHeader` helper removed.

Bundles PR 1 (extract) and PR 2 (Guard adoption) from the epic — PR 1 alone has no consumer, so shipping the two together avoids a dead-code intermediate. PR 3 (Canvas workflow settings) and PR 4 (Lens cog) still to land per the epic breakdown.

## Test plan

- [ ] `pnpm --filter @conduct/web tsc --noEmit` clean (verified locally)
- [ ] Visit `/settings` as an admin — Vault / LLM Model Primitives / Appearance / Proxy / Members tabs all switch and each panel renders identically to before.
- [ ] Visit `/settings` as a non-admin — Members tab hidden; tip banner shows once, dismiss persists.
- [ ] Visit `/theguard/settings` as an admin — six tabs (Enforcement / Notifications / Cost & performance / Rate limits / Connections / Sync status). Enforcement is default. Each panel matches the pre-refactor content 1:1.
- [ ] Visit `/theguard/settings` as a non-admin — Rate limits tab hidden; view-only banner shows above the TabBar.
- [ ] Guard's top-level nav strip (Activity / Spend / Policies / Approvals / Discovery / Compliance / Settings) still renders correctly (proves `GuardShell` still wraps).
- [ ] Save actions on each Guard panel (enforcement radios, notification add/remove, guardrail toggles, rate limits save) work as before.

Closes half of #1359 (PR 1 + PR 2). Follow-ups: PR 3 Canvas workflow settings, PR 4 Lens cog.