### PR TITLE
feat(lens): 3 governance rollup tools — first free-function ToolDefs (#1281)

### DIFF
--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -679,6 +679,116 @@ _TOOLS: list[ToolDef] = [
 ]
 
 
+# ── #1295 + #1420 governance rollup tools ────────────────────────────────────
+# First tools registered under the new convention: free functions (no
+# Executor._tool_* shim). Impls import _compute_framework_coverage from the
+# governance router — a pure computation, safe to import.
+
+def _run_framework_coverage(workspace_id: str):
+    from app.core.database import SessionLocal
+    from app.routers.governance import _compute_framework_coverage
+    db = SessionLocal()
+    try:
+        return _compute_framework_coverage(db, workspace_id)
+    finally:
+        db.close()
+
+
+def get_governance_summary(ctx):
+    """Full framework coverage matrix — installed + bonus + rules totals."""
+    return _run_framework_coverage(ctx.workspace_id).model_dump()
+
+
+def get_soc2_status(ctx, framework: str = "SOC2"):
+    """Rollup for a single compliance framework. Defaults to SOC2. Returns
+    installed status + rules + controls + recommended pack for uninstalled."""
+    from app.routers.governance import RECOMMENDED_PACK
+    result = _run_framework_coverage(ctx.workspace_id)
+    fw = framework.upper()
+    for row in result.installed:
+        if row.framework == fw:
+            return {"status": "installed", **row.model_dump()}
+    for row in result.bonus:
+        if row.framework == fw:
+            return {"status": "bonus", **row.model_dump()}
+    return {
+        "status": "not_covered",
+        "framework": fw,
+        "rules_count": 0,
+        "controls": [],
+        "packs": [],
+        "recommended_pack": RECOMMENDED_PACK.get(fw),
+    }
+
+
+def get_ai_rollout_status(ctx):
+    """AI rollout instructions published for the workspace — published flag,
+    content length, version, last update, publisher."""
+    import uuid as _uuid
+    from app.core.database import SessionLocal
+    from app.models.workspace_instructions import WorkspaceInstructions
+    db = SessionLocal()
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+        row = db.query(WorkspaceInstructions).filter(
+            WorkspaceInstructions.workspace_id == ws_uuid
+        ).first()
+        if row is None:
+            return {
+                "published": False,
+                "content_length": 0,
+                "version": None,
+                "updated_at": None,
+                "updated_by": None,
+            }
+        return {
+            "published": True,
+            "content_length": len(row.content or ""),
+            "version": row.version,
+            "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+            "updated_by": row.updated_by,
+        }
+    finally:
+        db.close()
+
+
+_TOOLS.extend([
+    ToolDef(
+        name="get_governance_summary",
+        description="Full framework coverage matrix — installed frameworks, bonus (cross-tag) coverage, and rules totals.",
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=get_governance_summary,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_soc2_status",
+        description="Rollup for one compliance framework (defaults to SOC2). Returns installed status + rules + controls + recommended pack.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "framework": {
+                    "type": "string",
+                    "description": "Framework name: SOC2, HIPAA, OWASP, PCI_DSS, ISO_42001, GDPR, EU_AI_ACT, NIST, NIS2, DORA.",
+                },
+            },
+            "required": [],
+        },
+        impl=get_soc2_status,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="get_ai_rollout_status",
+        description="AI rollout instructions published for the workspace — published flag, content length, version, last update.",
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=get_ai_rollout_status,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+])
+
+
 def register(replace: bool = False) -> None:
     """Register all Lens tools into the default registry. Idempotent when
     replace=True (used only in tests that reload)."""

