### PR TITLE
feat(ux): move Rate limits to /settings; drop Guard Connections tab (#1359)

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -11,14 +11,16 @@ import MembersManager from "@/components/settings/MembersManager"
 import PreferencesPanel from "@/components/settings/PreferencesPanel"
 import ProxySettings from "@/components/settings/ProxySettings"
 import LLMPrimitivesPanel from "@/components/settings/LLMPrimitivesPanel"
+import RateLimitsPanel from "@/components/settings/RateLimitsPanel"
 
-type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "proxy"
+type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "proxy" | "rate_limits"
 
 const TABS: readonly SettingsTab<Tab>[] = [
   { key: "credentials",    label: "Vault" },
   { key: "llm_primitives", label: "LLM Model Primitives" },
   { key: "preferences",    label: "Appearance" },
   { key: "proxy",          label: "Proxy" },
+  { key: "rate_limits",    label: "Rate limits", adminOnly: true },
   { key: "members",        label: "Members & roles", adminOnly: true },
 ]
 
@@ -183,6 +185,7 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
     llm_primitives: <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />,
     preferences:    <PreferencesPanel />,
     proxy:          <ProxySettings workspaceId={workspaceId} getToken={getToken} />,
+    rate_limits:    <RateLimitsPanel isAdmin={isAdmin} />,
     members:        <MembersManager />,
   }
 

--- a/apps/web/src/app/(app)/theguard/settings/page.tsx
+++ b/apps/web/src/app/(app)/theguard/settings/page.tsx
@@ -34,16 +34,12 @@ type GuardSettingsTab =
   | "enforcement"
   | "notifications"
   | "guardrails"
-  | "rate_limits"
-  | "connections"
   | "sync"
 
 const GUARD_SETTINGS_TABS: readonly SettingsTab<GuardSettingsTab>[] = [
   { key: "enforcement",   label: "Enforcement" },
   { key: "notifications", label: "Notifications" },
   { key: "guardrails",    label: "Cost & performance" },
-  { key: "rate_limits",   label: "Rate limits", adminOnly: true },
-  { key: "connections",   label: "Connections" },
   { key: "sync",          label: "Sync status" },
 ]
 
@@ -408,172 +404,6 @@ function GuardToggle({ on, onClick, disabled }: { on: boolean; onClick: () => vo
     </span>
   )
 }
