### PR TITLE
docs(tools): new Lens tools land as ToolDef free functions (#1281)

### DIFF
--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -1,17 +1,44 @@
-"""Lens Executor tool registrations for the default ToolRegistry.
+"""Lens tool registrations for the default ToolRegistry.
 
-Each ToolDef.impl opens a SessionLocal, instantiates Executor bound to the
-caller's workspace, and dispatches to the matching `_tool_*` method. Every
-tool goes through MCPCore's policy gate before this impl runs, so we call
-`_tool_*` directly (bypassing Executor.call's second guard eval) — one
-policy source of truth per request.
+Every ToolDef here surfaces on the MCP HTTP surface, the stdio surface,
+and Lens chat via app.mcp.lens_adapter — same policy gate everywhere.
+Dispatch is enforced by MCPCore for MCP callers and by lens_adapter for
+Lens chat callers (both run the composable policy engine).
 
-Tools are read-only over Guard DB state; three of them (search_memory,
+── Adding a new Lens tool ────────────────────────────────────────────
+
+**New tools skip Executor** (team convention, 2026-08-29 / #1281 sweep).
+Write the impl as a free function in this module (or a companion module
+under app/modules/glens/) and point ToolDef.impl at it directly:
+
+    def get_soc2_status(ctx, framework: str = "SOC2"):
+        from app.core.database import SessionLocal
+        from app.modules.governance.rollup import compute_framework_coverage
+        db = SessionLocal()
+        try:
+            return compute_framework_coverage(db, ctx.workspace_id, framework=framework)
+        finally:
+            db.close()
+
+    _TOOLS.append(ToolDef(
+        name="get_soc2_status",
+        description="Framework coverage % + gaps for SOC2 / HIPAA / NIST AI RMF / EU AI Act.",
+        input_schema={"type": "object", "properties": {"framework": {"type": "string"}}},
+        impl=get_soc2_status,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ))
+
+── Legacy tools (44 tools, via Executor) ─────────────────────────────
+
+The 44 tools registered below via `_impl(method_name)` still route
+through `Executor._tool_{method_name}` (see app/modules/glens/executor.py).
+Kept as-is post-#1422 — no big-bang migration. New tools use the free-
+function pattern above so the codebase gradually flattens without churn.
+
+Read-only over Guard DB state; three of them (search_memory,
 search_sessions, search_knowledge) call the embedding provider and one
 (get_governance_narrative) calls the LLM — marked open_world for those.
-
-Adding a new Lens tool: add the method to Executor, add a ToolDef here.
-That's it.
 """
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Rewrites the `registrations/lens.py` header docstring to state the new convention (team direction 2026-08-29): **new Lens tools skip `Executor._tool_*` and register as free-function `ToolDef`s directly**. The 44 existing tools stay in `Executor` — no big-bang migration; the codebase flattens as new work lands.

The docstring now includes a concrete example a contributor sees when they open the file:

```python
def get_soc2_status(ctx, framework="SOC2"):
    from app.core.database import SessionLocal
    from app.modules.governance.rollup import compute_framework_coverage
    db = SessionLocal()
    try:
        return compute_framework_coverage(db, ctx.workspace_id, framework)
    finally:
        db.close()

_TOOLS.append(ToolDef(
    name="get_soc2_status",
    impl=get_soc2_status,   # free function, not Executor method
    ...
))
```

## Also posted

Matching "wiring update" comment on **11 issues**: the #1281 parent epic + all 10 open sub-issues (#1295, #1296, #1413–#1420) so anyone picking one up sees the same guidance before writing code.

## No code change

Only the module header docstring. All 44 existing `_impl(method_name)` registrations still work; Executor + its 44 `_tool_*` methods untouched.

Ref #1281.