### PR TITLE
chore(nav): remove Quality + Benchmark from console sidebar

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -120,8 +120,6 @@ function getBreadcrumbs(pathname: string, projects: Project[]): string[] {
   if (pathname.startsWith('/logs')) return ['Logs']
   if (pathname.startsWith('/runs')) return ['Runs']
   if (pathname.startsWith('/observability')) return ['Observability']
-  if (pathname.startsWith('/eval')) return ['Quality']
-  if (pathname.startsWith('/benchmark')) return ['Benchmark']
   if (pathname === '/workflows') return ['Agents']
   if (pathname.startsWith('/workflows/new')) return ['Canvas', 'New agent']
   if (pathname.startsWith('/workflows/')) return ['Canvas']
@@ -999,20 +997,6 @@ function AppShellInnerContent({
                 })}
               </div>
             )}
-            <SideNavItem
-              href="/eval"
-              label="Quality"
-              icon={<Icons.Star />}
-              active={pathname.startsWith("/eval")}
-              collapsed={collapsed}
-            />
-            <SideNavItem
-              href="/benchmark"
-              label="Benchmark"
-              icon={<Icons.Trophy />}
-              active={pathname.startsWith("/benchmark")}
-              collapsed={collapsed}
-            />
           </div>
         </nav>
 


### PR DESCRIPTION
## Summary

The Quality + Benchmark sidebar entries in the authenticated console linked to `/eval` and `/benchmark`. Those routes live under `apps/web/src/app/(marketing)/`, not `(app)/`, and render the same public 'playbook quality grades' and benchmark rollups whether or not the user is signed in — no workspace context, nothing to act on.

Having them in the authenticated console sidebar just bounced users out to a marketing page. Cleanup:

- Drop the two `<SideNavItem>` calls in `AppShell.tsx` (Quality + Benchmark with Star/Trophy icons).
- Drop the two matching breadcrumb branches (`/eval` → `['Quality']`, `/benchmark` → `['Benchmark']`) that only mattered when those routes appeared inside the console.

## Zero content loss

Marketing pages remain at `/eval` and `/benchmark` and are still reachable via the marketing site header.

## When to reconsider

If per-workspace eval or benchmark dashboards become a real ask, they belong under `(app)/eval` and `(app)/benchmark` as new features — showing this workspace's playbook quality, this workspace's benchmark runs. Repurposing marketing links for that would just delay building the real thing.

## Test plan

- [x] `tsc --noEmit` clean (verified locally via pre-commit hook)
- [ ] Console sidebar no longer shows Quality or Benchmark items
- [ ] Direct navigation to `/eval` and `/benchmark` still renders the marketing pages (no route removed)
- [ ] Breadcrumbs on any page inside `(app)/` unaffected