### PR TITLE
fix(lens): surface confirm envelope on chat/stream 'done' event (#1475)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -392,6 +392,23 @@ def _has_data(final_msgs: list[dict]) -> bool:
     return False
 
 
+def _extract_confirm_envelope(final_msgs: list[dict]) -> dict | None:
+    """First tool result whose JSON body has confirm_required=True.
+    Surfaces the actor envelope (from require_confirmation) to the SSE 'done'
+    event so the frontend can render ActionConfirmBubble instead of prose."""
+    for m in final_msgs:
+        if m.get("role") != "tool":
+            continue
+        content = m.get("content", "")
+        try:
+            r = json.loads(content) if isinstance(content, str) else content
+        except Exception:
+            continue
+        if isinstance(r, dict) and r.get("confirm_required") and r.get("approval_request_id"):
+            return r
+    return None
+
+
 def _build_drilldown(tool_calls: list[tuple[str, dict]]) -> str | None:
     """Build a grounded drilldown URL from the tool calls the LLM actually made."""
     page = "/logs/guard"
@@ -734,6 +751,7 @@ async def glens_chat_stream(
             # Phase 1: resolve tool calls (fast, non-streaming)
             final_msgs, early_text, tool_calls = await asyncio.to_thread(_resolve_tools, llm_messages, system, executor)
             drilldown = _build_drilldown(tool_calls) if _has_data(final_msgs) else None
+            confirm_envelope = _extract_confirm_envelope(final_msgs)
 
             if early_text:
                 answer = early_text
@@ -744,7 +762,7 @@ async def glens_chat_stream(
                 for char in answer:
                     await event_q.put({"type": "token", "text": char})
                     await asyncio.sleep(0)
-                await event_q.put({"type": "done", "answer": answer})
+                await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope})
                 return
 
             # Phase 2: stream synthesis (tools already resolved)
@@ -760,7 +778,7 @@ async def glens_chat_stream(
                     await event_q.put({"type": "token", "text": char})
                     await asyncio.sleep(0)
                 answer += link
-            await event_q.put({"type": "done", "answer": answer})
+            await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope})
         except Exception as e:
             # If it's a Guard block, surface the rule_id to logs + telemetry.
             # #1286 wired Lens through the same policy engine as the HTTP
@@ -799,7 +817,10 @@ async def glens_chat_stream(
                     capped = session_messages[-50:]
                     background_tasks.add_task(_bg_save_session, session_id_str, capped, None)
 
-                    yield f"data: {json.dumps({'type': 'done', 'session_id': session_id_str, 'skill': 'governance', 'answer': answer})}\n\n"
+                    done_payload = {"type": "done", "session_id": session_id_str, "skill": "governance", "answer": answer}
+                    if evt.get("confirm_envelope"):
+                        done_payload.update(evt["confirm_envelope"])
+                    yield f"data: {json.dumps(done_payload)}\n\n"
                     break
         except asyncio.TimeoutError:
             yield f"data: {json.dumps({'type': 'error', 'message': 'Request timed out. Please try again.'})}\n\n"

--- a/apps/api/tests/glens/test_extract_confirm_envelope.py
+++ b/apps/api/tests/glens/test_extract_confirm_envelope.py
@@ -1,0 +1,54 @@
+"""#1475 — the SSE 'done' event must surface a confirm envelope from tool
+results so the frontend renders ActionConfirmBubble instead of prose.
+
+_extract_confirm_envelope scans final_msgs (LLM tool-turn list) for the
+first tool result whose JSON body carries confirm_required=True +
+approval_request_id. Non-tool roles are ignored; unparseable content is
+skipped; the first match wins."""
+from __future__ import annotations
+
+import json
+
+from app.modules.glens.routers.chat import _extract_confirm_envelope
+
+
+ENVELOPE = {
+    "confirm_required": True,
+    "approval_request_id": "req_abc",
+    "tool_name": "run_workflow",
+    "summary": "Run self_driving_network_approval_demo?",
+    "warnings": [],
+    "expires_at": "2026-08-30T02:55:56+00:00",
+    "surface": "lens",
+}
+
+
+def test_returns_first_matching_tool_result():
+    msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": "ok"},
+        {"role": "tool", "content": json.dumps(ENVELOPE)},
+    ]
+    assert _extract_confirm_envelope(msgs) == ENVELOPE
+
+
+def test_none_when_no_tool_results():
+    assert _extract_confirm_envelope([{"role": "user", "content": "hi"}]) is None
+
+
+def test_none_when_tool_result_lacks_confirm():
+    msgs = [{"role": "tool", "content": json.dumps({"count": 5})}]
+    assert _extract_confirm_envelope(msgs) is None
+
+
+def test_skips_unparseable_tool_content_then_matches():
+    msgs = [
+        {"role": "tool", "content": "not json"},
+        {"role": "tool", "content": json.dumps(ENVELOPE)},
+    ]
+    assert _extract_confirm_envelope(msgs) == ENVELOPE
+
+
+def test_requires_both_flag_and_id():
+    msgs = [{"role": "tool", "content": json.dumps({"confirm_required": True})}]
+    assert _extract_confirm_envelope(msgs) is None

