### PR TITLE
feat(lens): list_my_runs + list_runs_in_session tools (#1480 PR 8)

### DIFF
--- a/apps/api/app/tools/registrations/lens/__init__.py
+++ b/apps/api/app/tools/registrations/lens/__init__.py
@@ -36,6 +36,7 @@ from app.tools.registrations.lens import (
     ops,
     policies,
     primitives,
+    runs,
     workflows,
     workspace,
 )
@@ -45,6 +46,7 @@ _ALL_TOOLS = [
     *guard_core.TOOLS,
     *policies.TOOLS,
     *workflows.TOOLS,
+    *runs.TOOLS,
     *workspace.TOOLS,
     *marketplace.TOOLS,
     *ops.TOOLS,

--- a/apps/api/app/tools/registrations/lens/runs.py
+++ b/apps/api/app/tools/registrations/lens/runs.py
@@ -1,0 +1,169 @@
+"""Lens tool registrations — run history (#1480 PR 8).
+
+Two tools that let Lens surface a user's / a session's run history without
+leaving the chat surface:
+
+- `list_my_runs` — cross-session, workspace-scoped, filtered by the calling
+  user's clerk_user_id (from `ctx`). Answers "what did I run today?"
+- `list_runs_in_session` — filter by the SSE session id introduced in PR 1.
+  Answers "what did we run in this conversation?"
+
+Both are read-only free-function tools (not routed through Executor) so
+we can read the current user + session directly from ctx.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from app.tools.types import ToolDef
+from app.tools.registrations.lens._shared import (
+    _LIMIT,
+    _LENS_TAGS,
+    _READ_ONLY,
+)
+
+
+_RUN_STATUS_ENUM = ["pending", "running", "paused", "succeeded", "failed", "cancelled"]
+
+
+def _serialize_row(row) -> dict[str, Any]:
+    """Common row shape — matches list_runs so consumers can share rendering."""
+    r = row.Run
+    return {
+        "run_id": str(r.id),
+        "workflow_id": str(row.workflow_id),
+        "workflow_name": row.workflow_name,
+        "status": r.status,
+        "triggered_by": r.triggered_by,
+        "started_at": r.started_at.isoformat() if r.started_at else None,
+        "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "actual_turns": r.actual_turns,
+    }
+
+
+def list_my_runs(ctx, status: str | None = None, limit: int = 20):
+    """Recent runs triggered by the current user across the workspace org.
+
+    Only returns runs where `triggered_by` matches the caller's
+    clerk_user_id — auth is enforced by ctx, not by the LLM. Same as
+    list_runs but scoped to me.
+    """
+    from app.core.database import SessionLocal
+    from app.models.run import Run
+    from app.models.workflow import Workflow, WorkflowVersion
+    from app.modules.glens.executor import _org_ws_subquery
+
+    clerk_user_id = getattr(ctx, "clerk_user_id", None)
+    if not clerk_user_id or clerk_user_id.startswith("system:"):
+        return {"error": "list_my_runs requires a real user context (not system/lens actor)"}
+
+    db = SessionLocal()
+    try:
+        org_ws = _org_ws_subquery(db, ctx.workspace_id)
+        q = (
+            db.query(Run, Workflow.name.label("workflow_name"), Workflow.id.label("workflow_id"))
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, WorkflowVersion.workflow_id == Workflow.id)
+            .filter(Run.workspace_id.in_(org_ws))
+            .filter(Run.triggered_by == clerk_user_id)
+        )
+        if status:
+            q = q.filter(Run.status == status)
+        rows = q.order_by(Run.created_at.desc()).limit(min(limit, 100)).all()
+        return [_serialize_row(row) for row in rows]
+    finally:
+        db.close()
+
+
+def list_runs_in_session(ctx, session_id: str | None = None, status: str | None = None, limit: int = 20):
+    """Runs triggered from a Lens chat session (populated by PR 1's
+    runs.session_id column). Defaults to the current session in ctx.
+    """
+    from app.core.database import SessionLocal
+    from app.models.run import Run
+    from app.models.workflow import Workflow, WorkflowVersion
+    from app.modules.glens.executor import _org_ws_subquery
+
+    sid = session_id or getattr(ctx, "session_id", None)
+    if not sid:
+        return {"error": "session_id required (no current session in ctx)"}
+    try:
+        sid_uuid = uuid.UUID(sid)
+    except (ValueError, TypeError):
+        return {"error": "session_id must be a UUID"}
+
+    db = SessionLocal()
+    try:
+        org_ws = _org_ws_subquery(db, ctx.workspace_id)
+        q = (
+            db.query(Run, Workflow.name.label("workflow_name"), Workflow.id.label("workflow_id"))
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, WorkflowVersion.workflow_id == Workflow.id)
+            .filter(Run.workspace_id.in_(org_ws))
+            .filter(Run.session_id == sid_uuid)
+        )
+        if status:
+            q = q.filter(Run.status == status)
+        rows = q.order_by(Run.created_at.desc()).limit(min(limit, 100)).all()
+        return [_serialize_row(row) for row in rows]
+    finally:
+        db.close()
+
+
+TOOLS: list[ToolDef] = [
+    ToolDef(
+        name="list_my_runs",
+        description=(
+            "Recent workflow runs triggered by the CURRENT user in this workspace org. "
+            "Use for 'what did I run today', 'my recent runs', 'show my last workflow'. "
+            "Returns run_id, workflow_name, status, timings. Cross-session — spans "
+            "every Lens conversation the user has had. For a single-session view "
+            "use list_runs_in_session instead."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": _RUN_STATUS_ENUM,
+                    "description": "Filter to one lifecycle state",
+                },
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=list_my_runs,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="list_runs_in_session",
+        description=(
+            "Runs triggered from THIS Lens chat session (or a specific session_id). "
+            "Use for 'what did we run here', 'runs from this conversation', 'show "
+            "everything I've kicked off in this session'. Only lists Lens-originated "
+            "runs — runs triggered from the workflow UI or CLI won't appear."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session UUID; defaults to current session in ctx",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": _RUN_STATUS_ENUM,
+                    "description": "Filter to one lifecycle state",
+                },
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=list_runs_in_session,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+]

--- a/apps/api/tests/glens/test_lens_run_tools.py
+++ b/apps/api/tests/glens/test_lens_run_tools.py
@@ -1,0 +1,87 @@
+"""Unit tests for list_my_runs + list_runs_in_session Lens tools (#1480 PR 8).
+
+Focus: registration + input/error paths. DB-touching query paths auto-skip
+without Postgres, same as the sibling test_run_tools.py.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools import registrations as _tool_registrations  # noqa: F401 populate
+from app.tools.registrations.lens.runs import list_my_runs, list_runs_in_session
+from app.tools.registry import default_registry
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+def test_list_my_runs_registered() -> None:
+    tool = default_registry.get("list_my_runs")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert tool.annotations.read_only is True
+
+
+def test_list_runs_in_session_registered() -> None:
+    tool = default_registry.get("list_runs_in_session")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert tool.annotations.read_only is True
+
+
+# ── list_my_runs input validation ─────────────────────────────────────────
+
+def test_list_my_runs_rejects_missing_user() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", clerk_user_id=None)
+    out = list_my_runs(ctx)
+    assert "error" in out
+    assert "real user" in out["error"]
+
+
+def test_list_my_runs_rejects_system_user() -> None:
+    """system:lens is the actor's synthetic id, not a real user — the tool
+    is 'what did I run', not 'what did the agent run'."""
+    ctx = SimpleNamespace(workspace_id="ws-1", clerk_user_id="system:lens")
+    out = list_my_runs(ctx)
+    assert "error" in out
+    assert "real user" in out["error"]
+
+
+# ── list_runs_in_session input validation ─────────────────────────────────
+
+def test_list_runs_in_session_requires_session() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", session_id=None)
+    out = list_runs_in_session(ctx)
+    assert "error" in out
+    assert "session_id" in out["error"]
+
+
+def test_list_runs_in_session_rejects_non_uuid() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", session_id="not-a-uuid")
+    out = list_runs_in_session(ctx, session_id="not-a-uuid")
+    assert "error" in out
+    assert "UUID" in out["error"]
+
+
+def test_list_runs_in_session_defaults_to_ctx_session_id() -> None:
+    """When no session_id arg passed, tool reads ctx.session_id.
+
+    We stub SessionLocal + query so no DB is required — the goal is
+    to prove the ctx fallback path resolves the session_id correctly
+    before the query attempts to run.
+    """
+    ctx = SimpleNamespace(
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        session_id="11111111-1111-1111-1111-111111111111",
+    )
+    with patch("app.core.database.SessionLocal") as mock_sl, \
+         patch("app.modules.glens.executor._org_ws_subquery", return_value=[]):
+        mock_db = MagicMock()
+        mock_db.query.return_value.join.return_value.join.return_value \
+            .filter.return_value.filter.return_value.order_by.return_value \
+            .limit.return_value.all.return_value = []
+        mock_sl.return_value = mock_db
+        out = list_runs_in_session(ctx)
+    assert out == []  # empty list — no error, ctx fallback worked


### PR DESCRIPTION
## Summary

Two read-only Lens tools so the chat surface can answer **"what did I run"** and **"what did we run in this session"** without leaving.

**Depends on** PR 1 (\`runs.session_id\` column). Stacked on PR 7 for merge convenience; no code dependency on PRs 2–7.

## New tools

### \`list_my_runs\`
Cross-session, workspace-scoped, filtered by the caller's \`clerk_user_id\`. Rejects with an error when ctx lacks a real user (\`system:lens\` actor id doesn't count — that's the agent, not the user).

### \`list_runs_in_session\`
Filters by \`session_id\`. Defaults to \`ctx.session_id\` so the LLM can call it with no args. Only surfaces Lens-originated runs (uses \`runs.session_id\` from PR 1); runs from workflow UI / CLI stay invisible here.

Both are **free-function tools** (not routed through the legacy Executor \`_impl\` helper) because they need ctx fields that \`_impl\` doesn't propagate — \`clerk_user_id\` and \`session_id\`.

## Regression posture

Additive only. Tool catalog: **70 → 72** lens-tagged tools. Zero change to existing impls, registrations, or the Executor. LLM gains two options; nothing it already uses moves.

## Test plan

- [x] Both tools registered with \`lens\` tag + read-only annotation
- [x] 6 unit tests pass — registration parity, real-user gate, non-UUID session rejection, ctx session_id fallback
- [x] 116 glens tests pass (was 103), no regressions
- [ ] Manual smoke: ask Lens "what did I run today?" and "show runs from this conversation"

Part of #1480.