### PR TITLE
fix(test): click Custom tab before asserting seeded rule visibility (closes bucket #1)

### DIFF
--- a/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
+++ b/apps/web/e2e/flows-per-role/policies-list-shows-custom-rule.spec.ts
@@ -11,5 +11,7 @@ test("policies list shows seeded custom rule", async ({ page, context }) => {
   ])
   await page.goto("/theguard/policies")
   await expect(page.locator("main, [role=main], body").first()).toBeVisible({ timeout: 10_000 })
+  // Page defaults to Security tab — the seeded custom rule lives under the Custom tab.
+  await page.getByRole("button", { name: /^Custom\d+$/ }).click()
   await expect(page.getByText(/e2e-block-rm-rf/).first()).toBeVisible({ timeout: 10_000 })
 })


### PR DESCRIPTION
## Summary
Two-line spec fix. Adds a \`getByRole("button", { name: /^Custom\d+$/ }).click()\` before the assertion so the test lands on the tab where its seeded rule actually lives.

## Why
Post-CORS fix (#1408), run [33244823173](https://github.com/sseshachala/conductai/actions/runs/33244823173) showed 4 remaining per-role failures — all on \`policies-list-shows-custom-rule.spec.ts\`. Page snapshot confirms the seeded rule exists (\`Custom1\` tab count shown, page renders \`dev-workspace\` correctly), but the page opens on the Security tab (22 rules) by default. Assertion timed out because \`e2e-block-rm-rf\` isn't on that tab.

Expected: 0 web-smoke failures after this lands + on next nightly.

## Test plan
- [ ] Merge → next \`web-smoke\` push run should show 0 failures across all 4 roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)