-
-// ─── #980 Rate Limits — workspace default RPM/TPM ─────────────────────────────
-// ponytail: workspace default only in V1. Per-agent overrides land when the
-// agent identity picker ships (backend already accepts agent_identity_id).
-
-function RateLimitsCard({ isAdmin }: { isAdmin: boolean }) {
-  const { authFetch } = useAuthFetch()
-  const [rpm, setRpm] = useState<string>("")
-  const [tpm, setTpm] = useState<string>("")
-  const [loaded, setLoaded] = useState(false)
-  const [saving, setSaving] = useState(false)
-  const [saved, setSaved] = useState(false)
-  const [err, setErr] = useState<string | null>(null)
-  const [overrideCount, setOverrideCount] = useState(0)
-
-  useEffect(() => {
-    if (!isAdmin) return  // GET requires admin; skip fetch for viewers/developers
-    let cancelled = false
-    guard.rateLimits.list(authFetch).then((rows) => {
-      if (cancelled) return
-      const def = rows.find(r => !r.agent_identity_id)
-      setRpm(def?.rpm != null ? String(def.rpm) : "")
-      setTpm(def?.tpm != null ? String(def.tpm) : "")
-      setOverrideCount(rows.filter(r => r.agent_identity_id).length)
-      setLoaded(true)
-    }).catch(() => setLoaded(true))
-    return () => { cancelled = true }
-  }, [authFetch, isAdmin])
-
-  if (!isAdmin) return null
-
-  async function save() {
-    setSaving(true); setErr(null); setSaved(false)
-    try {
-      const body: { agent_identity_id: null; rpm: number | null; tpm: number | null } = {
-        agent_identity_id: null,
-        rpm: rpm.trim() === "" ? null : Number(rpm),
-        tpm: tpm.trim() === "" ? null : Number(tpm),
-      }
-      await guard.rateLimits.upsert(authFetch, body)
-      setSaved(true)
-      setTimeout(() => setSaved(false), 2000)
-    } catch (e: any) {
-      setErr(e?.message || "Save failed")
-    } finally {
-      setSaving(false)
-    }
-  }
-
-  return (
-    <div className="card" style={{ overflow: "hidden", marginTop: 20 }}>
-      <div style={{ padding: "15px 20px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", gap: 10 }}>
-        <span style={{ width: 30, height: 30, borderRadius: 8, background: "var(--accent)", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
-          </svg>
-        </span>
-        <div style={{ fontWeight: 650, fontSize: 14.5 }}>Workspace default</div>
-        {saved && <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--ok)", fontWeight: 600 }}>Saved</span>}
-      </div>
-
-      <div style={{ padding: "16px 20px", display: "grid", gap: 14 }}>
-        <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
-          Leave a field blank to remove that cap. Overrides per-agent identity land soon
-          {overrideCount > 0 ? ` — ${overrideCount} override${overrideCount === 1 ? "" : "s"} currently active.` : "."}
-        </div>
-
-        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
-          <label style={{ display: "grid", gap: 4 }}>
-            <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-2)" }}>Requests / min (RPM)</span>
-            <input
-              type="number"
-              min={1}
-              placeholder="unlimited"
-              value={rpm}
-              onChange={e => setRpm(e.target.value)}
-              disabled={!isAdmin || !loaded}
-              style={{ padding: "9px 12px", fontSize: 13, border: "1px solid var(--border)", borderRadius: 6, background: "var(--surface)", color: "var(--text)" }}
-            />
-          </label>
-          <label style={{ display: "grid", gap: 4 }}>
-            <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-2)" }}>Tokens / min (TPM)</span>
-            <input
-              type="number"
-              min={1}
-              placeholder="unlimited"
-              value={tpm}
-              onChange={e => setTpm(e.target.value)}
-              disabled={!isAdmin || !loaded}
-              style={{ padding: "9px 12px", fontSize: 13, border: "1px solid var(--border)", borderRadius: 6, background: "var(--surface)", color: "var(--text)" }}
-            />
-          </label>
-        </div>
-
-        <RateLimitPresets isAdmin={isAdmin} onPick={(r, t) => { setRpm(String(r)); setTpm(String(t)) }} />
-
-        {err && <div style={{ fontSize: 12, color: "var(--danger)" }}>{err}</div>}
-
-        <div>
-          <button
-            type="button"
-            onClick={save}
-            disabled={!isAdmin || saving || !loaded}
-            className="btn btn-primary btn-sm"
-          >
-            {saving ? "Saving…" : "Save"}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-
-// Anthropic Tier 1 defaults for reference: 50 RPM, 40k input TPM.
-const RATE_LIMIT_PRESETS: Array<{ label: string; rpm: number; tpm: number; why: string }> = [
-  { label: "Solo dev / smoke test",     rpm: 2,   tpm: 500,     why: "trips the cap in a 3-call test — good for verifying enforcement" },
-  { label: "Small team, exploratory",   rpm: 60,  tpm: 100000,  why: "~1 req/sec sustained; enough for Cursor / Claude Code chat" },
-  { label: "Team of 10-20 devs",        rpm: 300, tpm: 500000,  why: "absorbs bursts, still catches runaway agents" },
-]
-
-function RateLimitPresets({ isAdmin, onPick }: { isAdmin: boolean; onPick: (rpm: number, tpm: number) => void }) {
-  return (
-    <div style={{ border: "1px dashed var(--border)", borderRadius: 8, padding: "10px 14px" }}>
-      <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>
-        Suggested defaults
-      </div>
-      <div style={{ display: "grid", gap: 6 }}>
-        {RATE_LIMIT_PRESETS.map(p => (
-          <button
-            key={p.label}
-            type="button"
-            onClick={() => onPick(p.rpm, p.tpm)}
-            disabled={!isAdmin}
-            style={{
-              display: "grid",
-              gridTemplateColumns: "160px 60px 80px 1fr",
-              gap: 10,
-              alignItems: "center",
-              padding: "6px 8px",
-              background: "transparent",
-              border: "1px solid transparent",
-              borderRadius: 6,
-              cursor: isAdmin ? "pointer" : "default",
-              textAlign: "left",
-              color: "var(--text-2)",
-              fontSize: 12.5,
-            }}
-            onMouseEnter={e => { if (isAdmin) e.currentTarget.style.background = "var(--surface-2)" }}
-            onMouseLeave={e => { e.currentTarget.style.background = "transparent" }}
-            title={isAdmin ? "Apply to fields" : "Admin only"}
-          >
-            <span style={{ fontWeight: 600, color: "var(--text)" }}>{p.label}</span>
-            <span style={{ fontVariantNumeric: "tabular-nums" }}>{p.rpm} rpm</span>
-            <span style={{ fontVariantNumeric: "tabular-nums" }}>{p.tpm.toLocaleString()} tpm</span>
-            <span style={{ color: "var(--text-3)", fontSize: 11.5 }}>{p.why}</span>
-          </button>
-        ))}
-      </div>
-      <div style={{ fontSize: 11, color: "var(--text-3)", marginTop: 8 }}>
-        Per-agent identity gets its own limits once the picker ships. Anthropic Tier 1 default for reference: 50 rpm, 40k tpm.
-      </div>
-    </div>
-  )
-}
-
 
 // ─── Main page ────────────────────────────────────────────────────────────────
 
@@ -1062,23 +892,6 @@ function SettingsContent() {
                 </div>
               ))}
               </div>
