### PR TITLE
feat(lens): thumbs up/down feedback — backend + component (unwired)

### DIFF
--- a/apps/api/alembic/versions/0107_glens_chat_feedback.py
+++ b/apps/api/alembic/versions/0107_glens_chat_feedback.py
@@ -1,0 +1,84 @@
+"""Add glens_chat_feedback table — per-message thumbs up/down.
+
+Revision ID: 0107
+Revises: 0106
+Create Date: 2026-08-29
+
+One row per (session, message, user); latest verdict wins on upsert
+(enforced by uq_glens_chat_feedback_session_msg_user). Feeds LLM tuning /
+prompt regression signal.
+
+Constraints/indexes named explicitly per project convention (Alembic
+autogenerate is banned on this repo — hand-written names avoid drift).
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision = "0107"
+down_revision = "0106"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "glens_chat_feedback",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True, server_default=sa.text("gen_random_uuid()")),
+        sa.Column(
+            "workspace_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey(
+                "workspaces.id",
+                ondelete="CASCADE",
+                name="glens_chat_feedback_workspace_id_fkey",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "session_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey(
+                "glens_chat_sessions.id",
+                ondelete="CASCADE",
+                name="glens_chat_feedback_session_id_fkey",
+            ),
+            nullable=False,
+        ),
+        sa.Column("message_id", sa.String(length=64), nullable=False),
+        sa.Column("verdict", sa.String(length=4), nullable=False),
+        sa.Column("comment", sa.Text(), nullable=True),
+        sa.Column("clerk_user_id", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint(
+            "session_id", "message_id", "clerk_user_id",
+            name="uq_glens_chat_feedback_session_msg_user",
+        ),
+        sa.CheckConstraint(
+            "verdict IN ('up', 'down')",
+            name="ck_glens_chat_feedback_verdict",
+        ),
+    )
+    op.create_index(
+        "ix_glens_chat_feedback_workspace_created",
+        "glens_chat_feedback",
+        ["workspace_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_glens_chat_feedback_workspace_created", table_name="glens_chat_feedback")
+    op.drop_table("glens_chat_feedback")

--- a/apps/api/app/modules/glens/models.py
+++ b/apps/api/app/modules/glens/models.py
@@ -1,7 +1,7 @@
 import uuid
 from datetime import datetime, timezone
 
-from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Text
+from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
 from sqlalchemy.dialects.postgresql import UUID as PG_UUID
 
 from app.core.database import Base
@@ -34,4 +34,61 @@ class GlensChatSession(Base):
 
     __table_args__ = (
         Index("ix_glens_chat_sessions_updated_at", "updated_at"),
+    )
+
+
+class GlensChatFeedback(Base):
+    """Per-message thumbs up/down feedback for Lens chat responses.
+
+    Aggregated to feed the LLM tuning / prompt regression loop — every
+    response gets a data point of "did this actually help?". One row per
+    (session, message, user); latest verdict wins on upsert.
+    """
+    __tablename__ = "glens_chat_feedback"
+
+    id = Column(PG_UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE", name="glens_chat_feedback_workspace_id_fkey"),
+        nullable=False,
+    )
+    session_id = Column(
+        PG_UUID(as_uuid=True),
+        ForeignKey("glens_chat_sessions.id", ondelete="CASCADE", name="glens_chat_feedback_session_id_fkey"),
+        nullable=False,
+    )
+    # Position of the assistant message within GlensChatSession.messages —
+    # kept as a plain string so we can accept UUIDs later without a schema
+    # change. Today it's the array index or a client-supplied stable id.
+    message_id = Column(String(64), nullable=False)
+    verdict = Column(String(4), nullable=False)                   # "up" | "down"
+    comment = Column(Text, nullable=True)                          # optional freeform (mostly on downs)
+    clerk_user_id = Column(Text, nullable=True)                    # who left the feedback
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        # One feedback per (session, message, user) — verdict can be updated (upsert).
+        UniqueConstraint(
+            "session_id", "message_id", "clerk_user_id",
+            name="uq_glens_chat_feedback_session_msg_user",
+        ),
+        # Fast per-workspace analytics rollups.
+        Index(
+            "ix_glens_chat_feedback_workspace_created",
+            "workspace_id", "created_at",
+        ),
+        CheckConstraint(
+            "verdict IN ('up', 'down')",
+            name="ck_glens_chat_feedback_verdict",
+        ),
     )

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -14,10 +14,10 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_workspace_id, require_permission
+from app.core.auth import get_user_id, get_workspace_id, require_permission
 from app.core.database import get_db
 from app.modules.glens.executor import Executor
-from app.modules.glens.models import GlensChatSession
+from app.modules.glens.models import GlensChatFeedback, GlensChatSession
 from app.modules.guard.models import GuardConfig, GuardSpendBudget, WorkspaceCustomRule
 from app.tools import registrations as _tool_registrations  # noqa: F401  # side-effect: populate default_registry before TOOLS derives
 
@@ -1094,3 +1094,83 @@ def spend_config_apply(
 
     scope = "workspace" if req.email is None else f"developer:{req.email}"
     return {"ok": True, "action": action, "scope": scope}
+
+
+# ── Feedback (thumbs up/down per message) ────────────────────────────────────
+
+class FeedbackIn(BaseModel):
+    session_id: str
+    message_id: str                    # position/id of the assistant message
+    verdict: str                        # "up" | "down"
+    comment: str | None = None
+
+
+@router.post("/chat/feedback")
+def submit_feedback(
+    req: FeedbackIn,
+    _: str = Depends(require_permission("guard.activity.view_own")),
+    workspace_id: str = Depends(get_workspace_id),
+    user_id: str | None = Depends(get_user_id),
+    db: Session = Depends(get_db),
+):
+    """Record thumbs up/down for one assistant message. Upsert on
+    (session_id, message_id, clerk_user_id) — a user can flip their vote
+    or add a comment; latest wins.
+
+    Downstream: aggregated feedback feeds the LLM tuning + prompt
+    regression loop (nightly rollup, not part of this endpoint).
+    """
+    if req.verdict not in ("up", "down"):
+        raise HTTPException(status_code=400, detail="verdict must be 'up' or 'down'")
+    if not req.message_id.strip():
+        raise HTTPException(status_code=400, detail="message_id is required")
+    if req.comment is not None and len(req.comment) > 2000:
+        raise HTTPException(status_code=400, detail="comment must be <= 2000 chars")
+
+    ws_uuid = _parse_workspace_id(workspace_id)
+    try:
+        session_uuid = uuid.UUID(req.session_id)
+    except (ValueError, TypeError):
+        raise HTTPException(status_code=400, detail="session_id is not a UUID")
+
+    # Confirm the session belongs to this workspace so users can't leave
+    # feedback on someone else's session by guessing the id.
+    session = (
+        db.query(GlensChatSession)
+        .filter(
+            GlensChatSession.id == session_uuid,
+            GlensChatSession.workspace_id == ws_uuid,
+        )
+        .first()
+    )
+    if session is None:
+        raise HTTPException(status_code=404, detail="session not found")
+
+    existing = (
+        db.query(GlensChatFeedback)
+        .filter(
+            GlensChatFeedback.session_id == session_uuid,
+            GlensChatFeedback.message_id == req.message_id,
+            GlensChatFeedback.clerk_user_id == user_id,
+        )
+        .first()
+    )
+
+    now = datetime.now(timezone.utc)
+    if existing:
+        existing.verdict = req.verdict
+        existing.comment = req.comment
+        existing.updated_at = now
+        db.commit()
+        return {"ok": True, "action": "updated", "verdict": req.verdict}
+
+    db.add(GlensChatFeedback(
+        workspace_id=ws_uuid,
+        session_id=session_uuid,
+        message_id=req.message_id,
+        verdict=req.verdict,
+        comment=req.comment,
+        clerk_user_id=user_id,
+    ))
+    db.commit()
+    return {"ok": True, "action": "created", "verdict": req.verdict}

--- a/apps/api/tests/glens/test_chat_feedback_endpoint.py
+++ b/apps/api/tests/glens/test_chat_feedback_endpoint.py
@@ -1,0 +1,136 @@
+"""Validate POST /glens/chat/feedback — verdict validation, upsert semantics,
+workspace scoping. Backed by mocked SQLAlchemy sessions so tests don't
+require Postgres.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from app.modules.glens.routers.chat import FeedbackIn, submit_feedback
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+_SESSION = "11111111-1111-1111-1111-111111111111"
+_USER = "user_test_123"
+
+
+def _mock_session_ok():
+    """A DB mock where the target GlensChatSession exists in the workspace."""
+    session_row = MagicMock()
+    session_row.id = uuid.UUID(_SESSION)
+    session_row.workspace_id = uuid.UUID(_WS)
+
+    class _Q:
+        def __init__(self, first_val):
+            self._first = first_val
+        def filter(self, *_a, **_k): return self
+        def first(self): return self._first
+
+    db = MagicMock()
+    # First query() call → returns the session lookup. Second → existing
+    # feedback lookup (None so we hit the "create" branch by default).
+    db.query.side_effect = [_Q(session_row), _Q(None)]
+    return db
+
+
+def test_submit_feedback_rejects_invalid_verdict():
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="maybe")
+    with pytest.raises(HTTPException) as exc:
+        submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=MagicMock())
+    assert exc.value.status_code == 400
+    assert "verdict" in exc.value.detail.lower()
+
+
+def test_submit_feedback_rejects_empty_message_id():
+    req = FeedbackIn(session_id=_SESSION, message_id="   ", verdict="up")
+    with pytest.raises(HTTPException) as exc:
+        submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=MagicMock())
+    assert exc.value.status_code == 400
+    assert "message_id" in exc.value.detail.lower()
+
+
+def test_submit_feedback_rejects_bad_session_uuid():
+    req = FeedbackIn(session_id="not-a-uuid", message_id="msg-1", verdict="up")
+    with pytest.raises(HTTPException) as exc:
+        submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=MagicMock())
+    assert exc.value.status_code == 400
+    assert "session_id" in exc.value.detail.lower()
+
+
+def test_submit_feedback_rejects_long_comment():
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="down", comment="x" * 2001)
+    with pytest.raises(HTTPException) as exc:
+        submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=MagicMock())
+    assert exc.value.status_code == 400
+
+
+def test_submit_feedback_404_when_session_not_in_workspace():
+    class _Q:
+        def filter(self, *_a, **_k): return self
+        def first(self): return None
+    db = MagicMock()
+    db.query.return_value = _Q()
+
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="up")
+    with pytest.raises(HTTPException) as exc:
+        submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=db)
+    assert exc.value.status_code == 404
+
+
+def test_submit_feedback_created_when_no_prior():
+    db = _mock_session_ok()
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="up")
+
+    out = submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=db)
+
+    assert out == {"ok": True, "action": "created", "verdict": "up"}
+    db.add.assert_called_once()
+    added = db.add.call_args.args[0]
+    assert added.verdict == "up"
+    assert added.message_id == "msg-1"
+    assert added.clerk_user_id == _USER
+    db.commit.assert_called_once()
+
+
+def test_submit_feedback_updated_when_prior_exists():
+    """User flips their vote from up → down; existing row's verdict + comment
+    get overwritten, no new row inserted."""
+    session_row = MagicMock()
+    session_row.id = uuid.UUID(_SESSION)
+
+    existing = MagicMock()
+    existing.verdict = "up"
+    existing.comment = None
+
+    class _Q:
+        def __init__(self, first_val): self._first = first_val
+        def filter(self, *_a, **_k): return self
+        def first(self): return self._first
+
+    db = MagicMock()
+    db.query.side_effect = [_Q(session_row), _Q(existing)]
+
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="down", comment="unhelpful")
+    out = submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=db)
+
+    assert out == {"ok": True, "action": "updated", "verdict": "down"}
+    assert existing.verdict == "down"
+    assert existing.comment == "unhelpful"
+    db.add.assert_not_called()
+    db.commit.assert_called_once()
+
+
+def test_submit_feedback_accepts_comment_on_down():
+    db = _mock_session_ok()
+    req = FeedbackIn(session_id=_SESSION, message_id="msg-1", verdict="down", comment="wrong data")
+
+    out = submit_feedback(req, _="ok", workspace_id=_WS, user_id=_USER, db=db)
+
+    assert out["action"] == "created"
+    assert out["verdict"] == "down"
+    added = db.add.call_args.args[0]
+    assert added.comment == "wrong data"

