### PR TITLE
feat(ux): dedicated 'Canvas' tab in /settings (#1359)

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -6,6 +6,7 @@ import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api"
 import { SettingsShell, type SettingsTab } from "@/components/SettingsShell"
 import { useWorkspace } from "@/lib/WorkspaceContext"
+import CanvasPanel from "@/components/settings/CanvasPanel"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
 import PreferencesPanel from "@/components/settings/PreferencesPanel"
@@ -13,12 +14,13 @@ import ProxySettings from "@/components/settings/ProxySettings"
 import LLMPrimitivesPanel from "@/components/settings/LLMPrimitivesPanel"
 import RateLimitsPanel from "@/components/settings/RateLimitsPanel"
 
-type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "proxy" | "rate_limits"
+type Tab = "credentials" | "llm_primitives" | "members" | "preferences" | "canvas" | "proxy" | "rate_limits"
 
 const TABS: readonly SettingsTab<Tab>[] = [
   { key: "credentials",    label: "Vault" },
   { key: "llm_primitives", label: "LLM Model Primitives" },
   { key: "preferences",    label: "Appearance" },
+  { key: "canvas",         label: "Canvas" },
   { key: "proxy",          label: "Proxy" },
   { key: "rate_limits",    label: "Rate limits", adminOnly: true },
   { key: "members",        label: "Members & roles", adminOnly: true },
@@ -184,6 +186,7 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
     credentials:    <EnvironmentsManager isAdmin={isAdmin} />,
     llm_primitives: <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />,
     preferences:    <PreferencesPanel />,
+    canvas:         <CanvasPanel />,
     proxy:          <ProxySettings workspaceId={workspaceId} getToken={getToken} />,
     rate_limits:    <RateLimitsPanel isAdmin={isAdmin} />,
     members:        <MembersManager />,

--- a/apps/web/src/components/settings/CanvasPanel.tsx
+++ b/apps/web/src/components/settings/CanvasPanel.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+/**
+ * Canvas panel — workspace-wide toggles for the workflow canvas UI.
+ * Extracted from PreferencesPanel during #1359 so canvas options aren't
+ * buried under Appearance (theme/accent). Storage still lives in the
+ * same workspace preferences endpoint.
+ */
+
+import { usePreferences } from "@/lib/PreferencesContext"
+
+function ToggleRow({
+  label,
+  description,
+  checked,
+  onChange,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (v: boolean) => void
+}) {
+  return (
+    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 24, padding: "14px 0", borderBottom: "1px solid var(--border)" }}>
+      <div style={{ flex: 1 }}>
+        <p style={{ fontSize: 13.5, fontWeight: 600, color: "var(--text)" }}>{label}</p>
+        <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>{description}</p>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        onClick={() => onChange(!checked)}
+        style={{ position: "relative", display: "inline-flex", width: 36, height: 20, flexShrink: 0, alignItems: "center", borderRadius: 10, border: "none", cursor: "pointer", marginTop: 2, background: checked ? "var(--accent)" : "var(--border-2, #d4d0cb)", transition: "background .15s" }}
+      >
+        <span
+          style={{ display: "inline-block", width: 14, height: 14, borderRadius: "50%", background: "#fff", boxShadow: "0 1px 3px rgba(0,0,0,.2)", transition: "transform .15s", transform: checked ? "translateX(18px)" : "translateX(3px)" }}
+        />
+      </button>
+    </div>
+  )
+}
+
+export default function CanvasPanel() {
+  const { prefs, loading, update } = usePreferences()
+
+  if (loading) {
+    return <div style={{ fontSize: 13, color: "var(--text-muted)", padding: "16px 0" }}>Loading preferences…</div>
+  }
+
+  return (
+    <div style={{ maxWidth: 760 }}>
+      <div className="eyebrow" style={{ marginBottom: 12 }}>Canvas toolbar</div>
+      <div className="card" style={{ padding: "0 18px" }}>
+        <ToggleRow
+          label="Show Test Trigger button"
+          description="Adds a 'Test Trigger' button to the canvas toolbar — fires a real run with a safe dummy payload."
+          checked={prefs.show_test_trigger}
+          onChange={v => update({ show_test_trigger: v })}
+        />
+        <ToggleRow
+          label="Show Dry Run button"
+          description="Adds a 'Dry Run' button to the canvas toolbar — simulates the workflow without calling any external APIs."
+          checked={prefs.show_dry_run}
+          onChange={v => update({ show_dry_run: v })}
+        />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/settings/PreferencesPanel.tsx
+++ b/apps/web/src/components/settings/PreferencesPanel.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { useState, useEffect } from "react"
-import { usePreferences } from "@/lib/PreferencesContext"
 
 const ACCENTS: Record<string, { base: string; hover: string; ring: string; weak: string; weak2: string; text: string }> = {
   indigo:  { base: "#4f46e5", hover: "#4338ca", ring: "#818cf8", weak: "#eef2ff", weak2: "#e0e7ff", text: "#4338ca" },
@@ -57,38 +56,6 @@ function applyTheme(look: string, accent: string) {
   for (const v of SEMANTIC_VARS) r.removeProperty(v)
 }
 
-function ToggleRow({
-  label,
-  description,
-  checked,
-  onChange,
-}: {
-  label: string
-  description: string
-  checked: boolean
-  onChange: (v: boolean) => void
-}) {
-  return (
-    <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 24, padding: "14px 0", borderBottom: "1px solid var(--border)" }}>
-      <div style={{ flex: 1 }}>
-        <p style={{ fontSize: 13.5, fontWeight: 600, color: "var(--text)" }}>{label}</p>
-        <p style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 2 }}>{description}</p>
-      </div>
-      <button
-        type="button"
-        role="switch"
-        aria-checked={checked}
-        onClick={() => onChange(!checked)}
-        style={{ position: "relative", display: "inline-flex", width: 36, height: 20, flexShrink: 0, alignItems: "center", borderRadius: 10, border: "none", cursor: "pointer", marginTop: 2, background: checked ? "var(--accent)" : "var(--border-2, #d4d0cb)", transition: "background .15s" }}
-      >
-        <span
-          style={{ display: "inline-block", width: 14, height: 14, borderRadius: "50%", background: "#fff", boxShadow: "0 1px 3px rgba(0,0,0,.2)", transition: "transform .15s", transform: checked ? "translateX(18px)" : "translateX(3px)" }}
-        />
-      </button>
-    </div>
-  )
-}
-
 function ThemePreview({ dark }: { dark: boolean }) {
   const v = dark
     ? { bg: "#0b0a09", side: "#141210", bd: "#2a2624", t: "#f5f3f0", t2: "#8c847d", card: "#1c1917", acc: "var(--accent)" }
@@ -113,7 +80,6 @@ function ThemePreview({ dark }: { dark: boolean }) {
 }
 
 export default function PreferencesPanel() {
-  const { prefs, loading, update } = usePreferences()
   const [look, setLookState] = useState("light")
   const [accent, setAccentState] = useState("indigo")
 
@@ -134,10 +100,6 @@ export default function PreferencesPanel() {
     setAccentState(k)
     if (typeof window !== "undefined") localStorage.setItem("conduct-accent", k)
     applyTheme(look, k)
-  }
-
-  if (loading) {
-    return <div style={{ fontSize: 13, color: "var(--text-muted)", padding: "16px 0" }}>Loading preferences…</div>
   }
 
   return (
@@ -185,21 +147,6 @@ export default function PreferencesPanel() {
         <span style={{ fontSize: 12.5, color: "var(--text-muted)", textTransform: "capitalize" }}>Selected: {accent}</span>
       </div>
 
-      <div className="eyebrow" style={{ marginBottom: 12 }}>Canvas options</div>
-      <div className="card" style={{ padding: "0 18px" }}>
-        <ToggleRow
-          label="Show Test Trigger button"
-          description="Adds a 'Test Trigger' button to the canvas toolbar — fires a real run with a safe dummy payload."
-          checked={prefs.show_test_trigger}
-          onChange={v => update({ show_test_trigger: v })}
-        />
-        <ToggleRow
-          label="Show Dry Run button"
-          description="Adds a 'Dry Run' button to the canvas toolbar — simulates the workflow without calling any external APIs."
-          checked={prefs.show_dry_run}
-          onChange={v => update({ show_dry_run: v })}
-        />
-      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

Canvas toolbar toggles (Show Test Trigger, Show Dry Run) were buried under "Appearance" — a tab that otherwise holds theme + accent colour. Wrong home. Moves them to a dedicated "Canvas" tab in workspace `/settings`, adjacent to Appearance.

- **New `apps/web/src/components/settings/CanvasPanel.tsx`** — extracted from `PreferencesPanel`. Same workspace-scoped storage via `usePreferences()` (`show_test_trigger` / `show_dry_run`). Local `ToggleRow` helper.
- **`apps/web/src/app/(app)/settings/page.tsx`** — adds `canvas` tab between Appearance and Proxy in `TABS` + panels dict.
- **`apps/web/src/components/settings/PreferencesPanel.tsx`** — strip the Canvas options section, the `ToggleRow` helper (no longer used), and the `usePreferences` import. Net −53 lines.

No behaviour change: same toggles, same storage, same effect on the workflow canvas — just found where users expect.

## Test plan

- [x] `tsc --noEmit` clean (verified locally, ran automatically via pre-commit hook)
- [ ] Visit `/settings` → new "Canvas" tab visible in the vertical rail between Appearance and Proxy
- [ ] Toggle "Show Test Trigger" → refresh → canvas toolbar reflects the setting on `/workflows/[id]`
- [ ] Toggle "Show Dry Run" → same
- [ ] Old "Canvas options" section no longer appears under Appearance

Ref #1359. Follows #1409, #1410, #1412.