### PR TITLE
feat(ux): SettingsShell vertical rail + Canvas typography (#1359)

### DIFF
--- a/apps/web/src/app/(app)/workflows/[id]/settings/page.tsx
+++ b/apps/web/src/app/(app)/workflows/[id]/settings/page.tsx
@@ -115,7 +115,14 @@ export default function AgentSettingsPage() {
   return (
     <div style={{ flex: 1, overflow: "auto" }}>
         <div style={{ maxWidth: 672, margin: "0 auto", padding: "40px 24px" }}>
-          <h2 style={{ fontSize: 20, fontWeight: 600, color: "var(--text)", marginBottom: 24 }}>Workflow Settings</h2>
+          <div style={{ marginBottom: 24 }}>
+            <h1 style={{ fontSize: 25, fontWeight: 680, letterSpacing: "-.02em", color: "var(--text)", margin: 0 }}>
+              Workflow settings
+            </h1>
+            <p style={{ fontSize: 14, color: "var(--text-3)", margin: "5px 0 0" }}>
+              Execution mode, environment, turn budget, and deletion. Rename from the workflows list.
+            </p>
+          </div>
 
           {loading ? (
             <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>

--- a/apps/web/src/components/SettingsShell.tsx
+++ b/apps/web/src/components/SettingsShell.tsx
@@ -1,19 +1,23 @@
 "use client"
 
 /**
- * Shared settings surface — header + TabBar + tabpanels, wrapped in AppShell.
+ * Shared settings surface — header + vertical left-rail sub-nav + tabpanels,
+ * wrapped in AppShell.
  *
  * Used by /settings (workspace), /theguard/settings (Guard), and workflow
  * settings so every settings page has the same shape. See issue #1359.
  *
+ * Vertical left-rail matches the standard settings pattern used by Vercel,
+ * Linear, Stripe, GitHub, and Datadog — instantly distinguishable from any
+ * horizontal parent nav (e.g. Guard's top strip) and scales past 6+ tabs.
+ *
  * When embedding inside another page shell (e.g. GuardShell already owns
  * AppShell + h1 + top-level nav), pass wrapInAppShell={false} and omit
- * title — SettingsShell then renders only the TabBar + panels.
+ * title — SettingsShell then renders only the left rail + panels.
  */
 
 import { useState, type ReactNode } from "react"
 import AppShell from "@/components/AppShell"
-import { TabBar } from "@/components/TabBar"
 
 export interface SettingsTab<K extends string> {
   key: K
@@ -45,8 +49,6 @@ export function SettingsShell<K extends string>({
   const visibleTabs = tabs.filter(t => !t.adminOnly || isAdmin)
   const firstKey = visibleTabs[0]?.key as K
   const [activeTab, setActiveTab] = useState<K>(initialTab ?? firstKey)
-  const labels = Object.fromEntries(visibleTabs.map(t => [t.key, t.label])) as Record<K, string>
-  const tabKeys = visibleTabs.map(t => t.key) as readonly K[]
 
   const body = (
     <>
@@ -68,21 +70,51 @@ export function SettingsShell<K extends string>({
 
       {children}
 
-      <div style={{ marginBottom: 24 }}>
-        <TabBar tabs={tabKeys} labels={labels} activeTab={activeTab} onSelect={setActiveTab} />
-      </div>
+      <div style={{ display: "grid", gridTemplateColumns: "220px 1fr", gap: 32, alignItems: "start", marginTop: 8 }}>
+        <nav role="tablist" aria-orientation="vertical" style={{ display: "flex", flexDirection: "column", gap: 2, borderRight: "1px solid var(--border)", paddingRight: 16 }}>
+          {visibleTabs.map(t => {
+            const active = activeTab === t.key
+            return (
+              <button
+                key={t.key}
+                role="tab"
+                aria-selected={active}
+                aria-controls={`tabpanel-${t.key}`}
+                id={`tab-${t.key}`}
+                onClick={() => setActiveTab(t.key)}
+                style={{
+                  textAlign: "left",
+                  padding: "8px 12px",
+                  fontSize: 13.5,
+                  fontWeight: active ? 650 : 500,
+                  color: active ? "var(--text)" : "var(--text-3)",
+                  background: active ? "var(--surface-2)" : "transparent",
+                  border: "none",
+                  borderRadius: 6,
+                  cursor: "pointer",
+                  transition: "background .12s, color .12s",
+                }}
+              >
+                {t.label}
+              </button>
+            )
+          })}
+        </nav>
 
-      {visibleTabs.map(t => (
-        <div
-          key={t.key}
-          role="tabpanel"
-          id={`tabpanel-${t.key}`}
-          aria-labelledby={`tab-${t.key}`}
-          hidden={activeTab !== t.key}
-        >
-          {panels[t.key]}
+        <div style={{ minWidth: 0 }}>
+          {visibleTabs.map(t => (
+            <div
+              key={t.key}
+              role="tabpanel"
+              id={`tabpanel-${t.key}`}
+              aria-labelledby={`tab-${t.key}`}
+              hidden={activeTab !== t.key}
+            >
+              {panels[t.key]}
+            </div>
+          ))}
         </div>
-      ))}
+      </div>
     </>
   )
 
@@ -90,7 +122,7 @@ export function SettingsShell<K extends string>({
 
   return (
     <AppShell>
-      <div style={{ maxWidth: 960, margin: "0 auto", padding: "40px 24px" }}>
+      <div style={{ maxWidth: 1080, margin: "0 auto", padding: "40px 24px" }}>
         {body}
       </div>
     </AppShell>


### PR DESCRIPTION
## Summary

Two follow-ups on top of #1409 and #1410:

### 1. `<SettingsShell>` → vertical left-rail sub-nav

Two stacked horizontal underline tab strips (Guard's top nav + the old horizontal SettingsShell sub-nav) was an anti-pattern — users couldn't tell parent from child at a glance. Switches to the vertical left-rail pattern used by Vercel, Linear, Stripe, GitHub, and Datadog settings.

- 220px left rail (border-right, muted labels, `surface-2` background on active), 32px gutter, content pane on the right.
- `role="tablist"` with `aria-orientation="vertical"`; each tab keeps `role="tab"`, `aria-selected`, `aria-controls` wired to the matching panel.
- Grid container `maxWidth` bumped 960 → 1080 to accommodate the rail without shrinking panel content.
- `TabBar` import removed from SettingsShell (TabBar remains available for non-settings surfaces like agent-identity).

Behavior for both consumers (workspace `/settings` + Guard `/theguard/settings`) is unchanged: same tabs, same admin gating, same panels. Only the sub-nav visual changes.

### 2. Canvas workflow settings typography

Small header pass on `/workflows/[id]/settings` so its header matches the workspace + Guard pattern: `h1` 25px / 680 weight, `letterSpacing: -.02em`, 14px muted description below. Cards untouched.

Not adopting `<SettingsShell>` on Canvas here — the page has 5 short cards on one screen; a vertical sub-nav would be more chrome than useful. Revisit if Canvas settings grows past ~5 groupings.

## Test plan

- [ ] `pnpm --filter @conduct/web tsc --noEmit` clean (verified locally)
- [ ] Visit `/settings` — vertical left rail with Vault / LLM Model Primitives / Appearance / Proxy / Rate limits / Members. Clicking a tab swaps the panel; active tab has `surface-2` background + bold label.
- [ ] Visit `/settings` as a non-admin — Rate limits + Members hidden from the rail.
- [ ] Visit `/theguard/settings` — Guard's horizontal top strip (Activity / Spend / … / Settings) sits above; below, vertical left rail with Enforcement / Notifications / Cost & performance / Sync status. No visual confusion between the two levels.
- [ ] Visit `/workflows/[id]/settings` — header is now h1 25px + muted description. Cards unchanged.
- [ ] Keyboard nav: `Tab` reaches the rail buttons; `Enter`/`Space` activates; `aria-selected` updates.

Ref #1359. Follows #1409 and #1410.