### PR TITLE
fix(actor): let any authorized human decide agent-proposed actions (#1475)

### DIFF
--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -235,10 +235,28 @@ def _enforce_ownership(
     clerk_user_id: str | None,
     session_id: str | None,
 ) -> None:
-    """The proposer must own the pending action. Session_id must match when
-    both sides carry one — protects against a compromised LLM in a different
-    session confirming actions from this session."""
-    if row.requester_user_id and clerk_user_id and row.requester_user_id != clerk_user_id:
+    """Enforce that only an authorized decider can act on the pending row.
+
+    Two proposer classes:
+      1. Human-proposed (real clerk_user_id) — same human must decide, matches
+         the pre-actor-substrate model.
+      2. Agent-proposed (requester_agent_ident set, or synthetic user id like
+         'system:lens') — this is HITL: an agent proposes, a human approves.
+         Route auth already gated the caller via `platform.approvals.decide`,
+         so any workspace user with that permission may decide.
+
+    Session_id still matches when both sides carry one — protects against a
+    compromised LLM in a different session confirming this session's rows.
+    """
+    is_agent_proposed = bool(getattr(row, "requester_agent_ident", None)) or (
+        isinstance(row.requester_user_id, str) and row.requester_user_id.startswith("system:")
+    )
+    if (
+        not is_agent_proposed
+        and row.requester_user_id
+        and clerk_user_id
+        and row.requester_user_id != clerk_user_id
+    ):
         raise ConfirmError(403, "only the proposer can decide this action")
     if row.session_id and session_id and row.session_id != session_id:
         raise ConfirmError(403, "action belongs to a different chat session")

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -395,17 +395,32 @@ def _has_data(final_msgs: list[dict]) -> bool:
 def _extract_confirm_envelope(final_msgs: list[dict]) -> dict | None:
     """First tool result whose JSON body has confirm_required=True.
     Surfaces the actor envelope (from require_confirmation) to the SSE 'done'
-    event so the frontend can render ActionConfirmBubble instead of prose."""
-    for m in final_msgs:
-        if m.get("role") != "tool":
-            continue
-        content = m.get("content", "")
+    event so the frontend can render ActionConfirmBubble instead of prose.
+
+    OpenAI/Perplexity shape:  {"role": "tool", "content": "<json>"}
+    Anthropic shape:          {"role": "user", "content": [{"type": "tool_result", "content": "<json>"}, ...]}
+    """
+    def _match(raw) -> dict | None:
         try:
-            r = json.loads(content) if isinstance(content, str) else content
+            r = json.loads(raw) if isinstance(raw, str) else raw
         except Exception:
-            continue
+            return None
         if isinstance(r, dict) and r.get("confirm_required") and r.get("approval_request_id"):
             return r
+        return None
+
+    for m in final_msgs:
+        content = m.get("content", "")
+        if m.get("role") == "tool":
+            hit = _match(content)
+            if hit:
+                return hit
+        elif m.get("role") == "user" and isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict) and blk.get("type") == "tool_result":
+                    hit = _match(blk.get("content", ""))
+                    if hit:
+                        return hit
     return None
 
 

--- a/apps/api/tests/glens/test_actor_chat_confirm.py
+++ b/apps/api/tests/glens/test_actor_chat_confirm.py
@@ -170,3 +170,30 @@ def test_enforce_ownership_lenient_when_row_has_no_session():
 
     row = SimpleNamespace(requester_user_id="user_abc", session_id=None)
     _enforce_ownership(row, clerk_user_id="user_abc", session_id=None)
+
+
+def test_agent_proposed_row_can_be_confirmed_by_any_human():
+    """#1475 HITL: Lens session proposes as an agent identity, a real human
+    clicks Confirm. Ownership check must NOT require user equality when
+    the row was proposed by an agent."""
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(
+        requester_user_id="system:lens",
+        requester_agent_ident="ai_lens_session_1",
+        session_id=None,
+    )
+    _enforce_ownership(row, clerk_user_id="user_real_human", session_id=None)
+
+
+def test_agent_proposed_by_synthetic_user_id_also_lenient():
+    """Belt-and-braces: even without requester_agent_ident, a 'system:*'
+    requester_user_id marks the row as agent-proposed."""
+    from app.modules.glens.actor.helpers import _enforce_ownership
+
+    row = SimpleNamespace(
+        requester_user_id="system:lens",
+        requester_agent_ident=None,
+        session_id=None,
+    )
+    _enforce_ownership(row, clerk_user_id="user_real_human", session_id=None)

--- a/apps/api/tests/glens/test_extract_confirm_envelope.py
+++ b/apps/api/tests/glens/test_extract_confirm_envelope.py
@@ -52,3 +52,13 @@ def test_skips_unparseable_tool_content_then_matches():
 def test_requires_both_flag_and_id():
     msgs = [{"role": "tool", "content": json.dumps({"confirm_required": True})}]
     assert _extract_confirm_envelope(msgs) is None
+
+
+def test_anthropic_tool_result_shape():
+    """Anthropic batches tool results as {role: user, content: [{type: tool_result, content: ...}]}."""
+    msgs = [
+        {"role": "user", "content": [
+            {"type": "tool_result", "tool_use_id": "t1", "content": json.dumps(ENVELOPE)},
+        ]},
+    ]
+    assert _extract_confirm_envelope(msgs) == ENVELOPE


### PR DESCRIPTION
Follow-up to #1476 + #1478. Fixes the *button-click* half of #1475.

## Symptom

Once the ActionConfirmBubble started rendering (post-#1478), clicking
**Confirm** returned:

> Failed to confirm: only the proposer can decide this action

## Cause

`_enforce_ownership` compared `row.requester_user_id` to the caller's
Clerk user id. Lens actor rows are proposed with `requester_user_id =
'system:lens'` (session-scoped agent identity), so a real human clicking
Confirm is never equal — 403.

This inverts the HITL model: the agent proposes, the human approves. The
strict user-equality rule is only correct when a *human* proposed the row
themselves (pre-actor-substrate flow).

## Fix

Detect agent-proposed rows and skip the user-equality check for them:

- `requester_agent_ident` set, OR
- `requester_user_id` starts with `system:`

Route auth already gated the caller with `platform.approvals.decide`, so
any workspace user with that permission may decide. Session-id
enforcement is unchanged (still prevents cross-session prompt injection).

## Tests

- \`test_agent_proposed_row_can_be_confirmed_by_any_human\` — HITL happy path (both agent_ident + system:* set)
- \`test_agent_proposed_by_synthetic_user_id_also_lenient\` — belt-and-braces (only system:* set)

\`getattr(row, \"requester_agent_ident\", None)\` shim keeps existing
SimpleNamespace-based test fixtures compatible.

\`\`\`
tests/glens/test_actor_chat_confirm.py .............   [100%]
13 passed in 0.22s
\`\`\`

## Verify after merge

1. Lens: \"run self_driving_network_approval_demo\"
2. Card renders (thanks to #1476 + #1478)
3. Click **Confirm** → run enqueues, no 403
4. Slack HITL / mid-run pauses continue to behave the same