### PR TITLE
feat(lens): copy button + animated typing indicator (chat UX)

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -300,6 +300,24 @@ body {
 @keyframes conduct-dot-pulse { 0%,100%{ opacity:1 } 50%{ opacity:.35 } }
 .pulse { animation: conduct-dot-pulse 1.6s ease-in-out infinite; }
 
+/* Typing indicator — three dots bouncing on a stagger. Used in Lens
+   loading bubble to signal "we heard you, working on it" during phase 1
+   (tool resolution) latency. */
+@keyframes conduct-typing-bounce {
+  0%, 80%, 100% { transform: translateY(0); opacity: 0.4; }
+  40%           { transform: translateY(-4px); opacity: 1; }
+}
+.conduct-typing-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: conduct-typing-bounce 1.2s ease-in-out infinite;
+}
+.conduct-typing-dot:nth-child(2) { animation-delay: 0.15s; }
+.conduct-typing-dot:nth-child(3) { animation-delay: 0.30s; }
+
 /* sbadge run / idle variants */
 .sbadge.run  { color: var(--info);      background: var(--info-bg);  border: 1px solid var(--info-bd);  }
 .sbadge.idle { color: var(--text-muted); background: var(--surface-3); border: 1px solid var(--border); }

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -398,6 +398,9 @@ function AnswerBubble({ text, skill, drilldown, followups, onFollowup, understoo
             </div>
           )}
         </div>
+        <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 4, marginRight: -4 }}>
+          <CopyButton text={text} />
+        </div>
         {followups && followups.length > 0 && onFollowup && (
           <div style={{ display: "flex", flexWrap: "wrap", gap: 6, marginTop: 8 }}>
             {followups.map(q => (
@@ -432,12 +435,80 @@ function LoadingBubble({ label }: { label?: string }) {
         color: "var(--text-muted)",
         display: "flex",
         alignItems: "center",
-        gap: 8,
-      }}>
-        <span style={{ letterSpacing: 3 }}>···</span>
+        gap: 10,
+      }} aria-label="Lens is thinking" role="status">
+        <span style={{ display: "inline-flex", alignItems: "flex-end", gap: 4, height: 12 }}>
+          <span className="conduct-typing-dot" />
+          <span className="conduct-typing-dot" />
+          <span className="conduct-typing-dot" />
+        </span>
         {label && <span style={{ fontSize: 12, opacity: 0.8 }}>{label}</span>}
       </div>
     </div>
+  )
+}
+
+// ── Copy button (shared) ──────────────────────────────────────────────────────
+
+function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" }) {
+  const [copied, setCopied] = useState(false)
+  const iconSize = size === "sm" ? 12 : 14
+  const padding = size === "sm" ? "4px 8px" : "5px 10px"
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // Older browsers / insecure contexts — fall back to a hidden textarea.
+      const ta = document.createElement("textarea")
+      ta.value = text
+      ta.style.position = "fixed"
+      ta.style.opacity = "0"
+      document.body.appendChild(ta)
+      ta.select()
+      try { document.execCommand("copy") } catch {}
+      document.body.removeChild(ta)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      aria-label={copied ? "Copied" : "Copy response"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 4,
+        padding,
+        fontSize: 11,
+        fontWeight: 500,
+        color: copied ? "var(--ok, #10b981)" : "var(--text-muted)",
+        background: "transparent",
+        border: "1px solid transparent",
+        borderRadius: 6,
+        cursor: "pointer",
+        transition: "background 0.12s, color 0.12s",
+      }}
+      onMouseEnter={e => (e.currentTarget.style.background = "var(--surface-3, rgba(0,0,0,0.04))")}
+      onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+    >
+      {copied ? (
+        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+          <polyline points="20 6 9 17 4 12" />
+        </svg>
+      ) : (
+        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+          <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+        </svg>
+      )}
+      {copied ? "Copied" : "Copy"}
+    </button>
   )
 }
 


### PR DESCRIPTION
## Summary

Two small UX wins on the Lens chat surface. Both are frontend-only; no backend changes.

### 1. Typing indicator during phase 1 (tool resolution)

Old `LoadingBubble` showed a static `···` — users didn't know if it was working or hung. New version renders **three bouncing dots** via a CSS keyframe animation (`conduct-typing-bounce`, staggered by 0.15s per dot).

Perceived latency drops even though actual latency is unchanged. Compounds with:
- **#1433** — Anthropic prompt caching on the tool catalog (cuts LLM ingestion time on cache hit)
- **#1434** — parallel tool dispatch (cuts DB query time when N tools are dispatched per turn)

Accessible via `aria-label="Lens is thinking"` and `role="status"`.

### 2. Copy button on assistant answers

New `CopyButton` component: `navigator.clipboard.writeText` with a textarea fallback for older browsers / insecure contexts (HTTP dev environments).

- Renders as a small ghost button below the answer bubble.
- Switches to green **✓ Copied** for 1.5s on success, then reverts.
- Wired into `AnswerBubble`; shape lets us drop it into `BlocksBubble`, `PageBubble`, etc. as follow-ups.

## Files touched

- `apps/web/src/app/globals.css` — new `@keyframes conduct-typing-bounce` + `.conduct-typing-dot` class.
- `apps/web/src/components/glens/GLensChatPage.tsx` — `LoadingBubble` rewrite + new `CopyButton` component + wired into `AnswerBubble`.

## Test plan

- [x] `tsc --noEmit` clean (pre-commit hook)
- [ ] Ask Lens any question → typing dots animate (not static)
- [ ] Answer bubble shows a small "Copy" button below it
- [ ] Click Copy → button turns green with checkmark + "Copied" for 1.5s
- [ ] Paste into a text editor → gets the answer text
- [ ] Older browser / non-HTTPS dev env → textarea fallback works
- [ ] Screen reader hits "Lens is thinking" aria-label during loading

## Follow-up (deliberately separate PR)

**Thumbs up/down feedback**: needs a backend endpoint (`POST /glens/chat/feedback`), a `glens_chat_feedback` table, and paired Alembic migration. Bigger scope; keeping it out of this PR so this reviews as a pure frontend polish change.