### PR TITLE
feat(lens): worker run.status_changed events + live <RunBubble> (#1480 PR 5)

### DIFF
--- a/apps/api/app/modules/glens/run_events.py
+++ b/apps/api/app/modules/glens/run_events.py
@@ -1,0 +1,43 @@
+"""Publish run.* events on the Lens session channel (#1480 PR 5).
+
+Only Lens-originated runs (run.session_id is not NULL) push events —
+every other run trigger (workflow UI, CLI, webhooks, scheduler) leaves
+session_id NULL and this module skips silently.
+
+Runtime call sites:
+- executor.py at status → "running"  (worker picks up the run)
+- executor.py at status → "failed"   (worker crash / uncaught exception)
+- dag_runner.py at status → "succeeded" | "failed" (normal completion)
+
+Block-level events (run.block_started / run.block_completed) are a
+follow-up — this PR wires the coarse status transitions only, which
+already unlocks live pill updates on the <RunBubble>.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.run import Run
+from app.modules.glens.events import publish_session_event
+
+
+def publish_run_status(run: Run, *, error: str | None = None) -> None:
+    """Emit run.status_changed with the run's current status.
+
+    No-op when the run has no session_id — nothing to route to.
+    Fail-open inside publish_session_event (Redis outage never breaks
+    the worker).
+    """
+    if not getattr(run, "session_id", None):
+        return
+    payload: dict[str, Any] = {
+        "status": run.status,
+    }
+    if error:
+        payload["error"] = error
+    publish_session_event(
+        str(run.session_id),
+        "run.status_changed",
+        entity={"type": "run", "id": str(run.id)},
+        payload=payload,
+    )

--- a/apps/api/app/runtime/dag_runner.py
+++ b/apps/api/app/runtime/dag_runner.py
@@ -1254,6 +1254,13 @@ def _execute_dag(
     except Exception:
         pass
 
+    # #1480 PR 5 — tee terminal transition to Lens session stream when Lens-originated.
+    try:
+        from app.modules.glens.run_events import publish_run_status
+        publish_run_status(run, error=fail_error if failed else None)
+    except Exception:
+        pass
+
     if failed and not fail_summary and fail_error:
         fail_summary = _classify_failure(RuntimeError(fail_error), None)
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -231,6 +231,9 @@ def execute_run(run_id: str):
         run.attempt_count = (run.attempt_count or 0) + 1
         db.commit()
         _emit(db, run_id, None, "run_started", {"node_count": len((version.graph or {}).get("nodes", []))})
+        # #1480 PR 5 — tee to Lens session stream when Lens-originated.
+        from app.modules.glens.run_events import publish_run_status
+        publish_run_status(run)
 
         # Accumulated state — includes previous run segment outputs on resume
         state: dict[str, Any] = dict(run.state or {})
@@ -427,6 +430,12 @@ def execute_run(run_id: str):
                 db.commit()
                 _emit_run_analytics(run, None, {}, db, outcome="failed", error=str(e))
                 _enqueue_online_eval(str(run.id))
+                # #1480 PR 5 — surface worker crash on Lens session stream.
+                try:
+                    from app.modules.glens.run_events import publish_run_status
+                    publish_run_status(run, error=str(e))
+                except Exception:
+                    pass
         except Exception:
             pass
     finally:

--- a/apps/api/tests/glens/test_run_events_publisher.py
+++ b/apps/api/tests/glens/test_run_events_publisher.py
@@ -1,0 +1,70 @@
+"""Verify publish_run_status tees run.status_changed to the run's session
+channel — foundation for the <RunBubble> live status (#1480 PR 5).
+
+Contract:
+- No-op when run.session_id is None (non-Lens-originated runs)
+- Publishes entity=run + payload={status} on happy path
+- Includes error when passed
+- session_id and run.id stringified for the publisher
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.modules.glens.run_events import publish_run_status
+
+
+def _run(session_id="sess-abc", run_id="run-xyz", status="running"):
+    return SimpleNamespace(id=run_id, session_id=session_id, status=status)
+
+
+def test_no_publish_when_run_has_no_session_id() -> None:
+    """Runs from workflow UI / CLI / webhooks leave session_id NULL and
+    must not touch the session channel — nothing to route to."""
+    run = _run(session_id=None)
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    mock_pub.assert_not_called()
+
+
+def test_publishes_run_status_changed_with_entity_and_status() -> None:
+    run = _run(status="running")
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    session_id, event_type = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == "sess-abc"
+    assert event_type == "run.status_changed"
+    assert kwargs["entity"] == {"type": "run", "id": "run-xyz"}
+    assert kwargs["payload"] == {"status": "running"}
+
+
+def test_error_included_when_provided() -> None:
+    run = _run(status="failed")
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run, error="boom")
+    assert mock_pub.call_args.kwargs["payload"] == {"status": "failed", "error": "boom"}
+
+
+def test_uuid_ids_stringified() -> None:
+    import uuid
+    session_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    run = _run(session_id=session_uuid, run_id=run_uuid)
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    session_id, _ = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == str(session_uuid)
+    assert kwargs["entity"]["id"] == str(run_uuid)
+
+
+def test_no_publish_when_session_id_attr_missing() -> None:
+    """Defensive: SimpleNamespace without session_id at all — getattr default
+    catches this. Real Run rows always have the column post-PR-1 but tests
+    with dummy objects should still be safe."""
+    run = SimpleNamespace(id="r1", status="running")  # no session_id attr
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    mock_pub.assert_not_called()

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -36,6 +36,7 @@ type Message =
   | { role: "assistant"; kind: "page"; answer: string; pageKind: string; pageData: Record<string, unknown>; warning?: string; skill: string }
   | { role: "assistant"; kind: "policy_confirm"; answer: string; action: string; draft: Record<string, unknown>; mapping: PolicyMapping[]; targetRuleId?: string; sessionId: string; skill: string; warning?: string }
   | { role: "assistant"; kind: "action_confirm"; toolName: string; approvalRequestId: string; summary: string; warnings?: string[]; expiresAt?: string }
+  | { role: "assistant"; kind: "run"; runId: string; workflowName: string; initialStatus: string }
   | { role: "assistant"; kind: "blocks"; answer: string; blocks: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
   | { role: "assistant"; kind: "table"; answer: string; columns?: unknown[]; rows: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
 
@@ -833,6 +834,7 @@ function ActionConfirmBubble({
   authFetch,
   stream,
   onResult,
+  onRunStarted,
 }: {
   toolName: string
   approvalRequestId: string
@@ -842,6 +844,7 @@ function ActionConfirmBubble({
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
   stream: LensSessionStream | null
   onResult: (text: string) => void
+  onRunStarted?: (runId: string, workflowName: string, initialStatus: string) => void
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
   const [idCopied, setIdCopied] = useState(false)
@@ -849,22 +852,38 @@ function ActionConfirmBubble({
   // first wins. Race is fine because the payload shape is identical.
   const handledRef = useRef(false)
 
-  const finish = (text: string) => {
+  const finishText = (text: string) => {
     if (handledRef.current) return
     handledRef.current = true
     setStatus("done")
     onResult(text)
   }
 
-  const messageForConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string): string => {
+  const finishRun = (runId: string, workflowName: string, initialStatus: string) => {
+    if (handledRef.current) return
+    handledRef.current = true
+    setStatus("done")
+    if (onRunStarted) {
+      onRunStarted(runId, workflowName, initialStatus)
+    } else {
+      // Flag OFF or no run-bubble callback wired — fall back to text link.
+      onResult(`Run started for **${workflowName}**. [View run →](/runs/${runId})`)
+    }
+  }
+
+  const dispatchConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string) => {
     const result = (payload?.result ?? {}) as Record<string, unknown>
     const label = (payload?.tool_name as string | undefined) ?? fallbackTool
     const runId = result.run_id as string | undefined
     if (runId) {
       const wfName = (result.workflow_name as string | undefined) ?? label
-      return `Run started for **${wfName}**. [View run →](/runs/${runId})`
+      // Initial status from the run row when we have it; "pending" otherwise
+      // (the worker will emit run.status_changed within seconds).
+      const initialStatus = (result.status as string | undefined) ?? "pending"
+      finishRun(runId, wfName, initialStatus)
+    } else {
+      finishText(`${label} executed successfully.`)
     }
-    return `${label} executed successfully.`
   }
 
   // #1480 PR 4 — react to action.confirmed / action.cancelled events on the
@@ -873,9 +892,9 @@ function ActionConfirmBubble({
   // feature flag is off — subscription is a silent no-op then.
   useLensEvent(stream, "approval", approvalRequestId, (evt) => {
     if (evt.type === "action.confirmed") {
-      finish(messageForConfirmed(evt.payload, toolName))
+      dispatchConfirmed(evt.payload, toolName)
     } else if (evt.type === "action.cancelled") {
-      finish("Action cancelled.")
+      finishText("Action cancelled.")
     }
   })
 
@@ -888,21 +907,21 @@ function ActionConfirmBubble({
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        finish(`Failed to ${action}: ${err.detail ?? res.status}`)
+        finishText(`Failed to ${action}: ${err.detail ?? res.status}`)
         return
       }
-      // When the SSE stream is live, it will call `finish` with the
+      // When the SSE stream is live, it will call `finish*` with the
       // event-derived message; the POST body is redundant then. When SSE
       // is off (flag disabled) or subscribed too late, fall through and
-      // use the response body directly. `finish` deduplicates either way.
+      // use the response body directly. `handledRef` deduplicates either way.
       const data = await res.json()
       if (action === "confirm") {
-        finish(messageForConfirmed(data as Record<string, unknown>, toolName))
+        dispatchConfirmed(data as Record<string, unknown>, toolName)
       } else {
-        finish("Action cancelled.")
+        finishText("Action cancelled.")
       }
     } catch {
-      finish("Network error. Please try again.")
+      finishText("Network error. Please try again.")
     }
   }
 
@@ -972,6 +991,65 @@ function ActionConfirmBubble({
           </div>
         )}
         {status === "loading" && <div style={{ fontSize: 13, color: "var(--text-muted)" }}>Working…</div>}
+      </div>
+    </div>
+  )
+}
+
+// ─── Run bubble ──────────────────────────────────────────────────────────────
+// #1480 PR 5 — live run status inline in chat. Subscribes to run.status_changed
+// events on the session stream and updates its pill in place. Always renders
+// the "View run →" link so the user can jump to the run detail page.
+
+function RunBubble({
+  runId,
+  workflowName,
+  initialStatus,
+  stream,
+}: {
+  runId: string
+  workflowName: string
+  initialStatus: string
+  stream: LensSessionStream | null
+}) {
+  const [status, setStatus] = useState(initialStatus)
+  const [error, setError] = useState<string | null>(null)
+
+  useLensEvent(stream, "run", runId, (evt) => {
+    if (evt.type !== "run.status_changed") return
+    const nextStatus = (evt.payload?.status as string | undefined) ?? status
+    setStatus(nextStatus)
+    const evtErr = evt.payload?.error as string | undefined
+    if (evtErr) setError(evtErr)
+  })
+
+  const pillColor = (() => {
+    switch (status) {
+      case "succeeded": return { bg: "var(--ok-bg, #dcfce7)", fg: "var(--ok-text, #166534)" }
+      case "failed":    return { bg: "var(--err-bg, #fee2e2)", fg: "var(--err-text, #991b1b)" }
+      case "running":   return { bg: "var(--accent-weak, rgba(59,130,246,0.12))", fg: "var(--accent-text, #2563eb)" }
+      default:          return { bg: "var(--surface-3, #f3f4f6)", fg: "var(--text-muted)" }
+    }
+  })()
+
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
+      <div style={{ maxWidth: "80%", background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: "4px 14px 14px 14px", padding: "16px 20px" }}>
+        <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>Run · {workflowName}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+          <span style={{
+            fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 999,
+            background: pillColor.bg, color: pillColor.fg, textTransform: "capitalize",
+          }}>{status}</span>
+          <a href={`/runs/${runId}`} style={{ fontSize: 13, color: "var(--accent)", textDecoration: "none" }}>
+            View run →
+          </a>
+        </div>
+        {error && (
+          <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
+            {error}
+          </div>
+        )}
       </div>
     </div>
   )
@@ -1412,6 +1490,19 @@ export function GLensChatPage() {
                         { role: "assistant", kind: "answer", text },
                         ...prev.slice(i + 1),
                       ])}
+                      onRunStarted={lensStream ? (runId, wfName, initialStatus) => setMessages(prev => [
+                        ...prev.slice(0, i),
+                        { role: "assistant", kind: "run", runId, workflowName: wfName, initialStatus },
+                        ...prev.slice(i + 1),
+                      ]) : undefined}
+                    />
+                  )}
+                  {msg.kind === "run" && (
+                    <RunBubble
+                      runId={msg.runId}
+                      workflowName={msg.workflowName}
+                      initialStatus={msg.initialStatus}
+                      stream={lensStream}
                     />
                   )}
                   {msg.kind === "policy_confirm" && (


### PR DESCRIPTION
## Summary

**The big user-visible slice.** Lens-originated runs now push status transitions into the chat surface. The static "View run →" link becomes a live-updating \`<RunBubble>\` with a pill that reflects **pending → running → succeeded / failed** as the worker progresses.

Behind the same flag as PR 4: \`NEXT_PUBLIC_LENS_SSE_SURFACE\`. Zero change when flag off — text link fallback preserved.

**Depends on** #1485, #1486, #1487, #1489. Stacked on PR 4 branch.

## Backend

New helper: \`apps/api/app/modules/glens/run_events.py\`

\`\`\`python
publish_run_status(run, error=None)
\`\`\`

No-op when \`run.session_id\` is None (non-Lens runs — workflow UI, CLI, webhooks, scheduler, etc.). Fail-open via \`publish_session_event\` (PR 1).

Wired at three transitions:

1. \`executor.py\` — status → \`"running"\` (worker picks up the run)
2. \`executor.py\` — status → \`"failed"\` (worker crash / uncaught exception)
3. \`dag_runner.py\` — status → \`"succeeded"\` | \`"failed"\` (normal completion)

Block-level events (\`run.block_started\` / \`run.block_completed\`) are **follow-up scope** — the coarse transitions already unlock live pill updates, which is the user-visible win.

## Frontend

New message kind: \`{ kind: "run"; runId; workflowName; initialStatus }\`

New component: \`<RunBubble runId workflowName initialStatus stream />\`

- Subscribes to \`run.status_changed\` via \`useLensEvent\` (PR 4)
- Renders status pill with color mapping (running=blue, succeeded=green, failed=red)
- Shows worker's error message inline when failed
- Always renders "View run →" link to \`/runs/{runId}\`

\`ActionConfirmBubble.dispatchConfirmed\` dispatches to either \`onRunStarted\` (when we have a \`run_id\` AND \`onRunStarted\` is wired — only true when \`lensStream\` is live) or \`onResult\` (text link fallback). Dedupe via \`handledRef\` unchanged from PR 4.

## Behavior matrix

| Flag OFF | Flag ON |
|----------|---------|
| Text: \`Run started for X. [View run →](/runs/id)\` | \`<RunBubble>\` renders inline. Pill starts "pending", flips to "running" when worker picks up, then "succeeded" or "failed" on completion. Worker error surfaces inline. |

## Test plan
- [x] 98 glens tests pass (5 new tests on \`publish_run_status\`)
- [x] TypeScript clean (\`tsc --noEmit\`)
- [x] Publisher smoke — no-op on missing session_id, correct entity/payload shape, error propagates, UUIDs stringified
- [ ] Manual smoke (flag OFF): confirm a Lens run_workflow action, verify text link fallback (byte-for-byte parity)
- [ ] Manual smoke (flag ON): confirm a run_workflow action, watch pill transition pending → running → succeeded
- [ ] Manual smoke (worker crash): trigger a failure, verify "failed" pill + error message renders

## What's next (post-#1480 v1)

- Block-level events: \`run.block_started\` / \`run.block_completed\` for step-by-step progress
- Slack-side approval events: \`approval.decided\` from Slack webhooks
- Feature flag removal after 2 weeks of green telemetry
- Cancel-over-SSE (unlikely — REST commands work fine)

Closes the v1 pipeline for #1480. Post-merge cleanup: rebase PR 2/3/4 branches to \`main\` after each parent merges.

Part of #1480.