### PR TITLE
feat(lens): SSE session-stream endpoint with Last-Event-Id replay (#1480 PR 2)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -37,6 +37,7 @@ from app.modules.glens.routers import config as glens_config
 from app.modules.glens.routers import feedback as glens_feedback
 from app.modules.glens.routers import opener as glens_opener
 from app.modules.glens.routers import policy as glens_policy
+from app.modules.glens.routers import session_stream as glens_session_stream
 from app.modules.glens.routers import sessions as glens_sessions
 from app.modules.glens.actor import routes as glens_actor_routes
 from app.modules.glens.routers import lens_sessions as glens_lens_sessions
@@ -162,6 +163,7 @@ app.include_router(guard_verify.router)
 app.include_router(guard_knowledge_search.router)
 app.include_router(glens_chat.router)
 app.include_router(glens_sessions.router)
+app.include_router(glens_session_stream.router)
 app.include_router(glens_feedback.router)
 app.include_router(glens_opener.router)
 app.include_router(glens_policy.router)

--- a/apps/api/app/modules/glens/routers/session_stream.py
+++ b/apps/api/app/modules/glens/routers/session_stream.py
@@ -1,0 +1,149 @@
+"""SSE endpoint for the Lens session event stream — PR 2 of #1480.
+
+    GET /glens/sessions/{session_id}/stream
+
+Long-lived Server-Sent Events connection scoped to one Lens chat session.
+Subscribes to Redis pub/sub `chan:session:<id>` for real-time fan-out.
+If the client sends a `Last-Event-Id` header, first replays events from
+the Redis Stream `stream:session:<id>` starting AFTER that id, then
+attaches to pub/sub.
+
+Ordering guarantee: subscribe → replay → forward pub/sub. Subscribe
+first so any event published during the replay phase is queued on
+pub/sub, not lost.
+
+Producers are wired in later PRs; this endpoint only READS. Publisher
+lives in `apps/api/app/modules/glens/events.py` (PR 1).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import redis.asyncio as aioredis
+import structlog
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.config import settings
+from app.core.database import get_db
+
+from ..events import _channel_key, _stream_key
+from ._helpers import _get_session, _parse_workspace_id
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/glens", tags=["glens"])
+
+
+# Send an SSE comment every N seconds during idle so intermediary proxies
+# (nginx, cloudflare) don't drop the connection as stale.
+IDLE_KEEPALIVE_SECONDS = 30
+# Short pub/sub poll timeout — lets us check request.is_disconnected() and
+# emit keepalives without holding a blocking call for minutes.
+PUBSUB_POLL_SECONDS = 5
+
+
+def _sse_frame(entry_id: str, data: str) -> str:
+    """Format one SSE frame with the entry id as the `id:` line so clients
+    can resume via `Last-Event-Id` after reconnect."""
+    if entry_id:
+        return f"id: {entry_id}\ndata: {data}\n\n"
+    return f"data: {data}\n\n"
+
+
+@router.get("/sessions/{session_id}/stream")
+async def glens_session_stream(
+    session_id: str,
+    request: Request,
+    last_event_id: str | None = Header(default=None, alias="Last-Event-Id"),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+):
+    """SSE stream of events for one Lens session.
+
+    Auth: same permission as chat/stream + we assert the session belongs
+    to the caller's workspace (`_get_session` 404s otherwise). This is
+    the only door out — anyone opening it subscribes to every event on
+    the session, so cross-workspace leakage must be impossible.
+    """
+    ws_uuid = _parse_workspace_id(workspace_id)
+    _get_session(db, session_id, ws_uuid)  # 404 if not in workspace
+
+    stream_key = _stream_key(session_id)
+    channel_key = _channel_key(session_id)
+
+    async def event_stream():
+        r = aioredis.from_url(settings.redis_url, decode_responses=True)
+        pubsub = r.pubsub()
+        try:
+            # Subscribe FIRST so events published during replay queue on
+            # pub/sub — otherwise a race can drop events landing between
+            # the XREAD and the SUBSCRIBE.
+            await pubsub.subscribe(channel_key)
+
+            # Replay from Last-Event-Id if the client is reconnecting.
+            if last_event_id:
+                try:
+                    replay = await r.xread({stream_key: last_event_id})
+                    for _, entries in replay:
+                        for entry_id, fields in entries:
+                            body = fields.get("body")
+                            if not body:
+                                continue
+                            # Wrap the stored body with the stream id so
+                            # the client sees the same envelope shape it
+                            # gets from live pub/sub messages.
+                            envelope = json.dumps({"id": entry_id, **json.loads(body)})
+                            yield _sse_frame(entry_id, envelope)
+                except Exception as exc:
+                    log.warning(
+                        "glens.stream.replay_failed",
+                        session_id=session_id,
+                        last_event_id=last_event_id,
+                        error=str(exc),
+                    )
+
+            # Live pub/sub loop.
+            loop = asyncio.get_event_loop()
+            last_activity = loop.time()
+
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                msg = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=PUBSUB_POLL_SECONDS,
+                )
+                if msg is not None:
+                    raw = msg.get("data") or ""
+                    try:
+                        envelope = json.loads(raw)
+                        yield _sse_frame(envelope.get("id", ""), raw)
+                    except Exception:
+                        # Malformed publish — skip, don't crash the stream.
+                        pass
+                    last_activity = loop.time()
+                elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
+                    # Comment frame — clients ignore, proxies see traffic.
+                    yield ": keepalive\n\n"
+                    last_activity = loop.time()
+        finally:
+            try:
+                await pubsub.unsubscribe(channel_key)
+                await pubsub.close()
+                await r.close()
+            except Exception:
+                pass
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # nginx: disable proxy buffering
+        },
+    )

--- a/apps/api/tests/glens/test_session_stream_endpoint.py
+++ b/apps/api/tests/glens/test_session_stream_endpoint.py
@@ -1,0 +1,87 @@
+"""Verify GET /glens/sessions/{id}/stream — auth, response type, replay wrapper.
+
+Focus: the auth boundary + SSE response shape. The pub/sub read loop
+requires a live Redis; we do NOT exercise it here — PR 3 wires actor
+endpoints as publishers and covers the round-trip in an integration
+test if we ever add one. Env vars come from tests/conftest.py.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import app.models.run          # noqa: F401
+import app.models.workspace    # noqa: F401
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.database import get_db
+from app.main import app
+from app.modules.glens.routers.session_stream import _sse_frame
+
+
+WS_ID = str(uuid.uuid4())
+SESSION_ID = str(uuid.uuid4())
+
+
+def _make_client(session_lookup_ok: bool = True):
+    def _noop_permission(perm):
+        async def _check():
+            return "admin"
+        return _check
+
+    if session_lookup_ok:
+        def _stub_session(db, session_id, ws_uuid):
+            s = MagicMock()
+            s.id = uuid.UUID(session_id)
+            s.workspace_id = ws_uuid
+            return s
+    else:
+        def _stub_session(db, session_id, ws_uuid):
+            raise HTTPException(status_code=404, detail="Session not found")
+
+    app.dependency_overrides[get_db] = lambda: iter([MagicMock()])
+    app.dependency_overrides[get_workspace_id] = lambda: WS_ID
+    app.dependency_overrides[require_permission] = _noop_permission
+    import app.modules.glens.routers.session_stream as mod
+    mod._get_session = _stub_session
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _teardown():
+    app.dependency_overrides.clear()
+    import app.modules.glens.routers.session_stream as mod
+    from app.modules.glens.routers._helpers import _get_session as real
+    mod._get_session = real
+
+
+def test_returns_404_when_session_not_in_workspace() -> None:
+    client = _make_client(session_lookup_ok=False)
+    try:
+        resp = client.get(f"/glens/sessions/{SESSION_ID}/stream")
+        assert resp.status_code == 404
+    finally:
+        _teardown()
+
+
+def test_sse_frame_includes_id_line_when_entry_id_present() -> None:
+    frame = _sse_frame("1699999999999-0", '{"foo":"bar"}')
+    assert frame.startswith("id: 1699999999999-0\n")
+    assert 'data: {"foo":"bar"}' in frame
+    assert frame.endswith("\n\n")
+
+
+def test_sse_frame_omits_id_line_when_entry_id_blank() -> None:
+    frame = _sse_frame("", '{"foo":"bar"}')
+    assert not frame.startswith("id:")
+    assert frame == 'data: {"foo":"bar"}\n\n'
+
+
+def test_endpoint_is_registered_on_app() -> None:
+    """FastAPI does not always expose sub-router routes via app.routes at
+    the top level; the openapi schema is the authoritative source."""
+    schema = app.openapi()
+    assert "/glens/sessions/{session_id}/stream" in schema["paths"]
+    assert "get" in schema["paths"]["/glens/sessions/{session_id}/stream"]


### PR DESCRIPTION
## Summary

    GET /glens/sessions/{session_id}/stream

Long-lived SSE connection scoped to one Lens chat session. Subscribes to Redis pub/sub \`chan:session:<id>\` for real-time fan-out. If the client sends a \`Last-Event-Id\` header, first replays from Redis Stream \`stream:session:<id>\` starting after that id, then attaches to pub/sub.

**Depends on** #1485 (PR 1 — publisher + \`runs.session_id\`). PR base is the PR 1 branch — will be re-targeted to \`main\` after #1485 merges.

## Ordering guarantee

Subscribe → replay → forward pub/sub. Subscribe FIRST so events published during replay queue on pub/sub instead of being lost. Race window between \`XREAD\` and \`SUBSCRIBE\` is closed by construction.

## Auth

Same permission gate as \`chat/stream\` (\`guard.activity.view_own\`) + assertion that the session belongs to the caller's workspace (\`_get_session\` 404s otherwise). One open connection sees every event on the session — cross-workspace leakage must be impossible, and this is the only door.

## Keepalive + disconnect

- Poll pub/sub with a 5s timeout, check \`request.is_disconnected()\` each iteration
- Emit \`: keepalive\` comment every 30s of idle
- \`X-Accel-Buffering: no\` on response so nginx doesn't buffer

## Test plan
- [x] 4 endpoint tests pass (auth 404 path, SSE frame format, openapi registration)
- [x] 88 glens tests pass, no regressions
- [x] \`redis.asyncio\` available via \`redis==5.3.1\`
- [ ] Manual verify: \`curl -N http://localhost:8000/glens/sessions/<uuid>/stream\` returns \`text/event-stream\` after auth headers
- [ ] Manual verify: reconnect with \`Last-Event-Id: <stream_id>\` replays events after that id

## What ships next

- **PR 3**: tee events from actor confirm/cancel/decide — first real events flow through this stream
- **PR 4**: frontend \`useLensSessionStream\` hook + reactive \`ActionConfirmBubble\` behind \`lens.sse_surface\` flag
- **PR 5**: worker publishes \`run.*\` events + \`<RunBubble>\`

Part of #1480.