### PR TITLE
feat(lens): tee action.confirmed / action.cancelled to session stream (#1480 PR 3)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -37,6 +37,7 @@ from app.modules.glens.routers import config as glens_config
 from app.modules.glens.routers import feedback as glens_feedback
 from app.modules.glens.routers import opener as glens_opener
 from app.modules.glens.routers import policy as glens_policy
+from app.modules.glens.routers import session_stream as glens_session_stream
 from app.modules.glens.routers import sessions as glens_sessions
 from app.modules.glens.actor import routes as glens_actor_routes
 from app.modules.glens.routers import lens_sessions as glens_lens_sessions
@@ -162,6 +163,7 @@ app.include_router(guard_verify.router)
 app.include_router(guard_knowledge_search.router)
 app.include_router(glens_chat.router)
 app.include_router(glens_sessions.router)
+app.include_router(glens_session_stream.router)
 app.include_router(glens_feedback.router)
 app.include_router(glens_opener.router)
 app.include_router(glens_policy.router)

--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -18,6 +18,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.modules.glens.actor.types import ActionCtx, ActionSpec
+from app.modules.glens.events import publish_session_event
 from app.modules.guard.approval import (
     apply_decision,
     can_decide,
@@ -25,6 +26,32 @@ from app.modules.guard.approval import (
     sweep_if_timed_out,
 )
 from app.modules.guard.models import GuardApprovalRequest
+
+
+def _publish_action_event(row: GuardApprovalRequest, event_type: str, *, result: Any = None, cached: bool = False) -> None:
+    """Tee an action.* event to the row's originating Lens session so any
+    open session-stream connection can update its bubble reactively.
+
+    No-op when the row has no session_id (HTTP actor calls without chat
+    context — nothing to route to). Fail-open inside publish_session_event
+    means Redis outages never fail the decide operation.
+    """
+    if not row.session_id:
+        return
+    payload: dict[str, Any] = {
+        "tool_name": row.tool_name,
+        "status": row.status,
+    }
+    if result is not None:
+        payload["result"] = result
+    if cached:
+        payload["cached"] = True
+    publish_session_event(
+        row.session_id,
+        event_type,
+        entity={"type": "approval", "id": str(row.id)},
+        payload=payload,
+    )
 
 
 def _idempotency_key(tool_name: str, resolved_input: dict[str, Any]) -> str:
@@ -285,13 +312,17 @@ def dispatch_confirm(
 
     # Idempotent success — already executed, return cached result.
     if row.status == "approved" and (row.tool_input or {}).get("_execute_result") is not None:
+        cached_result = row.tool_input.get("_execute_result")
+        # Re-publish so cross-tab subscribers that missed the first event
+        # (e.g. tab opened after the confirm) still see the resolution.
+        _publish_action_event(row, "action.confirmed", result=cached_result, cached=True)
         return {
             "executed": True,
             "cached": True,
             "action_id": str(row.id),
             "tool_name": row.tool_name,
             "status": row.status,
-            "result": row.tool_input.get("_execute_result"),
+            "result": cached_result,
         }
 
     if row.status != "pending":
@@ -339,6 +370,8 @@ def dispatch_confirm(
     row.tool_input = {**(row.tool_input or {}), "_execute_result": result}
     db.commit()
 
+    _publish_action_event(row, "action.confirmed", result=result)
+
     return {
         "executed": True,
         "cached": False,
@@ -375,6 +408,9 @@ def dispatch_cancel(
         decider_user_id=clerk_user_id,
         reason=reason or f"lens.actor.cancelled:{row.tool_name}",
     )
+
+    _publish_action_event(row, "action.cancelled")
+
     return {
         "cancelled": True,
         "action_id": str(row.id),

--- a/apps/api/app/modules/glens/routers/session_stream.py
+++ b/apps/api/app/modules/glens/routers/session_stream.py
@@ -1,0 +1,149 @@
+"""SSE endpoint for the Lens session event stream — PR 2 of #1480.
+
+    GET /glens/sessions/{session_id}/stream
+
+Long-lived Server-Sent Events connection scoped to one Lens chat session.
+Subscribes to Redis pub/sub `chan:session:<id>` for real-time fan-out.
+If the client sends a `Last-Event-Id` header, first replays events from
+the Redis Stream `stream:session:<id>` starting AFTER that id, then
+attaches to pub/sub.
+
+Ordering guarantee: subscribe → replay → forward pub/sub. Subscribe
+first so any event published during the replay phase is queued on
+pub/sub, not lost.
+
+Producers are wired in later PRs; this endpoint only READS. Publisher
+lives in `apps/api/app/modules/glens/events.py` (PR 1).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import redis.asyncio as aioredis
+import structlog
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.config import settings
+from app.core.database import get_db
+
+from ..events import _channel_key, _stream_key
+from ._helpers import _get_session, _parse_workspace_id
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/glens", tags=["glens"])
+
+
+# Send an SSE comment every N seconds during idle so intermediary proxies
+# (nginx, cloudflare) don't drop the connection as stale.
+IDLE_KEEPALIVE_SECONDS = 30
+# Short pub/sub poll timeout — lets us check request.is_disconnected() and
+# emit keepalives without holding a blocking call for minutes.
+PUBSUB_POLL_SECONDS = 5
+
+
+def _sse_frame(entry_id: str, data: str) -> str:
+    """Format one SSE frame with the entry id as the `id:` line so clients
+    can resume via `Last-Event-Id` after reconnect."""
+    if entry_id:
+        return f"id: {entry_id}\ndata: {data}\n\n"
+    return f"data: {data}\n\n"
+
+
+@router.get("/sessions/{session_id}/stream")
+async def glens_session_stream(
+    session_id: str,
+    request: Request,
+    last_event_id: str | None = Header(default=None, alias="Last-Event-Id"),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+):
+    """SSE stream of events for one Lens session.
+
+    Auth: same permission as chat/stream + we assert the session belongs
+    to the caller's workspace (`_get_session` 404s otherwise). This is
+    the only door out — anyone opening it subscribes to every event on
+    the session, so cross-workspace leakage must be impossible.
+    """
+    ws_uuid = _parse_workspace_id(workspace_id)
+    _get_session(db, session_id, ws_uuid)  # 404 if not in workspace
+
+    stream_key = _stream_key(session_id)
+    channel_key = _channel_key(session_id)
+
+    async def event_stream():
+        r = aioredis.from_url(settings.redis_url, decode_responses=True)
+        pubsub = r.pubsub()
+        try:
+            # Subscribe FIRST so events published during replay queue on
+            # pub/sub — otherwise a race can drop events landing between
+            # the XREAD and the SUBSCRIBE.
+            await pubsub.subscribe(channel_key)
+
+            # Replay from Last-Event-Id if the client is reconnecting.
+            if last_event_id:
+                try:
+                    replay = await r.xread({stream_key: last_event_id})
+                    for _, entries in replay:
+                        for entry_id, fields in entries:
+                            body = fields.get("body")
+                            if not body:
+                                continue
+                            # Wrap the stored body with the stream id so
+                            # the client sees the same envelope shape it
+                            # gets from live pub/sub messages.
+                            envelope = json.dumps({"id": entry_id, **json.loads(body)})
+                            yield _sse_frame(entry_id, envelope)
+                except Exception as exc:
+                    log.warning(
+                        "glens.stream.replay_failed",
+                        session_id=session_id,
+                        last_event_id=last_event_id,
+                        error=str(exc),
+                    )
+
+            # Live pub/sub loop.
+            loop = asyncio.get_event_loop()
+            last_activity = loop.time()
+
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                msg = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=PUBSUB_POLL_SECONDS,
+                )
+                if msg is not None:
+                    raw = msg.get("data") or ""
+                    try:
+                        envelope = json.loads(raw)
+                        yield _sse_frame(envelope.get("id", ""), raw)
+                    except Exception:
+                        # Malformed publish — skip, don't crash the stream.
+                        pass
+                    last_activity = loop.time()
+                elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
+                    # Comment frame — clients ignore, proxies see traffic.
+                    yield ": keepalive\n\n"
+                    last_activity = loop.time()
+        finally:
+            try:
+                await pubsub.unsubscribe(channel_key)
+                await pubsub.close()
+                await r.close()
+            except Exception:
+                pass
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # nginx: disable proxy buffering
+        },
+    )

--- a/apps/api/tests/glens/test_actor_publish_tee.py
+++ b/apps/api/tests/glens/test_actor_publish_tee.py
@@ -1,0 +1,80 @@
+"""Verify actor helpers tee action.confirmed / action.cancelled events to
+the row's originating Lens session (#1480 PR 3).
+
+Focus: the _publish_action_event helper. Its contract:
+  - No-op when row.session_id is None (HTTP calls without chat context)
+  - Publishes action.confirmed with entity=approval + payload=result/cached
+  - Publishes action.cancelled with entity=approval, no result
+  - Uses row.session_id + row.id for routing
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.modules.glens.actor.helpers import _publish_action_event
+
+
+def _row(session_id="sess-abc", row_id="row-xyz", tool_name="run_workflow", status="approved"):
+    return SimpleNamespace(
+        id=row_id,
+        session_id=session_id,
+        tool_name=tool_name,
+        status=status,
+    )
+
+
+def test_no_publish_when_row_has_no_session_id() -> None:
+    """HTTP actor calls without chat context leave session_id NULL — nothing
+    to route to, so publish is skipped entirely."""
+    row = _row(session_id=None)
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"run_id": "r1"})
+    mock_pub.assert_not_called()
+
+
+def test_confirmed_event_shape() -> None:
+    row = _row()
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"run_id": "r1"})
+    mock_pub.assert_called_once()
+    session_id, event_type = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == "sess-abc"
+    assert event_type == "action.confirmed"
+    assert kwargs["entity"] == {"type": "approval", "id": "row-xyz"}
+    assert kwargs["payload"] == {
+        "tool_name": "run_workflow",
+        "status": "approved",
+        "result": {"run_id": "r1"},
+    }
+
+
+def test_confirmed_event_marks_cached_when_flagged() -> None:
+    row = _row()
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"foo": "bar"}, cached=True)
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"]["cached"] is True
+
+
+def test_cancelled_event_omits_result() -> None:
+    row = _row(status="rejected")
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.cancelled")
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"] == {"tool_name": "run_workflow", "status": "rejected"}
+    assert "result" not in kwargs["payload"]
+    assert "cached" not in kwargs["payload"]
+
+
+def test_row_id_stringified_for_entity() -> None:
+    """entity.id must be a string — approval rows carry UUID; the publisher
+    contract expects string ids."""
+    import uuid
+    row_uuid = uuid.uuid4()
+    row = _row(row_id=row_uuid)
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed")
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["entity"]["id"] == str(row_uuid)

