### PR TITLE
feat(lens): session event publisher + runs.session_id column (#1480 PR 1)

### DIFF
--- a/apps/api/alembic/versions/0108_runs_session_id.py
+++ b/apps/api/alembic/versions/0108_runs_session_id.py
@@ -1,0 +1,41 @@
+"""Add nullable runs.session_id + index — foundation for #1480 SSE surface.
+
+Revision ID: 0108
+Revises: 0107
+Create Date: 2026-08-30
+
+Only Lens-originated runs (from _execute_run_workflow) will set this; every
+other trigger (workflow UI, CLI, webhooks, scheduler, security scanners,
+nested runs) leaves it NULL. Pattern mirrors nullable agent_role_id.
+
+No FK to glens_chat_sessions on purpose — session deletion must not
+cascade run history. Index is for the worker's "runs I need to publish
+events for" lookup by session.
+
+Constraints/indexes named explicitly per project convention (Alembic
+autogenerate is banned on this repo — hand-written names avoid drift).
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "0108"
+down_revision = "0107"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "runs",
+        sa.Column("session_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.create_index("ix_runs_session_id", "runs", ["session_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_runs_session_id", table_name="runs")
+    op.drop_column("runs", "session_id")

--- a/apps/api/app/models/run.py
+++ b/apps/api/app/models/run.py
@@ -15,6 +15,11 @@ class Run(Base):
     workspace_id = Column(UUID(as_uuid=True), ForeignKey("workspaces.id"), nullable=False)
     triggered_by = Column(String(255), nullable=True)  # user_id / 'webhook' / 'schedule'
     agent_role_id = Column(String(36), nullable=True)
+    # Nullable — only Lens-originated runs (from _execute_run_workflow) set this
+    # so the SSE session channel can push run.* events back into the chat bubble
+    # that started the run (#1480). No FK: session deletion must not cascade
+    # run history.
+    session_id = Column(UUID(as_uuid=True), nullable=True)
     status = Column(String(50), nullable=False, default="pending")  # pending/running/paused/succeeded/failed/cancelled
     started_at = Column(DateTime(timezone=True), nullable=True)
     paused_at = Column(DateTime(timezone=True), nullable=True)
@@ -50,6 +55,7 @@ class Run(Base):
         sa.Index("ix_runs_workspace_id", "workspace_id"),
         sa.Index("ix_runs_workspace_created", "workspace_id", sa.text("created_at DESC")),
         sa.Index("ix_runs_workspace_status", "workspace_id", "status"),
+        sa.Index("ix_runs_session_id", "session_id"),
     )
 
 

--- a/apps/api/app/modules/glens/events.py
+++ b/apps/api/app/modules/glens/events.py
@@ -86,8 +86,11 @@ def publish_session_event(
     if payload:
         body["payload"] = payload
 
-    r = client or _redis()
     try:
+        # Construct the Redis client inside the try so an unreachable Redis
+        # (from_url succeeds but pool init fails, or a mocked-to-raise
+        # from_url in tests) still fails open — see docstring.
+        r = client or _redis()
         # XADD returns the auto-generated stream id (e.g. "1699999999999-0")
         entry_id = r.xadd(
             _stream_key(sid),

--- a/apps/api/app/modules/glens/events.py
+++ b/apps/api/app/modules/glens/events.py
@@ -1,0 +1,115 @@
+"""Session event publisher — foundation for the Lens interactive SSE surface (#1480).
+
+One function. Every state-changing endpoint (actor confirm/cancel/decide, run
+worker, approval webhooks) calls `publish_session_event(...)` on success.
+
+Two Redis writes per publish:
+
+1. `XADD stream:session:<id>` (MAXLEN 500, TTL 1h) — durable-ish buffer used
+   by the SSE endpoint's `Last-Event-Id` replay on reconnect.
+2. `PUBLISH chan:session:<id>` — real-time fan-out to any live subscriber
+   (SSE endpoint's generator listens on this channel).
+
+Ordering guarantee: subscribers must replay from the Stream from
+`Last-Event-Id` FIRST, THEN attach to pub/sub. The stream id from XADD is
+what gets sent to the client as the SSE `id:` field.
+
+Zero endpoints exposed. This module is the substrate; consumers wire it in.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import redis
+import structlog
+
+from app.core.config import settings
+
+log = structlog.get_logger(__name__)
+
+
+STREAM_MAXLEN = 500  # per-session ring buffer size — bounds Redis memory
+STREAM_TTL_SECONDS = 3600  # 1h reconnect window
+
+
+def _stream_key(session_id: str) -> str:
+    return f"stream:session:{session_id}"
+
+
+def _channel_key(session_id: str) -> str:
+    return f"chan:session:{session_id}"
+
+
+def _redis() -> redis.Redis:
+    return redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def publish_session_event(
+    session_id: str | uuid.UUID,
+    event_type: str,
+    entity: dict[str, str] | None = None,
+    payload: dict[str, Any] | None = None,
+    *,
+    client: redis.Redis | None = None,
+) -> str:
+    """Publish an event to a Lens session channel.
+
+    Returns the Redis Stream entry id (used as SSE `id:` field so clients can
+    resume via `Last-Event-Id`).
+
+    Args:
+        session_id: Lens chat session UUID (from `glens_chat_sessions.id`).
+        event_type: dotted string, e.g. `action.confirmed`, `run.block_started`.
+            See #1480 for the vocabulary.
+        entity: optional `{type, id}` for entity-scoped subscription on the
+            client (`useLensEvent(stream, "approval", "<id>", ...)`).
+        payload: event-specific data. Kept small — no full run state, no
+            LLM history. Consumers can re-fetch by id if they need more.
+        client: injectable Redis client for tests.
+
+    Fail-open: publish errors are logged and swallowed. A live SSE stream
+    dropping an event is preferable to failing the underlying business
+    operation (Confirm succeeded → run enqueued → publish blows up → user
+    sees a 500 despite the run running). SSE is a UX enhancement, not a
+    consistency boundary.
+    """
+    sid = str(session_id)
+    body = {
+        "type": event_type,
+        "at": datetime.now(timezone.utc).isoformat(),
+    }
+    if entity:
+        body["entity"] = entity
+    if payload:
+        body["payload"] = payload
+
+    r = client or _redis()
+    try:
+        # XADD returns the auto-generated stream id (e.g. "1699999999999-0")
+        entry_id = r.xadd(
+            _stream_key(sid),
+            {"body": json.dumps(body)},
+            maxlen=STREAM_MAXLEN,
+            approximate=True,  # ~ trim, cheaper and bounded
+        )
+        # Refresh TTL on the stream key — bounds Redis memory for sessions
+        # that go quiet. Subscribers within the last hour still get replay.
+        r.expire(_stream_key(sid), STREAM_TTL_SECONDS)
+
+        # Envelope the payload with the stream id so subscribers can send it
+        # as SSE `id:` and clients can resume from it.
+        fanout = json.dumps({"id": entry_id, **body})
+        r.publish(_channel_key(sid), fanout)
+        return entry_id
+    except Exception as exc:
+        # Fail-open — see docstring.
+        log.warning(
+            "glens.event.publish_failed",
+            session_id=sid,
+            event_type=event_type,
+            error=str(exc),
+        )
+        return ""

--- a/apps/api/tests/glens/test_events_publisher.py
+++ b/apps/api/tests/glens/test_events_publisher.py
@@ -1,0 +1,101 @@
+"""Verify publish_session_event XADDs + PUBLISHes with the right shape.
+
+Foundation test for #1480 SSE surface (PR 1). Real Redis not required —
+publisher takes an injectable client so we assert on MagicMock calls.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from app.modules.glens.events import (
+    STREAM_MAXLEN,
+    STREAM_TTL_SECONDS,
+    publish_session_event,
+)
+
+
+_SESSION = "11111111-1111-1111-1111-111111111111"
+
+
+def _mock_redis(entry_id: str = "1699999999999-0") -> MagicMock:
+    r = MagicMock()
+    r.xadd.return_value = entry_id
+    return r
+
+
+def test_publishes_stream_entry_with_bounded_maxlen() -> None:
+    r = _mock_redis()
+    publish_session_event(_SESSION, "action.confirmed", client=r)
+
+    r.xadd.assert_called_once()
+    args, kwargs = r.xadd.call_args
+    assert args[0] == f"stream:session:{_SESSION}"
+    assert kwargs["maxlen"] == STREAM_MAXLEN
+    assert kwargs["approximate"] is True
+
+
+def test_publishes_pub_sub_with_stream_id_envelope() -> None:
+    r = _mock_redis(entry_id="1699999999999-0")
+    publish_session_event(
+        _SESSION,
+        "action.confirmed",
+        entity={"type": "approval", "id": "abc"},
+        payload={"outcome": "ok"},
+        client=r,
+    )
+
+    r.publish.assert_called_once()
+    channel, raw = r.publish.call_args.args
+    assert channel == f"chan:session:{_SESSION}"
+    body = json.loads(raw)
+    # Stream id envelope — clients use it for Last-Event-Id resume
+    assert body["id"] == "1699999999999-0"
+    assert body["type"] == "action.confirmed"
+    assert body["entity"] == {"type": "approval", "id": "abc"}
+    assert body["payload"] == {"outcome": "ok"}
+    assert "at" in body
+
+
+def test_returns_stream_id_for_use_as_sse_event_id() -> None:
+    r = _mock_redis(entry_id="1699999999999-0")
+    entry_id = publish_session_event(_SESSION, "run.completed", client=r)
+    assert entry_id == "1699999999999-0"
+
+
+def test_stream_ttl_refreshed_on_every_publish() -> None:
+    r = _mock_redis()
+    publish_session_event(_SESSION, "action.confirmed", client=r)
+    r.expire.assert_called_once_with(f"stream:session:{_SESSION}", STREAM_TTL_SECONDS)
+
+
+def test_optional_entity_and_payload_omitted_from_body() -> None:
+    r = _mock_redis()
+    publish_session_event(_SESSION, "session.closed", client=r)
+    body = json.loads(r.publish.call_args.args[1])
+    assert "entity" not in body
+    assert "payload" not in body
+
+
+def test_publish_is_fail_open_when_redis_errors() -> None:
+    """A dropped SSE event must never fail the underlying business op.
+
+    Publisher is called AFTER Confirm/Cancel/Decide has already committed.
+    If Redis is down, the run is enqueued — the user just misses a live
+    event. Returning empty string signals "no id" without raising.
+    """
+    r = MagicMock()
+    r.xadd.side_effect = RuntimeError("redis down")
+    entry_id = publish_session_event(_SESSION, "action.confirmed", client=r)
+    assert entry_id == ""
+    # Publish must NOT be attempted when xadd blew up (would fail too, and
+    # the fanout envelope needs a real stream id anyway).
+    r.publish.assert_not_called()
+
+
+def test_uuid_session_id_accepted() -> None:
+    import uuid
+
+    r = _mock_redis()
+    publish_session_event(uuid.UUID(_SESSION), "run.status_changed", client=r)
+    assert r.xadd.call_args.args[0] == f"stream:session:{_SESSION}"

--- a/apps/api/tests/glens/test_events_publisher.py
+++ b/apps/api/tests/glens/test_events_publisher.py
@@ -99,3 +99,16 @@ def test_uuid_session_id_accepted() -> None:
     r = _mock_redis()
     publish_session_event(uuid.UUID(_SESSION), "run.status_changed", client=r)
     assert r.xadd.call_args.args[0] == f"stream:session:{_SESSION}"
+
+
+def test_fail_open_when_redis_from_url_itself_raises() -> None:
+    """Regression test: earlier version constructed the Redis client OUTSIDE
+    the try/except, so a mocked-to-raise `redis.from_url` (as used by
+    executor lifecycle tests) blew past the fail-open handler and crashed
+    the caller. Every failure mode inside publish_session_event MUST be
+    swallowed."""
+    from unittest.mock import patch
+
+    with patch("app.modules.glens.events.redis.from_url", side_effect=RuntimeError("redis down")):
+        entry_id = publish_session_event(_SESSION, "action.confirmed")
+    assert entry_id == ""


### PR DESCRIPTION
## Summary

Foundation-only slice of the #1480 interactive SSE surface epic. **Zero endpoints exposed, zero user-visible change.** Prepares two things every later PR in the epic will build on.

### 1. \`runs.session_id\` — nullable UUID + index

Only Lens-originated runs (from \`_execute_run_workflow\`) will set this. Every other trigger — workflow UI Run button, CLI \`conduct run\`, webhooks × 4, security scanners × 2, scheduler, nested runs — leaves it NULL and sees zero change in behavior.

Pattern mirrors existing nullable \`agent_role_id\` / \`triggered_by\`. **No FK** to \`glens_chat_sessions\` on purpose — session deletion must not cascade run history. Index is for the worker's "runs I need to publish events for" lookups.

Migration \`0108_runs_session_id.py\` — hand-written per repo convention.

### 2. \`publish_session_event()\` — one helper, two Redis writes

\`apps/api/app/modules/glens/events.py\`

Every state-changing endpoint (actor confirm/cancel/decide, run worker, approval webhooks — all wired in later PRs) will call:

\`\`\`python
publish_session_event(session_id, "action.confirmed",
                      entity={"type": "approval", "id": "..."},
                      payload={"outcome": "ok"})
\`\`\`

Publisher does:
- \`XADD stream:session:<id>\` (MAXLEN 500, TTL 1h) — reconnect buffer
- \`PUBLISH chan:session:<id>\` — real-time fan-out to SSE subscribers
- Returns the stream id so the SSE endpoint can send it as \`id:\` and clients can resume via \`Last-Event-Id\` after reconnect

**Fail-open**: Redis errors are logged and swallowed. A dropped SSE event must never fail the underlying business op (Confirm succeeded → run enqueued → publish blows up should NOT return 500 to the user). SSE is a UX enhancement, not a consistency boundary.

Injectable Redis client for tests — 7 unit tests cover shape, TTL refresh, envelope, fail-open path, UUID acceptance, optional fields.

## Design decisions (from #1480 design session, memory recorded)

- **Transport**: SSE server→client + REST client→server commands (not WebSocket)
- **Event store**: Redis pub/sub + per-session Redis Stream (not Postgres LISTEN/NOTIFY)
- **Client**: per-bubble entity subscription (no global reducer)
- **Cross-tab**: free — both tabs subscribe to same Redis channel

## What ships next

- **PR 2**: \`GET /glens/sessions/{id}/stream\` — SSE endpoint that subscribes to the channel + replays from the stream on \`Last-Event-Id\`
- **PR 3**: Tee events from actor confirm/cancel/decide endpoints
- **PR 4**: Frontend \`useLensSessionStream\` + reactive \`ActionConfirmBubble\` behind \`lens.sse_surface\` flag — **first user-visible win**
- **PR 5**: Worker publishes \`run.*\` events + \`<RunBubble>\` live progress

## Test plan
- [x] Run model imports cleanly with new column + 9 indexes
- [x] Migration 0108 loads, has upgrade + downgrade
- [x] 7 publisher unit tests pass
- [x] 84 glens tests pass, no regressions
- [ ] CI schema drift test green (\`tests/test_z_migration_round_trip.py\`)
- [ ] CI full suite green

Part of #1480.