-              </div>
-            ),
-            rate_limits: <RateLimitsCard isAdmin={isAdmin} />,
-            connections: (
-              <div className="card" style={{ padding: "14px 20px", display: "flex", alignItems: "center", gap: 12 }}>
-            <span style={{ width: 30, height: 30, borderRadius: 8, background: "var(--accent)", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/>
-              </svg>
-            </span>
-            <div style={{ flex: 1 }}>
-              <div style={{ fontWeight: 600, fontSize: 13.5 }}>MCP servers</div>
-              <div style={{ fontSize: 12, color: "var(--text-muted)" }}>Conduct AI Guard is enabled by default. Connect Claude.ai, Desktop, or Work from the MCP servers page.</div>
-            </div>
-            <a href="/integrations" className="btn btn-ghost btn-sm" style={{ textDecoration: "none" }}>
-              Manage MCP →
-            </a>
               </div>
             ),
           }}

--- a/apps/web/src/components/settings/RateLimitsPanel.tsx
+++ b/apps/web/src/components/settings/RateLimitsPanel.tsx
@@ -1,0 +1,174 @@
+"use client"
+
+/**
+ * Workspace-default RPM/TPM caps on proxy traffic. Blocks return 429 with
+ * x-guard reason. Extracted from Guard settings during #1359 so the workspace
+ * defaults live under /settings alongside other workspace-level config. The
+ * enforcement backend (guard.rateLimits) is unchanged.
+ *
+ * ponytail: workspace default only in V1. Per-agent overrides land when the
+ * agent identity picker ships (backend already accepts agent_identity_id).
+ */
+
+import { useEffect, useState } from "react"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { guard } from "@/lib/api"
+
+const RATE_LIMIT_PRESETS: Array<{ label: string; rpm: number; tpm: number; why: string }> = [
+  { label: "Solo dev / smoke test",   rpm: 2,   tpm: 500,     why: "trips the cap in a 3-call test — good for verifying enforcement" },
+  { label: "Small team, exploratory", rpm: 60,  tpm: 100000,  why: "~1 req/sec sustained; enough for Cursor / Claude Code chat" },
+  { label: "Team of 10-20 devs",      rpm: 300, tpm: 500000,  why: "absorbs bursts, still catches runaway agents" },
+]
+
+function RateLimitPresets({ isAdmin, onPick }: { isAdmin: boolean; onPick: (rpm: number, tpm: number) => void }) {
+  return (
+    <div style={{ border: "1px dashed var(--border)", borderRadius: 8, padding: "10px 14px" }}>
+      <div style={{ fontSize: 11, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>
+        Suggested defaults
+      </div>
+      <div style={{ display: "grid", gap: 6 }}>
+        {RATE_LIMIT_PRESETS.map(p => (
+          <button
+            key={p.label}
+            type="button"
+            onClick={() => onPick(p.rpm, p.tpm)}
+            disabled={!isAdmin}
+            style={{
+              display: "grid",
+              gridTemplateColumns: "160px 60px 80px 1fr",
+              gap: 10,
+              alignItems: "center",
+              padding: "6px 8px",
+              background: "transparent",
+              border: "1px solid transparent",
+              borderRadius: 6,
+              cursor: isAdmin ? "pointer" : "default",
+              textAlign: "left",
+              color: "var(--text-2)",
+              fontSize: 12.5,
+            }}
+            onMouseEnter={e => { if (isAdmin) e.currentTarget.style.background = "var(--surface-2)" }}
+            onMouseLeave={e => { e.currentTarget.style.background = "transparent" }}
+            title={isAdmin ? "Apply to fields" : "Admin only"}
+          >
+            <span style={{ fontWeight: 600, color: "var(--text)" }}>{p.label}</span>
+            <span style={{ fontVariantNumeric: "tabular-nums" }}>{p.rpm} rpm</span>
+            <span style={{ fontVariantNumeric: "tabular-nums" }}>{p.tpm.toLocaleString()} tpm</span>
+            <span style={{ color: "var(--text-3)", fontSize: 11.5 }}>{p.why}</span>
+          </button>
+        ))}
+      </div>
+      <div style={{ fontSize: 11, color: "var(--text-3)", marginTop: 8 }}>
+        Per-agent identity gets its own limits once the picker ships. Anthropic Tier 1 default for reference: 50 rpm, 40k tpm.
+      </div>
+    </div>
+  )
+}
+
+export default function RateLimitsPanel({ isAdmin }: { isAdmin: boolean }) {
+  const { authFetch } = useAuthFetch()
+  const [rpm, setRpm] = useState<string>("")
+  const [tpm, setTpm] = useState<string>("")
+  const [loaded, setLoaded] = useState(false)
+  const [saving, setSaving] = useState(false)
+  const [saved, setSaved] = useState(false)
+  const [err, setErr] = useState<string | null>(null)
+  const [overrideCount, setOverrideCount] = useState(0)
+
+  useEffect(() => {
+    if (!isAdmin) return  // GET requires admin; skip fetch for viewers/developers
+    let cancelled = false
+    guard.rateLimits.list(authFetch).then((rows) => {
+      if (cancelled) return
+      const def = rows.find(r => !r.agent_identity_id)
+      setRpm(def?.rpm != null ? String(def.rpm) : "")
+      setTpm(def?.tpm != null ? String(def.tpm) : "")
+      setOverrideCount(rows.filter(r => r.agent_identity_id).length)
+      setLoaded(true)
+    }).catch(() => setLoaded(true))
+    return () => { cancelled = true }
+  }, [authFetch, isAdmin])
+
+  if (!isAdmin) return null
+
+  async function save() {
+    setSaving(true); setErr(null); setSaved(false)
+    try {
+      const body: { agent_identity_id: null; rpm: number | null; tpm: number | null } = {
+        agent_identity_id: null,
+        rpm: rpm.trim() === "" ? null : Number(rpm),
+        tpm: tpm.trim() === "" ? null : Number(tpm),
+      }
+      await guard.rateLimits.upsert(authFetch, body)
+      setSaved(true)
+      setTimeout(() => setSaved(false), 2000)
+    } catch (e: any) {
+      setErr(e?.message || "Save failed")
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="card" style={{ overflow: "hidden" }}>
+      <div style={{ padding: "15px 20px", borderBottom: "1px solid var(--border)", display: "flex", alignItems: "center", gap: 10 }}>
+        <span style={{ width: 30, height: 30, borderRadius: 8, background: "var(--accent)", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+          </svg>
+        </span>
+        <div style={{ fontWeight: 650, fontSize: 14.5 }}>Workspace default</div>
+        {saved && <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--ok)", fontWeight: 600 }}>Saved</span>}
+      </div>
+
+      <div style={{ padding: "16px 20px", display: "grid", gap: 14 }}>
+        <div style={{ fontSize: 12, color: "var(--text-muted)" }}>
+          Requests-per-minute and tokens-per-minute caps on proxy traffic. Blocks return 429 with x-guard reason. Leave a field blank to remove that cap. Overrides per-agent identity land soon
+          {overrideCount > 0 ? ` — ${overrideCount} override${overrideCount === 1 ? "" : "s"} currently active.` : "."}
+        </div>
+
+        <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 14 }}>
+          <label style={{ display: "grid", gap: 4 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-2)" }}>Requests / min (RPM)</span>
+            <input
+              type="number"
+              min={1}
+              placeholder="unlimited"
+              value={rpm}
+              onChange={e => setRpm(e.target.value)}
+              disabled={!isAdmin || !loaded}
+              style={{ padding: "9px 12px", fontSize: 13, border: "1px solid var(--border)", borderRadius: 6, background: "var(--surface)", color: "var(--text)" }}
+            />
+          </label>
+          <label style={{ display: "grid", gap: 4 }}>
+            <span style={{ fontSize: 12, fontWeight: 600, color: "var(--text-2)" }}>Tokens / min (TPM)</span>
+            <input
+              type="number"
+              min={1}
+              placeholder="unlimited"
+              value={tpm}
+              onChange={e => setTpm(e.target.value)}
+              disabled={!isAdmin || !loaded}
+              style={{ padding: "9px 12px", fontSize: 13, border: "1px solid var(--border)", borderRadius: 6, background: "var(--surface)", color: "var(--text)" }}
+            />
+          </label>
+        </div>
+
+        <RateLimitPresets isAdmin={isAdmin} onPick={(r, t) => { setRpm(String(r)); setTpm(String(t)) }} />
+
+        {err && <div style={{ fontSize: 12, color: "var(--danger)" }}>{err}</div>}
+
+        <div>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!isAdmin || saving || !loaded}
+            className="btn btn-primary btn-sm"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Follow-up to #1409. Rate limits are workspace-level default caps on proxy traffic (RPM/TPM), not Guard-policy config — so their surface moves from Guard settings to workspace `/settings`, where they sit next to Vault / LLM Primitives / Appearance / Proxy / Members. Guard's Connections tab was a bare link to `/integrations` — removed since Guard's own top-level nav already covers that path.

- **New** `apps/web/src/components/settings/RateLimitsPanel.tsx` — extracted from `RateLimitsCard` + `RATE_LIMIT_PRESETS` + `RateLimitPresets` in the Guard settings page. `guard.rateLimits.*` API calls unchanged; only the UI surface moves.
- `apps/web/src/app/(app)/settings/page.tsx`: adds `rate_limits` tab (admin-only) between Proxy and Members.
- `apps/web/src/app/(app)/theguard/settings/page.tsx`: **−187 lines**. Drops `RateLimitsCard`, `RATE_LIMIT_PRESETS`, `RateLimitPresets`, and the `rate_limits` + `connections` tab entries and their panels. Guard settings is now four tabs: Enforcement / Notifications / Cost & performance / Sync status.

## Test plan

- [ ] `pnpm --filter @conduct/web tsc --noEmit` clean (verified locally)
- [ ] Visit `/settings` as an admin — new "Rate limits" tab sits between "Proxy" and "Members & roles". Panel loads existing workspace RPM/TPM defaults; Save persists.
- [ ] Visit `/settings` as a non-admin — "Rate limits" tab hidden (matches "Members & roles" gating).
- [ ] Preset buttons (Solo / Small team / Team of 10-20) populate RPM + TPM inputs on click.
- [ ] Save with empty fields clears the cap (backend returns 200, next load shows blanks).
- [ ] Visit `/theguard/settings` — four tabs only (Enforcement / Notifications / Cost & performance / Sync status). No Rate limits or Connections tab.
- [ ] `/integrations` still reachable from Guard's top-level nav (or the app-shell nav).

Ref #1359.