### PR TITLE
feat(audit): AGENT badges always link to agent identity page (#1471)

### DIFF
--- a/apps/web/src/components/guard/ActivityRow.tsx
+++ b/apps/web/src/components/guard/ActivityRow.tsx
@@ -342,12 +342,17 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
                 {isHuman ? "HUMAN" : "AGENT"}
               </span>
             )
-            // AGENT rows with a known identity → deep-link to /agent-identity
-            // (uses the ?id=<uuid> highlight from PR #1286).
-            if (!isHuman && ev.agent_identity_id) {
+            // AGENT rows always link to /agent-identity — deep-link with
+            // ?id=<uuid> when the identity is known (highlight from PR #1286),
+            // fall back to the identities list otherwise (#1471).
+            if (!isHuman) {
+              const href = ev.agent_identity_id
+                ? `/agent-identity?tab=identities&id=${ev.agent_identity_id}`
+                : "/agent-identity?tab=identities"
               return (
-                <a href={`/agent-identity?tab=identities&id=${ev.agent_identity_id}`}
-                   title={`View agent identity ${ev.agent_identity_id}`}
+                <a href={href}
+                   title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
+                   onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
                    style={{ textDecoration: "none" }}>
                   {pill}
                 </a>
@@ -395,11 +400,26 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
               : formatToolCall(ev.tool_call)}
         </span>
         {ev.source === "proxy" && <ProxyPill />}
-        {ev.source === "brain_block" && (
-          <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: ".06em", padding: "1px 5px", borderRadius: 3, background: "#ede9fe", color: "#6d28d9", border: "1px solid #c4b5fd" }}>
-            AGENT
-          </span>
-        )}
+        {ev.source === "brain_block" && (() => {
+          const pill = (
+            <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: ".06em", padding: "1px 5px", borderRadius: 3, background: "#ede9fe", color: "#6d28d9", border: "1px solid #c4b5fd" }}>
+              AGENT
+            </span>
+          )
+          // #1471 — link the brain_block AGENT badge to the specific identity
+          // when known; fall back to the agent identity list otherwise.
+          const href = ev.agent_identity_id
+            ? `/agent-identity?tab=identities&id=${ev.agent_identity_id}`
+            : "/agent-identity?tab=identities"
+          return (
+            <a href={href}
+               title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
+               onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
+               style={{ textDecoration: "none" }}>
+              {pill}
+            </a>
+          )
+        })()}
         {ev.source === "local_audit" && <LocalRiskPill />}
       </div>
       <div className="mono" style={{ fontSize: 11, color: "var(--text-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>


### PR DESCRIPTION
Closes **#1471**.

Two AGENT badges render on Guard Activity rows:
1. ACTOR column — HUMAN vs AGENT pill on every event
2. TOOL column — the workflow brain_block marker

Before this PR:
- ACTOR pill linked only when `agent_identity_id` was present. Rows without an id were dead-end pills.
- TOOL brain_block badge never linked at all.

## Fix

Both badges now link every time the row is an agent:
- **ACTOR pill**: deep-link with `?id=<uuid>` when known (highlight uses PR #1286 handling); fall back to the identities list when unknown.
- **TOOL brain_block badge**: same treatment.
- `stopPropagation` on both link clicks so the parent row's `onClick` doesn't fire the drilldown.

## Scope

- Frontend only. Backend already surfaces `agent_identity_id` on the event.
- `apps/web/src/components/guard/ActivityRow.tsx` — two small blocks changed.

## Test plan

- [x] Local `tsc --noEmit` clean
- [ ] CI green
- [ ] Manual: Guard Activity — click AGENT badge on any brain_block row → land on `/agent-identity?tab=identities` (list, if id missing) or with a highlighted identity (if id present).