--- a/apps/api/tests/glens/test_session_stream_endpoint.py
+++ b/apps/api/tests/glens/test_session_stream_endpoint.py
@@ -1,0 +1,87 @@
+"""Verify GET /glens/sessions/{id}/stream — auth, response type, replay wrapper.
+
+Focus: the auth boundary + SSE response shape. The pub/sub read loop
+requires a live Redis; we do NOT exercise it here — PR 3 wires actor
+endpoints as publishers and covers the round-trip in an integration
+test if we ever add one. Env vars come from tests/conftest.py.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import app.models.run          # noqa: F401
+import app.models.workspace    # noqa: F401
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.database import get_db
+from app.main import app
+from app.modules.glens.routers.session_stream import _sse_frame
+
+
+WS_ID = str(uuid.uuid4())
+SESSION_ID = str(uuid.uuid4())
+
+
+def _make_client(session_lookup_ok: bool = True):
+    def _noop_permission(perm):
+        async def _check():
+            return "admin"
+        return _check
+
+    if session_lookup_ok:
+        def _stub_session(db, session_id, ws_uuid):
+            s = MagicMock()
+            s.id = uuid.UUID(session_id)
+            s.workspace_id = ws_uuid
+            return s
+    else:
+        def _stub_session(db, session_id, ws_uuid):
+            raise HTTPException(status_code=404, detail="Session not found")
+
+    app.dependency_overrides[get_db] = lambda: iter([MagicMock()])
+    app.dependency_overrides[get_workspace_id] = lambda: WS_ID
+    app.dependency_overrides[require_permission] = _noop_permission
+    import app.modules.glens.routers.session_stream as mod
+    mod._get_session = _stub_session
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _teardown():
+    app.dependency_overrides.clear()
+    import app.modules.glens.routers.session_stream as mod
+    from app.modules.glens.routers._helpers import _get_session as real
+    mod._get_session = real
+
+
+def test_returns_404_when_session_not_in_workspace() -> None:
+    client = _make_client(session_lookup_ok=False)
+    try:
+        resp = client.get(f"/glens/sessions/{SESSION_ID}/stream")
+        assert resp.status_code == 404
+    finally:
+        _teardown()
+
+
+def test_sse_frame_includes_id_line_when_entry_id_present() -> None:
+    frame = _sse_frame("1699999999999-0", '{"foo":"bar"}')
+    assert frame.startswith("id: 1699999999999-0\n")
+    assert 'data: {"foo":"bar"}' in frame
+    assert frame.endswith("\n\n")
+
+
+def test_sse_frame_omits_id_line_when_entry_id_blank() -> None:
+    frame = _sse_frame("", '{"foo":"bar"}')
+    assert not frame.startswith("id:")
+    assert frame == 'data: {"foo":"bar"}\n\n'
+
+
+def test_endpoint_is_registered_on_app() -> None:
+    """FastAPI does not always expose sub-router routes via app.routes at
+    the top level; the openapi schema is the authoritative source."""
+    schema = app.openapi()
+    assert "/glens/sessions/{session_id}/stream" in schema["paths"]
+    assert "get" in schema["paths"]["/glens/sessions/{session_id}/stream"]


### PR DESCRIPTION
## Summary

Actor helpers (\`dispatch_confirm\` / \`dispatch_cancel\` in \`app/modules/glens/actor/helpers.py\`) now publish an \`action.*\` event to the approval row's originating Lens session on success. Any subscriber on the session's SSE channel (PR 2) receives it and can update its bubble reactively.

**Depends on** #1485 (PR 1 — publisher) and #1486 (PR 2 — SSE endpoint). Stacked on the PR 2 branch — will re-target to \`main\` after both merge.

## Where events fire

1. \`dispatch_confirm\` — fresh execute succeeds  
   → \`action.confirmed\` with \`payload={tool_name, status, result}\`
2. \`dispatch_confirm\` — idempotent cached-return path  
   → \`action.confirmed\` with \`payload={..., cached: True}\`  
   So a second tab that missed the first event still gets the resolution.
3. \`dispatch_cancel\` — successful cancel  
   → \`action.cancelled\` with \`payload={tool_name, status}\`

## No-op cases (silent)

- \`row.session_id\` is NULL — HTTP actor calls without chat context; nothing to route to. Only Lens-originated actions carry \`session_id\` today; other paths keep NULL.
- Redis unavailable — \`publish_session_event\` is fail-open (PR 1); Redis outages never fail the underlying decide operation.

## Why in helpers, not routes

Both HTTP actor endpoint (\`POST /glens/actions/{id}/confirm\`) AND the LLM-callable \`confirm_pending_action\` tool (#1465) route through \`dispatch_confirm\`. Publishing in the helper means both surfaces tee the same event — button click and chat "yes" produce identical stream output. DRY win with no coupling cost.

## Test plan
- [x] 5 unit tests on \`_publish_action_event\` (no-op when session_id NULL, confirmed shape, cached flag, cancelled shape, UUID stringification)
- [x] Existing actor / publisher / session-stream tests still pass (29 total in the intersecting suite)
- [ ] Manual smoke (post-merge chain): open SSE stream, decide a Lens action from the UI, verify \`action.confirmed\` frame with correct entity id and payload

## What ships next

- **PR 4**: Frontend \`useLensSessionStream\` + reactive \`ActionConfirmBubble\` behind \`lens.sse_surface\` flag — first user-visible win
- **PR 5**: Worker publishes \`run.*\` events + \`<RunBubble>\` live progress

Part of #1480.