### PR TITLE
feat(lens): reactive ActionConfirmBubble via SSE session stream (#1480 PR 4)

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -3,6 +3,8 @@ import { API } from "@/lib/api"
 
 import { useEffect, useRef, useState } from "react"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { useLensEvent } from "@/hooks/useLensEvent"
+import { useLensSessionStream, type LensSessionStream } from "@/hooks/useLensSessionStream"
 import { GlensDashboard } from "@/components/glens/GlensDashboard"
 import type { GlensDashboardSpec } from "@/components/glens/GlensDashboard"
 import { GlensPageBubble } from "@/components/glens/GlensPageBubble"
@@ -829,6 +831,7 @@ function ActionConfirmBubble({
   warnings,
   expiresAt,
   authFetch,
+  stream,
   onResult,
 }: {
   toolName: string
@@ -837,10 +840,44 @@ function ActionConfirmBubble({
   warnings?: string[]
   expiresAt?: string
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
+  stream: LensSessionStream | null
   onResult: (text: string) => void
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
   const [idCopied, setIdCopied] = useState(false)
+  // Dedupe: whichever source (POST response or SSE event) reports resolution
+  // first wins. Race is fine because the payload shape is identical.
+  const handledRef = useRef(false)
+
+  const finish = (text: string) => {
+    if (handledRef.current) return
+    handledRef.current = true
+    setStatus("done")
+    onResult(text)
+  }
+
+  const messageForConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string): string => {
+    const result = (payload?.result ?? {}) as Record<string, unknown>
+    const label = (payload?.tool_name as string | undefined) ?? fallbackTool
+    const runId = result.run_id as string | undefined
+    if (runId) {
+      const wfName = (result.workflow_name as string | undefined) ?? label
+      return `Run started for **${wfName}**. [View run →](/runs/${runId})`
+    }
+    return `${label} executed successfully.`
+  }
+
+  // #1480 PR 4 — react to action.confirmed / action.cancelled events on the
+  // session stream. Fires for cross-tab confirms, Slack-side approvals, or
+  // any decide path that touches this row. `stream` is null when the SSE
+  // feature flag is off — subscription is a silent no-op then.
+  useLensEvent(stream, "approval", approvalRequestId, (evt) => {
+    if (evt.type === "action.confirmed") {
+      finish(messageForConfirmed(evt.payload, toolName))
+    } else if (evt.type === "action.cancelled") {
+      finish("Action cancelled.")
+    }
+  })
 
   async function post(action: "confirm" | "cancel") {
     setStatus("loading")
@@ -851,26 +888,22 @@ function ActionConfirmBubble({
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        onResult(`Failed to ${action}: ${err.detail ?? res.status}`)
+        finish(`Failed to ${action}: ${err.detail ?? res.status}`)
+        return
+      }
+      // When the SSE stream is live, it will call `finish` with the
+      // event-derived message; the POST body is redundant then. When SSE
+      // is off (flag disabled) or subscribed too late, fall through and
+      // use the response body directly. `finish` deduplicates either way.
+      const data = await res.json()
+      if (action === "confirm") {
+        finish(messageForConfirmed(data as Record<string, unknown>, toolName))
       } else {
-        const data = await res.json()
-        if (action === "confirm") {
-          const label = data.tool_name ?? toolName
-          const runId = data.result?.run_id as string | undefined
-          if (runId) {
-            const wfName = data.result?.workflow_name ?? label
-            onResult(`Run started for **${wfName}**. [View run →](/runs/${runId})`)
-          } else {
-            onResult(`${label} executed successfully.`)
-          }
-        } else {
-          onResult(`Action cancelled.`)
-        }
+        finish("Action cancelled.")
       }
     } catch {
-      onResult("Network error. Please try again.")
+      finish("Network error. Please try again.")
     }
-    setStatus("done")
   }
 
   const isMutation = toolName !== "decide_approval"  // heuristic — decide is itself an approve/reject
@@ -1028,6 +1061,10 @@ export function GLensChatPage() {
 
   const [sessions, setSessions] = useState<GLensSession[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
+  // #1480 PR 4 — SSE session stream. Returns null when the feature flag
+  // (NEXT_PUBLIC_LENS_SSE_SURFACE) is off or no active session yet; bubbles
+  // that opt in via useLensEvent silently degrade to the existing REST flow.
+  const lensStream = useLensSessionStream(activeId)
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(false)
   const [suggestions, setSuggestions] = useState<string[]>(DEFAULT_SUGGESTIONS)
@@ -1369,6 +1406,7 @@ export function GLensChatPage() {
                       warnings={msg.warnings}
                       expiresAt={msg.expiresAt}
                       authFetch={authFetch}
+                      stream={lensStream}
                       onResult={text => setMessages(prev => [
                         ...prev.slice(0, i),
                         { role: "assistant", kind: "answer", text },

--- a/apps/web/src/hooks/useLensEvent.ts
+++ b/apps/web/src/hooks/useLensEvent.ts
@@ -1,0 +1,35 @@
+"use client"
+
+/**
+ * Subscribe a component to Lens session events for one entity (#1480 PR 4).
+ *
+ * Component-level entity subscription — no global reducer, no coupled state.
+ * Each bubble subscribes to its own approval_id or run_id and reacts when
+ * events arrive from the session stream.
+ *
+ * Silent no-op when `stream` is null (feature flag off, or no active session).
+ */
+import { useEffect, useRef } from "react"
+
+import type { LensEvent, LensSessionStream } from "./useLensSessionStream"
+
+
+export function useLensEvent(
+  stream: LensSessionStream | null,
+  entityType: string,
+  entityId: string | null | undefined,
+  handler: (evt: LensEvent) => void,
+): void {
+  // Keep the latest handler in a ref so we don't tear down + re-subscribe
+  // every time the parent re-renders with a new closure.
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+
+  useEffect(() => {
+    if (!stream || !entityId) return
+    return stream.subscribe(
+      (evt) => evt.entity?.type === entityType && evt.entity?.id === entityId,
+      (evt) => handlerRef.current(evt),
+    )
+  }, [stream, entityType, entityId])
+}

--- a/apps/web/src/hooks/useLensSessionStream.ts
+++ b/apps/web/src/hooks/useLensSessionStream.ts
@@ -1,0 +1,159 @@
+"use client"
+
+/**
+ * Client for the Lens session SSE stream (#1480 PR 4).
+ *
+ *   GET /glens/sessions/{id}/stream  →  SSE frames of session events
+ *
+ * We use fetch + ReadableStream instead of the browser's EventSource so we
+ * can attach the Clerk Bearer token + X-Workspace-ID header (EventSource
+ * only supports cookies). The wire format is standard SSE; we parse it in
+ * ~30 lines below.
+ *
+ * Consumers use `useLensEvent(stream, entityType, entityId, handler)` from
+ * `useLensEvent.ts` to react to events for one entity (approval/run) without
+ * building a global reducer.
+ *
+ * Reconnect: on network error / stream end, wait 3s and reconnect with the
+ * last-seen event id so the server replays anything we missed.
+ *
+ * Feature flag: NEXT_PUBLIC_LENS_SSE_SURFACE === "true" — off by default.
+ */
+import { useEffect, useRef, useState } from "react"
+
+import { API } from "@/lib/api"
+
+import { useAuthFetch } from "./useAuthFetch"
+
+export type LensEvent = {
+  id: string
+  type: string
+  at: string
+  entity?: { type: string; id: string }
+  payload?: Record<string, unknown>
+}
+
+type Subscriber = {
+  predicate: (evt: LensEvent) => boolean
+  handler: (evt: LensEvent) => void
+}
+
+export type LensSessionStream = {
+  subscribe: (
+    predicate: (evt: LensEvent) => boolean,
+    handler: (evt: LensEvent) => void,
+  ) => () => void
+}
+
+const SSE_ENABLED = process.env.NEXT_PUBLIC_LENS_SSE_SURFACE === "true"
+const RECONNECT_DELAY_MS = 3000
+
+
+export function useLensSessionStream(sessionId: string | null): LensSessionStream | null {
+  const { authFetch } = useAuthFetch()
+  const subsRef = useRef<Subscriber[]>([])
+  const [stream, setStream] = useState<LensSessionStream | null>(null)
+
+  useEffect(() => {
+    if (!SSE_ENABLED || !sessionId) {
+      setStream(null)
+      return
+    }
+
+    let cancelled = false
+    let lastEventId: string | null = null
+    let controller = new AbortController()
+
+    const streamHandle: LensSessionStream = {
+      subscribe(predicate, handler) {
+        const sub = { predicate, handler }
+        subsRef.current.push(sub)
+        return () => {
+          subsRef.current = subsRef.current.filter((s) => s !== sub)
+        }
+      },
+    }
+    setStream(streamHandle)
+
+    const dispatch = (evt: LensEvent) => {
+      for (const sub of subsRef.current) {
+        try {
+          if (sub.predicate(evt)) sub.handler(evt)
+        } catch {
+          // Subscriber threw — swallow so one bad bubble doesn't nuke the stream.
+        }
+      }
+    }
+
+    const connect = async () => {
+      while (!cancelled) {
+        controller = new AbortController()
+        try {
+          const headers: Record<string, string> = {}
+          if (lastEventId) headers["Last-Event-Id"] = lastEventId
+          const res = await authFetch(`${API}/glens/sessions/${sessionId}/stream`, {
+            method: "GET",
+            headers,
+            signal: controller.signal,
+          })
+          if (!res.ok || !res.body) {
+            throw new Error(`stream open failed: ${res.status}`)
+          }
+
+          const reader = res.body.getReader()
+          const decoder = new TextDecoder()
+          let buf = ""
+
+          while (!cancelled) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buf += decoder.decode(value, { stream: true })
+
+            // SSE frames are separated by a blank line.
+            const parts = buf.split("\n\n")
+            buf = parts.pop() ?? ""
+            for (const raw of parts) {
+              // Ignore SSE comments (keepalives) — they start with ":".
+              if (raw.startsWith(":") || raw.trim() === "") continue
+
+              let idLine = ""
+              let dataLine = ""
+              for (const line of raw.split("\n")) {
+                if (line.startsWith("id: ")) idLine = line.slice(4)
+                else if (line.startsWith("data: ")) dataLine = line.slice(6)
+              }
+              if (!dataLine) continue
+
+              try {
+                const parsed = JSON.parse(dataLine) as LensEvent
+                if (idLine) lastEventId = idLine
+                else if (parsed.id) lastEventId = parsed.id
+                dispatch(parsed)
+              } catch {
+                // Malformed frame — skip, don't crash the stream.
+              }
+            }
+          }
+        } catch (err) {
+          if (cancelled) return
+          if (err instanceof Error && err.name === "AbortError") return
+          // Fall through to reconnect after delay.
+        }
+        if (cancelled) return
+        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS))
+      }
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      subsRef.current = []
+      setStream(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId])
+
+  return stream
+}


### PR DESCRIPTION
## Summary

**First user-visible slice** of the interactive SSE surface. Behind flag \`NEXT_PUBLIC_LENS_SSE_SURFACE\` — off by default, byte-for-byte parity with current behavior when off.

**Depends on** #1485 (PR 1), #1486 (PR 2), #1487 (PR 3). Stacked on the PR 3 branch.

## New hooks

### \`useLensSessionStream(sessionId)\`

Opens fetch-based SSE connection to \`GET /glens/sessions/{id}/stream\` (PR 2). We use fetch + ReadableStream instead of native \`EventSource\` so we can attach the Clerk Bearer token + \`X-Workspace-ID\` header — \`EventSource\` only supports cookies.

- **Reconnect**: on stream end / network error, wait 3s and reconnect with \`Last-Event-Id\` header so the server replays missed events
- **Flag gate at hook boundary**: returns null when off, so every downstream \`useLensEvent\` is a no-op
- **Cleanup on unmount** aborts the fetch

### \`useLensEvent(stream, entityType, entityId, handler)\`

Component-level entity subscription. No global reducer, no coupled state — each bubble subscribes to its own entity id and reacts. Handler held in a ref so parent re-renders don't tear down the subscription.

## \`ActionConfirmBubble\` migration

- Accepts new \`stream\` prop
- Subscribes to \`action.confirmed\` / \`action.cancelled\` events for its own \`approvalRequestId\`
- Dedupes via \`handledRef\` — whichever source (POST response or SSE event) arrives first wins. Race is fine because payloads carry identical shapes.
- POST-response fallback preserved: when SSE is off / not yet subscribed, response body drives the finish state (identical to pre-PR behavior)

**Behavior with flag OFF**: byte-for-byte identical to today. \`useLensEvent\` receives \`stream=null\`, \`useLensSessionStream\` returns null. POST handles everything.

**Behavior with flag ON**: cross-tab confirms + Slack-side approvals + any other decide path that touches the row now update the bubble live. The originating tab's own click still succeeds via POST-response fallback if SSE is slower.

## Test plan

- [x] TypeScript clean (\`tsc --noEmit\` — no errors)
- [x] Wire path: \`useLensSessionStream\` mounted in \`GLensChatPage\`, \`stream\` prop passed to \`ActionConfirmBubble\`
- [ ] Manual smoke (flag OFF): confirm/cancel a Lens action, behavior identical to today
- [ ] Manual smoke (flag ON, single tab): confirm a Lens action, verify SSE frame arrives and bubble updates
- [ ] Manual smoke (flag ON, cross-tab): open Lens in two tabs, confirm from one, verify the other tab's bubble also updates
- [ ] Manual smoke (flag ON, reconnect): close network for 10s during a pending action, verify SSE reconnects with Last-Event-Id and replays

## What ships next

- **PR 5**: Worker publishes \`run.*\` events + \`<RunBubble>\` live progress inline in chat instead of just a "View run →" link

Part of #1480.