--- a/apps/api/tests/tools/test_governance_rollup_tools.py
+++ b/apps/api/tests/tools/test_governance_rollup_tools.py
@@ -1,0 +1,132 @@
+"""Registration + dispatch parity for the three governance rollup tools
+(#1295 + #1420). First tools registered under the free-function convention
+(no Executor._tool_* shim). Verifies the ToolDef reaches the registry,
+dispatch goes through the LensAdapter, and the return shape matches what
+Lens chat expects.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from app.guard.policy_types import PolicyAction, PolicyDecision
+from app.mcp.lens_adapter import dispatch as lens_dispatch
+from app.mcp.server import MCPContext
+from app.tools import registrations  # noqa: F401  # side-effect: populate registry
+from app.tools.registry import default_registry
+
+
+_CTX = MCPContext(workspace_id="00000000-0000-0000-0000-000000000000", surface="lens")
+
+_ALLOW = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+
+
+def test_governance_tools_registered():
+    """All three tools appear in default_registry with the lens tag."""
+    for name in ("get_governance_summary", "get_soc2_status", "get_ai_rollout_status"):
+        tool = default_registry.get(name)
+        assert tool is not None, f"{name} not registered"
+        assert "lens" in tool.tags
+        assert tool.annotations.read_only, f"{name} should be read_only"
+
+
+def test_get_governance_summary_dispatch():
+    """get_governance_summary calls _compute_framework_coverage and
+    serialises the result."""
+    from app.routers.governance import FrameworksOut
+    fake_result = FrameworksOut(installed=[], bonus=[], total_rules=0, rules_with_framework=0)
+
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=_ALLOW), \
+         patch("app.tools.registrations.lens._run_framework_coverage",
+               return_value=fake_result) as mock_helper:
+        result = lens_dispatch("get_governance_summary", "{}", _CTX)
+
+    mock_helper.assert_called_once_with(_CTX.workspace_id)
+    payload = json.loads(result)
+    assert payload["installed"] == []
+    assert payload["bonus"] == []
+    assert payload["total_rules"] == 0
+
+
+def test_get_soc2_status_installed_row():
+    """When SOC2 is in the installed list, status='installed' + row fields."""
+    from app.routers.governance import FrameworkRow, FrameworksOut
+    fake = FrameworksOut(
+        installed=[FrameworkRow(
+            framework="SOC2", rules_count=42, controls=["CC6.1", "CC8.1"], packs=["conduct-soc2"],
+        )],
+        bonus=[], total_rules=42, rules_with_framework=42,
+    )
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=_ALLOW), \
+         patch("app.tools.registrations.lens._run_framework_coverage", return_value=fake):
+        result = lens_dispatch("get_soc2_status", "{}", _CTX)
+    payload = json.loads(result)
+    assert payload["status"] == "installed"
+    assert payload["framework"] == "SOC2"
+    assert payload["rules_count"] == 42
+    assert payload["controls"] == ["CC6.1", "CC8.1"]
+
+
+def test_get_soc2_status_not_covered_returns_recommended_pack():
+    """Framework not present in installed or bonus → status='not_covered'
+    with the recommended pack surfaced."""
+    from app.routers.governance import FrameworksOut
+    empty = FrameworksOut(installed=[], bonus=[], total_rules=0, rules_with_framework=0)
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=_ALLOW), \
+         patch("app.tools.registrations.lens._run_framework_coverage", return_value=empty):
+        result = lens_dispatch("get_soc2_status", '{"framework": "HIPAA"}', _CTX)
+    payload = json.loads(result)
+    assert payload["status"] == "not_covered"
+    assert payload["framework"] == "HIPAA"
+    assert payload["recommended_pack"] == "conduct-hipaa"
+
+
+def test_get_ai_rollout_status_unpublished():
+    """No WorkspaceInstructions row → published=False, zero content."""
+
+    class _Q:
+        def filter(self, *_a, **_k): return self
+        def first(self): return None
+
+    class _DB:
+        def query(self, *_a, **_k): return _Q()
+        def close(self): pass
+
+    with patch("app.core.database.SessionLocal", return_value=_DB()):
+        from app.tools.registrations.lens import get_ai_rollout_status
+        out = get_ai_rollout_status(_CTX)
+
+    assert out["published"] is False
+    assert out["content_length"] == 0
+    assert out["version"] is None
+    assert out["updated_at"] is None
+    assert out["updated_by"] is None
+
+
+def test_get_ai_rollout_status_published():
+    """WorkspaceInstructions row exists → published=True with metadata."""
+    from datetime import datetime, timezone
+
+    class _Row:
+        content = "Use only approved models. Do not paste secrets."
+        version = "v3"
+        updated_at = datetime(2026, 8, 15, 12, 0, tzinfo=timezone.utc)
+        updated_by = "admin@example.com"
+
+    class _Q:
+        def filter(self, *_a, **_k): return self
+        def first(self): return _Row()
+
+    class _DB:
+        def query(self, *_a, **_k): return _Q()
+        def close(self): pass
+
+    with patch("app.core.database.SessionLocal", return_value=_DB()):
+        from app.tools.registrations.lens import get_ai_rollout_status
+        out = get_ai_rollout_status(_CTX)
+
+    assert out["published"] is True
+    assert out["content_length"] == len(_Row.content)
+    assert out["version"] == "v3"
+    assert out["updated_at"] == "2026-08-15T12:00:00+00:00"
+    assert out["updated_by"] == "admin@example.com"

--- a/apps/api/tests/tools/test_lens_registrations.py
+++ b/apps/api/tests/tools/test_lens_registrations.py
@@ -24,6 +24,14 @@ def _executor_tool_methods() -> set[str]:
     }
 
 
+def _legacy_registrations() -> list[ToolDef]:
+    """Tools wired via `_impl(name)` — those need a matching Executor
+    `_tool_*` method. New tools (post-#1281) register free functions
+    directly and skip Executor entirely; they're exempt from this check.
+    """
+    return [t for t in lens_reg._TOOLS if getattr(t.impl, "__name__", "").startswith("lens_impl_")]
+
+
 def test_every_executor_tool_has_registration():
     method_names = _executor_tool_methods()
     registered_names = {t.name for t in lens_reg._TOOLS}
@@ -32,10 +40,14 @@ def test_every_executor_tool_has_registration():
     assert not missing, f"Executor tools without registrations: {sorted(missing)}"
 
 
-def test_registrations_target_real_executor_methods():
+def test_legacy_registrations_target_real_executor_methods():
+    """Registrations built via `_impl(name)` must map to a real
+    `Executor._tool_{name}`. Free-function registrations are exempt (they
+    hold their own impl in the ToolDef)."""
     method_names = _executor_tool_methods()
-    unknown = {t.name for t in lens_reg._TOOLS} - method_names
-    assert not unknown, f"Registrations point at missing Executor methods: {sorted(unknown)}"
+    legacy_names = {t.name for t in _legacy_registrations()}
+    unknown = legacy_names - method_names
+    assert not unknown, f"Legacy registrations point at missing Executor methods: {sorted(unknown)}"
 
 
 def test_default_registry_contains_all_lens_tools():


### PR DESCRIPTION
## Summary

First tools registered under the new #1281 convention (per PR #1428 + team direction 2026-08-29): **free functions, no `Executor._tool_*` shim**. Reuses the existing `_compute_framework_coverage` computation in `routers/governance.py` and the `WorkspaceInstructions` model — **zero new tables, zero migrations**.

## What ships

Three `ToolDef`s in `app/tools/registrations/lens.py`:

- **`get_governance_summary`** — full framework matrix (installed + bonus + rules totals). *Closes #1420.*
- **`get_soc2_status`** — one-framework rollup, defaults to SOC2. Returns `installed` / `bonus` / `not_covered` status; when `not_covered`, surfaces the recommended pack from `RECOMMENDED_PACK`. *Closes half of #1295.*
- **`get_ai_rollout_status`** — reads `WorkspaceInstructions` for `published` + `content_length` + `version` + `updated_{at,by}`. *Closes the other half of #1295.*

Registry count: **61 → 64**. Auto-appears on MCP HTTP, MCP stdio, and Lens chat via the shared registry (#1422).

## Why no new tables

Parent epic #1281 flagged both #1295 and #1296 as "blocked on model design". Real state: both were engineering-preference stalls. `_compute_framework_coverage` is a pure computation over installed packs + `SkillPack.rules` JSONB — a shared helper answers every framework question we care about today. Historical trending (which would justify a `compliance_reports` table) isn't in scope for read tools.

## Tests

6/6 green locally:

- All 3 tools registered with `lens` tag + `read_only` annotation.
- `get_governance_summary` dispatches through `LensAdapter`, calls the framework-coverage helper, serialises the pydantic result.
- `get_soc2_status`: installed-row path + not_covered-recommended-pack path.
- `get_ai_rollout_status`: unpublished (no row) + published (row with content) paths.

## Closes

- Closes #1295
- Closes #1420

Follow-ups: 8 remaining #1281 sub-issues (#1296, #1413, #1414, #1415, #1416, #1417, #1418, #1419) using the same free-function pattern.