### PR TITLE
feat(mcp): LensAdapter — Lens chat consumes ToolRegistry (#1227)

### DIFF
--- a/apps/api/app/mcp/lens_adapter.py
+++ b/apps/api/app/mcp/lens_adapter.py
@@ -1,0 +1,93 @@
+"""LensAdapter — Lens chat consumes the same ToolRegistry as the MCP surfaces.
+
+Lens chat historically dispatched tools via `Executor.call(name, args)` which
+did its own `getattr(self, f"_tool_{name}")` lookup. That path was parallel to
+the MCP HTTP/stdio adapters and had its own per-tool guard_check flow. Any
+tool added to the ToolRegistry was invisible to Lens until the Executor got
+a matching method — a permanent drift risk (#1219 / #1227).
+
+This adapter closes the loop: Lens chat calls `lens_adapter.dispatch(name,
+args_json, ctx)` and gets back the same JSON envelope `Executor.call` used to
+produce. Under the hood it looks up the ToolDef in `default_registry`,
+runs the composable policy engine (same shape as `app/mcp/server.py::dispatch`
+but with `provider="lens"`), and invokes `tool.impl(ctx, **args)`.
+
+Contract mirrors the legacy `Executor.call`:
+
+- Returns a JSON string (chat.py passes it back to the model as tool result)
+- Unknown tool → `{"error": "Unknown tool: <name>"}`
+- Guard BLOCK → `{"error": "Blocked by Guard rule ...", "blocked_by": ..., "rule_id": ...}`
+- Impl exception → `{"error": "<message>"}`
+- Otherwise → `json.dumps(impl_return_value)`
+
+Every registered Lens ToolDef's impl (see `app/tools/registrations/lens.py`)
+already opens its own SessionLocal + Executor and dispatches to
+`_tool_{method_name}` — so the adapter does not need to hold DB state.
+"""
+from __future__ import annotations
+
+import json
+
+import structlog
+
+from app.guard.policy import evaluate_composed
+from app.guard.policy_types import PolicyAction, PolicyContext
+from app.mcp.server import MCPContext
+from app.tools.registry import default_registry
+
+log = structlog.get_logger(__name__)
+
+
+def dispatch(name: str, arguments_json: str, ctx: MCPContext) -> str:
+    """Look up tool in registry, run guard_check, invoke impl.
+
+    Signature matches `Executor.call(name, arguments)` so the chat handler
+    swap is one line. `arguments_json` is a JSON-encoded object; empty
+    string is treated as `{}`.
+    """
+    try:
+        args = json.loads(arguments_json) if arguments_json else {}
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid arguments JSON: {e}"})
+
+    tool = default_registry.get(name)
+    if tool is None:
+        return json.dumps({"error": f"Unknown tool: {name}"})
+
+    # Per-tool policy gate — same shape Executor.call used (#1218 Step 4).
+    # provider="lens" so rules can scope to the Lens surface independently
+    # of MCP/HTTP callers.
+    policy_ctx = PolicyContext(
+        workspace_id=ctx.workspace_id,
+        clerk_user_id=ctx.clerk_user_id,
+        provider="lens",
+        model="tool",
+        body={"tool_name": name, "arguments": args},
+        extras={"kind": "lens_tool", "tool_name": name, "surface": ctx.surface},
+    )
+    try:
+        decision = evaluate_composed(policy_ctx)
+    except Exception as e:
+        # Guard eval itself broke — fail-open, matches Executor.call behaviour.
+        log.warning("lens_adapter.guard_check_failed", tool=name, err=str(e))
+        decision = None
+
+    if decision is not None and decision.action == PolicyAction.BLOCK:
+        log.warning("lens_adapter.blocked",
+                    tool=name,
+                    rule=decision.rule_id,
+                    source=decision.source)
+        return json.dumps({
+            "error": (
+                f"Blocked by Guard rule {decision.rule_id}: "
+                f"{decision.reason or 'policy violation'}"
+            ),
+            "blocked_by": decision.source,
+            "rule_id": decision.rule_id,
+        })
+
+    try:
+        return json.dumps(tool.impl(ctx, **args))
+    except Exception as e:
+        log.warning("lens_adapter.impl_error", tool=name, err=str(e))
+        return json.dumps({"error": str(e)})

--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -43,52 +43,13 @@ class Executor:
         # to the session-scoped AgentIdentity. None outside chat (tool registrations).
         self.agent_identity_id = agent_identity_id
 
-    def call(self, name: str, arguments: str) -> str:
-        args = json.loads(arguments) if arguments else {}
-        fn = getattr(self, f"_tool_{name}", None)
-        if not fn:
-            return json.dumps({"error": f"Unknown tool: {name}"})
-
-        # #1218 Step 4 — per-tool guard_check.
-        # Each tool invocation goes through the composable engine as a
-        # synthetic "tool call" so prompt-injection can't fan out unchecked
-        # once the endpoint-level require_permission has passed.
-        try:
-            from app.guard.policy import evaluate_composed as _eval_composed
-            from app.guard.policy_types import PolicyAction as _PolicyAction, PolicyContext as _PolicyContext
-
-            _tool_ctx = _PolicyContext(
-                workspace_id=self.workspace_id,
-                provider="lens",
-                model="tool",
-                body={"tool_name": name, "arguments": args},
-                extras={"kind": "lens_tool", "tool_name": name},
-            )
-            _tool_decision = _eval_composed(_tool_ctx)
-            if _tool_decision.action == _PolicyAction.BLOCK:
-                log.warning("glens.executor.blocked",
-                            tool=name,
-                            rule=_tool_decision.rule_id,
-                            source=_tool_decision.source)
-                return json.dumps({
-                    "error": (
-                        f"Blocked by Guard rule {_tool_decision.rule_id}: "
-                        f"{_tool_decision.reason or 'policy violation'}"
-                    ),
-                    "blocked_by": _tool_decision.source,
-                    "rule_id": _tool_decision.rule_id,
-                })
-        except Exception as e:
-            # Guard check itself failed — fail-open per current spend/rate
-            # source conventions. Log so ops can catch a persistent failure.
-            log.warning("glens.executor.guard_check_failed",
-                        tool=name, err=str(e))
-
-        try:
-            return json.dumps(fn(**args))
-        except Exception as e:
-            log.warning("glens.executor.error", tool=name, error=str(e))
-            return json.dumps({"error": str(e)})
+    # Tool dispatch used to happen here via `call(name, arguments)`. That path
+    # is now `app.mcp.lens_adapter.dispatch`, which reads the same
+    # ToolRegistry the MCP HTTP/stdio adapters use (#1227). The 44 `_tool_*`
+    # methods below remain as impls — the registry's `_impl(method_name)`
+    # wrapper in `app/tools/registrations/lens.py` instantiates an Executor
+    # per call and dispatches to the matching `_tool_*`. Phase 4 flattens
+    # these into free functions.
 
     # ── Spend / events ────────────────────────────────────────────────────────
 

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -476,17 +476,24 @@ def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tup
     """Phase 1: Execute tool calls. Returns (final_msgs, early_text, tool_calls_made).
 
     Each LLM turn goes through Guard's in-process `guarded_llm_call` (#1254) —
-    same policy + audit path as the HTTP proxy. The Lens-side `_llm_client`
-    is still constructed to reuse the client's provider-neutral message
-    formatters (`make_assistant_turn`, `make_tool_results_turn`); only the
-    upstream call itself is now Guard-mediated.
+    same policy + audit path as the HTTP proxy. Tool dispatch itself now
+    goes through `lens_adapter.dispatch` (#1227) so Lens shares the same
+    ToolRegistry as the MCP HTTP/stdio surfaces.
     """
+    from app.mcp.lens_adapter import dispatch as lens_dispatch
+    from app.mcp.server import MCPContext
     from app.runtime.llm_client import LLMToolUseBlock
 
     client, provider, model = _llm_config(executor)
     log.info("glens.llm_call", provider=provider, model=model)
     msgs = list(messages)
     tool_calls_made: list[tuple[str, dict]] = []
+
+    lens_ctx = MCPContext(
+        workspace_id=executor.workspace_id,
+        clerk_user_id="system:lens",
+        surface="lens",
+    )
 
     for _ in range(5):
         resp = _guarded_openai_completion(
@@ -503,7 +510,7 @@ def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tup
         results = []
         for block in tool_blocks:
             tool_calls_made.append((block.name, block.input))
-            result = executor.call(block.name, json.dumps(block.input))
+            result = lens_dispatch(block.name, json.dumps(block.input), lens_ctx)
             log.debug("glens.tool", name=block.name, result_len=len(result))
             results.append((block.id, result))
         msgs.extend(client.make_tool_results_turn(results))

--- a/apps/api/tests/guard/test_executor_guard_check.py
+++ b/apps/api/tests/guard/test_executor_guard_check.py
@@ -1,46 +1,53 @@
-"""Per-tool guard_check in Executor.call() — #1218 Step 4."""
+"""Per-tool guard_check in the Lens dispatch path — #1218 Step 4, moved
+from `Executor.call` to `app.mcp.lens_adapter.dispatch` in #1227.
+
+Behaviour is unchanged: same error envelope, same policy path
+(provider="lens"), same fail-open semantics. Tool impls still live on
+Executor as `_tool_*` methods; the registry projects them via
+`_impl(method_name)` in `app/tools/registrations/lens.py`.
+"""
 from __future__ import annotations
 
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 from app.guard.policy_types import PolicyAction, PolicyDecision
-from app.modules.glens.executor import Executor
+from app.mcp.lens_adapter import dispatch as lens_dispatch
+from app.mcp.server import MCPContext
+from app.tools import registrations  # noqa: F401  # side-effect: populate default_registry
 
 
-def _executor():
-    return Executor(db=MagicMock(), workspace_id="00000000-0000-0000-0000-000000000000")
+_CTX = MCPContext(workspace_id="00000000-0000-0000-0000-000000000000", surface="lens")
 
 
-def test_call_unknown_tool_short_circuits_before_guard():
+def test_dispatch_unknown_tool_short_circuits_before_guard():
     """Unknown tool returns error immediately — no guard eval needed."""
-    ex = _executor()
-    with patch("app.guard.policy.evaluate_composed") as mock_eval:
-        result = ex.call("nonexistent_tool", "{}")
+    with patch("app.mcp.lens_adapter.evaluate_composed") as mock_eval:
+        result = lens_dispatch("nonexistent_tool", "{}", _CTX)
     assert "Unknown tool" in result
     assert not mock_eval.called
 
 
-def test_call_allowed_tool_runs_normally():
-    ex = _executor()
+def test_dispatch_allowed_tool_runs_normally():
     allow_decision = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
-    with patch("app.guard.policy.evaluate_composed", return_value=allow_decision), \
-         patch.object(ex, "_tool_get_spend_summary", return_value={"ok": True}):
-        result = ex.call("get_spend_summary", "{}")
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=allow_decision), \
+         patch("app.modules.glens.executor.Executor._tool_get_spend_summary",
+               return_value={"ok": True}, create=True):
+        result = lens_dispatch("get_spend_summary", "{}", _CTX)
     assert json.loads(result) == {"ok": True}
 
 
-def test_call_blocked_tool_returns_error_envelope():
-    ex = _executor()
+def test_dispatch_blocked_tool_returns_error_envelope():
     block_decision = PolicyDecision(
         action=PolicyAction.BLOCK,
         source="rule",
         rule_id="lens.no_secrets_search",
         reason="Blocked search for secrets",
     )
-    with patch("app.guard.policy.evaluate_composed", return_value=block_decision), \
-         patch.object(ex, "_tool_search_knowledge") as mock_tool:
-        result = ex.call("search_knowledge", '{"q": "aws_secret_key"}')
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=block_decision), \
+         patch("app.modules.glens.executor.Executor._tool_search_knowledge",
+               create=True) as mock_tool:
+        result = lens_dispatch("search_knowledge", '{"q": "aws_secret_key"}', _CTX)
     parsed = json.loads(result)
     assert "Blocked by Guard rule" in parsed["error"]
     assert parsed["blocked_by"] == "rule"
