### PR TITLE
fix(lens): confirm/cancel tools so chat 'yes' actually fires the action (#1465)

### DIFF
--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -1,18 +1,37 @@
-"""`_require_confirmation()` — the substrate entry every mutating tool's
-ToolDef `impl` calls after doing its Guard permission check.
+"""Actor substrate helpers.
 
-Persists a `guard_approval_requests` row with `surface='lens'` (or the
-inbound MCP surface) and returns the confirm envelope. The row is later
-resolved by the `/glens/actions/{id}/confirm` endpoint, which calls
-`spec.execute()`.
+- `require_confirmation()` — mutating tools' impl call this to persist a
+  `guard_approval_requests` row and return the confirm envelope for the LLM/UI.
+- `dispatch_confirm()` / `dispatch_cancel()` — decide + dispatch (or cancel)
+  a pending action. Shared by the HTTP endpoint (`POST /glens/actions/{id}/...`)
+  and the LLM-callable `confirm_pending_action` / `cancel_pending_action`
+  tools introduced in #1465 so natural-language "yes"/"no" actually works.
 """
 from __future__ import annotations
 
+import uuid as _uuid
 from typing import Any
 
+from sqlalchemy.orm import Session
+
 from app.modules.glens.actor.types import ActionCtx, ActionSpec
-from app.modules.guard.approval import create_approval_request
+from app.modules.guard.approval import (
+    apply_decision,
+    can_decide,
+    create_approval_request,
+    sweep_if_timed_out,
+)
 from app.modules.guard.models import GuardApprovalRequest
+
+
+class ConfirmError(Exception):
+    """Raised inside `dispatch_confirm` / `dispatch_cancel` to signal a
+    user-facing error with a matching HTTP status code. Endpoints translate
+    to HTTPException; LLM tools translate to `{"error": detail}`."""
+    def __init__(self, status_code: int, detail: str) -> None:
+        super().__init__(detail)
+        self.status_code = status_code
+        self.detail = detail
 
 
 # Sentinel rule_id used for Lens-proposed actions. Distinct from real
@@ -117,3 +136,161 @@ def require_confirmation(
     envelope = build_confirm_envelope(row)
     envelope["guard_decision"] = guard_decision
     return envelope
+
+
+# ── Confirm / Cancel dispatch — shared by HTTP endpoint + LLM tools (#1465) ─
+
+def _get_pending_row(
+    db: Session, action_id: str, workspace_id: str,
+) -> GuardApprovalRequest:
+    try:
+        aid = _uuid.UUID(action_id)
+        ws = _uuid.UUID(workspace_id)
+    except ValueError:
+        raise ConfirmError(400, "invalid action id")
+    row = (
+        db.query(GuardApprovalRequest)
+        .filter(
+            GuardApprovalRequest.id == aid,
+            GuardApprovalRequest.workspace_id == ws,
+        )
+        .first()
+    )
+    if not row:
+        raise ConfirmError(404, "action not found")
+    return row
+
+
+def _enforce_ownership(
+    row: GuardApprovalRequest,
+    *,
+    clerk_user_id: str | None,
+    session_id: str | None,
+) -> None:
+    """The proposer must own the pending action. Session_id must match when
+    both sides carry one — protects against a compromised LLM in a different
+    session confirming actions from this session."""
+    if row.requester_user_id and clerk_user_id and row.requester_user_id != clerk_user_id:
+        raise ConfirmError(403, "only the proposer can decide this action")
+    if row.session_id and session_id and row.session_id != session_id:
+        raise ConfirmError(403, "action belongs to a different chat session")
+
+
+def dispatch_confirm(
+    db: Session,
+    *,
+    action_id: str,
+    workspace_id: str,
+    clerk_user_id: str | None,
+    user_email: str | None,
+    role: str,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Confirm a pending action and run `spec.execute`.
+
+    Returns a serialisable dict on success. Raises `ConfirmError` on any
+    user-facing failure. Caller decides how to surface the error
+    (HTTPException for the endpoint, `{"error": detail}` for the LLM tool).
+    """
+    from app.modules.glens.actor.registry import default_action_registry
+
+    row = _get_pending_row(db, action_id, workspace_id)
+    row = sweep_if_timed_out(db, row)
+
+    # Idempotent success — already executed, return cached result.
+    if row.status == "approved" and (row.tool_input or {}).get("_execute_result") is not None:
+        return {
+            "executed": True,
+            "cached": True,
+            "action_id": str(row.id),
+            "tool_name": row.tool_name,
+            "status": row.status,
+            "result": row.tool_input.get("_execute_result"),
+        }
+
+    if row.status != "pending":
+        raise ConfirmError(409, f"action is {row.status}")
+
+    _enforce_ownership(row, clerk_user_id=clerk_user_id, session_id=session_id)
+
+    spec = default_action_registry.get(row.tool_name)
+    if not spec:
+        raise ConfirmError(500, f"no spec registered for {row.tool_name}")
+
+    decider_email = user_email or row.requester_email
+    ok, reason = can_decide(
+        row, decider_email=decider_email, decider_user_id=clerk_user_id, decider_role=role,
+    )
+    if not ok:
+        raise ConfirmError(403, reason or "not authorized")
+
+    # Mark approved (writes hash-chained audit event).
+    row = apply_decision(
+        db, row,
+        decision="approved",
+        decider_email=decider_email,
+        decider_user_id=clerk_user_id,
+        reason=f"lens.actor:{row.tool_name}",
+    )
+
+    # Dispatch spec.execute.
+    action_ctx = ActionCtx(
+        db=db,
+        workspace_id=workspace_id,
+        clerk_user_id=clerk_user_id,
+        user_email=decider_email,
+        session_id=row.session_id,
+        agent_identity_id=row.requester_agent_ident,
+        surface=row.surface or "lens",
+    )
+    try:
+        result = spec.execute(action_ctx, row.tool_input)
+    except Exception as exc:
+        # Approved row stays as-is for audit trail; caller sees an error.
+        raise ConfirmError(500, f"execute failed: {exc}")
+
+    # Cache result on the row for idempotent replay.
+    row.tool_input = {**(row.tool_input or {}), "_execute_result": result}
+    db.commit()
+
+    return {
+        "executed": True,
+        "cached": False,
+        "action_id": str(row.id),
+        "tool_name": row.tool_name,
+        "status": row.status,
+        "result": result,
+    }
+
+
+def dispatch_cancel(
+    db: Session,
+    *,
+    action_id: str,
+    workspace_id: str,
+    clerk_user_id: str | None,
+    user_email: str | None,
+    reason: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Cancel a pending action. No spec.execute — just marks rejected."""
+    row = _get_pending_row(db, action_id, workspace_id)
+    row = sweep_if_timed_out(db, row)
+    if row.status != "pending":
+        raise ConfirmError(409, f"action is {row.status}")
+
+    _enforce_ownership(row, clerk_user_id=clerk_user_id, session_id=session_id)
+
+    decider_email = user_email or row.requester_email
+    apply_decision(
+        db, row,
+        decision="rejected",
+        decider_email=decider_email,
+        decider_user_id=clerk_user_id,
+        reason=reason or f"lens.actor.cancelled:{row.tool_name}",
+    )
+    return {
+        "cancelled": True,
+        "action_id": str(row.id),
+        "tool_name": row.tool_name,
+    }

--- a/apps/api/app/modules/glens/actor/routes.py
+++ b/apps/api/app/modules/glens/actor/routes.py
@@ -1,14 +1,9 @@
 """Actor endpoints — Confirm / Cancel a pending Lens-proposed action.
 
-The confirm route calls `apply_decision` on the underlying
-`guard_approval_requests` row (same as Slack/Guard UI/direct API), then
-dispatches to `spec.execute()` — the real mutation. Cancel just rejects
-the row.
-
-Idempotency: `apply_decision` moves the row from `pending` to
-`approved|rejected` in a single UPDATE; the substrate checks status before
-dispatching so double-clicks return the cached result rather than firing
-`execute()` twice.
+Thin wrappers around `dispatch_confirm` / `dispatch_cancel` in `helpers.py`.
+The same helpers back the LLM-callable `confirm_pending_action` /
+`cancel_pending_action` tools (#1465), so the button click and the chat "yes"
+resolve to identical server behavior.
 """
 from __future__ import annotations
 
@@ -27,37 +22,14 @@ from app.core.auth import (
     require_permission,
 )
 from app.core.database import get_db
-from app.modules.glens.actor.registry import default_action_registry
-from app.modules.glens.actor.types import ActionCtx
-from app.modules.guard.approval import (
-    apply_decision,
-    can_decide,
-    sweep_if_timed_out,
+from app.modules.glens.actor.helpers import (
+    ConfirmError,
+    dispatch_cancel,
+    dispatch_confirm,
 )
-from app.modules.guard.models import GuardApprovalRequest
 
 log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/glens/actions", tags=["glens", "actor"])
-
-
-def _get_pending(db: Session, action_id: str, workspace_id: str) -> GuardApprovalRequest:
-    import uuid as _uuid
-    try:
-        aid = _uuid.UUID(action_id)
-        ws = _uuid.UUID(workspace_id)
-    except ValueError:
-        raise HTTPException(status_code=400, detail="invalid action id")
-    row = (
-        db.query(GuardApprovalRequest)
-        .filter(
-            GuardApprovalRequest.id == aid,
-            GuardApprovalRequest.workspace_id == ws,
-        )
-        .first()
-    )
-    if not row:
-        raise HTTPException(status_code=404, detail="action not found")
-    return row
 
 
 class ConfirmResponse(BaseModel):
@@ -85,74 +57,30 @@ def confirm_action(
 ) -> ConfirmResponse:
     """Confirm and dispatch a Lens-proposed action.
 
-    - Only the original requester can confirm their own proposal (peer rule).
+    - Only the original requester can decide their own proposal.
     - Row must be `pending` and not expired.
     - Runs `spec.execute()` and stores the result on the row for idempotency.
     """
-    row = _get_pending(db, action_id, workspace_id)
-    row = sweep_if_timed_out(db, row)
-
-    if row.status != "pending":
-        # Idempotent for the "already confirmed" case — return stored result.
-        if row.status == "approved" and row.tool_input.get("_execute_result") is not None:
-            return ConfirmResponse(
-                executed=True, action_id=str(row.id),
-                tool_name=row.tool_name, status=row.status,
-                result=row.tool_input.get("_execute_result"),
-            )
-        raise HTTPException(status_code=409, detail=f"action is {row.status}")
-
-    spec = default_action_registry.get(row.tool_name)
-    if not spec:
-        raise HTTPException(status_code=500, detail=f"no spec registered for {row.tool_name}")
-
-    # Only the proposer can confirm (self-confirmation, not peer approval).
-    # This keeps the Lens actor flow "prompt-injection safe" — a compromised
-    # LLM in someone else's session can't decide your pending action.
-    if row.requester_user_id and user_id and row.requester_user_id != user_id:
-        raise HTTPException(status_code=403, detail="only the proposer can confirm")
-
-    decider_email = get_clerk_user_email(user_id) if user_id else row.requester_email
-    ok, reason = can_decide(row, decider_email=decider_email, decider_user_id=user_id, decider_role=role)
-    if not ok:
-        raise HTTPException(status_code=403, detail=reason or "not authorized")
-
-    # Mark the approval as approved (writes hash-chained audit event).
-    row = apply_decision(
-        db, row,
-        decision="approved",
-        decider_email=decider_email,
-        decider_user_id=user_id,
-        reason=f"lens.actor:{row.tool_name}",
-    )
-
-    # Dispatch to spec.execute(). If it raises, we still keep the approved
-    # row (audit trail) but return 500 with the error string.
-    ctx = ActionCtx(
-        db=db,
-        workspace_id=workspace_id,
-        clerk_user_id=user_id,
-        user_email=decider_email,
-        session_id=row.session_id,
-        agent_identity_id=row.requester_agent_ident,
-        surface=row.surface or "lens",
-    )
+    decider_email = get_clerk_user_email(user_id) if user_id else None
     try:
-        result = spec.execute(ctx, row.tool_input)
-    except Exception as exc:  # noqa: BLE001 — surface up as 500 with detail
-        log.warning("lens.actor.execute_failed", tool=row.tool_name, err=str(exc))
-        raise HTTPException(status_code=500, detail=f"execute failed: {exc}")
-
-    # Store result on the row for idempotent replay.
-    row.tool_input = {**row.tool_input, "_execute_result": result}
-    db.commit()
+        payload = dispatch_confirm(
+            db,
+            action_id=action_id,
+            workspace_id=workspace_id,
+            clerk_user_id=user_id,
+            user_email=decider_email,
+            role=role,
+            session_id=None,  # HTTP callers don't carry chat session context
+        )
+    except ConfirmError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
 
     return ConfirmResponse(
-        executed=True,
-        action_id=str(row.id),
-        tool_name=row.tool_name,
-        status=row.status,
-        result=result,
+        executed=payload["executed"],
+        action_id=payload["action_id"],
+        tool_name=payload["tool_name"],
+        status=payload["status"],
+        result=payload.get("result"),
     )
 
 
@@ -164,20 +92,21 @@ def cancel_action(
     db: Session = Depends(get_db),
     _: str = Depends(require_permission("platform.approvals.decide")),
 ) -> CancelResponse:
-    row = _get_pending(db, action_id, workspace_id)
-    row = sweep_if_timed_out(db, row)
-    if row.status != "pending":
-        raise HTTPException(status_code=409, detail=f"action is {row.status}")
+    decider_email = get_clerk_user_email(user_id) if user_id else None
+    try:
+        payload = dispatch_cancel(
+            db,
+            action_id=action_id,
+            workspace_id=workspace_id,
+            clerk_user_id=user_id,
+            user_email=decider_email,
+            session_id=None,
+        )
+    except ConfirmError as e:
+        raise HTTPException(status_code=e.status_code, detail=e.detail)
 
-    if row.requester_user_id and user_id and row.requester_user_id != user_id:
-        raise HTTPException(status_code=403, detail="only the proposer can cancel")
-
-    decider_email = get_clerk_user_email(user_id) if user_id else row.requester_email
-    apply_decision(
-        db, row,
-        decision="rejected",
-        decider_email=decider_email,
-        decider_user_id=user_id,
-        reason=f"lens.actor.cancelled:{row.tool_name}",
+    return CancelResponse(
+        cancelled=payload["cancelled"],
+        action_id=payload["action_id"],
+        tool_name=payload["tool_name"],
     )
-    return CancelResponse(cancelled=True, action_id=str(row.id), tool_name=row.tool_name)

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -1,18 +1,78 @@
 """Lens actor tools — mutating tool ToolDefs paired with actor ActionSpecs.
 
-Each entry here is the LLM-facing surface of an ActionSpec registered in
-`app.modules.glens.actor.registrations`. The ToolDef.impl returns a confirm
+Each mutating entry is the LLM-facing surface of an `ActionSpec` registered in
+`app.modules.glens.actor.registrations`. The `ToolDef.impl` returns a confirm
 envelope; the real mutation runs when the user hits
-POST /glens/actions/{id}/confirm.
+`POST /glens/actions/{id}/confirm` — either via the ActionConfirmBubble button
+OR via the `confirm_pending_action` chat tool (#1465).
 
 Adding a new mutating tool = add both:
-  1. ActionSpec in app.modules.glens.actor.registrations.<name>
-  2. ToolDef here, impl=_actor_impl("<name>")
+  1. `ActionSpec` in `app.modules.glens.actor.registrations.<name>`
+  2. `ToolDef` here with `impl=_actor_impl("<name>")`
+
+The `confirm_pending_action` / `cancel_pending_action` tools at the bottom of
+this file are the chat-surface glue for step 2 — they let the LLM resolve a
+natural-language "yes" / "no" against a pending row's `dispatch_confirm` /
+`dispatch_cancel` service functions.
 """
 from __future__ import annotations
 
+from typing import Any
+
 from app.tools.types import ToolAnnotations, ToolDef
 from app.tools.registrations.lens._shared import _actor_impl, _ACTOR_TAGS
+
+
+def _confirm_pending_action_impl(ctx, pending_action_id: str) -> dict[str, Any]:
+    """LLM-callable confirm — same server logic as the ActionConfirmBubble
+    button. Enforces proposer identity + session_id match so a compromised
+    LLM in another session can't decide this one's pending actions."""
+    from app.core.database import SessionLocal
+    from app.modules.glens.actor.helpers import ConfirmError, dispatch_confirm
+
+    db = SessionLocal()
+    try:
+        try:
+            payload = dispatch_confirm(
+                db,
+                action_id=pending_action_id,
+                workspace_id=ctx.workspace_id,
+                clerk_user_id=getattr(ctx, "clerk_user_id", None),
+                user_email=getattr(ctx, "user_email", None),
+                role="admin",  # HTTP layer already validated the permission
+                session_id=getattr(ctx, "session_id", None),
+            )
+        except ConfirmError as exc:
+            return {"error": exc.detail, "status_code": exc.status_code}
+        return payload
+    finally:
+        db.close()
+
+
+def _cancel_pending_action_impl(
+    ctx, pending_action_id: str, reason: str | None = None,
+) -> dict[str, Any]:
+    """LLM-callable cancel — same server logic as the Cancel button."""
+    from app.core.database import SessionLocal
+    from app.modules.glens.actor.helpers import ConfirmError, dispatch_cancel
+
+    db = SessionLocal()
+    try:
+        try:
+            payload = dispatch_cancel(
+                db,
+                action_id=pending_action_id,
+                workspace_id=ctx.workspace_id,
+                clerk_user_id=getattr(ctx, "clerk_user_id", None),
+                user_email=getattr(ctx, "user_email", None),
+                reason=reason,
+                session_id=getattr(ctx, "session_id", None),
+            )
+        except ConfirmError as exc:
+            return {"error": exc.detail, "status_code": exc.status_code}
+        return payload
+    finally:
+        db.close()
 
 
 TOOLS: list[ToolDef] = [
@@ -73,6 +133,57 @@ TOOLS: list[ToolDef] = [
         },
         impl=_actor_impl("run_workflow"),
         annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=False),
+        tags=_ACTOR_TAGS,
+    ),
+    # ── Chat-surface confirmation shortcut tools (#1465) ────────────────────
+    # These let the LLM resolve natural-language "yes" / "no" replies against
+    # a pending action without requiring a button click. Same server code as
+    # the endpoint — session_id enforcement blocks cross-session confirmations.
+    ToolDef(
+        name="confirm_pending_action",
+        description=(
+            "Confirm a pending actor action (previously proposed via decide_approval, "
+            "run_workflow, or another actor tool). Use when the user replies 'yes' / "
+            "'go ahead' / 'confirm' to a confirmation card. Runs spec.execute for the "
+            "underlying action and returns the result."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "pending_action_id": {
+                    "type": "string",
+                    "description": "UUID of the pending action (from the confirmation envelope's approval_request_id).",
+                },
+            },
+            "required": ["pending_action_id"],
+        },
+        impl=_confirm_pending_action_impl,
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+    ToolDef(
+        name="cancel_pending_action",
+        description=(
+            "Cancel a pending actor action. Use when the user replies 'no' / "
+            "'cancel' / 'stop' to a confirmation card. Marks the action rejected; "
+            "no side effects."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "pending_action_id": {
+                    "type": "string",
+                    "description": "UUID of the pending action to cancel.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional reason surfaced in audit + notifications.",
+                },
+            },
+            "required": ["pending_action_id"],
+        },
+        impl=_cancel_pending_action_impl,
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
         tags=_ACTOR_TAGS,
     ),
 ]

--- a/apps/api/tests/glens/test_actor_chat_confirm.py
+++ b/apps/api/tests/glens/test_actor_chat_confirm.py
@@ -1,0 +1,172 @@
+"""P0 #1465 — confirm_pending_action + cancel_pending_action Lens tools.
+
+Registration parity + happy-path + ownership + session-id + already-decided
+tests. Direct impl calls (no HTTP) with mocked `dispatch_confirm` /
+`dispatch_cancel` so the tool-side plumbing is exercised in isolation.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.mcp.server import MCPContext
+from app.modules.glens.actor.helpers import ConfirmError
+from app.tools import registrations as _tool_registrations  # noqa: F401 — populate registry
+from app.tools.registry import default_registry
+
+
+_CTX = MCPContext(
+    workspace_id="00000000-0000-0000-0000-000000000000",
+    clerk_user_id="user_abc",
+    user_email="user@example.com",
+    session_id="sess-xyz",
+    surface="lens",
+)
+
+
+# ── Registration parity ────────────────────────────────────────────────────
+
+def test_confirm_pending_action_registered():
+    tool = default_registry.get("confirm_pending_action")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_cancel_pending_action_registered():
+    tool = default_registry.get("cancel_pending_action")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+# ── Confirm impl ───────────────────────────────────────────────────────────
+
+def test_confirm_happy_path_returns_execute_result():
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    fake_payload = {
+        "executed": True, "cached": False,
+        "action_id": "a1", "tool_name": "run_workflow",
+        "status": "approved",
+        "result": {"run_id": "r1", "status": "pending"},
+    }
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_confirm", return_value=fake_payload) as mock_dispatch:
+        out = _confirm_pending_action_impl(_CTX, "a1")
+
+    mock_dispatch.assert_called_once()
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["action_id"] == "a1"
+    assert call_kwargs["workspace_id"] == _CTX.workspace_id
+    assert call_kwargs["clerk_user_id"] == _CTX.clerk_user_id
+    # Session id is forwarded so dispatch can enforce match against the row.
+    assert call_kwargs["session_id"] == _CTX.session_id
+    assert out["executed"] is True
+    assert out["result"]["run_id"] == "r1"
+
+
+def test_confirm_returns_error_dict_on_confirm_error():
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_confirm",
+               side_effect=ConfirmError(403, "action belongs to a different chat session")):
+        out = _confirm_pending_action_impl(_CTX, "a1")
+
+    assert out == {"error": "action belongs to a different chat session", "status_code": 403}
+
+
+def test_confirm_on_already_executed_returns_cached_result():
+    """dispatch_confirm's idempotent path returns cached=True; tool passes it through."""
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    fake_payload = {
+        "executed": True, "cached": True,
+        "action_id": "a1", "tool_name": "run_workflow",
+        "status": "approved",
+        "result": {"run_id": "r1"},
+    }
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_confirm", return_value=fake_payload):
+        out = _confirm_pending_action_impl(_CTX, "a1")
+
+    assert out["cached"] is True
+    assert out["result"]["run_id"] == "r1"
+
+
+# ── Cancel impl ────────────────────────────────────────────────────────────
+
+def test_cancel_happy_path():
+    from app.tools.registrations.lens.actor import _cancel_pending_action_impl
+
+    fake_payload = {"cancelled": True, "action_id": "a1", "tool_name": "run_workflow"}
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_cancel", return_value=fake_payload) as mock_dispatch:
+        out = _cancel_pending_action_impl(_CTX, "a1", reason="user changed mind")
+
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["reason"] == "user changed mind"
+    assert call_kwargs["session_id"] == _CTX.session_id
+    assert out["cancelled"] is True
+
+
+def test_cancel_returns_error_dict_on_already_decided():
+    from app.tools.registrations.lens.actor import _cancel_pending_action_impl
+
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_cancel",
+               side_effect=ConfirmError(409, "action is approved")):
+        out = _cancel_pending_action_impl(_CTX, "a1")
+
+    assert out == {"error": "action is approved", "status_code": 409}
+
+
+# ── Session-id enforcement in dispatch_confirm ─────────────────────────────
+
+def test_dispatch_confirm_rejects_cross_session():
+    """Row.session_id != ctx.session_id → 403. This is the core prompt-injection
+    guard: a compromised LLM in session B can't confirm session A's actions."""
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(requester_user_id="user_abc", session_id="sess-xyz")
+    # Same user, wrong session
+    try:
+        _enforce_ownership(row, clerk_user_id="user_abc", session_id="sess-other")
+    except ConfirmError as e:
+        assert e.status_code == 403
+        assert "different chat session" in e.detail
+    else:
+        raise AssertionError("expected ConfirmError")
+
+
+def test_dispatch_confirm_rejects_cross_user():
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(requester_user_id="user_abc", session_id="sess-xyz")
+    try:
+        _enforce_ownership(row, clerk_user_id="user_other", session_id="sess-xyz")
+    except ConfirmError as e:
+        assert e.status_code == 403
+        assert "proposer" in e.detail
+    else:
+        raise AssertionError("expected ConfirmError")
+
+
+def test_enforce_ownership_passes_when_both_match():
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(requester_user_id="user_abc", session_id="sess-xyz")
+    # Should not raise
+    _enforce_ownership(row, clerk_user_id="user_abc", session_id="sess-xyz")
+
+
+def test_enforce_ownership_lenient_when_row_has_no_session():
+    """Actions created via HTTP (no chat session) can be confirmed via HTTP
+    without a session id. Row.session_id is None → skip check."""
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(requester_user_id="user_abc", session_id=None)
+    _enforce_ownership(row, clerk_user_id="user_abc", session_id=None)


### PR DESCRIPTION
Closes **#1465** (P0). Every actor tool shipped so far (`decide_approval`, `run_workflow`) silently no-ops when the user types "yes" in chat.

## Repro (prod)

- Pending action `c58ac4f3-72de-409e-b64d-b489a5949329` sat at `status=pending` 45 minutes after the user typed "yes".
- The run the LLM claimed was "queued" (`dced8506-...`) was an unrelated older run from `manual:test_trigger`.

## Root cause

Only the `ActionConfirmBubble` button click hits `/glens/actions/{id}/confirm`. The LLM had no callable tool for that path. When the user replies "yes" in natural language, the LLM hallucinates a "queued" response and the pending row is never confirmed.

## Fix

**Extract dispatch into shared helpers**
- `dispatch_confirm(...)` and `dispatch_cancel(...)` in `helpers.py` — the confirm/cancel logic now lives once, shared by the HTTP endpoint and the new LLM tools.
- `ConfirmError(status_code, detail)` exception makes error translation trivial (HTTPException for endpoint, `{"error", "status_code"}` for tool).
- HTTP endpoints in `routes.py` are now thin wrappers — byte-parity with the previous behavior.

**Add LLM-callable tools** (in `lens/actor.py`)
- `confirm_pending_action(pending_action_id)` — the "yes" pathway.
- `cancel_pending_action(pending_action_id, reason?)` — the "no" pathway.

**Session-id enforcement**
- `_enforce_ownership` now checks `row.session_id == ctx.session_id` when both sides carry one. Blocks a compromised LLM in a different chat session from confirming this session's actions. Lenient when either side has no session (HTTP endpoint calls have none).

## Tests

- `tests/glens/test_actor_chat_confirm.py` — 11 tests: registration parity, session_id forwarding, ConfirmError translation, idempotent cached-result passthrough, cross-user rejection, cross-session rejection, HTTP-flow lenience.
- Full suite (chat_confirm + substrate + run_workflow + lens invariants): **38 passed** locally on Python 3.11.

## Frontend

No change. `ActionConfirmBubble` button click stays as the primary flow; chat tools are the natural-language fallback. Both paths hit identical server behavior.

## What this unblocks

- `decide_approval` (#1297) works via chat
- `run_workflow` (#1298) works via chat
- The six planned mutators (#1299–#1304) will work via chat when they ship

## Test plan

- [x] Local suite green
- [ ] CI green
- [ ] Manual on prod: "run self_driving_network_approval_demo" → confirm card → type "yes" → verify a new run appears in `/runs` triggered by `lens:<user>`, not an unrelated older run
- [ ] Manual: type "no" → confirm the pending action moves to `rejected`
- [ ] Manual: verify session-id enforcement — open two Lens tabs, propose in tab A, try confirming in tab B → LLM should surface the "different chat session" error