### PR TITLE
feat(llm-client): cache_tools — Anthropic prefix cache on tool catalog

### DIFF
--- a/apps/api/app/runtime/adapters/anthropic.py
+++ b/apps/api/app/runtime/adapters/anthropic.py
@@ -55,6 +55,7 @@ class AnthropicClient:
         tool_choice: dict | None = None,
         max_tokens: int = 4096,
         cache_system: bool = True,
+        cache_tools: bool = True,
         idempotency_key: str | None = None,
         on_retry: Callable[[dict[str, Any]], None] | None = None,
         outer_attempt: int = 1,
@@ -77,7 +78,17 @@ class AnthropicClient:
             kwargs["system"] = system
 
         if tools:
-            kwargs["tools"] = tools
+            # Anthropic prompt caching: a single cache_control marker on the LAST
+            # tool in the array caches the whole request prefix (system + tools).
+            # ~10 KB of Lens tool schemas costs ~90% less on cache hit. Deep-copy
+            # only the last tool so we don't mutate the caller's list.
+            if cache_tools and tools:
+                cached = list(tools)
+                cached[-1] = {**cached[-1], "cache_control": {"type": "ephemeral"}}
+                kwargs["tools"] = cached
+                extra_headers["anthropic-beta"] = "prompt-caching-2024-07-31"
+            else:
+                kwargs["tools"] = tools
         if tool_choice:
             kwargs["tool_choice"] = tool_choice
 

--- a/apps/api/app/runtime/adapters/openai.py
+++ b/apps/api/app/runtime/adapters/openai.py
@@ -49,13 +49,15 @@ class OpenAIClient:
         tool_choice: dict | None = None,
         max_tokens: int = 4096,
         cache_system: bool = True,
+        cache_tools: bool = True,
         idempotency_key: str | None = None,
         on_retry: Callable[[dict[str, Any]], None] | None = None,
         outer_attempt: int = 1,
     ) -> LLMResponse:
         # OpenAI Chat Completions expects the system prompt as a system message.
-        # cache_system is Anthropic-specific; ignored here.
-        _ = cache_system
+        # cache_system + cache_tools are Anthropic-specific; OpenAI's prompt
+        # cache is automatic on identical prefixes (no markers needed).
+        _ = cache_system, cache_tools
 
         oai_messages = [{"role": "system", "content": system}, *messages]
         payload: dict[str, Any] = {

--- a/apps/api/app/runtime/llm_client.py
+++ b/apps/api/app/runtime/llm_client.py
@@ -99,6 +99,7 @@ class LLMClient(Protocol):
         tool_choice: dict | None = None,
         max_tokens: int = 4096,
         cache_system: bool = True,
+        cache_tools: bool = True,
         idempotency_key: str | None = None,
         on_retry: Callable[[dict[str, Any]], None] | None = None,
     ) -> LLMResponse:
@@ -116,6 +117,11 @@ class LLMClient(Protocol):
             max_tokens:   Max tokens for this response
             cache_system: When True, adapter wraps system prompt with cache_control so
                           turns 2-N in an agentic loop read from cache (~10% cost)