@@ -49,41 +56,41 @@ def test_call_blocked_tool_returns_error_envelope():
     assert not mock_tool.called
 
 
-def test_call_guard_check_failure_fails_open():
+def test_dispatch_guard_check_failure_fails_open():
     """If the composable engine itself crashes, we fail-open (log + proceed)
     so a broken policy source can't lock Lens out of all tools."""
-    ex = _executor()
-    with patch("app.guard.policy.evaluate_composed", side_effect=RuntimeError("db down")), \
-         patch.object(ex, "_tool_get_spend_summary", return_value={"fallback": True}):
-        result = ex.call("get_spend_summary", "{}")
+    with patch("app.mcp.lens_adapter.evaluate_composed",
+               side_effect=RuntimeError("db down")), \
+         patch("app.modules.glens.executor.Executor._tool_get_spend_summary",
+               return_value={"fallback": True}, create=True):
+        result = lens_dispatch("get_spend_summary", "{}", _CTX)
     assert json.loads(result) == {"fallback": True}
 
 
-def test_call_tool_exception_returns_error_envelope():
-    """Tool implementation raises — Executor catches + returns error dict."""
-    ex = _executor()
+def test_dispatch_tool_exception_returns_error_envelope():
+    """Tool implementation raises — adapter catches + returns error dict."""
     allow_decision = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
