### PR TITLE
feat(lens): TOOLS derived from default_registry — no more drift (#1281)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -19,14 +19,24 @@ from app.core.database import get_db
 from app.modules.glens.executor import Executor
 from app.modules.glens.models import GlensChatSession
 from app.modules.guard.models import GuardConfig, GuardSpendBudget, WorkspaceCustomRule
+from app.tools import registrations as _tool_registrations  # noqa: F401  # side-effect: populate default_registry before TOOLS derives
 
 log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/glens", tags=["glens"])
 
 
 # ── Tools exposed to the LLM ─────────────────────────────────────────────────
+#
+# TOOLS is DERIVED from `default_registry` — every ToolDef tagged 'lens' becomes
+# an entry the LLM can invoke. `_LEGACY_TOOLS` below carries the hand-tuned
+# descriptions from the pre-#1281 catalog; those override the ToolDef.description
+# for the ~21 tools that had detailed formatting instructions. New tools use
+# their ToolDef.description straight from registrations/lens.py.
+#
+# Result: one source of truth for the tool catalog. Adding a new ToolDef ⇒ the
+# LLM sees it immediately.
 
-TOOLS = [
+_LEGACY_TOOLS = [
     {
         "name": "get_event_count",
         "description": "Count Guard audit events. Use for 'how many blocks/warnings/allows' questions. Returns a single integer.",
@@ -281,6 +291,31 @@ TOOLS = [
         },
     },
 ]
+
+# Detailed descriptions from the hand-tuned catalog (index by tool name).
+_LEGACY_DESCRIPTIONS: dict[str, str] = {t["name"]: t["description"] for t in _LEGACY_TOOLS}
+
+
+def _lens_tools_for_llm() -> list[dict]:
+    """Project every 'lens'-tagged ToolDef in default_registry into the LLM's
+    function-calling shape. Detailed descriptions from _LEGACY_DESCRIPTIONS
+    override the ToolDef.description for the 21 tools that had specialised
+    formatting instructions; new tools use their ToolDef.description straight
+    from registrations/lens.py."""
+    from app.tools.registry import default_registry
+
+    return [
+        {
+            "name": t.name,
+            "description": _LEGACY_DESCRIPTIONS.get(t.name, t.description),
+            "input_schema": t.input_schema,
+        }
+        for t in default_registry.list(tag="lens")
+    ]
+
+
+TOOLS = _lens_tools_for_llm()
+
 
 def _load_system_prompt() -> str:
     from pathlib import Path

--- a/apps/api/tests/glens/test_tools_catalog_from_registry.py
+++ b/apps/api/tests/glens/test_tools_catalog_from_registry.py
@@ -1,0 +1,63 @@
+"""Lens TOOLS (LLM catalog) is derived from default_registry (#1281 wiring
+fix). Locks the invariant that adding a ToolDef tagged 'lens' automatically
+makes the LLM aware of it, and that hand-tuned detailed descriptions from
+the pre-#1281 catalog are preserved verbatim.
+"""
+from __future__ import annotations
+
+from app.modules.glens.routers.chat import TOOLS, _LEGACY_DESCRIPTIONS
+from app.tools.registry import default_registry
+
+
+def test_tools_matches_registry_lens_tag():
+    """Every 'lens'-tagged ToolDef appears in TOOLS, and TOOLS contains only
+    those tools (no extras, no leftovers from the old hardcoded list)."""
+    registry_names = {t.name for t in default_registry.list(tag="lens")}
+    catalog_names = {t["name"] for t in TOOLS}
+    assert catalog_names == registry_names, (
+        f"catalog vs registry mismatch. "
+        f"registry-only: {sorted(registry_names - catalog_names)}. "
+        f"catalog-only: {sorted(catalog_names - registry_names)}."
+    )
+
+
+def test_new_read_tools_are_reachable_by_llm():
+    """The 12 tools added in the #1281 sweep are in the LLM catalog."""
+    expected_new = {
+        # Governance rollups (#1295, #1420)
+        "get_governance_summary", "get_soc2_status", "get_ai_rollout_status",
+        # Batch A (#1413, #1416, #1418, #1419)
+        "list_playbooks", "get_playbook",
+        "list_machines_sync_state",
+        "get_llm_primitives", "get_rate_limits",
+        # Batch B (#1414, #1415, #1417, #1296)
+        "get_workspace_kpis", "list_discovered_agents",
+        "list_credentials", "get_autopilot_activity",
+    }
+    catalog_names = {t["name"] for t in TOOLS}
+    missing = expected_new - catalog_names
+    assert not missing, f"Expected new tools missing from LLM catalog: {sorted(missing)}"
+
+
+def test_legacy_detailed_descriptions_preserved():
+    """Tools that had hand-tuned formatting instructions in the pre-#1281
+    hardcoded list still carry those descriptions verbatim (protects LLM
+    tool-selection behaviour for well-covered questions)."""
+    for tool in TOOLS:
+        legacy = _LEGACY_DESCRIPTIONS.get(tool["name"])
+        if legacy is None:
+            continue
+        assert tool["description"] == legacy, (
+            f"{tool['name']} lost its legacy description "
+            f"(catalog: {tool['description'][:60]!r}; expected: {legacy[:60]!r})"
+        )
+
+
+def test_tools_shape_is_llm_ready():
+    """Every entry has the name / description / input_schema fields the
+    Anthropic + OpenAI tool-use APIs expect."""
+    for tool in TOOLS:
+        assert isinstance(tool["name"], str) and tool["name"]
+        assert isinstance(tool["description"], str) and tool["description"]
+        assert isinstance(tool["input_schema"], dict)
+        assert tool["input_schema"].get("type") == "object"


### PR DESCRIPTION
## Summary

Bug surfaced when a user asked *\"What playbooks are available?\"* and Lens answered with `list_workflows` (workspace workflows) instead of `list_playbooks` (builtin templates). Screenshot in the issue thread.

**Root cause**: the LLM catalog `TOOLS` in `apps/api/app/modules/glens/routers/chat.py` was a **hardcoded list of ~21 tool schemas** — parallel to `default_registry` and out of sync with every registration added in the #1281 sweep. All 12 new tools were invisible to the LLM; it picked the nearest legacy tool (`list_workflows`) instead.

Same drift risk we killed for **dispatch** with the LensAdapter (#1422). Now killed for the **catalog** too.

## Fix

Derive `TOOLS` from `default_registry.list(tag='lens')` at module load. Hand-tuned descriptions from the pre-#1281 hardcoded list live in `_LEGACY_DESCRIPTIONS` (indexed by tool name) and override the `ToolDef.description` for those ~21 tools — so LLM tool-selection behaviour for well-covered questions doesn't regress. New tools use their `ToolDef.description` straight from `registrations/lens.py`.

- `chat.py` imports `app.tools.registrations` for side-effect so the registry populates before `TOOLS` derives at module load.
- `_LEGACY_TOOLS` (renamed from `TOOLS`) stays as the source of legacy descriptions.
- `_lens_tools_for_llm()` returns the derived catalog.
- `TOOLS = _lens_tools_for_llm()` at module scope — one call, cached.

## Effect

Adding a new `ToolDef` anywhere in `registrations/lens.py` now appears in the LLM catalog immediately.

- Registry today: **73 tools** (post-batch A + batch B merges)
- Lens-tagged tools: **56** (reachable from Lens chat)
- LLM catalog before this PR: 21
- LLM catalog after this PR: 56 (matches the lens-tagged set exactly)

## Tests

4/4 new + 58 existing tool tests green locally:

- `test_tools_matches_registry_lens_tag` — `TOOLS` is *exactly* the registry's lens-tagged set (no drift either way).
- `test_new_read_tools_are_reachable_by_llm` — the 12 tools from the #1281 sweep appear in the LLM catalog.
- `test_legacy_detailed_descriptions_preserved` — every hand-tuned description is preserved verbatim.
- `test_tools_shape_is_llm_ready` — every entry has `name` / `description` / `input_schema.type=object` (Anthropic + OpenAI tool-use ready).

## Try it after merge + deploy

Ask Lens: *\"What playbooks are available?\"* — should now hit `list_playbooks` and return the builtin catalog (incident_response, soc2_evidence, etc.), not the workspace's Workflow rows.