--- a/apps/web/src/components/guard/ActivityRow.tsx
+++ b/apps/web/src/components/guard/ActivityRow.tsx
@@ -342,12 +342,17 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
                 {isHuman ? "HUMAN" : "AGENT"}
               </span>
             )
-            // AGENT rows with a known identity → deep-link to /agent-identity
-            // (uses the ?id=<uuid> highlight from PR #1286).
-            if (!isHuman && ev.agent_identity_id) {
+            // AGENT rows always link to /agent-identity — deep-link with
+            // ?id=<uuid> when the identity is known (highlight from PR #1286),
+            // fall back to the identities list otherwise (#1471).
+            if (!isHuman) {
+              const href = ev.agent_identity_id
+                ? `/agent-identity?tab=identities&id=${ev.agent_identity_id}`
+                : "/agent-identity?tab=identities"
               return (
-                <a href={`/agent-identity?tab=identities&id=${ev.agent_identity_id}`}
-                   title={`View agent identity ${ev.agent_identity_id}`}
+                <a href={href}
+                   title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
+                   onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
                    style={{ textDecoration: "none" }}>
                   {pill}
                 </a>
@@ -395,11 +400,26 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
               : formatToolCall(ev.tool_call)}
         </span>
         {ev.source === "proxy" && <ProxyPill />}
-        {ev.source === "brain_block" && (
-          <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: ".06em", padding: "1px 5px", borderRadius: 3, background: "#ede9fe", color: "#6d28d9", border: "1px solid #c4b5fd" }}>
-            AGENT
-          </span>
-        )}
+        {ev.source === "brain_block" && (() => {
+          const pill = (
+            <span style={{ fontSize: 8, fontWeight: 700, letterSpacing: ".06em", padding: "1px 5px", borderRadius: 3, background: "#ede9fe", color: "#6d28d9", border: "1px solid #c4b5fd" }}>
+              AGENT
+            </span>
+          )
+          // #1471 — link the brain_block AGENT badge to the specific identity
+          // when known; fall back to the agent identity list otherwise.
+          const href = ev.agent_identity_id
+            ? `/agent-identity?tab=identities&id=${ev.agent_identity_id}`
+            : "/agent-identity?tab=identities"
+          return (
+            <a href={href}
+               title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
+               onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
+               style={{ textDecoration: "none" }}>
+              {pill}
+            </a>
+          )
+        })()}
         {ev.source === "local_audit" && <LocalRiskPill />}
       </div>
       <div className="mono" style={{ fontSize: 11, color: "var(--text-3)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>


### PR DESCRIPTION
Fixes #1475.

## Root cause

Actor tools that call `require_confirmation()` (e.g. `run_workflow`) return
a JSON envelope with `confirm_required`, `approval_request_id`, `tool_name`,
`summary`, `expires_at`, `surface`. That envelope lands in `final_msgs` as
a `role="tool"` result — but `_run_work` only forwarded `answer` on the
terminal `done` event, so the frontend's `data.confirm_required && data.approval_request_id`
branch (`apps/web/src/components/glens/GLensChatPage.tsx` L1138) never
matched and fell through to a plain answer bubble.

Screenshot in the linked issue showed the LLM's markdown table prose
("Reply yes to confirm or no to cancel") instead of `<ActionConfirmBubble>`.

## Fix

- `_extract_confirm_envelope(final_msgs)` — new helper next to `_has_data`; scans tool results for the first JSON body with both flags set.
- `_run_work` — attaches the envelope (or `None`) to the internal `done` event on both the early-text and stream-synthesis paths.
- `generate()` — spreads the envelope keys into the SSE `done` payload the browser sees. No change to the wire contract beyond the added keys the frontend already looks for.

Frontend renderer (#1456 / #1467 / #1469) is unchanged and already handles
these keys — this PR just makes them reach the client.

## Test

`apps/api/tests/glens/test_extract_confirm_envelope.py` — 5 cases:

- returns first matching tool result
- `None` when no tool results
- `None` when tool result lacks confirm
- skips unparseable content, then matches
- requires both `confirm_required` and `approval_request_id`

```
tests/glens/test_extract_confirm_envelope.py .....   [100%]
5 passed in 0.22s
```

## Verify after merge

1. In Lens: "run this agent self_driving_network_approval_demo"
2. Card should render with Confirm/Cancel buttons + visible `approval_request_id` — not prose.
3. DevTools → Network → `POST /glens/chat/stream` → last `data:` line before end should include `confirm_required: true`, `approval_request_id`, `tool_name`, `expires_at`.