-    with patch("app.guard.policy.evaluate_composed", return_value=allow_decision), \
-         patch.object(ex, "_tool_get_spend_summary", side_effect=RuntimeError("boom")):
-        result = ex.call("get_spend_summary", "{}")
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=allow_decision), \
+         patch("app.modules.glens.executor.Executor._tool_get_spend_summary",
+               side_effect=RuntimeError("boom"), create=True):
+        result = lens_dispatch("get_spend_summary", "{}", _CTX)
     parsed = json.loads(result)
     assert parsed["error"] == "boom"
 
 
-def test_call_arguments_passed_to_tool():
-    ex = _executor()
+def test_dispatch_arguments_passed_to_tool():
     allow_decision = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
-    with patch("app.guard.policy.evaluate_composed", return_value=allow_decision), \
-         patch.object(ex, "_tool_get_spend_summary", return_value={"month": "2026-08"}) as mock_tool:
-        result = ex.call("get_spend_summary", '{"month": "2026-08"}')
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=allow_decision), \
+         patch("app.modules.glens.executor.Executor._tool_get_spend_summary",
+               return_value={"month": "2026-08"}, create=True) as mock_tool:
+        result = lens_dispatch("get_spend_summary", '{"month": "2026-08"}', _CTX)
     assert json.loads(result) == {"month": "2026-08"}
     mock_tool.assert_called_once_with(month="2026-08")
 
 
