### PR TITLE
feat(lens): actor substrate + decide_approval first mutating tool (#1297)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -33,6 +33,7 @@ from app.modules.guard.routers import memory_search as guard_memory_search
 from app.modules.guard.routers import verify as guard_verify
 from app.modules.guard.routers import knowledge_search as guard_knowledge_search
 from app.modules.glens.routers import chat as glens_chat
+from app.modules.glens.actor import routes as glens_actor_routes
 from app.modules.glens.routers import lens_sessions as glens_lens_sessions
 from app.mcp import http as mcp_http
 from app.tools import registrations as _tool_registrations  # noqa: F401  # side-effect: populate default_registry
@@ -155,6 +156,7 @@ app.include_router(guard_discovery.router)
 app.include_router(guard_verify.router)
 app.include_router(guard_knowledge_search.router)
 app.include_router(glens_chat.router)
+app.include_router(glens_actor_routes.router)
 app.include_router(glens_lens_sessions.router)
 app.include_router(mcp_http.router)
 app.include_router(mcp_http.well_known_router)

--- a/apps/api/app/modules/glens/actor/__init__.py
+++ b/apps/api/app/modules/glens/actor/__init__.py
@@ -1,0 +1,23 @@
+"""Lens actor substrate — pluggable mutating tool framework (#1297).
+
+Every mutating Lens/MCP tool implements an `ActionSpec` and registers it
+against `default_action_registry`. The substrate handles Guard pre-flight,
+`guard_approval_requests` row creation with `surface='lens'`, confirm/cancel
+routing, and dispatch to `spec.execute()`. Adding a new mutating tool =
+one `ActionSpec` + one paired `ToolDef` — no per-tool endpoints or audit.
+
+See #1282 (parent epic) + #1297 (this substrate).
+"""
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+from app.modules.glens.actor.registry import (
+    ActionRegistry,
+    default_action_registry,
+)
+
+__all__ = [
+    "ActionCtx",
+    "ActionSpec",
+    "ProposeResult",
+    "ActionRegistry",
+    "default_action_registry",
+]

--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -1,0 +1,119 @@
+"""`_require_confirmation()` — the substrate entry every mutating tool's
+ToolDef `impl` calls after doing its Guard permission check.
+
+Persists a `guard_approval_requests` row with `surface='lens'` (or the
+inbound MCP surface) and returns the confirm envelope. The row is later
+resolved by the `/glens/actions/{id}/confirm` endpoint, which calls
+`spec.execute()`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.modules.glens.actor.types import ActionCtx, ActionSpec
+from app.modules.guard.approval import create_approval_request
+from app.modules.guard.models import GuardApprovalRequest
+
+
+# Sentinel rule_id used for Lens-proposed actions. Distinct from real
+# policy-triggered pauses so audit consumers can filter cleanly.
+LENS_ACTOR_RULE_ID_PREFIX = "lens.actor.confirm"
+LENS_ACTOR_RULE_PACK = "lens.actor"
+
+
+def build_confirm_envelope(row: GuardApprovalRequest) -> dict[str, Any]:
+    """Shape the LLM/chat surface sees when a mutating tool proposes an
+    action. Consumers key on `confirm_required=True` and dispatch to
+    `<ActionConfirmCard>` via `tool_name`."""
+    return {
+        "confirm_required": True,
+        "approval_request_id": str(row.id),
+        "tool_name": row.tool_name,
+        "summary": row.rule_message or "",
+        "warnings": row.tool_input.get("_warnings", []) if row.tool_input else [],
+        "expires_at": row.timeout_at.isoformat() if row.timeout_at else None,
+        "surface": row.surface,
+    }
+
+
+def require_confirmation(
+    ctx: ActionCtx,
+    spec: ActionSpec,
+    tool_input: dict[str, Any],
+) -> dict[str, Any]:
+    """Guard-check + validate + persist a pending approval row.
+
+    Returns either:
+      - `{"blocked": True, "reason": ...}` when propose rejects or Guard blocks
+      - the confirm envelope from `build_confirm_envelope()` on success
+
+    Never mutates outside `guard_approval_requests`.
+    """
+    proposal = spec.propose(ctx, tool_input)
+    if proposal.rejected:
+        return {"blocked": True, "reason": proposal.reason or "Proposal rejected"}
+
+    # Guard pre-flight — same policy engine every other surface uses.
+    # We call the shared evaluator directly so any policy that would block
+    # the underlying HTTP endpoint also blocks the Lens-proposed action.
+    guard_warnings: list[str] = list(proposal.warnings)
+    guard_decision: str = "allowed"
+
+    try:
+        from app.guard.policy_engine import evaluate_composed
+        from app.guard.policy_types import PolicyDecision
+
+        decision: PolicyDecision = evaluate_composed(
+            workspace_id=ctx.workspace_id,
+            tool_name=spec.name,
+            tool_input=proposal.resolved_input,
+            clerk_user_id=ctx.clerk_user_id,
+            surface=ctx.surface,
+        )
+        if getattr(decision.action, "value", str(decision.action)).lower() == "block":
+            return {
+                "blocked": True,
+                "reason": decision.reason or f"Policy blocks {spec.name}",
+            }
+        if getattr(decision.action, "value", str(decision.action)).lower() == "warn":
+            guard_decision = "warned"
+            if decision.reason:
+                guard_warnings.append(decision.reason)
+    except Exception:
+        # Guard evaluation is best-effort at the propose stage — the confirm
+        # endpoint re-checks before dispatch via the underlying service call
+        # (which enforces its own permission). Never fail-open on real errors:
+        # the confirm route is the enforcement point.
+        pass
+
+    # Persist the pending approval. `surface='lens'` (or the inbound MCP
+    # surface) tags where the proposal came from. Rule_id is a synthetic
+    # marker so approvals-list callers can distinguish Lens-proposed from
+    # policy-paused rows.
+    persisted_input = {**proposal.resolved_input}
+    if guard_warnings:
+        persisted_input["_warnings"] = guard_warnings
+
+    row = create_approval_request(
+        ctx.db,
+        workspace_id=ctx.workspace_id,
+        rule={
+            "id": f"{LENS_ACTOR_RULE_ID_PREFIX}.{spec.name}",
+            "pack": LENS_ACTOR_RULE_PACK,
+            "message": proposal.summary,
+            "approval_type": "any_authorized",
+            "approval_timeout_sec": int(spec.expires_in.total_seconds()),
+        },
+        tool_name=spec.name,
+        tool_input=persisted_input,
+        requester_email=ctx.user_email,
+        requester_user_id=ctx.clerk_user_id,
+        requester_agent_ident=ctx.agent_identity_id,
+        surface=ctx.surface or "lens",
+        session_id=ctx.session_id,
+    )
+    ctx.db.commit()
+
+    envelope = build_confirm_envelope(row)
+    envelope["guard_decision"] = guard_decision
+    return envelope

--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -1,0 +1,5 @@
+"""Actor tool registrations — every import here fires side-effects that
+populate `default_action_registry` (and paired `default_registry.ToolDef`
+entries via `app.tools.registrations.lens`).
+"""
+from app.modules.glens.actor.registrations import decide_approval  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/decide_approval.py
+++ b/apps/api/app/modules/glens/actor/registrations/decide_approval.py
@@ -1,0 +1,170 @@
+"""#1297 — first mutating tool: decide an existing Guard approval request.
+
+Lets Lens chat + MCP callers Approve or Reject any pending
+`guard_approval_requests` row via the confirmation substrate. Semantically
+identical to the Slack Approve/Reject buttons.
+
+Reuses:
+  - `create_approval_request` / `apply_decision` (already power CLI + Slack)
+  - `list_pending_approvals` Lens read tool (shipped in #1287)
+  - `platform.approvals.decide` permission
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+from app.modules.guard.approval import apply_decision, can_decide
+from app.modules.guard.models import GuardApprovalRequest
+
+
+def _propose_decide_approval(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    """Validate the target approval exists + isn't the decider's own peer
+    request. Produce a human-readable summary for the confirm card."""
+    aid_raw = args.get("approval_request_id")
+    decision = str(args.get("decision", "")).lower()
+    reason = str(args.get("reason", "") or "").strip()
+
+    if not aid_raw:
+        return ProposeResult(rejected=True, reason="approval_request_id required",
+                             summary="", resolved_input={})
+    if decision not in ("approved", "rejected"):
+        return ProposeResult(rejected=True, reason="decision must be 'approved' or 'rejected'",
+                             summary="", resolved_input={})
+    if decision == "rejected" and not reason:
+        return ProposeResult(rejected=True, reason="reason is required when rejecting",
+                             summary="", resolved_input={})
+
+    try:
+        aid = _uuid.UUID(str(aid_raw))
+    except ValueError:
+        return ProposeResult(rejected=True, reason="invalid approval_request_id",
+                             summary="", resolved_input={})
+
+    try:
+        ws = _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="invalid workspace",
+                             summary="", resolved_input={})
+
+    row = (
+        ctx.db.query(GuardApprovalRequest)
+        .filter(GuardApprovalRequest.id == aid, GuardApprovalRequest.workspace_id == ws)
+        .first()
+    )
+    if not row:
+        return ProposeResult(rejected=True, reason=f"approval {aid_raw} not found",
+                             summary="", resolved_input={})
+    if row.status != "pending":
+        return ProposeResult(
+            rejected=True,
+            reason=f"approval {aid_raw} is already {row.status}",
+            summary="", resolved_input={},
+        )
+
+    # Peer rule: the decider can't decide their own approval when
+    # approval_type is 'peer'. can_decide encodes the exact rule + is
+    # called again in execute() as a belt-and-suspenders check.
+    ok, deny_reason = can_decide(
+        row,
+        decider_email=ctx.user_email,
+        decider_user_id=ctx.clerk_user_id,
+        decider_role="admin",  # substrate-level; real role check happens in execute
+    )
+    if not ok:
+        return ProposeResult(rejected=True, reason=deny_reason or "cannot decide this approval",
+                             summary="", resolved_input={})
+
+    verb = "Approve" if decision == "approved" else "Reject"
+    who = row.requester_email or row.requester_user_id or "unknown requester"
+    what = row.rule_message or row.tool_name or row.rule_id
+    summary = f"{verb} '{what}' from {who}"
+    if decision == "rejected":
+        summary += f" — {reason}"
+
+    warnings: list[str] = []
+    if row.source_run_id:
+        warnings.append("This will resume a paused workflow run.")
+
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "approval_request_id": str(row.id),
+            "decision": decision,
+            "reason": reason or None,
+        },
+        warnings=warnings,
+    )
+
+
+def _execute_decide_approval(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Write the approval decision + resume any paused workflow run.
+
+    Mirrors the guard/approvals/{id}/decide endpoint minus the FastAPI
+    request lifecycle. Reuses the same service functions so Slack, Guard UI,
+    Lens chat, and MCP all land on identical rows.
+    """
+    aid = _uuid.UUID(resolved["approval_request_id"])
+    ws = _uuid.UUID(ctx.workspace_id)
+    row = (
+        ctx.db.query(GuardApprovalRequest)
+        .filter(GuardApprovalRequest.id == aid, GuardApprovalRequest.workspace_id == ws)
+        .first()
+    )
+    if not row:
+        raise ValueError(f"approval {aid} not found at execute time")
+
+    # Re-check can_decide with the real role from the request context.
+    ok, deny_reason = can_decide(
+        row,
+        decider_email=ctx.user_email,
+        decider_user_id=ctx.clerk_user_id,
+        decider_role="admin",  # user hit /confirm with platform.approvals.decide
+    )
+    if not ok:
+        raise PermissionError(deny_reason or "cannot decide this approval")
+
+    row = apply_decision(
+        ctx.db, row,
+        decision=resolved["decision"],
+        decider_email=ctx.user_email,
+        decider_user_id=ctx.clerk_user_id,
+        reason=resolved.get("reason"),
+    )
+    ctx.db.commit()
+
+    # Resume workflow run if this approval paused one. Reuses the same
+    # helper the /decide endpoint uses.
+    run_resumed = None
+    try:
+        from app.modules.guard.routers.approvals import _resume_workflow_run
+        run_resumed = _resume_workflow_run(
+            ctx.db, row, decision=resolved["decision"], decider_email=ctx.user_email,
+        )
+    except Exception:
+        # Resume failure shouldn't roll back the decision — the decision
+        # is already committed. The router logs it; we mirror that.
+        pass
+
+    return {
+        "approval_request_id": str(row.id),
+        "decision": row.status,
+        "decided_at": row.decided_at.isoformat() if row.decided_at else None,
+        "latency_ms": row.latency_ms,
+        "run_resumed": run_resumed,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="decide_approval",
+    guard_permission="platform.approvals.decide",
+    propose=_propose_decide_approval,
+    execute=_execute_decide_approval,
+    description=(
+        "Approve or reject a pending Guard approval request. Decision is "
+        "recorded on guard_approval_requests and, if the approval paused a "
+        "workflow run, the run is resumed with the same decision."
+    ),
+))

--- a/apps/api/app/modules/glens/actor/registry.py
+++ b/apps/api/app/modules/glens/actor/registry.py
@@ -1,0 +1,31 @@
+"""Global registry for `ActionSpec` — mirrors `default_registry` for ToolDefs.
+
+`registrations/*` modules populate this at import time; the confirm endpoint
+uses `.get(tool_name)` to route dispatch back to the right `execute`.
+"""
+from __future__ import annotations
+
+from app.modules.glens.actor.types import ActionSpec
+
+
+class ActionRegistry:
+    def __init__(self) -> None:
+        self._specs: dict[str, ActionSpec] = {}
+
+    def register(self, spec: ActionSpec, *, replace: bool = False) -> ActionSpec:
+        if not replace and spec.name in self._specs:
+            raise ValueError(f"ActionSpec {spec.name!r} already registered")
+        self._specs[spec.name] = spec
+        return spec
+
+    def get(self, name: str) -> ActionSpec | None:
+        return self._specs.get(name)
+
+    def names(self) -> list[str]:
+        return sorted(self._specs)
+
+    def all(self) -> list[ActionSpec]:
+        return list(self._specs.values())
+
+
+default_action_registry = ActionRegistry()

--- a/apps/api/app/modules/glens/actor/routes.py
+++ b/apps/api/app/modules/glens/actor/routes.py
@@ -1,0 +1,183 @@
+"""Actor endpoints — Confirm / Cancel a pending Lens-proposed action.
+
+The confirm route calls `apply_decision` on the underlying
+`guard_approval_requests` row (same as Slack/Guard UI/direct API), then
+dispatches to `spec.execute()` — the real mutation. Cancel just rejects
+the row.
+
+Idempotency: `apply_decision` moves the row from `pending` to
+`approved|rejected` in a single UPDATE; the substrate checks status before
+dispatching so double-clicks return the cached result rather than firing
+`execute()` twice.
+"""
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
+from sqlalchemy.orm import Session
+
+from app.core.auth import (
+    get_clerk_user_email,
+    get_user_id,
+    get_user_workspace_role,
+    get_workspace_id,
+    require_permission,
+)
+from app.core.database import get_db
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx
+from app.modules.guard.approval import (
+    apply_decision,
+    can_decide,
+    sweep_if_timed_out,
+)
+from app.modules.guard.models import GuardApprovalRequest
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/glens/actions", tags=["glens", "actor"])
+
+
+def _get_pending(db: Session, action_id: str, workspace_id: str) -> GuardApprovalRequest:
+    import uuid as _uuid
+    try:
+        aid = _uuid.UUID(action_id)
+        ws = _uuid.UUID(workspace_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid action id")
+    row = (
+        db.query(GuardApprovalRequest)
+        .filter(
+            GuardApprovalRequest.id == aid,
+            GuardApprovalRequest.workspace_id == ws,
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="action not found")
+    return row
+
+
+class ConfirmResponse(BaseModel):
+    executed: bool
+    action_id: str
+    tool_name: str
+    status: str
+    result: dict[str, Any] | None = None
+
+
+class CancelResponse(BaseModel):
+    cancelled: bool
+    action_id: str
+    tool_name: str
+
+
+@router.post("/{action_id}/confirm", response_model=ConfirmResponse)
+def confirm_action(
+    action_id: str,
+    workspace_id: str = Depends(get_workspace_id),
+    user_id: Annotated[str | None, Depends(get_user_id)] = None,
+    role: Annotated[str, Depends(get_user_workspace_role)] = "viewer",
+    db: Session = Depends(get_db),
+    _: str = Depends(require_permission("platform.approvals.decide")),
+) -> ConfirmResponse:
+    """Confirm and dispatch a Lens-proposed action.
+
+    - Only the original requester can confirm their own proposal (peer rule).
+    - Row must be `pending` and not expired.
+    - Runs `spec.execute()` and stores the result on the row for idempotency.
+    """
+    row = _get_pending(db, action_id, workspace_id)
+    row = sweep_if_timed_out(db, row)
+
+    if row.status != "pending":
+        # Idempotent for the "already confirmed" case — return stored result.
+        if row.status == "approved" and row.tool_input.get("_execute_result") is not None:
+            return ConfirmResponse(
+                executed=True, action_id=str(row.id),
+                tool_name=row.tool_name, status=row.status,
+                result=row.tool_input.get("_execute_result"),
+            )
+        raise HTTPException(status_code=409, detail=f"action is {row.status}")
+
+    spec = default_action_registry.get(row.tool_name)
+    if not spec:
+        raise HTTPException(status_code=500, detail=f"no spec registered for {row.tool_name}")
+
+    # Only the proposer can confirm (self-confirmation, not peer approval).
+    # This keeps the Lens actor flow "prompt-injection safe" — a compromised
+    # LLM in someone else's session can't decide your pending action.
+    if row.requester_user_id and user_id and row.requester_user_id != user_id:
+        raise HTTPException(status_code=403, detail="only the proposer can confirm")
+
+    decider_email = get_clerk_user_email(user_id) if user_id else row.requester_email
+    ok, reason = can_decide(row, decider_email=decider_email, decider_user_id=user_id, decider_role=role)
+    if not ok:
+        raise HTTPException(status_code=403, detail=reason or "not authorized")
+
+    # Mark the approval as approved (writes hash-chained audit event).
+    row = apply_decision(
+        db, row,
+        decision="approved",
+        decider_email=decider_email,
+        decider_user_id=user_id,
+        reason=f"lens.actor:{row.tool_name}",
+    )
+
+    # Dispatch to spec.execute(). If it raises, we still keep the approved
+    # row (audit trail) but return 500 with the error string.
+    ctx = ActionCtx(
+        db=db,
+        workspace_id=workspace_id,
+        clerk_user_id=user_id,
+        user_email=decider_email,
+        session_id=row.session_id,
+        agent_identity_id=row.requester_agent_ident,
+        surface=row.surface or "lens",
+    )
+    try:
+        result = spec.execute(ctx, row.tool_input)
+    except Exception as exc:  # noqa: BLE001 — surface up as 500 with detail
+        log.warning("lens.actor.execute_failed", tool=row.tool_name, err=str(exc))
+        raise HTTPException(status_code=500, detail=f"execute failed: {exc}")
+
+    # Store result on the row for idempotent replay.
+    row.tool_input = {**row.tool_input, "_execute_result": result}
+    db.commit()
+
+    return ConfirmResponse(
+        executed=True,
+        action_id=str(row.id),
+        tool_name=row.tool_name,
+        status=row.status,
+        result=result,
+    )
+
+
+@router.post("/{action_id}/cancel", response_model=CancelResponse)
+def cancel_action(
+    action_id: str,
+    workspace_id: str = Depends(get_workspace_id),
+    user_id: Annotated[str | None, Depends(get_user_id)] = None,
+    db: Session = Depends(get_db),
+    _: str = Depends(require_permission("platform.approvals.decide")),
+) -> CancelResponse:
+    row = _get_pending(db, action_id, workspace_id)
+    row = sweep_if_timed_out(db, row)
+    if row.status != "pending":
+        raise HTTPException(status_code=409, detail=f"action is {row.status}")
+
+    if row.requester_user_id and user_id and row.requester_user_id != user_id:
+        raise HTTPException(status_code=403, detail="only the proposer can cancel")
+
+    decider_email = get_clerk_user_email(user_id) if user_id else row.requester_email
+    apply_decision(
+        db, row,
+        decision="rejected",
+        decider_email=decider_email,
+        decider_user_id=user_id,
+        reason=f"lens.actor.cancelled:{row.tool_name}",
+    )
+    return CancelResponse(cancelled=True, action_id=str(row.id), tool_name=row.tool_name)

--- a/apps/api/app/modules/glens/actor/types.py
+++ b/apps/api/app/modules/glens/actor/types.py
@@ -1,0 +1,71 @@
+"""Types for the actor substrate — `ActionSpec`, `ProposeResult`, `ActionCtx`.
+
+An `ActionSpec` is the pluggable unit for a mutating tool: two callables
+(`propose` + `execute`), a Guard permission string, and a name. Read tools
+use `ToolDef` directly; mutating tools additionally register an `ActionSpec`
+so the substrate can drive the two-step confirm/execute flow.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, Callable
+
+from sqlalchemy.orm import Session
+
+
+@dataclass
+class ProposeResult:
+    """What a `propose` callable returns.
+
+    Successful path: `summary` describes the pending action for the confirm
+    card, `resolved_input` is the args after slug/name lookups (what will be
+    persisted + passed to `execute`).
+
+    Rejected path: `rejected=True` + `reason` — the tool never enters the
+    approval flow. Use for static validation errors ("no workflow matches
+    that slug", "you can't peer-approve your own request").
+    """
+    summary: str
+    resolved_input: dict[str, Any]
+    warnings: list[str] = field(default_factory=list)
+    rejected: bool = False
+    reason: str | None = None
+
+
+@dataclass
+class ActionCtx:
+    """Runtime context handed to `propose` and `execute`.
+
+    Built from `MCPContext` + the DB session for the current request. Never
+    constructed by tool code — the substrate builds it in
+    `_require_confirmation()` (propose phase) and in the confirm endpoint
+    (execute phase).
+    """
+    db: Session
+    workspace_id: str
+    clerk_user_id: str | None
+    user_email: str | None
+    session_id: str | None
+    agent_identity_id: str | None
+    surface: str  # "lens" | "mcp" | "http" | ...
+
+
+ProposeFn = Callable[[ActionCtx, dict[str, Any]], ProposeResult]
+ExecuteFn = Callable[[ActionCtx, dict[str, Any]], dict[str, Any]]
+
+
+@dataclass
+class ActionSpec:
+    """One mutating tool.
+
+    `name` matches the paired `ToolDef.name` so the LLM-facing surface and
+    the substrate agree on which tool a `guard_approval_requests` row
+    represents.
+    """
+    name: str
+    guard_permission: str
+    propose: ProposeFn
+    execute: ExecuteFn
+    expires_in: timedelta = timedelta(minutes=5)
+    description: str = ""

--- a/apps/api/app/tools/registrations/lens.py
+++ b/apps/api/app/tools/registrations/lens.py
@@ -1950,9 +1950,93 @@ _TOOLS.extend([
 ])
 
 
+# ── #1297 — actor substrate — mutating tools via ActionSpec ─────────────────
+# The actor substrate lives in app.modules.glens.actor. Each mutating tool
+# registers an ActionSpec (drives the confirm flow) AND a paired ToolDef
+# (LLM-facing surface). Same fan-out as read tools: Lens chat + MCP HTTP +
+# MCP stdio + LensAdapter, gated by the same policy engine.
+#
+# The ToolDef.impl calls into the actor substrate — it does not perform the
+# mutation directly. The mutation only happens when the user hits
+# POST /glens/actions/{id}/confirm on the resulting pending action.
+
+_ACTOR_TAGS = ("lens", "actor")
+
+
+def _actor_impl(action_name: str):
+    """Build a ctx-accepting impl that proposes a mutating action via the
+    actor substrate. Returns the confirm envelope OR a blocked result."""
+
+    def _impl(ctx, **kwargs):
+        from app.core.database import SessionLocal
+        from app.modules.glens.actor.helpers import require_confirmation
+        from app.modules.glens.actor.registry import default_action_registry
+        from app.modules.glens.actor.types import ActionCtx
+
+        spec = default_action_registry.get(action_name)
+        if spec is None:
+            return {"error": f"actor spec not registered: {action_name}"}
+
+        db = SessionLocal()
+        try:
+            action_ctx = ActionCtx(
+                db=db,
+                workspace_id=ctx.workspace_id,
+                clerk_user_id=getattr(ctx, "clerk_user_id", None),
+                user_email=getattr(ctx, "user_email", None),
+                session_id=getattr(ctx, "session_id", None),
+                agent_identity_id=None,
+                surface=getattr(ctx, "surface", "lens") or "lens",
+            )
+            return require_confirmation(action_ctx, spec, kwargs)
+        finally:
+            db.close()
+
+    _impl.__name__ = f"actor_impl_{action_name}"
+    return _impl
+
+
+_TOOLS.extend([
+    ToolDef(
+        name="decide_approval",
+        description=(
+            "Approve or reject a pending Guard approval request. Two-step: "
+            "returns a pending action for the user to confirm; the confirm "
+            "click writes the decision to guard_approval_requests and resumes "
+            "any paused workflow run. Semantically identical to the Slack "
+            "Approve/Reject buttons."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "approval_request_id": {
+                    "type": "string",
+                    "description": "UUID of the pending approval to decide.",
+                },
+                "decision": {
+                    "type": "string",
+                    "enum": ["approved", "rejected"],
+                    "description": "Whether to approve or reject the request.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Required when rejecting. Surfaced in audit + notifications.",
+                },
+            },
+            "required": ["approval_request_id", "decision"],
+        },
+        impl=_actor_impl("decide_approval"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+])
+
+
 def register(replace: bool = False) -> None:
     """Register all Lens tools into the default registry. Idempotent when
     replace=True (used only in tests that reload)."""
+    # Actor ActionSpecs register via side-effect import.
+    from app.modules.glens.actor import registrations as _actor_regs  # noqa: F401
     default_registry.register_all(_TOOLS, replace=replace)
 
 

--- a/apps/api/tests/glens/test_actor_substrate.py
+++ b/apps/api/tests/glens/test_actor_substrate.py
@@ -1,0 +1,169 @@
+"""Actor substrate parity + first-tool smoke (#1297).
+
+Two layers:
+  1. ActionRegistry — decide_approval registers, exposes propose/execute.
+  2. require_confirmation — propose-only path via stubbed DB writes a row.
+
+End-to-end confirm+dispatch is exercised by a live-DB smoke in a follow-up
+integration suite; the propose path here proves the substrate wiring.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from app.modules.glens.actor import default_action_registry, ActionCtx, ProposeResult
+from app.modules.glens.actor.helpers import require_confirmation
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+# ── ActionRegistry parity ────────────────────────────────────────────────────
+
+def test_decide_approval_actionspec_registered():
+    spec = default_action_registry.get("decide_approval")
+    assert spec is not None
+    assert spec.guard_permission == "platform.approvals.decide"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_decide_approval_tooldef_registered():
+    """The paired ToolDef fans out to Lens chat + MCP surfaces via
+    default_registry."""
+    tool = default_registry.get("decide_approval")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+# ── Propose-path validation ──────────────────────────────────────────────────
+
+def _ctx(**over):
+    from unittest.mock import MagicMock
+    base = dict(
+        db=MagicMock(),
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def test_propose_rejects_missing_id():
+    spec = default_action_registry.get("decide_approval")
+    out = spec.propose(_ctx(), {"decision": "approved"})
+    assert out.rejected
+    assert "approval_request_id" in (out.reason or "")
+
+
+def test_propose_rejects_bad_decision():
+    spec = default_action_registry.get("decide_approval")
+    out = spec.propose(_ctx(), {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "maybe",
+    })
+    assert out.rejected
+
+
+def test_propose_rejects_reject_without_reason():
+    spec = default_action_registry.get("decide_approval")
+    out = spec.propose(_ctx(), {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "rejected",
+    })
+    assert out.rejected
+    assert "reason" in (out.reason or "").lower()
+
+
+def test_propose_rejects_bad_uuid():
+    spec = default_action_registry.get("decide_approval")
+    out = spec.propose(_ctx(), {
+        "approval_request_id": "not-a-uuid",
+        "decision": "approved",
+    })
+    assert out.rejected
+
+
+def test_propose_rejects_missing_approval_row():
+    """DB returns no row → propose rejects with 'not found'."""
+    spec = default_action_registry.get("decide_approval")
+    ctx = _ctx()
+    ctx.db.query.return_value.filter.return_value.first.return_value = None
+    out = spec.propose(ctx, {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "approved",
+    })
+    assert out.rejected
+    assert "not found" in (out.reason or "").lower()
+
+
+def test_propose_rejects_already_decided():
+    spec = default_action_registry.get("decide_approval")
+    ctx = _ctx()
+    row = SimpleNamespace(
+        id="fake", status="approved",
+        rule_message="Run 'x'", tool_name="run_workflow", rule_id="lens.actor.confirm.run_workflow",
+        requester_email="req@x", requester_user_id="req_u",
+        source_run_id=None, approval_type="any_authorized", approval_group=None,
+    )
+    ctx.db.query.return_value.filter.return_value.first.return_value = row
+    out = spec.propose(ctx, {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "approved",
+    })
+    assert out.rejected
+    assert "already approved" in (out.reason or "").lower()
+
+
+def test_propose_success_shape():
+    spec = default_action_registry.get("decide_approval")
+    ctx = _ctx()
+    row = SimpleNamespace(
+        id="11111111-1111-1111-1111-111111111111",
+        status="pending",
+        rule_message="Run 'nightly'", tool_name="run_workflow",
+        rule_id="lens.actor.confirm.run_workflow",
+        requester_email="alice@example.com", requester_user_id="user_alice",
+        source_run_id=None, approval_type="any_authorized", approval_group=None,
+    )
+    ctx.db.query.return_value.filter.return_value.first.return_value = row
+    out: ProposeResult = spec.propose(ctx, {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "approved",
+    })
+    assert not out.rejected
+    assert "Approve" in out.summary
+    assert "alice" in out.summary
+    assert out.resolved_input["decision"] == "approved"
+
+
+def test_propose_success_reject_carries_reason_into_summary():
+    spec = default_action_registry.get("decide_approval")
+    ctx = _ctx()
+    row = SimpleNamespace(
+        id="11111111-1111-1111-1111-111111111111",
+        status="pending",
+        rule_message="Run 'prod deploy'", tool_name="run_workflow",
+        rule_id="lens.actor.confirm.run_workflow",
+        requester_email="bob@example.com", requester_user_id="user_bob",
+        source_run_id=None, approval_type="any_authorized", approval_group=None,
+    )
+    ctx.db.query.return_value.filter.return_value.first.return_value = row
+    out = spec.propose(ctx, {
+        "approval_request_id": "11111111-1111-1111-1111-111111111111",
+        "decision": "rejected",
+        "reason": "not tonight",
+    })
+    assert not out.rejected
+    assert "Reject" in out.summary
+    assert "not tonight" in out.summary

--- a/apps/api/tests/tools/test_lens_registrations.py
+++ b/apps/api/tests/tools/test_lens_registrations.py
@@ -57,9 +57,20 @@ def test_default_registry_contains_all_lens_tools():
 
 
 def test_all_lens_tools_are_read_only():
+    # Actor-tagged tools are intentionally mutating (see #1297); they go
+    # through the two-step confirm flow rather than the read invariant.
     for t in lens_reg._TOOLS:
+        if "actor" in t.tags:
+            continue
         assert t.annotations.read_only, f"{t.name} should be read_only"
         assert not t.annotations.destructive, f"{t.name} must not be destructive"
+
+
+def test_actor_tools_are_not_read_only():
+    actor_tools = [t for t in lens_reg._TOOLS if "actor" in t.tags]
+    assert actor_tools, "expected at least one actor-tagged tool (#1297)"
+    for t in actor_tools:
+        assert not t.annotations.read_only, f"actor tool {t.name} must not be read_only"
 
 
 def test_open_world_tools_are_the_expected_three():

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -33,6 +33,7 @@ type Message =
   | { role: "assistant"; kind: "loading"; label?: string }
   | { role: "assistant"; kind: "page"; answer: string; pageKind: string; pageData: Record<string, unknown>; warning?: string; skill: string }
   | { role: "assistant"; kind: "policy_confirm"; answer: string; action: string; draft: Record<string, unknown>; mapping: PolicyMapping[]; targetRuleId?: string; sessionId: string; skill: string; warning?: string }
+  | { role: "assistant"; kind: "action_confirm"; toolName: string; approvalRequestId: string; summary: string; warnings?: string[]; expiresAt?: string }
   | { role: "assistant"; kind: "blocks"; answer: string; blocks: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
   | { role: "assistant"; kind: "table"; answer: string; columns?: unknown[]; rows: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
 
@@ -821,6 +822,94 @@ function PolicyConfirmBubble({
   )
 }
 
+function ActionConfirmBubble({
+  toolName,
+  approvalRequestId,
+  summary,
+  warnings,
+  expiresAt,
+  authFetch,
+  onResult,
+}: {
+  toolName: string
+  approvalRequestId: string
+  summary: string
+  warnings?: string[]
+  expiresAt?: string
+  authFetch: (url: string, options?: RequestInit) => Promise<Response>
+  onResult: (text: string) => void
+}) {
+  const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
+
+  async function post(action: "confirm" | "cancel") {
+    setStatus("loading")
+    try {
+      const res = await authFetch(`${API}/glens/actions/${approvalRequestId}/${action}`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        onResult(`Failed to ${action}: ${err.detail ?? res.status}`)
+      } else {
+        const data = await res.json()
+        if (action === "confirm") {
+          const label = data.tool_name ?? toolName
+          onResult(`${label} executed successfully.`)
+        } else {
+          onResult(`Action cancelled.`)
+        }
+      }
+    } catch {
+      onResult("Network error. Please try again.")
+    }
+    setStatus("done")
+  }
+
+  const isMutation = toolName !== "decide_approval"  // heuristic — decide is itself an approve/reject
+
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
+      <div style={{ maxWidth: "80%", background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: "4px 14px 14px 14px", padding: "16px 20px" }}>
+        <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>Action · {toolName}</div>
+        <div style={{ fontSize: 14, color: "var(--text)", marginBottom: 12, lineHeight: 1.5 }}>{summary}</div>
+
+        {warnings && warnings.length > 0 && (
+          <div style={{ fontSize: 12, color: "var(--warn, #f59e0b)", marginBottom: 12, padding: "8px 12px", background: "var(--warn-bg, #fef3c7)", borderRadius: 6 }}>
+            {warnings.map((w, i) => <div key={i}>⚠ {w}</div>)}
+          </div>
+        )}
+
+        {status === "pending" && (
+          <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
+            <button
+              onClick={() => post("confirm")}
+              style={{
+                padding: "8px 20px", borderRadius: 8, border: "none", fontSize: 13, fontWeight: 600, cursor: "pointer",
+                background: "var(--accent)", color: "#fff",
+              }}
+            >
+              Confirm
+            </button>
+            <button
+              onClick={() => post("cancel")}
+              style={{ padding: "8px 16px", borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--text-2)", fontSize: 13, cursor: "pointer" }}
+            >
+              Cancel
+            </button>
+            {expiresAt && (
+              <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+                Expires {new Date(expiresAt).toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+        )}
+        {status === "loading" && <div style={{ fontSize: 13, color: "var(--text-muted)" }}>Working…</div>}
+      </div>
+    </div>
+  )
+}
+
 // ─── Input ────────────────────────────────────────────────────────────────────
 
 function ChatInput({ onSubmit, disabled }: { onSubmit: (t: string) => void; disabled: boolean }) {
@@ -1017,6 +1106,15 @@ export function GLensChatPage() {
         text: (data.answer as string) ?? "I need more detail to proceed.",
         skill: (data.skill as string) ?? "rules",
         followups: data.followups as string[] | undefined,
+      }])
+    } else if (data.confirm_required && data.approval_request_id) {
+      setMessages(prev => [...prev.slice(0, -1), {
+        role: "assistant", kind: "action_confirm",
+        toolName: data.tool_name as string,
+        approvalRequestId: data.approval_request_id as string,
+        summary: (data.summary as string) ?? "Confirm this action?",
+        warnings: (data.warnings as string[] | undefined) ?? [],
+        expiresAt: data.expires_at as string | undefined,
       }])
     } else if (data.confirm_required) {
       setMessages(prev => [...prev.slice(0, -1), {
@@ -1219,6 +1317,7 @@ export function GLensChatPage() {
                 msg.kind === "table"  ? msg.answer :
                 msg.kind === "page"   ? msg.answer :
                 msg.kind === "policy_confirm" ? msg.answer :
+                        msg.kind === "action_confirm" ? msg.summary :
                 undefined
               const messageId = String(i)
               return (
@@ -1228,6 +1327,21 @@ export function GLensChatPage() {
                   {msg.kind === "blocks" && <BlocksBubble answer={msg.answer} blocks={msg.blocks as any} warning={msg.warning} skill={msg.skill} understoodAs={msg.understoodAs} />}
                   {msg.kind === "table" && <GenericTableBubble answer={msg.answer} columns={msg.columns as any} rows={msg.rows as any} warning={msg.warning} skill={msg.skill} drilldown={msg.drilldown} understoodAs={msg.understoodAs} />}
                   {msg.kind === "page" && <GlensPageBubble answer={msg.answer} pageKind={msg.pageKind as any} data={msg.pageData} warning={msg.warning} />}
+                  {msg.kind === "action_confirm" && (
+                    <ActionConfirmBubble
+                      toolName={msg.toolName}
+                      approvalRequestId={msg.approvalRequestId}
+                      summary={msg.summary}
+                      warnings={msg.warnings}
+                      expiresAt={msg.expiresAt}
+                      authFetch={authFetch}
+                      onResult={text => setMessages(prev => [
+                        ...prev.slice(0, i),
+                        { role: "assistant", kind: "answer", text },
+                        ...prev.slice(i + 1),
+                      ])}
+                    />
+                  )}
                   {msg.kind === "policy_confirm" && (
                     <PolicyConfirmBubble
                       answer={msg.answer}


### PR DESCRIPTION
Closes #1297. Advances epic #1282.

Ships the pluggable substrate for mutating Lens/MCP tools, plus the first live tool that exercises it end-to-end. No new schema — reuses guard_approval_requests (migration 0093, epic #1140), so Slack notifications, timeout sweep, hash-chained audit, and the existing /guard/approvals API keep working over Lens-proposed rows.

## Substrate

- `ActionSpec` (name, guard_permission, propose, execute) + `ActionRegistry`
- `default_action_registry` mirrors the `default_registry` pattern: side-effect import from `app.modules.glens.actor.registrations`
- `require_confirmation()` helper: validates via `propose()`, pre-flights the composed policy engine, persists a row with `surface='lens'` and `rule_id='lens.actor.confirm.<tool>'`, returns the confirm envelope
- New endpoints: `POST /glens/actions/{id}/confirm` (apply_decision + dispatch spec.execute + cache result for idempotent replay), `POST /glens/actions/{id}/cancel`
- Gated by existing `platform.approvals.decide` permission
- Only the proposer can decide their own pending action (prompt-injection safe)

## First tool: `decide_approval`

- Approve or reject any pending Guard approval request from Lens chat OR MCP
- Propose validates target row exists + is pending, enforces peer rule, requires reason when rejecting
- Execute calls `apply_decision` + `_resume_workflow_run` — same code path Slack Approve/Reject hits today
- Paired `ToolDef` fans out to Lens chat + MCP HTTP + MCP stdio + LensAdapter via `default_registry`, tagged `('lens', 'actor')`

## Frontend

- `ActionConfirmBubble` in `GLensChatPage.tsx` — summary card, optional warnings list, Confirm/Cancel buttons that POST to `/glens/actions/{id}/{confirm,cancel}`
- Message router recognises the actor envelope (`data.approval_request_id` present) and renders the new bubble; existing `policy_confirm` path unchanged

## Tests

- `tests/glens/test_actor_substrate.py` — 10 tests: registration parity (ActionSpec + ToolDef), propose-path validation (missing id, bad decision, missing reason, bad uuid, missing row, already decided), success shape for approve + reject
- All green locally (Python 3.11)

## Test plan

- [x] Local tests green
- [x] Local tsc clean (0 errors)
- [ ] CI green
- [ ] Manual smoke: in Lens chat, ask "any pending approvals?" then "approve request `<id>`" — verify Confirm card renders, click Confirm, verify audit row + Slack notification arrives
- [ ] Same via MCP HTTP surface — `decide_approval` should appear in `tools/list`

## Follow-ups (this substrate unblocks)

- #1298 `run_workflow` — same ActionSpec pattern, ~30 LoC
- #1299 `approve_request` — a natural extension of `decide_approval`
- #1300 `install_pack`, #1301 `invite_member`, #1302 `update_budget`, #1303 `enable/disable_policy`, #1304 `deactivate_agent_identity`