### PR TITLE
feat(lens): run_workflow — actor tool #2 on the substrate (#1298)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -3,3 +3,4 @@ populate `default_action_registry` (and paired `default_registry.ToolDef`
 entries via `app.tools.registrations.lens`).
 """
 from app.modules.glens.actor.registrations import decide_approval  # noqa: F401
+from app.modules.glens.actor.registrations import run_workflow  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/run_workflow.py
+++ b/apps/api/app/modules/glens/actor/registrations/run_workflow.py
@@ -1,0 +1,167 @@
+"""#1298 — trigger a workflow run from Lens or MCP via the actor substrate.
+
+Compact re-implementation of the essential path from
+`apps.api.app.routers.runs.create_run` — resolve workflow, build initial
+state, enrich contract, insert Run, enqueue. Skips canvas-only features
+(per-run guard override, dry_run, per-run persona) — those are workflow-
+level defaults for Lens callers.
+
+ponytail: initial state minimal — Lens caller sends {inputs?}. Add canvas-style
+overrides only if callers actually need them (currently: none do).
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger(__name__)
+
+
+def _resolve_workflow(db, workspace_id: str, name_or_id: str):
+    """Match by UUID id first, then by playbook_slug, then by name (case-insensitive)."""
+    from app.models.workflow import Workflow
+
+    try:
+        ws = _uuid.UUID(workspace_id)
+    except ValueError:
+        return None
+
+    # UUID hit
+    try:
+        wid = _uuid.UUID(str(name_or_id))
+        wf = db.query(Workflow).filter(
+            Workflow.id == wid, Workflow.workspace_id == ws,
+        ).first()
+        if wf:
+            return wf
+    except ValueError:
+        pass
+
+    # Playbook slug hit
+    wf = db.query(Workflow).filter(
+        Workflow.workspace_id == ws,
+        Workflow.playbook_slug == str(name_or_id),
+    ).first()
+    if wf:
+        return wf
+
+    # Case-insensitive name hit
+    wf = db.query(Workflow).filter(
+        Workflow.workspace_id == ws,
+        Workflow.name.ilike(str(name_or_id)),
+    ).first()
+    return wf
+
+
+def _propose_run_workflow(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    name_or_id = str(args.get("name_or_id") or "").strip()
+    if not name_or_id:
+        return ProposeResult(rejected=True, reason="name_or_id required",
+                             summary="", resolved_input={})
+
+    workflow = _resolve_workflow(ctx.db, ctx.workspace_id, name_or_id)
+    if not workflow:
+        return ProposeResult(
+            rejected=True, reason=f"No workflow matches '{name_or_id}'",
+            summary="", resolved_input={},
+        )
+
+    if not workflow.current_version_id:
+        return ProposeResult(
+            rejected=True, reason=f"Workflow '{workflow.name}' has no published version",
+            summary="", resolved_input={},
+        )
+
+    warnings: list[str] = []
+    if not getattr(workflow, "guard_enabled", True):
+        warnings.append("Guard is disabled on this workflow.")
+
+    inputs = args.get("inputs")
+    if inputs is not None and not isinstance(inputs, dict):
+        return ProposeResult(rejected=True, reason="inputs must be an object",
+                             summary="", resolved_input={})
+
+    summary = f"Run '{workflow.name}' now"
+    if inputs:
+        summary += f" with {len(inputs)} input(s)"
+
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "workflow_id": str(workflow.id),
+            "workflow_name": workflow.name,
+            "inputs": inputs or {},
+        },
+        warnings=warnings,
+    )
+
+
+def _execute_run_workflow(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Insert a Run and enqueue. Reuses the same models + Redis queue the
+    CLI/API path uses. No per-run overrides — Lens callers get workflow
+    defaults."""
+    from app.models.run import Run
+    from app.models.workflow import Workflow
+    from app.routers.runs import _enqueue_run
+    from app.runtime.run_contract import enrich_run_state_contract
+
+    workflow_id = _uuid.UUID(resolved["workflow_id"])
+    workflow = ctx.db.query(Workflow).filter(Workflow.id == workflow_id).first()
+    if not workflow:
+        raise ValueError(f"workflow {workflow_id} disappeared between propose and execute")
+
+    initial_state: dict[str, Any] = dict(resolved.get("inputs") or {})
+    # ponytail: Lens callers don't set contract inputs today — enrich with
+    # workflow defaults and let the runtime handle missing pieces.
+    initial_state = enrich_run_state_contract(
+        initial_state,
+        source="lens",
+        trigger_provider="lens",
+        workflow_id=str(workflow.id),
+        workspace_id=ctx.workspace_id,
+        max_turns=getattr(workflow, "default_max_turns", None) or 20,
+    )
+
+    run = Run(
+        workflow_version_id=workflow.current_version_id,
+        workspace_id=workflow.workspace_id,
+        triggered_by=f"lens:{ctx.clerk_user_id or 'unknown'}",
+        status="pending",
+        state=initial_state,
+        max_turns=getattr(workflow, "default_max_turns", None) or 20,
+    )
+    ctx.db.add(run)
+    ctx.db.commit()
+    ctx.db.refresh(run)
+
+    try:
+        _enqueue_run(str(run.id))
+    except Exception as exc:
+        log.warning("lens.actor.enqueue_failed", run_id=str(run.id), err=str(exc))
+        # Run row is still in the DB and will be picked up on the next
+        # worker heartbeat — don't fail the confirm.
+
+    return {
+        "run_id": str(run.id),
+        "workflow_id": str(workflow.id),
+        "workflow_name": workflow.name,
+        "status": run.status,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="run_workflow",
+    guard_permission="platform.workflows.run",
+    propose=_propose_run_workflow,
+    execute=_execute_run_workflow,
+    description=(
+        "Trigger a workflow run by playbook slug, workflow ID, or name. Two-step: "
+        "returns a pending action for the user to confirm; the confirm click "
+        "inserts the Run + enqueues it — same code path as `conduct run`."
+    ),
+))

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -48,4 +48,31 @@ TOOLS: list[ToolDef] = [
         annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
         tags=_ACTOR_TAGS,
     ),
+    ToolDef(
+        name="run_workflow",
+        description=(
+            "Trigger a workflow run by playbook slug, workflow ID, or name. "
+            "Two-step: returns a pending action for the user to confirm; the "
+            "confirm click inserts the Run and enqueues it via the same code "
+            "path `conduct run` uses. Guard policy platform.workflows.run "
+            "still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name_or_id": {
+                    "type": "string",
+                    "description": "Workflow UUID, playbook slug, or workflow name (case-insensitive).",
+                },
+                "inputs": {
+                    "type": "object",
+                    "description": "Optional key/value overrides for run initial_state.",
+                },
+            },
+            "required": ["name_or_id"],
+        },
+        impl=_actor_impl("run_workflow"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=False),
+        tags=_ACTOR_TAGS,
+    ),
 ]

--- a/apps/api/tests/glens/test_actor_run_workflow.py
+++ b/apps/api/tests/glens/test_actor_run_workflow.py
@@ -1,0 +1,128 @@
+"""#1298 — actor ActionSpec + ToolDef parity for run_workflow.
+
+Propose-path only; live-DB confirm+dispatch is covered by the follow-up
+integration suite. Same shape as tests/glens/test_actor_substrate.py.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def test_run_workflow_actionspec_registered():
+    spec = default_action_registry.get("run_workflow")
+    assert spec is not None
+    assert spec.guard_permission == "platform.workflows.run"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_run_workflow_tooldef_registered():
+    tool = default_registry.get("run_workflow")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_propose_rejects_empty_name():
+    spec = default_action_registry.get("run_workflow")
+    out = spec.propose(_ctx(), {})
+    assert out.rejected
+    assert "name_or_id" in (out.reason or "")
+
+
+def test_propose_rejects_workflow_not_found():
+    spec = default_action_registry.get("run_workflow")
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=None):
+        out = spec.propose(_ctx(), {"name_or_id": "nonexistent"})
+    assert out.rejected
+    assert "No workflow matches" in (out.reason or "")
+
+
+def test_propose_rejects_no_published_version():
+    spec = default_action_registry.get("run_workflow")
+    fake_wf = SimpleNamespace(
+        id="w1", name="Nightly", current_version_id=None, guard_enabled=True,
+    )
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=fake_wf):
+        out = spec.propose(_ctx(), {"name_or_id": "Nightly"})
+    assert out.rejected
+    assert "no published version" in (out.reason or "").lower()
+
+
+def test_propose_rejects_bad_inputs_shape():
+    spec = default_action_registry.get("run_workflow")
+    fake_wf = SimpleNamespace(
+        id="w1", name="Nightly", current_version_id="v1", guard_enabled=True,
+    )
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=fake_wf):
+        out = spec.propose(_ctx(), {"name_or_id": "Nightly", "inputs": "not a dict"})
+    assert out.rejected
+    assert "inputs must be an object" in (out.reason or "")
+
+
+def test_propose_success_shape():
+    spec = default_action_registry.get("run_workflow")
+    fake_wf = SimpleNamespace(
+        id="w1", name="Nightly scan", current_version_id="v1", guard_enabled=True,
+    )
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=fake_wf):
+        out = spec.propose(_ctx(), {"name_or_id": "Nightly scan"})
+    assert not out.rejected
+    assert "Run 'Nightly scan' now" == out.summary
+    assert out.resolved_input == {
+        "workflow_id": "w1",
+        "workflow_name": "Nightly scan",
+        "inputs": {},
+    }
+    assert out.warnings == []
+
+
+def test_propose_warns_when_guard_disabled():
+    spec = default_action_registry.get("run_workflow")
+    fake_wf = SimpleNamespace(
+        id="w1", name="Nightly", current_version_id="v1", guard_enabled=False,
+    )
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=fake_wf):
+        out = spec.propose(_ctx(), {"name_or_id": "Nightly"})
+    assert not out.rejected
+    assert any("Guard is disabled" in w for w in out.warnings)
+
+
+def test_propose_summary_mentions_input_count():
+    spec = default_action_registry.get("run_workflow")
+    fake_wf = SimpleNamespace(
+        id="w1", name="X", current_version_id="v1", guard_enabled=True,
+    )
+    with patch("app.modules.glens.actor.registrations.run_workflow._resolve_workflow",
+               return_value=fake_wf):
+        out = spec.propose(_ctx(), {
+            "name_or_id": "X",
+            "inputs": {"foo": 1, "bar": 2, "baz": 3},
+        })
+    assert "3 input" in out.summary


