### PR TITLE
fix(actor): session-scoped idempotency in require_confirmation (#1470)

### DIFF
--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -9,7 +9,10 @@
 """
 from __future__ import annotations
 
+import hashlib
+import json
 import uuid as _uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -22,6 +25,53 @@ from app.modules.guard.approval import (
     sweep_if_timed_out,
 )
 from app.modules.guard.models import GuardApprovalRequest
+
+
+def _idempotency_key(tool_name: str, resolved_input: dict[str, Any]) -> str:
+    """Stable per-(tool, input) key used to dedupe pending proposals within
+    a session. `_warnings` and `_execute_result` are computed post-facto so
+    they are stripped before hashing."""
+    scrub = {k: v for k, v in resolved_input.items() if not k.startswith("_")}
+    payload = json.dumps({"tool": tool_name, "input": scrub}, sort_keys=True, default=str)
+    return hashlib.sha256(payload.encode()).hexdigest()[:32]
+
+
+def _find_existing_pending(
+    db: Session,
+    *,
+    workspace_id: str,
+    session_id: str | None,
+    tool_name: str,
+    idem_key: str,
+) -> GuardApprovalRequest | None:
+    """Look for an unexpired PENDING row matching the same session + tool +
+    idempotency key. Session-scoped so unrelated sessions don't collide."""
+    try:
+        ws = _uuid.UUID(workspace_id)
+    except ValueError:
+        return None
+
+    q = (
+        db.query(GuardApprovalRequest)
+        .filter(
+            GuardApprovalRequest.workspace_id == ws,
+            GuardApprovalRequest.tool_name == tool_name,
+            GuardApprovalRequest.status == "pending",
+            GuardApprovalRequest.timeout_at > datetime.now(timezone.utc),
+        )
+    )
+    if session_id is not None:
+        q = q.filter(GuardApprovalRequest.session_id == session_id)
+    else:
+        q = q.filter(GuardApprovalRequest.session_id.is_(None))
+
+    # Filter idem_key in Python — tool_input is JSONB and we stash the key in
+    # a private field. Fetching a handful of rows per (workspace, session,
+    # tool) is fine at Lens volume.
+    for row in q.order_by(GuardApprovalRequest.created_at.desc()).limit(10).all():
+        if (row.tool_input or {}).get("_idem_key") == idem_key:
+            return row
+    return None
 
 
 class ConfirmError(Exception):
@@ -105,11 +155,29 @@ def require_confirmation(
         # the confirm route is the enforcement point.
         pass
 
+    # Session-scoped idempotency (#1470). Re-proposing the exact same action
+    # in the same session returns the ORIGINAL envelope + row, so the LLM
+    # can call `run_workflow` twice without losing the ActionConfirmBubble
+    # or creating duplicate pending rows.
+    idem_key = _idempotency_key(spec.name, proposal.resolved_input)
+    existing = _find_existing_pending(
+        ctx.db,
+        workspace_id=ctx.workspace_id,
+        session_id=ctx.session_id,
+        tool_name=spec.name,
+        idem_key=idem_key,
+    )
+    if existing is not None:
+        envelope = build_confirm_envelope(existing)
+        envelope["guard_decision"] = guard_decision
+        envelope["deduped"] = True
+        return envelope
+
     # Persist the pending approval. `surface='lens'` (or the inbound MCP
     # surface) tags where the proposal came from. Rule_id is a synthetic
     # marker so approvals-list callers can distinguish Lens-proposed from
     # policy-paused rows.
-    persisted_input = {**proposal.resolved_input}
+    persisted_input = {**proposal.resolved_input, "_idem_key": idem_key}
     if guard_warnings:
         persisted_input["_warnings"] = guard_warnings
 

--- a/apps/api/tests/glens/test_actor_dedup.py
+++ b/apps/api/tests/glens/test_actor_dedup.py
@@ -1,0 +1,124 @@
+"""#1470 — require_confirmation dedupes same-session re-proposals.
+
+Key computation is stable per (tool, resolved_input) after stripping
+underscore-prefixed private fields. Live-DB dedup is exercised on the
+integration side; here we verify the pure key logic + the lookup filter.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.modules.glens.actor.helpers import (
+    _find_existing_pending,
+    _idempotency_key,
+)
+
+
+# ── Key stability ────────────────────────────────────────────────────────────
+
+def test_key_stable_for_same_input():
+    a = _idempotency_key("run_workflow", {"workflow_id": "wf-1", "inputs": {"a": 1}})
+    b = _idempotency_key("run_workflow", {"workflow_id": "wf-1", "inputs": {"a": 1}})
+    assert a == b
+
+
+def test_key_differs_by_tool_name():
+    a = _idempotency_key("run_workflow", {"x": 1})
+    b = _idempotency_key("decide_approval", {"x": 1})
+    assert a != b
+
+
+def test_key_differs_by_input_value():
+    a = _idempotency_key("run_workflow", {"workflow_id": "wf-1"})
+    b = _idempotency_key("run_workflow", {"workflow_id": "wf-2"})
+    assert a != b
+
+
+def test_key_ignores_underscore_fields():
+    """Private fields like _warnings / _execute_result / _idem_key are
+    computed post-facto and must not affect the key."""
+    a = _idempotency_key("run_workflow", {"workflow_id": "wf-1"})
+    b = _idempotency_key("run_workflow", {
+        "workflow_id": "wf-1",
+        "_warnings": ["Guard is disabled"],
+        "_idem_key": "should-be-ignored",
+        "_execute_result": {"run_id": "r1"},
+    })
+    assert a == b
+
+
+def test_key_stable_across_dict_order():
+    a = _idempotency_key("run_workflow", {"a": 1, "b": 2})
+    b = _idempotency_key("run_workflow", {"b": 2, "a": 1})
+    assert a == b
+
+
+# ── Lookup filter ────────────────────────────────────────────────────────────
+
+class _StubQuery:
+    def __init__(self, rows):
+        self._rows = rows
+    def filter(self, *a, **kw): return self
+    def order_by(self, *a, **kw): return self
+    def limit(self, *a, **kw): return self
+    def all(self): return self._rows
+
+
+def _make_db(rows):
+    db = MagicMock()
+    db.query.return_value = _StubQuery(rows)
+    return db
+
+
+def test_lookup_returns_row_with_matching_key():
+    matching = SimpleNamespace(tool_input={"_idem_key": "abc123", "workflow_id": "wf-1"})
+    db = _make_db([matching])
+    out = _find_existing_pending(
+        db,
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        session_id="sess-xyz",
+        tool_name="run_workflow",
+        idem_key="abc123",
+    )
+    assert out is matching
+
+
+def test_lookup_skips_row_with_different_key():
+    other = SimpleNamespace(tool_input={"_idem_key": "different", "workflow_id": "wf-1"})
+    db = _make_db([other])
+    out = _find_existing_pending(
+        db,
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        session_id="sess-xyz",
+        tool_name="run_workflow",
+        idem_key="abc123",
+    )
+    assert out is None
+
+
+def test_lookup_skips_row_with_no_key_stashed():
+    """Legacy rows written before #1470 have no _idem_key. Should not match."""
+    legacy = SimpleNamespace(tool_input={"workflow_id": "wf-1"})
+    db = _make_db([legacy])
+    out = _find_existing_pending(
+        db,
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        session_id="sess-xyz",
+        tool_name="run_workflow",
+        idem_key="abc123",
+    )
+    assert out is None
+
+
+def test_lookup_returns_none_on_bad_workspace_uuid():
+    db = _make_db([])
+    out = _find_existing_pending(
+        db,
+        workspace_id="not-a-uuid",
+        session_id="sess-xyz",
+        tool_name="run_workflow",
+        idem_key="abc",
+    )
+    assert out is None


### PR DESCRIPTION
Closes **#1470**.

Re-proposing the same actor action in the same session (LLM calls `run_workflow` twice back-to-back) used to create duplicate pending rows. The LLM defensively skipped the second call and fell back to prose — losing the ActionConfirmBubble card + visible ID + Confirm/Cancel buttons.

## Fix

Dedupe at the substrate layer:

1. **Compute a stable idempotency key** from `(spec.name, resolved_input)` after stripping underscore-prefixed private fields (`_warnings`, `_idem_key`, `_execute_result`).
2. **Look up an unexpired pending row** in the same `(workspace, session, tool_name)` with matching `_idem_key` stashed in `tool_input`.
3. **If found** → return the ORIGINAL envelope (same `approval_request_id`, same card, same buttons) with `deduped: true` set for diagnostics.
4. **If not** → persist as today, but include `_idem_key` in `tool_input` so future re-proposals can find it.

**No migration needed** — key lives in the existing JSONB `tool_input` column.

## Tests

- `tests/glens/test_actor_dedup.py` — 9 tests: key stability across dict order, key differences by tool/input, private-field ignore, lookup match, lookup miss (different key + no key + bad workspace uuid).
- Combined actor suite: **39 passed** locally (Python 3.11).

## Behavior after this ships

- `run_workflow("X")` twice in the same session → same envelope both times → card + ID + buttons re-render on the second call.
- `run_workflow("Y")` (different workflow) → new pending action.
- `run_workflow("X", inputs={"a": 1})` → different from `run_workflow("X")` because inputs differ.
- Legacy pending rows (created before this PR, no `_idem_key`) are never deduped against — safe rollback path.

## Test plan

- [x] Local suite green
- [ ] CI green
- [ ] Manual on prod: propose `run_workflow` for `self_driving_network_approval_demo` twice → verify same ActionConfirmBubble renders both times with matching `approval_request_id`.