-def test_call_context_shape_for_tool_policy_eval():
+def test_dispatch_context_shape_for_tool_policy_eval():
     """PolicyContext passed to composable engine should identify the tool
     call — enables rules that target specific tools or arg patterns."""
-    ex = _executor()
     allow_decision = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
     captured_ctx = []
 
@@ -91,9 +98,10 @@ def test_call_context_shape_for_tool_policy_eval():
         captured_ctx.append(ctx)
         return allow_decision
 
-    with patch("app.guard.policy.evaluate_composed", side_effect=_capture), \
-         patch.object(ex, "_tool_search_memory", return_value={"hits": []}):
-        ex.call("search_memory", '{"q": "hello"}')
+    with patch("app.mcp.lens_adapter.evaluate_composed", side_effect=_capture), \
+         patch("app.modules.glens.executor.Executor._tool_search_memory",
+               return_value={"hits": []}, create=True):
+        lens_dispatch("search_memory", '{"q": "hello"}', _CTX)
 
     assert len(captured_ctx) == 1
     ctx = captured_ctx[0]


### PR DESCRIPTION
## Summary

Closes the drift risk between the Lens chat dispatch path and the MCP HTTP/stdio surfaces. Before this PR, Lens chat called `Executor.call(name, args)` which did its own `getattr(self, '_tool_' + name)` lookup with its own guard_check flow — a permanent divergence risk. Any tool added to the `ToolRegistry` was invisible to Lens until someone thought to add a matching `_tool_*` method to `Executor`.

- **New `app/mcp/lens_adapter.py`** — `dispatch(name, args_json, ctx) -> str`. Looks up `ToolDef` in `default_registry`, runs `evaluate_composed` with `provider="lens"`, invokes `tool.impl(ctx, **args)`. Return contract matches the legacy `Executor.call` exactly (JSON string with `error` / `blocked_by` / `rule_id` envelopes) so the call-site swap is one line.
- **`app/modules/glens/routers/chat.py`** — replace `executor.call(...)` with `lens_adapter.dispatch(...)` at the tool-loop call site. Builds an `MCPContext(workspace_id, clerk_user_id="system:lens", surface="lens")` once per `_resolve_tools` invocation.
- **`app/modules/glens/executor.py`** — delete `Executor.call()` (verified via `grep` that it was the only remaining caller). The 44 `_tool_*` methods stay: `registrations/lens.py::_impl(name)` still instantiates an `Executor` per call and dispatches to `_tool_{method_name}`. **Phase 4 flattens those into free functions.**
- **`tests/guard/test_executor_guard_check.py`** — rewrite the 7 policy / envelope / arg-passing tests to target `lens_adapter.dispatch`. Same assertions, new dispatch surface.

## Effect

Adding a Lens tool = one `register(ToolDef)` call in `app/tools/registrations/lens.py`. It appears on the MCP HTTP surface, the stdio surface, and Lens chat — same policy gate everywhere. No drift risk.

Total registry count at startup: 61 tools (17 guard-tagged, 44 lens-tagged). Verified locally via `python3.11 -c "..."` boot.

## Test plan

- [x] `pytest tests/guard/test_executor_guard_check.py` — 7/7 green locally
- [ ] Chat a simple query via `/lens` that dispatches a tool (`get_spend_summary`, `get_recent_events`) — result envelope shape matches pre-refactor
- [ ] Force a guard block via a workspace policy that matches `provider=='lens'` — response contains `error`, `blocked_by`, `rule_id` fields
- [ ] Chat a tool that raises — response contains `error` field with the exception message
- [ ] Register a new `ToolDef` in `registrations/lens.py`, restart, verify it's callable from Lens chat without any executor changes

## Ref
- Blocks #1219 Phase 4 (cutover — retire `/guard/mcp` + `conductguard-mcp` binary once byte-parity regression fixtures land).
- Follow-up: flatten `Executor._tool_*` methods into free functions in `registrations/lens.py`. Doesn't change behaviour, keeps this PR small.