### PR TITLE
feat(lens): show approval_request_id in ActionConfirmBubble (#1468)

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -840,6 +840,7 @@ function ActionConfirmBubble({
   onResult: (text: string) => void
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
+  const [idCopied, setIdCopied] = useState(false)
 
   async function post(action: "confirm" | "cancel") {
     setStatus("loading")
@@ -872,7 +873,34 @@ function ActionConfirmBubble({
     <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
       <div style={{ maxWidth: "80%", background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: "4px 14px 14px 14px", padding: "16px 20px" }}>
         <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>Action · {toolName}</div>
-        <div style={{ fontSize: 14, color: "var(--text)", marginBottom: 12, lineHeight: 1.5 }}>{summary}</div>
+        <div style={{ fontSize: 14, color: "var(--text)", marginBottom: 10, lineHeight: 1.5 }}>{summary}</div>
+
+        {/* Approval request identifier (#1468) — visible so the user knows which pending
+             action a natural-language "yes" is confirming when multiple are outstanding. */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12, fontSize: 11, color: "var(--text-muted)" }}>
+          <span style={{ textTransform: "uppercase", letterSpacing: ".06em", fontWeight: 600 }}>ID</span>
+          <code style={{ fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", color: "var(--text-2)", fontSize: 11 }}>
+            {approvalRequestId.slice(0, 8)}…{approvalRequestId.slice(-4)}
+          </code>
+          <button
+            type="button"
+            title={idCopied ? "Copied" : "Copy full ID"}
+            onClick={() => {
+              navigator.clipboard.writeText(approvalRequestId).then(
+                () => { setIdCopied(true); setTimeout(() => setIdCopied(false), 1200) },
+                () => {},
+              )
+            }}
+            style={{
+              padding: "2px 6px", borderRadius: 4, border: "none",
+              background: idCopied ? "var(--accent-weak, rgba(59,130,246,0.12))" : "transparent",
+              color: idCopied ? "var(--accent-text, #2563eb)" : "var(--text-muted)",
+              cursor: "pointer", fontSize: 11, lineHeight: 1,
+            }}
+          >
+            {idCopied ? "✓" : "⧉"}
+          </button>
+        </div>
 
         {warnings && warnings.length > 0 && (
           <div style={{ fontSize: 12, color: "var(--warn, #f59e0b)", marginBottom: 12, padding: "8px 12px", background: "var(--warn-bg, #fef3c7)", borderRadius: 6 }}>


### PR DESCRIPTION
Closes **#1468**. Post-#1465/#1467 the LLM can resolve natural-language "yes" against the right pending action because it holds the envelope in its message history. The human user did not have the same signal — with two pending actions in the same session, "yes" was ambiguous from the user's point of view.

## Change

Single row added to `ActionConfirmBubble` between summary and warnings/buttons:

```
ID   c58ac4f3…9329  [copy]
```

- Truncated `<first-8>…<last-4>` for readability.
- Copy button grabs the full UUID into the clipboard.
- Uses existing tokens (`var(--text-muted)`, `var(--accent-weak)`, `ui-monospace` stack). No new deps.

## Scope

- Backend: no change — envelope already carries `approval_request_id`.
- Frontend: one row + a small `idCopied` state on the bubble in `GLensChatPage.tsx`.

## Test plan

- [x] Local `tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: propose a `run_workflow` → verify ID row renders with truncated UUID + copy button → click copy → paste full UUID matches `approval_request_id` in the tool response.
- [ ] Manual: multi-pending case — propose two actions back-to-back → each card shows a distinct ID.