+            cache_tools:  When True, adapter caches the tool catalogue too — Anthropic
+                          applies cache_control ephemeral to the last tool in the array,
+                          which caches the whole prefix (system prompt + all tools).
+                          Big win for Lens (~10 KB of tool schemas) and long agent loops.
+                          OpenAI adapter ignores this flag (their prompt cache is automatic).
         """
         ...
 

--- a/apps/api/tests/test_anthropic_cache_tools.py
+++ b/apps/api/tests/test_anthropic_cache_tools.py
@@ -1,0 +1,107 @@
+"""Anthropic adapter caches the tool catalogue when cache_tools=True.
+
+Locks the invariant: with a non-empty tools list and cache_tools=True, the
+LAST tool in the array carries `cache_control: {"type": "ephemeral"}`, which
+tells Anthropic to cache the entire request prefix (system prompt + all
+tools). This is the biggest win for Lens — ~10 KB of tool schemas paid
+~90% less on cache hit within the 5-minute TTL.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _fake_response():
+    """Minimal Anthropic response object shape the adapter expects."""
+    r = MagicMock()
+    r.content = []
+    r.stop_reason = "end_turn"
+    r.usage = MagicMock(input_tokens=0, output_tokens=0, cache_read_input_tokens=0, cache_creation_input_tokens=0)
+    r.model = "claude-test"
+    return r
+
+
+def _build_client_with_mock_sdk():
+    """Instantiate AnthropicClient with a mocked SDK — skip __init__ so no
+    real Anthropic client is created (would need a live API key)."""
+    # Import via llm_client (parent) to avoid the adapter's circular import
+    # chain when adapter is imported first.
+    from app.runtime.llm_client import AnthropicClient
+    client = AnthropicClient.__new__(AnthropicClient)  # skip __init__
+    client._client = MagicMock()
+    client._client.messages.create.return_value = _fake_response()
+    client._pricing_snapshot = {}
+    client._provider = "anthropic"
+    return client
+
+
+_TOOLS = [
+    {"name": "get_a", "description": "A", "input_schema": {"type": "object", "properties": {}}},
+    {"name": "get_b", "description": "B", "input_schema": {"type": "object", "properties": {}}},
+    {"name": "get_c", "description": "C", "input_schema": {"type": "object", "properties": {}}},
+]
+
+
+def _captured_kwargs(cache_tools: bool, tools=_TOOLS) -> dict:
+    client = _build_client_with_mock_sdk()
+    client.create(
+        model="claude-test",
+        messages=[{"role": "user", "content": "hi"}],
+        system="you are a helper",
+        tools=tools,
+        cache_tools=cache_tools,
+    )
+    assert client._client.messages.create.called
+    return client._client.messages.create.call_args.kwargs
+
+
+def test_cache_tools_true_marks_last_tool():
+    kwargs = _captured_kwargs(cache_tools=True)
+    tools_out = kwargs["tools"]
+    assert len(tools_out) == 3
+    # Only the LAST tool carries the marker — one marker caches the whole prefix
+    assert "cache_control" not in tools_out[0]
+    assert "cache_control" not in tools_out[1]
+    assert tools_out[-1]["cache_control"] == {"type": "ephemeral"}
+
+
+def test_cache_tools_true_does_not_mutate_input():
+    """The caller's tool list must not be mutated in place."""
+    tools_input = [dict(t) for t in _TOOLS]
+    client = _build_client_with_mock_sdk()
+    client.create(
+        model="claude-test",
+        messages=[{"role": "user", "content": "hi"}],
+        system="s",
+        tools=tools_input,
+        cache_tools=True,
+    )
+    for t in tools_input:
+        assert "cache_control" not in t, "adapter mutated caller's tool list"
+
+
+def test_cache_tools_false_leaves_tools_untouched():
+    kwargs = _captured_kwargs(cache_tools=False)
+    tools_out = kwargs["tools"]
+    for t in tools_out:
+        assert "cache_control" not in t
+
+
+def test_cache_tools_true_sets_anthropic_beta_header():
+    kwargs = _captured_kwargs(cache_tools=True)
+    headers = kwargs.get("extra_headers") or {}
+    assert headers.get("anthropic-beta") == "prompt-caching-2024-07-31"
+
+
+def test_no_tools_no_crash():
+    """cache_tools=True with tools=None is a no-op."""
+    client = _build_client_with_mock_sdk()
+    client.create(
+        model="claude-test",
+        messages=[{"role": "user", "content": "hi"}],
+        system="s",
+        tools=None,
+        cache_tools=True,
+    )
+    kwargs = client._client.messages.create.call_args.kwargs
+    assert "tools" not in kwargs


### PR DESCRIPTION
## Summary

`cache_system=True` has been on by default since the Anthropic adapter shipped. System prompt gets cached; **tool array wasn't**. Every Lens turn re-shipped ~10 KB of tool schemas and paid full ingestion cost.

**Fix**: add `cache_tools: bool = True` to `LLMClient.create()`. Anthropic adapter applies `cache_control: ephemeral` to the **last** tool in the array — one marker at the end caches the whole request prefix (system + all tools). Cache hit within the 5-minute TTL costs ~90% less on that prefix.

## Changes

- **`llm_client.py`** — protocol gains `cache_tools: bool = True` with a docstring explaining Anthropic-vs-OpenAI behaviour.
- **`adapters/anthropic.py`** — cached tools list is a shallow copy so the caller's list is never mutated. Sets the `anthropic-beta: prompt-caching-2024-07-31` header.
- **`adapters/openai.py`** — accepts `cache_tools` for API consistency but ignores it. OpenAI-family providers (openai, perplexity, together, fireworks) cache automatically on identical prefixes; no marker to apply.
- **Gateway (`guarded_client_call`)** — calls `.create()` without explicitly setting cache flags, so picks up the True default automatically. No downstream changes needed.

## Impact on Lens

- System prompt: ~2 KB — already cached
- Tools: 56 tool schemas ~10 KB — **now cached**
- Total request prefix now cached: ~12 KB
- Repeat query within 5 min: ~90% cheaper on that prefix + faster TTFT

## Tests

5/5 green locally (`tests/test_anthropic_cache_tools.py`):

- Last tool carries `cache_control: ephemeral`; others do not.
- Caller's tool list is not mutated (shallow copy invariant enforced).
- `cache_tools=False` leaves tools untouched.
- Correct `anthropic-beta` header set.
- `tools=None` with `cache_tools=True` is a no-op (no crash).

## Provider matrix

| Adapter | Behaviour |
|---|---|
| **Anthropic** | Applies `cache_control: ephemeral` on last tool ← the win |
| **OpenAI (incl. GPT-4o+)** | No-op — provider auto-detects identical prefixes |
| **Perplexity / Together / Fireworks** | Same as OpenAI (OpenAI-compatible endpoint) |

Nothing regresses; nothing new to configure for OpenAI-family callers.

## Follow-ups (mentioned but not in this PR)

- Parallel tool dispatch (see #1281 discussion): move the `for block in tool_blocks:` loop into a shared `LLMClient.dispatch_tool_blocks` helper using `ThreadPoolExecutor`. Compounds with this PR — cache hit gives cheaper LLM calls, parallel dispatch gives faster tool execution when the LLM emits multiple `tool_use` blocks per turn.
- Selective Redis TTL cache for tool results (`list_playbooks`, `get_governance_summary`, etc.) — only worth it once the caching + parallel wins land and we still see complaints.