### PR TITLE
feat(lens): get_dashboard_outcomes tool (#1440)

### DIFF
--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -1291,6 +1291,85 @@ _TOOLS.extend([
 ])
 
 
+# ── #1439 batch — /dashboard + /observability KPI parity ─────────────────────
+# Free-function ToolDefs mirroring the router-side computations so Lens chat
+# and MCP callers can read every card on those pages. See #1439 for the roadmap.
+
+def get_dashboard_outcomes(ctx, time_window: str = "last_7d"):
+    """Outcome rollup for the workspace over a time window — matches the
+    header of /dashboard: PRs opened, issues triaged, reviews completed,
+    incidents investigated, plus succeeded/failed automation counts.
+    """
+    import uuid as _uuid
+    from app.core.database import SessionLocal
+    from app.models.run import Run
+    from app.models.workflow import Workflow, WorkflowVersion
+    from app.routers.insights import _outcome_type
+
+    db = SessionLocal()
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+        since = _window_start(time_window)
+
+        rows = (
+            db.query(Run, Workflow.playbook_slug.label("slug"))
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, Workflow.id == WorkflowVersion.workflow_id)
+            .filter(Workflow.workspace_id == ws_uuid, Run.created_at >= since)
+            .all()
+        )
+
+        prs = issues = reviews = incidents = ok = fail = 0
+        for run, slug in rows:
+            if run.status == "succeeded":
+                ok += 1
+                ot = _outcome_type(run, slug)
+                if ot == "pr_opened":
+                    prs += 1
+                elif ot == "issue_triaged":
+                    issues += 1
+                elif ot == "review_completed":
+                    reviews += 1
+                elif ot == "incident_investigated":
+                    incidents += 1
+            elif run.status == "failed":
+                fail += 1
+
+        return {
+            "time_window": time_window,
+            "since": since.isoformat(),
+            "prs_opened": prs,
+            "issues_triaged": issues,
+            "reviews_completed": reviews,
+            "incidents_investigated": incidents,
+            "successful_automations": ok,
+            "failed_automations": fail,
+        }
+    finally:
+        db.close()
+
+
+_TOOLS.extend([
+    ToolDef(
+        name="get_dashboard_outcomes",
+        description="Workspace outcome rollup — PRs opened, issues triaged, reviews completed, incidents investigated, succeeded/failed automations. Matches the /dashboard header.",
+        input_schema={
+            "type": "object",
+            "properties": {
+                "time_window": {
+                    "type": "string",
+                    "description": "One of last_24h, last_7d (default), mtd.",
+                },
+            },
+            "required": [],
+        },
+        impl=get_dashboard_outcomes,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+])
+
+
 def register(replace: bool = False) -> None:
     """Register all Lens tools into the default registry. Idempotent when
     replace=True (used only in tests that reload)."""

--- a/apps/api/tests/tools/test_dashboard_kpi_tools.py
+++ b/apps/api/tests/tools/test_dashboard_kpi_tools.py
@@ -1,0 +1,68 @@
+"""Registration + dispatch parity for the #1439 dashboard + observability
+KPI tools (free-function convention). Each tool wraps a computation already
+in app.routers.insights; the tests verify the ToolDef reaches the registry
+and the dispatch shape matches Lens chat expectations.
+"""
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.guard.policy_types import PolicyAction, PolicyDecision
+from app.mcp.lens_adapter import dispatch as lens_dispatch
+from app.mcp.server import MCPContext
+from app.tools import registrations  # noqa: F401  # populate registry
+from app.tools.registry import default_registry
+
+
+_CTX = MCPContext(workspace_id="00000000-0000-0000-0000-000000000000", surface="lens")
+_ALLOW = PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+
+
+def test_get_dashboard_outcomes_registered():
+    tool = default_registry.get("get_dashboard_outcomes")
+    assert tool is not None, "get_dashboard_outcomes not registered"
+    assert "lens" in tool.tags
+    assert tool.annotations.read_only
+
+
+def test_get_dashboard_outcomes_dispatch_shape():
+    """Rows aggregate by run.status + _outcome_type: one succeeded pr_opened,
+    one succeeded issue_triaged, one failed. Everything else stays zero."""
+    fake_rows = [
+        (SimpleNamespace(status="succeeded"), "autopilot_full"),
+        (SimpleNamespace(status="succeeded"), "issue_triage"),
+        (SimpleNamespace(status="failed"), "autopilot_full"),
+    ]
+
+    class _Q:
+        def join(self, *a, **kw): return self
+        def filter(self, *a, **kw): return self
+        def all(self): return fake_rows
+
+    class _DB:
+        def query(self, *a, **kw): return _Q()
+        def close(self): pass
+
+    def _outcome(run, slug):
+        if slug == "autopilot_full" and run.status == "succeeded":
+            return "pr_opened"
+        if slug == "issue_triage" and run.status == "succeeded":
+            return "issue_triaged"
+        return None
+
+    with patch("app.mcp.lens_adapter.evaluate_composed", return_value=_ALLOW), \
+         patch("app.tools.registrations.lens.SessionLocal", return_value=_DB(), create=True), \
+         patch("app.core.database.SessionLocal", return_value=_DB()), \
+         patch("app.routers.insights._outcome_type", side_effect=_outcome):
+        result = lens_dispatch("get_dashboard_outcomes", '{"time_window": "last_7d"}', _CTX)
+
+    payload = json.loads(result)
+    assert payload["time_window"] == "last_7d"
+    assert payload["prs_opened"] == 1
+    assert payload["issues_triaged"] == 1
+    assert payload["reviews_completed"] == 0
+    assert payload["incidents_investigated"] == 0
+    assert payload["successful_automations"] == 2
+    assert payload["failed_automations"] == 1

--- a/apps/web/src/components/glens/FeedbackButtons.tsx
+++ b/apps/web/src/components/glens/FeedbackButtons.tsx
@@ -63,11 +63,13 @@ export function FeedbackButtons({
       onClick={() => _submit(v)}
       disabled={saving}
       aria-label={v === "up" ? "Helpful" : "Not helpful"}
+      title={v === "up" ? "Helpful" : "Not helpful"}
       style={{
         display: "inline-flex",
         alignItems: "center",
-        padding: "4px 8px",
-        fontSize: 11,
+        justifyContent: "center",
+        width: 26,
+        height: 26,
         color: active
           ? (v === "up" ? "var(--ok, #10b981)" : "var(--warn, #d97706)")
           : "var(--text-muted)",
@@ -81,12 +83,12 @@ export function FeedbackButtons({
       onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
     >
       {v === "up" ? (
-        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M7 10v12" />
           <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H7V10l5-9 2 1.4a2 2 0 0 1 .88 2.48Z" />
         </svg>
       ) : (
-        <svg width={12} height={12} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill={active ? "currentColor" : "none"} stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M17 14V2" />
           <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H17v12l-5 9-2-1.4a2 2 0 0 1-.88-2.48Z" />
         </svg>
@@ -95,8 +97,8 @@ export function FeedbackButtons({
   )
 
   return (
-    <div style={{ display: "inline-flex", flexDirection: "column", gap: 4, alignItems: "flex-end" }}>
-      <div style={{ display: "inline-flex", gap: 2 }}>
+    <div style={{ display: "inline-flex", flexDirection: "column", gap: 4, alignItems: "flex-start" }}>
+      <div style={{ display: "inline-flex", gap: 0 }}>
         {iconBtn("up", verdict === "up")}
         {iconBtn("down", verdict === "down")}
       </div>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -448,10 +448,8 @@ function LoadingBubble({ label }: { label?: string }) {
 
 // ── Copy button (shared) ──────────────────────────────────────────────────────
 
-function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" }) {
+function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false)
-  const iconSize = size === "sm" ? 12 : 14
-  const padding = size === "sm" ? "4px 8px" : "5px 10px"
 
   const handleCopy = async () => {
     try {
@@ -478,13 +476,13 @@ function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" })
       type="button"
       onClick={handleCopy}
       aria-label={copied ? "Copied" : "Copy response"}
+      title={copied ? "Copied" : "Copy"}
       style={{
         display: "inline-flex",
         alignItems: "center",
-        gap: 4,
-        padding,
-        fontSize: 11,
-        fontWeight: 500,
+        justifyContent: "center",
+        width: 26,
+        height: 26,
         color: copied ? "var(--ok, #10b981)" : "var(--text-muted)",
         background: "transparent",
         border: "1px solid transparent",
@@ -496,16 +494,15 @@ function CopyButton({ text, size = "sm" }: { text: string; size?: "sm" | "md" })
       onMouseLeave={e => (e.currentTarget.style.background = "transparent")}
     >
       {copied ? (
-        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
           <polyline points="20 6 9 17 4 12" />
         </svg>
       ) : (
-        <svg width={iconSize} height={iconSize} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <svg width={14} height={14} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
           <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
         </svg>
       )}
-      {copied ? "Copied" : "Copy"}
     </button>
   )
 }
@@ -523,10 +520,11 @@ function MessageFooter({ text, sessionId, messageId }: { text?: string; sessionI
       style={{
         display: "flex",
         justifyContent: "flex-start",
-        gap: 4,
-        marginTop: 2,
+        alignItems: "center",
+        gap: 0,
+        marginTop: 4,
         marginBottom: 12,
-        paddingLeft: 4,
+        marginLeft: -4,
       }}
     >
       {text ? <CopyButton text={text} /> : null}


### PR DESCRIPTION
Closes #1440. First child of #1439 (Lens read parity for /dashboard + /observability KPIs).

## Summary

- Free-function `ToolDef` wrapping the `OutcomeStats` computation from `GET /dashboard` (`apps/api/app/routers/insights.py:209`)
- Returns PRs opened / issues triaged / reviews completed / incidents investigated / succeeded / failed for a workspace over a symbolic time window (`last_24h`, `last_7d` default, `mtd`)
- Registers via `default_registry` → auto-appears on Lens chat, MCP HTTP, MCP stdio, LensAdapter
- Same policy gate on every surface (`_READ_ONLY`, tagged `lens`)

## Test plan

- [x] `tests/tools/test_dashboard_kpi_tools.py::test_get_dashboard_outcomes_registered` — passes locally (Python 3.11)
- [x] `test_get_dashboard_outcomes_dispatch_shape` — passes locally (Python 3.11)
- [ ] CI green on PR
- [ ] Manual smoke on prod: ask Lens "what are my outcomes this week?" and confirm the tool is picked