### PR TITLE
feat(nav): collapsible Workspace group in sidebar footer

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -197,6 +197,14 @@ function AppShellInnerContent({
   const [wsOpen, setWsOpen] = useState(false)
   const wsRef = useRef<HTMLDivElement>(null)
 
+  // Workspace footer group (Integrations / Agent ID / Settings) — collapsed
+  // by default; auto-expands when any of its routes is active.
+  const workspaceRouteActive =
+    pathname.startsWith("/integrations") ||
+    pathname.startsWith("/agent-identity") ||
+    pathname.startsWith("/settings")
+  const [workspaceGroupOpen, setWorkspaceGroupOpen] = useState(false)
+
   // User menu (not used in new design — kept for UserMenu component)
   const [userMenuOpen, setUserMenuOpen] = useState(false)
   const userMenuRef = useRef<HTMLDivElement>(null)
@@ -1024,27 +1032,52 @@ function AppShellInnerContent({
               ›
             </button>
           )}
-          <SideNavItem
-            href="/integrations"
-            label="Integrations"
-            icon={<Icons.Plug />}
-            active={pathname.startsWith("/integrations")}
-            collapsed={collapsed}
-          />
-          <SideNavItem
-            href="/agent-identity"
-            label="Agent ID"
-            icon={<Icons.Lock />}
-            active={pathname.startsWith("/agent-identity")}
-            collapsed={collapsed}
-          />
-          <SideNavItem
-            href="/settings"
-            label="Settings"
-            icon={<Icons.Gear />}
-            active={pathname.startsWith("/settings")}
-            collapsed={collapsed}
-          />
+          {/* Workspace group — collapsible header. In the icon-only rail
+              (collapsed sidebar) items always render; in the expanded rail
+              they render only when the group is open or a workspace route
+              is active. */}
+          {!collapsed && (
+            <button
+              type="button"
+              onClick={() => setWorkspaceGroupOpen(v => !v)}
+              aria-expanded={workspaceGroupOpen || workspaceRouteActive}
+              style={{
+                display: "flex", alignItems: "center", justifyContent: "space-between",
+                width: "100%", padding: "8px 10px", marginBottom: 2,
+                background: "transparent", border: "none", cursor: "pointer",
+                fontSize: 10, fontWeight: 700, letterSpacing: ".12em",
+                textTransform: "uppercase", color: "var(--text-muted)",
+              }}
+            >
+              <span>Workspace</span>
+              <span aria-hidden style={{ fontSize: 11, transition: "transform .15s", transform: (workspaceGroupOpen || workspaceRouteActive) ? "rotate(90deg)" : "rotate(0deg)" }}>›</span>
+            </button>
+          )}
+          {(collapsed || workspaceGroupOpen || workspaceRouteActive) && (
+            <>
+              <SideNavItem
+                href="/integrations"
+                label="Integrations"
+                icon={<Icons.Plug />}
+                active={pathname.startsWith("/integrations")}
+                collapsed={collapsed}
+              />
+              <SideNavItem
+                href="/agent-identity"
+                label="Agent ID"
+                icon={<Icons.Lock />}
+                active={pathname.startsWith("/agent-identity")}
+                collapsed={collapsed}
+              />
+              <SideNavItem
+                href="/settings"
+                label="Settings"
+                icon={<Icons.Gear />}
+                active={pathname.startsWith("/settings")}
+                collapsed={collapsed}
+              />
+            </>
+          )}
         </div>
       </aside>
 


### PR DESCRIPTION
## Summary

Integrations / Agent ID / Settings sat always-expanded in the sidebar footer. Users doing runtime work (Guard, workflows, Lens) don't touch those often — they were nav clutter for the 90% path. Wrap them in a collapsible **Workspace** group.

## Behavior

- **Expanded sidebar**: "WORKSPACE" eyebrow header with a chevron. Click to toggle open/closed. **Auto-expands** when the user is on `/integrations`, `/agent-identity`, or `/settings/*` — so if they're actively in one of those pages, their context stays visible. Default state: **collapsed**.
- **Collapsed (icon-only) sidebar**: items still render as icons — no double-collapse cognitive tax. The icon-only rail is already a compact form; hiding entries there would surprise users hunting for Settings.

No route or content changes.

## Test plan

- [x] `tsc --noEmit` clean (verified locally via pre-commit hook)
- [ ] Default page (e.g. `/dashboard`): sidebar footer shows only the "WORKSPACE ›" header, no items visible
- [ ] Click the header → chevron rotates to ▾, three items appear
- [ ] Visit `/settings` — Workspace group auto-expands; Settings item highlights active
- [ ] Collapse the sidebar (via the topbar collapse button) → footer shows three icons (Plug, Lock, Gear) regardless of open state