--- a/apps/web/src/components/glens/FeedbackButtons.tsx
+++ b/apps/web/src/components/glens/FeedbackButtons.tsx
@@ -1,0 +1,149 @@
+"use client"
+
+/**
+ * Thumbs up/down feedback on a single Lens assistant message.
+ *
+ * Backend: POST /glens/chat/feedback (upserts on session_id + message_id +
+ * clerk_user_id). No wiring here — parent owns sessionId / messageId; drop
+ * this next to <CopyButton> when both PRs land.
+ */
+
+import { useState } from "react"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { API } from "@/lib/api"
+
+type Verdict = "up" | "down" | null
+
+export function FeedbackButtons({
+  sessionId,
+  messageId,
+  onSubmit,
+}: {
+  sessionId: string
+  messageId: string
+  onSubmit?: (verdict: "up" | "down") => void
+}) {
+  const [verdict, setVerdict] = useState<Verdict>(null)
+  const [showComment, setShowComment] = useState(false)
+  const [comment, setComment] = useState("")
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const { authFetch } = useAuthFetch()
+
+  async function _submit(v: "up" | "down", commentValue?: string) {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await authFetch(`${API}/glens/chat/feedback`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          session_id: sessionId,
+          message_id: messageId,
+          verdict: v,
+          comment: commentValue?.trim() ? commentValue.trim() : null,
+        }),
+      })
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}))
+        setError(detail?.detail ?? `Failed (${res.status})`)
+        return
+      }
+      setVerdict(v)
+      onSubmit?.(v)
+      if (v === "down" && !commentValue) setShowComment(true)
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const iconBtn = (v: "up" | "down", active: boolean) => (
+    <button
+      type="button"
+      onClick={() => _submit(v)}
+      disabled={saving}
+      aria-label={v === "up" ? "Helpful" : "Not helpful"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        padding: "4px 8px",
+        fontSize: 11,
+        color: active
+          ? (v === "up" ? "var(--ok, #10b981)" : "var(--warn, #d97706)")
+          : "var(--text-muted)",
+        background: "transparent",
+        border: "1px solid transparent",
+        borderRadius: 6,
+        cursor: saving ? "wait" : "pointer",
+        transition: "background 0.12s, color 0.12s",
+      }}
+      onMouseEnter={e => (e.currentTarget.style.background = "var(--surface-3, rgba(0,0,0,0.04))")}
+      onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
+    >
+      {v === "up" ? (
+        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M7 10v12" />
+          <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l5-9 2 1.4a2 2 0 0 1 .88 2.48Z" />
+        </svg>
+      ) : (
+        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M17 14V2" />
+          <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-5 9-2-1.4a2 2 0 0 1-.88-2.48Z" />
+        </svg>
+      )}
+    </button>
+  )
+
+  return (
+    <div style={{ display: "inline-flex", flexDirection: "column", gap: 4, alignItems: "flex-end" }}>
+      <div style={{ display: "inline-flex", gap: 2 }}>
+        {iconBtn("up", verdict === "up")}
+        {iconBtn("down", verdict === "down")}
+      </div>
+      {showComment && verdict === "down" && (
+        <div style={{ display: "flex", gap: 4, alignItems: "center", marginTop: 2 }}>
+          <input
+            type="text"
+            value={comment}
+            onChange={e => setComment(e.target.value)}
+            placeholder="Anything we can improve? (optional)"
+            maxLength={2000}
+            autoFocus
+            style={{
+              width: 260,
+              fontSize: 11,
+              padding: "4px 8px",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              background: "var(--surface)",
+              color: "var(--text)",
+            }}
+            onKeyDown={e => {
+              if (e.key === "Enter") { _submit("down", comment); setShowComment(false) }
+              else if (e.key === "Escape") setShowComment(false)
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => { _submit("down", comment); setShowComment(false) }}
+            disabled={saving}
+            style={{
+              fontSize: 11,
+              padding: "4px 10px",
+              border: "1px solid var(--border)",
+              borderRadius: 4,
+              background: "var(--surface-2)",
+              color: "var(--text)",
+              cursor: saving ? "wait" : "pointer",
+            }}
+          >
+            Send
+          </button>
+        </div>
+      )}
+      {error && (
+        <div style={{ fontSize: 10, color: "var(--err, #dc2626)" }}>{error}</div>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

New per-message feedback signal for Lens chat responses. Feeds the LLM tuning / prompt regression loop (nightly rollups are downstream — not implemented here).

Kept intentionally split from #1435 (copy button + typing indicator): that PR touches the same `AnswerBubble` render region. This PR ships the model + migration + endpoint + `<FeedbackButtons>` component in a new file, **but doesn't wire it into AnswerBubble yet** — that's a 5-line follow-up after #1435 lands (`<FeedbackButtons />` next to `<CopyButton />`).

## Backend

**Model** — new `GlensChatFeedback` in `modules/glens/models.py`:

- Columns: `workspace_id`, `session_id`, `message_id`, `verdict`, `comment`, `clerk_user_id`, `created_at`, `updated_at`
- `UniqueConstraint (session_id, message_id, clerk_user_id)` → one row per user per message; upsert semantics
- `CheckConstraint verdict IN ('up','down')` at the DB level
- Index `(workspace_id, created_at)` for per-workspace analytics rollups
- **Every constraint/index carries an explicit `name=`** (project convention — no autogenerate)

**Migration** — paired `0107_glens_chat_feedback.py`. Hand-written per CLAUDE.md (`alembic autogenerate` is banned on this repo). Constraint names mirror the model exactly.

**Endpoint** — `POST /glens/chat/feedback`:

- Auth: `require_permission("guard.activity.view_own")` + `workspace_id` + `user_id` (via `get_user_id`).
- Validates verdict ∈ `{up, down}`, `message_id` non-empty, `comment` ≤ 2000 chars, session belongs to caller's workspace (403 protection — users can't leave feedback on someone else's session by guessing the id).
- Upsert: existing `(session_id, message_id, clerk_user_id)` row → UPDATE verdict + comment + updated_at. Otherwise INSERT.

## Frontend (unwired)

`apps/web/src/components/glens/FeedbackButtons.tsx` — thumbs-up / thumbs-down icon buttons under a message. On thumbs-down, expands a small comment input (Enter to send, Esc to dismiss). Uses `useAuthFetch` + POST to the new endpoint.

Not wired into `AnswerBubble` here — will happen post-#1435 as a 5-line drop-in next to `<CopyButton />`.

## Tests

8/8 green locally (`tests/glens/test_chat_feedback_endpoint.py`):

- Verdict validation (invalid → 400)
- `message_id` validation (whitespace-only → 400)
- `session_id` validation (non-UUID → 400)
- Comment length cap (> 2000 → 400)
- Workspace scoping (session in another workspace → 404)
- **Create path** — no prior row → `db.add` called, `action="created"`
- **Update path** — prior row → verdict + comment overwritten, `db.add` NOT called, `action="updated"`
- Comment on downvote persists on the row