### PR TITLE
fix(nav): restore top-level Observability entry under OBSERVE

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -963,10 +963,10 @@ function AppShellInnerContent({
               href="/logs/guard"
               label="Logs"
               icon={<Icons.Pulse />}
-              active={pathname.startsWith("/logs") || pathname.startsWith("/runs") || pathname.startsWith("/observability")}
+              active={pathname.startsWith("/logs") || pathname.startsWith("/runs")}
               collapsed={collapsed}
             />
-            {(pathname.startsWith("/logs") || pathname.startsWith("/runs") || pathname.startsWith("/observability")) && !collapsed && (
+            {(pathname.startsWith("/logs") || pathname.startsWith("/runs")) && !collapsed && (
               <div style={{ marginLeft: 28, marginTop: 2, display: "flex", flexDirection: "column", gap: 1 }}>
                 {[
                   { label: "Guard", href: "/logs/guard" },
@@ -997,6 +997,13 @@ function AppShellInnerContent({
                 })}
               </div>
             )}
+            <SideNavItem
+              href="/observability"
+              label="Observability"
+              icon={<Icons.Spark />}
+              active={pathname === "/observability" || pathname.startsWith("/observability/")}
+              collapsed={collapsed}
+            />
           </div>
         </nav>
 


### PR DESCRIPTION
## Summary

Commit `1aa08b9c` added `/observability` as a top-level sidebar entry in May (health strip + agent-status grid dashboard). The `f78d8daf` shell redesign moved the label into the Logs expandable as `/logs/observability` and dropped the top-level link. The `/observability` page itself still exists at `apps/web/src/app/(app)/observability/page.tsx` and renders — it was just unreachable from the sidebar.

## Changes

- Add a `SideNavItem` for `/observability` under the OBSERVE group, right after the Logs expandable.
- Fix the Logs active-predicate so it no longer lights up when the user is on `/observability` (the sub-menu previously claimed that route). Logs stays active for `/logs/**` and `/runs/**` only.
- Kept the Logs → Observability sub-item at `/logs/observability` untouched — different content (log stream view). The two entries cover different surfaces.

## Test plan

- [x] `tsc --noEmit` clean (verified locally via pre-commit hook)
- [ ] Sidebar OBSERVE section shows: Logs (expandable) + Observability
- [ ] Visit `/observability` — Observability item highlights active, Logs does not
- [ ] Visit `/logs/observability` — Logs item highlights active (sub-menu opens, Observability sub-item highlights), top-level Observability does not
- [ ] Visit `/logs/guard` / `/logs/runs` / `/runs` — Logs highlights active as before