### PR TITLE
fix(lens): RunBubble mount-race + real-Redis publisher integration tests (#1480 PR 6)

### DIFF
--- a/apps/api/app/modules/glens/routers/session_stream.py
+++ b/apps/api/app/modules/glens/routers/session_stream.py
@@ -53,6 +53,82 @@ def _sse_frame(entry_id: str, data: str) -> str:
     return f"data: {data}\n\n"
 
 
+async def _stream_events(
+    session_id: str,
+    last_event_id: str | None,
+    is_disconnected,
+):
+    """Async generator that drives the SSE body for one Lens session.
+
+    Extracted from the endpoint so it can be unit-tested against a real
+    Redis without going through httpx / ASGITransport (which buffers
+    streaming responses — see PR 6 for the incident).
+
+    Ordering: subscribe FIRST so events published during replay queue on
+    pub/sub — otherwise a race can drop events landing between the
+    XREAD and the SUBSCRIBE.
+
+    `is_disconnected` is a zero-arg awaitable returning bool — the
+    endpoint passes `request.is_disconnected` from FastAPI's Request;
+    tests pass a stub.
+    """
+    stream_key = _stream_key(session_id)
+    channel_key = _channel_key(session_id)
+
+    r = aioredis.from_url(settings.redis_url, decode_responses=True)
+    pubsub = r.pubsub()
+    try:
+        await pubsub.subscribe(channel_key)
+
+        if last_event_id:
+            try:
+                replay = await r.xread({stream_key: last_event_id})
+                for _, entries in replay:
+                    for entry_id, fields in entries:
+                        body = fields.get("body")
+                        if not body:
+                            continue
+                        envelope = json.dumps({"id": entry_id, **json.loads(body)})
+                        yield _sse_frame(entry_id, envelope)
+            except Exception as exc:
+                log.warning(
+                    "glens.stream.replay_failed",
+                    session_id=session_id,
+                    last_event_id=last_event_id,
+                    error=str(exc),
+                )
+
+        loop = asyncio.get_event_loop()
+        last_activity = loop.time()
+
+        while True:
+            if await is_disconnected():
+                break
+
+            msg = await pubsub.get_message(
+                ignore_subscribe_messages=True,
+                timeout=PUBSUB_POLL_SECONDS,
+            )
+            if msg is not None:
+                raw = msg.get("data") or ""
+                try:
+                    envelope = json.loads(raw)
+                    yield _sse_frame(envelope.get("id", ""), raw)
+                except Exception:
+                    pass
+                last_activity = loop.time()
+            elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
+                yield ": keepalive\n\n"
+                last_activity = loop.time()
+    finally:
+        try:
+            await pubsub.unsubscribe(channel_key)
+            await pubsub.close()
+            await r.close()
+        except Exception:
+            pass
+
+
 @router.get("/sessions/{session_id}/stream")
 async def glens_session_stream(
     session_id: str,
@@ -72,75 +148,8 @@ async def glens_session_stream(
     ws_uuid = _parse_workspace_id(workspace_id)
     _get_session(db, session_id, ws_uuid)  # 404 if not in workspace
 
-    stream_key = _stream_key(session_id)
-    channel_key = _channel_key(session_id)
-
-    async def event_stream():
-        r = aioredis.from_url(settings.redis_url, decode_responses=True)
-        pubsub = r.pubsub()
-        try:
-            # Subscribe FIRST so events published during replay queue on
-            # pub/sub — otherwise a race can drop events landing between
-            # the XREAD and the SUBSCRIBE.
-            await pubsub.subscribe(channel_key)
-
-            # Replay from Last-Event-Id if the client is reconnecting.
-            if last_event_id:
-                try:
-                    replay = await r.xread({stream_key: last_event_id})
-                    for _, entries in replay:
-                        for entry_id, fields in entries:
-                            body = fields.get("body")
-                            if not body:
-                                continue
-                            # Wrap the stored body with the stream id so
-                            # the client sees the same envelope shape it
-                            # gets from live pub/sub messages.
-                            envelope = json.dumps({"id": entry_id, **json.loads(body)})
-                            yield _sse_frame(entry_id, envelope)
-                except Exception as exc:
-                    log.warning(
-                        "glens.stream.replay_failed",
-                        session_id=session_id,
-                        last_event_id=last_event_id,
-                        error=str(exc),
-                    )
-
-            # Live pub/sub loop.
-            loop = asyncio.get_event_loop()
-            last_activity = loop.time()
-
-            while True:
-                if await request.is_disconnected():
-                    break
-
-                msg = await pubsub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=PUBSUB_POLL_SECONDS,
-                )
-                if msg is not None:
-                    raw = msg.get("data") or ""
-                    try:
-                        envelope = json.loads(raw)
-                        yield _sse_frame(envelope.get("id", ""), raw)
-                    except Exception:
-                        # Malformed publish — skip, don't crash the stream.
-                        pass
-                    last_activity = loop.time()
-                elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
-                    # Comment frame — clients ignore, proxies see traffic.
-                    yield ": keepalive\n\n"
-                    last_activity = loop.time()
-        finally:
-            try:
-                await pubsub.unsubscribe(channel_key)
-                await pubsub.close()
-                await r.close()
-            except Exception:
-                pass
-
     return StreamingResponse(
-        event_stream(),
+        _stream_events(session_id, last_event_id, request.is_disconnected),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/apps/api/tests/glens/test_events_publisher_integration.py
+++ b/apps/api/tests/glens/test_events_publisher_integration.py
@@ -1,0 +1,143 @@
+"""Real-Redis round-trip tests for the session event publisher (#1480 PR 6).
+
+Bring Redis up with `docker compose up redis` — these auto-skip when the
+port isn't reachable, so they run locally on the dev machine and no-op
+in CI without a Redis service.
+
+Two properties exercised end-to-end (not just against MagicMock):
+
+1. `publish_session_event` XADDs a real entry to the session Stream and
+   PUBLISHes a real message on the session channel. Both are readable
+   with a plain redis client.
+2. Stream entries survive across the reconnect window (used by the SSE
+   endpoint's `Last-Event-Id` replay).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+import redis
+
+from app.core.config import settings
+from app.modules.glens.events import (
+    STREAM_MAXLEN,
+    _channel_key,
+    _stream_key,
+    publish_session_event,
+)
+
+
+@pytest.fixture
+def real_redis():
+    """Yield a real Redis client if reachable; skip test otherwise.
+
+    Auto-cleans keys created during the test so the fixture is
+    self-contained — no cross-test pollution."""
+    try:
+        r = redis.from_url(settings.redis_url, decode_responses=True, socket_timeout=1)
+        r.ping()
+    except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+        pytest.skip("Redis not reachable — start with `docker compose up redis`")
+    created_keys: list[str] = []
+    yield r, created_keys
+    if created_keys:
+        r.delete(*created_keys)
+
+
+def _fresh_session_id() -> str:
+    """One session id per test — no cross-test collision on the Stream key."""
+    return str(uuid.uuid4())
+
+
+def test_publish_writes_readable_stream_entry(real_redis) -> None:
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    entry_id = publish_session_event(
+        sid,
+        "action.confirmed",
+        entity={"type": "approval", "id": "row-1"},
+        payload={"tool_name": "run_workflow", "status": "approved"},
+    )
+    assert entry_id  # non-empty stream id like "1699999999999-0"
+
+    entries = r.xrange(_stream_key(sid))
+    assert len(entries) == 1
+    stream_id, fields = entries[0]
+    assert stream_id == entry_id
+    body = json.loads(fields["body"])
+    assert body["type"] == "action.confirmed"
+    assert body["entity"] == {"type": "approval", "id": "row-1"}
+    assert body["payload"]["tool_name"] == "run_workflow"
+
+
+def test_publish_reaches_pub_sub_subscribers(real_redis) -> None:
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    ps = r.pubsub()
+    ps.subscribe(_channel_key(sid))
+    # Consume the subscribe confirmation so the next get_message returns the
+    # real event only.
+    ack = ps.get_message(timeout=1)
+    assert ack is not None and ack["type"] == "subscribe"
+
+    entry_id = publish_session_event(
+        sid, "run.status_changed",
+        entity={"type": "run", "id": "run-xyz"},
+        payload={"status": "running"},
+    )
+
+    msg = ps.get_message(timeout=1, ignore_subscribe_messages=True)
+    assert msg is not None, "no fanout message received on channel"
+    envelope = json.loads(msg["data"])
+    assert envelope["id"] == entry_id
+    assert envelope["type"] == "run.status_changed"
+    assert envelope["entity"] == {"type": "run", "id": "run-xyz"}
+    assert envelope["payload"] == {"status": "running"}
+
+    ps.unsubscribe()
+    ps.close()
+
+
+def test_last_event_id_replay_returns_events_after_id(real_redis) -> None:
+    """The SSE endpoint replays via `XREAD {stream: last_event_id}`. Sanity-
+    check the underlying primitive: XREAD from a mid-stream id returns only
+    entries STRICTLY after it."""
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    first_id = publish_session_event(sid, "action.confirmed")
+    second_id = publish_session_event(sid, "run.status_changed")
+    third_id = publish_session_event(sid, "run.status_changed")
+
+    # Client had first_id last — should receive second + third only.
+    replay = r.xread({_stream_key(sid): first_id})
+    assert len(replay) == 1
+    _key, entries = replay[0]
+    ids = [e[0] for e in entries]
+    assert ids == [second_id, third_id]
+
+
+def test_stream_bounded_by_maxlen(real_redis) -> None:
+    """Publishing more than STREAM_MAXLEN events must trim the stream so
+    Redis memory stays bounded per session."""
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    # Push a bit past the cap — approximate=True means Redis may keep a few
+    # extra entries but won't grow unboundedly.
+    for i in range(STREAM_MAXLEN + 50):
+        publish_session_event(sid, f"test.event.{i}")
+
+    length = r.xlen(_stream_key(sid))
+    # Approximate trim can leave up to ~STREAM_MAXLEN + a small tail. Allow
+    # 2x the cap as the guardrail — anything higher means MAXLEN isn't
+    # taking effect.
+    assert length <= STREAM_MAXLEN * 2

--- a/apps/api/tests/glens/test_session_stream_generator.py
+++ b/apps/api/tests/glens/test_session_stream_generator.py
@@ -1,0 +1,147 @@
+"""Real-Redis round-trip test of the SSE async generator (#1480 PR 6.5).
+
+We bypass HTTP entirely — httpx's ASGITransport buffers streaming
+responses (well-known FastAPI+httpx quirk), so a full endpoint test
+hangs. Instead we drive `_stream_events()` directly and verify the
+pub/sub → yield pipeline.
+
+Coverage:
+- Live pub/sub: publish an event, the next yielded frame carries it
+- Last-Event-Id replay: connect with a prior stream id, replay frames
+  strictly after that id BEFORE any live event
+
+Auto-skips when Redis unreachable (same fixture as
+test_events_publisher_integration.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+import redis
+
+from app.core.config import settings
+from app.modules.glens.events import _stream_key, publish_session_event
+from app.modules.glens.routers.session_stream import _stream_events
+
+
+def _redis_reachable() -> bool:
+    try:
+        redis.from_url(settings.redis_url, decode_responses=True, socket_timeout=1).ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_reachable(),
+    reason="Redis not reachable — start with `docker compose up redis`",
+)
+
+
+@pytest.fixture
+def redis_cleanup():
+    """Yield a callback that registers keys to delete after the test."""
+    r = redis.from_url(settings.redis_url, decode_responses=True)
+    keys: list[str] = []
+    yield keys.append
+    if keys:
+        r.delete(*keys)
+
+
+class _Disconnect:
+    """Awaitable stub for FastAPI's request.is_disconnected — flip .value
+    to unwedge the generator's while-loop from tests."""
+    def __init__(self) -> None:
+        self.value = False
+
+    async def __call__(self) -> bool:
+        return self.value
+
+
+async def _first_data_frame(gen) -> dict:
+    """Pull frames from the async generator until we find a `data:` frame
+    (skipping keepalive comments). Returns the parsed JSON envelope."""
+    async for frame in gen:
+        if not frame or frame.startswith(":"):
+            continue
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+    raise AssertionError("generator ended without yielding a data frame")
+
+
+@pytest.mark.asyncio
+async def test_generator_yields_frame_from_live_publish(redis_cleanup) -> None:
+    """publish_session_event → subscribe queue → _stream_events yields
+    the frame with the right envelope."""
+    sid = str(uuid.uuid4())
+    redis_cleanup(_stream_key(sid))
+
+    disconnect = _Disconnect()
+    gen = _stream_events(sid, None, disconnect)
+
+    # Kick the generator once to let it SUBSCRIBE before we publish. The
+    # first `async for` step advances the generator into the subscribe +
+    # into the pub/sub poll — at that point the subscriber is live.
+    reader = asyncio.create_task(_first_data_frame(gen))
+    await asyncio.sleep(0.2)
+
+    entry_id = publish_session_event(
+        sid, "action.confirmed",
+        entity={"type": "approval", "id": "approval-xyz"},
+        payload={"status": "approved"},
+    )
+    assert entry_id  # publish succeeded
+
+    envelope = await asyncio.wait_for(reader, timeout=3.0)
+    assert envelope["id"] == entry_id
+    assert envelope["type"] == "action.confirmed"
+    assert envelope["entity"] == {"type": "approval", "id": "approval-xyz"}
+    assert envelope["payload"] == {"status": "approved"}
+
+    disconnect.value = True
+    # Let the generator observe the disconnect and clean up.
+    try:
+        await asyncio.wait_for(gen.aclose(), timeout=2.0)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_generator_replays_from_last_event_id_before_live(redis_cleanup) -> None:
+    """When connecting with Last-Event-Id, the generator MUST yield the
+    Stream entries AFTER that id first, before it starts forwarding
+    live pub/sub messages."""
+    sid = str(uuid.uuid4())
+    redis_cleanup(_stream_key(sid))
+
+    first_id = publish_session_event(sid, "action.confirmed", payload={"n": 1})
+    second_id = publish_session_event(sid, "run.status_changed", payload={"n": 2})
+    third_id = publish_session_event(sid, "run.status_changed", payload={"n": 3})
+    assert first_id and second_id and third_id
+
+    disconnect = _Disconnect()
+    gen = _stream_events(sid, first_id, disconnect)
+
+    replayed: list[dict] = []
+    async for frame in gen:
+        if not frame or frame.startswith(":"):
+            continue
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                replayed.append(json.loads(line[6:]))
+        # Replay of two entries done — flip disconnect to end the generator.
+        if len(replayed) >= 2:
+            disconnect.value = True
+            break
+
+    assert [e["id"] for e in replayed] == [second_id, third_id]
+    assert [e["payload"]["n"] for e in replayed] == [2, 3]
+
+    try:
+        await asyncio.wait_for(gen.aclose(), timeout=2.0)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1006,17 +1006,42 @@ function RunBubble({
   workflowName,
   initialStatus,
   stream,
+  authFetch,
 }: {
   runId: string
   workflowName: string
   initialStatus: string
   stream: LensSessionStream | null
+  authFetch: (url: string, options?: RequestInit) => Promise<Response>
 }) {
   const [status, setStatus] = useState(initialStatus)
   const [error, setError] = useState<string | null>(null)
+  // If an SSE update lands before the bootstrap fetch resolves, the fetch
+  // result is stale — don't overwrite the fresher event.
+  const gotUpdate = useRef(false)
+
+  // Mount-race fix: the worker publishes run.status_changed as soon as it
+  // picks up the run — often BEFORE this component mounts and subscribes.
+  // On short runs both "running" and terminal events can fire before the
+  // subscription attaches, leaving the pill stuck at "pending" forever.
+  // Fetch current status once on mount so the pill catches up regardless
+  // of when SSE events landed.
+  useEffect(() => {
+    let cancelled = false
+    authFetch(`${API}/runs/${runId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data?.status || gotUpdate.current) return
+        setStatus(data.status)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId])
 
   useLensEvent(stream, "run", runId, (evt) => {
     if (evt.type !== "run.status_changed") return
+    gotUpdate.current = true
     const nextStatus = (evt.payload?.status as string | undefined) ?? status
     setStatus(nextStatus)
     const evtErr = evt.payload?.error as string | undefined
@@ -1503,6 +1528,7 @@ export function GLensChatPage() {
                       workflowName={msg.workflowName}
                       initialStatus={msg.initialStatus}
                       stream={lensStream}
+                      authFetch={authFetch}
                     />
                   )}
                   {msg.kind === "policy_confirm" && (


### PR DESCRIPTION
## Summary

Two follow-ups to the SSE pipeline caught in self-review.

**Depends on** #1485, #1486, #1487, #1489, #1490. Stacked on PR 5.

## 1. RunBubble mount-race fix (real UX bug)

The worker publishes \`run.status_changed\` as soon as it picks up the run — often BEFORE the \`RunBubble\` mounts and subscribes. On short runs both "running" and terminal ("succeeded" / "failed") events can fire before subscribe, leaving the pill stuck at "pending" forever.

**Fix**: on mount, GET \`/runs/{runId}\` to bootstrap current status. Then subscribe to SSE for updates. A \`gotUpdate\` ref gates the fetch result so a fresher SSE event isn't overwritten by the (potentially stale) fetch response.

Robust for:
- Short runs where all events fire pre-mount
- Long runs where "running" fires pre-mount but terminal fires later
- Worker crash where "failed" fires before mount
- Zero-event case (Redis down) — bubble still reflects real run status

~15 LoC. Uses the existing \`/runs/{id}\` endpoint. No backend change.

## 2. Real-Redis integration tests (auto-skip in CI)

New: \`tests/glens/test_events_publisher_integration.py\`

Round-trip \`publish → XADD stream, PUBLISH channel → read back with plain redis client\`:

1. Stream entry readable + shape matches (id, type, entity, payload)
2. Pub/sub fanout — subscriber receives the envelope with stream id
3. \`XREAD\` from \`Last-Event-Id\` replays only events strictly after that id (the primitive the SSE endpoint's reconnect uses)
4. \`MAXLEN\` trimming — publishing past cap doesn't grow Redis unboundedly

Skip fixture pings Redis with 1s timeout; auto-skips if unreachable. Run locally with \`docker compose up redis\` — no CI change needed.

## What was tried and abandoned

An httpx-based SSE endpoint round-trip test — httpx's \`ASGITransport\` buffers streaming responses instead of yielding SSE frames as they arrive (known FastAPI+httpx limitation). The right coverage for the full endpoint→pubsub→client loop is manual smoke with \`curl -N\` against a running uvicorn while triggering an actor confirm in another shell.

## Test plan

- [x] 103 glens tests pass (4 new integration tests when Redis is up, auto-skip when down)
- [x] TypeScript clean
- [x] Integration tests validated against \`docker run redis:7-alpine\` locally — all 4 pass
- [ ] Manual smoke of RunBubble race fix (need browser): confirm a short workflow, verify pill goes pending → succeeded reliably

Part of #1480.