### PR TITLE
feat(lens): icon-only chat footer — match Claude's minimal aesthetic

### DIFF
--- a/apps/web/src/components/glens/FeedbackButtons.tsx
+++ b/apps/web/src/components/glens/FeedbackButtons.tsx
@@ -63,11 +63,13 @@ export function FeedbackButtons({
       onClick={() => _submit(v)}
       disabled={saving}
       aria-label={v === "up" ? "Helpful" : "Not helpful"}
+      title={v === "up" ? "Helpful" : "Not helpful"}
       style={{
         display: "inline-flex",
         alignItems: "center",
-        padding: "4px 8px",
-        fontSize: 11,
+        justifyContent: "center",
+        width: 26,
+        height: 26,
         color: active
           ? (v === "up" ? "var(--ok, #10b981)" : "var(--warn, #d97706)")
           : "var(--text-muted)",
@@ -81,12 +83,12 @@ export function FeedbackButtons({
       onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
     >
       {v === "up" ? (
-        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M7 10v12" />
           <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l5-9 2 1.4a2 2 0 0 1 .88 2.48Z" />
         </svg>
       ) : (
-        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M17 14V2" />
           <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-5 9-2-1.4a2 2 0 0 1-.88-2.48Z" />
         </svg>
@@ -95,8 +97,8 @@ export function FeedbackButtons({
   )
 
   return (
-    <div style={{ display: "inline-flex", flexDirection: "column", gap: 4, alignItems: "flex-end" }}>
-      <div style={{ display: "inline-flex", gap: 2 }}>
+    <div style={{ display: "inline-flex", flexDirection: "column", gap: 4, alignItems: "flex-start" }}>
+      <div style={{ display: "inline-flex", gap: 0 }}>
         {iconBtn("up", verdict === "up")}
         {iconBtn("down", verdict === "down")}
       </div>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -448,10 +448,8 @@ function LoadingBubble({ label }: { label?: string }) {
 
 // ── Copy button (shared) ──────────────────────────────────────────────────────
 
-function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" }) {
+function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
-  const iconSize = size === "sm" ? 12 : 14
-  const padding = size === "sm" ? "4px 8px" : "5px 10px"
 
   const handleCopy = async () => {
     try {
@@ -478,13 +476,13 @@ function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" })
       type="button"
       onClick={handleCopy}
       aria-label={copied ? "Copied" : "Copy response"}
+      title={copied ? "Copied" : "Copy"}
       style={{
         display: "inline-flex",
         alignItems: "center",
-        gap: 4,
-        padding,
-        fontSize: 11,
-        fontWeight: 500,
+        justifyContent: "center",
+        width: 26,
+        height: 26,
         color: copied ? "var(--ok, #10b981)" : "var(--text-muted)",
         background: "transparent",
         border: "1px solid transparent",
@@ -496,16 +494,15 @@ function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" })
       onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
     >
       {copied ? (
-        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <polyline points="20 6 9 17 4 12" />
         </svg>
       ) : (
-        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
         </svg>
       )}
-      {copied ? "Copied" : "Copy"}
     </button>
   )
 }
@@ -523,10 +520,11 @@ function MessageFooter({ text, sessionId, messageId }: { text?: string; sessionI
       style={{
         display: "flex",
         justifyContent: "flex-start",
-        gap: 4,
-        marginTop: 2,
+        alignItems: "center",
+        gap: 0,
+        marginTop: 4,
         marginBottom: 12,
-        paddingLeft: 4,
+        marginLeft: -4,
       }}
     >
       {text ? <CopyButton text={text} /> : null}


### PR DESCRIPTION
## Summary

Screenshot comparison: our footer showed a "Copy" text label next to the icon; thumbs sat next to it with different padding. Claude's footer is clean icon-only, uniform 26px hit targets, tight spacing.

Match:

- **`CopyButton`** — 26×26 square, no text label. Icon-only. Green checkmark on success (1.5s). `title="Copy"`/`"Copied"` for hover discoverability.
- **`FeedbackButtons`** — same 26×26 square shape. Icons only. Green thumbs-up when active, amber thumbs-down when active. `title` tooltips.
- **`MessageFooter`** — `gap: 0` between buttons (each has its own hover padding); left-aligned under the bubble.

## No API change

Same behavior:

- Copy: `navigator.clipboard.writeText` + textarea fallback
- Feedback: POST `/glens/chat/feedback` with upsert semantics; comment input still expands on downvote

## Accessibility preserved

`aria-label` + `title` + visible icons. Screen readers still announce "Copy response" / "Helpful" / "Not helpful".

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Ask Lens anything → footer shows: 📋 · 👍 · 👎 (no "Copy" text label)
- [ ] Click 📋 → icon flips to green ✓ for 1.5s; text is on clipboard
- [ ] Click 👍 → icon fills green; row upserts in `glens_chat_feedback`
- [ ] Click 👎 → icon fills amber; comment box expands
- [ ] Hover any icon → tooltip appears ("Copy" / "Helpful" / "Not helpful")