### PR DESCRIPTION
Closes #1298. Second child of epic #1282. Stacks on **#1456** (substrate + decide_approval).

Lets Lens chat and MCP callers trigger a workflow run by playbook slug, workflow ID, or case-insensitive name. Same insert-then-enqueue path `conduct run` uses.

## What lands

**ActionSpec** — `apps/api/app/modules/glens/actor/registrations/run_workflow.py`
- Propose: resolve workflow (UUID → slug → name), verify a published version exists, warn when workflow-level Guard is disabled, validate inputs shape
- Execute: enrich state contract with `source='lens'`, insert `Run`, enqueue via `_enqueue_run`. Guard permission `platform.workflows.run` gates the tool
- Skips canvas-only affordances (dry_run, per-run guard override, per-run persona) — Lens callers don't need them today

**Paired ToolDef** — added to `apps/api/app/tools/registrations/lens.py`
- Fans out to Lens chat + MCP HTTP + MCP stdio + LensAdapter via `default_registry`, tagged `('lens', 'actor')`

## Tests

- `tests/glens/test_actor_run_workflow.py` — 8 tests: registration parity (ActionSpec + ToolDef), propose-path validation (empty name, missing workflow, no published version, bad inputs shape, guard-disabled warning, success shape, input-count summary)
- All green locally (Python 3.11). Combined suite (substrate + this): **19/19**

## Test plan

- [x] Local tests green
- [ ] CI green (once #1456 merges the base can move to main)
- [ ] Manual smoke: in Lens chat, say "run self_driving_network_approval_demo" — verify ActionConfirmBubble, click Confirm, verify a Run row appears and the worker picks it up
- [ ] Same via MCP HTTP — `run_workflow` should appear in `tools/list`

## Follow-ups this pattern unblocks

Same shape (~30 LoC each):
- #1299 `approve_request` — natural extension of `decide_approval`
- #1300 `install_pack`
- #1301 `invite_member`
- #1302 `update_budget`
- #1303 `enable/disable_policy`
- #1304 `deactivate_agent_identity`