### PR TITLE
feat(lens): link to run page after Confirm dispatches (#1475)

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -856,7 +856,13 @@ function ActionConfirmBubble({
         const data = await res.json()
         if (action === "confirm") {
           const label = data.tool_name ?? toolName
-          onResult(`${label} executed successfully.`)
+          const runId = data.result?.run_id as string | undefined
+          if (runId) {
+            const wfName = data.result?.workflow_name ?? label
+            onResult(`Run started for **${wfName}**. [View run →](/runs/${runId})`)
+          } else {
+            onResult(`${label} executed successfully.`)
+          }
         } else {
           onResult(`Action cancelled.`)
         }


### PR DESCRIPTION
## Summary

Replace the dead-end \`run_workflow executed successfully.\` message with a markdown link to \`/runs/<id>\` so users can follow the run they just kicked off from a Lens confirm bubble.

Uses \`data.result.run_id\` + \`workflow_name\` already emitted by \`_execute_run_workflow\` in \`apps/api/app/modules/glens/actor/registrations/run_workflow.py\`.

Follow-up to #1475. Backend already returns the fields; this is the missing frontend hop.

## Test plan
- [ ] From Lens, ask a workflow question that surfaces a Confirm bubble
- [ ] Click Confirm → verify the resulting bubble reads \`Run started for **<workflow>**. [View run →](/runs/<id>)\`
- [ ] Click the link → lands on the correct run detail page
- [ ] Non-run actions (no \`result.run_id\`) still show \`<label> executed successfully.\`