### PR TITLE
fix(lens): extract confirm envelope from Anthropic tool_result shape (#1475)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -395,17 +395,32 @@ def _has_data(final_msgs: list[dict]) -> bool:
 def _extract_confirm_envelope(final_msgs: list[dict]) -> dict | None:
     """First tool result whose JSON body has confirm_required=True.
     Surfaces the actor envelope (from require_confirmation) to the SSE 'done'
-    event so the frontend can render ActionConfirmBubble instead of prose."""
-    for m in final_msgs:
-        if m.get("role") != "tool":
-            continue
-        content = m.get("content", "")
+    event so the frontend can render ActionConfirmBubble instead of prose.
+
+    OpenAI/Perplexity shape:  {"role": "tool", "content": "<json>"}
+    Anthropic shape:          {"role": "user", "content": [{"type": "tool_result", "content": "<json>"}, ...]}
+    """
+    def _match(raw) -> dict | None:
         try:
-            r = json.loads(content) if isinstance(content, str) else content
+            r = json.loads(raw) if isinstance(raw, str) else raw
         except Exception:
-            continue
+            return None
         if isinstance(r, dict) and r.get("confirm_required") and r.get("approval_request_id"):
             return r
+        return None
+
+    for m in final_msgs:
+        content = m.get("content", "")
+        if m.get("role") == "tool":
+            hit = _match(content)
+            if hit:
+                return hit
+        elif m.get("role") == "user" and isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict) and blk.get("type") == "tool_result":
+                    hit = _match(blk.get("content", ""))
+                    if hit:
+                        return hit
     return None
 
 

--- a/apps/api/tests/glens/test_extract_confirm_envelope.py
+++ b/apps/api/tests/glens/test_extract_confirm_envelope.py
@@ -52,3 +52,13 @@ def test_skips_unparseable_tool_content_then_matches():
 def test_requires_both_flag_and_id():
     msgs = [{"role": "tool", "content": json.dumps({"confirm_required": True})}]
     assert _extract_confirm_envelope(msgs) is None
+
+
+def test_anthropic_tool_result_shape():
+    """Anthropic batches tool results as {role: user, content: [{type: tool_result, content: ...}]}."""
+    msgs = [
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": json.dumps(ENVELOPE)},
+        ]},
+    ]
+    assert _extract_confirm_envelope(msgs) == ENVELOPE


### PR DESCRIPTION
Follow-up to #1476. Fixes remaining #1475 case.

## Why the first pass didn't finish the job

#1476 scanned \`final_msgs\` for messages with \`role=\"tool\"\` — which is
the OpenAI / Perplexity tool-results shape:

\`\`\`json
{\"role\": \"tool\", \"tool_call_id\": \"...\", \"content\": \"<json>\"}
\`\`\`

Anthropic batches tool results as a single \`user\` turn with nested
\`tool_result\` blocks:

\`\`\`json
{\"role\": \"user\", \"content\": [
  {\"type\": \"tool_result\", \"tool_use_id\": \"...\", \"content\": \"<json>\"}
]}
\`\`\`

Anthropic-provider workspaces therefore never had the envelope surface
to the SSE \`done\` event — user confirmed via DevTools EventStream that
the terminal frame lacked \`confirm_required\` after the first fix
deployed to Render.

## Fix

\`_extract_confirm_envelope\` now walks both shapes and returns the first
match.

## Test

\`test_anthropic_tool_result_shape\` added — 6/6 passing:

\`\`\`
tests/glens/test_extract_confirm_envelope.py ......   [100%]
6 passed in 0.24s
\`\`\`