### PR TITLE
feat(lens): outcome artifact link + elapsed timer in RunBubble (#1480 PR 10)

### DIFF
--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -853,4 +853,5 @@ def get_workspace_run(
         project_id=str(proj_id) if proj_id else None,
         project_name=proj_name,
         state=run.state,
+        outcome=run.outcome,
     )

--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -209,3 +209,7 @@ class RunWithWorkflowOut(RunOut):
     # expand a block inline without a second fetch. Same auth boundary
     # already applies (require_permission("platform.runs.view")).
     state: Optional[dict[str, Any]] = None
+    # {type, artifact_url} written at run completion (#1480 PR 10) — the
+    # Lens <RunBubble> renders artifact_url as a prominent link so users
+    # see the produced PR / issue / report without leaving chat.
+    outcome: Optional[dict[str, Any]] = None

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -998,6 +998,17 @@ function ActionConfirmBubble({
 
 // ─── Run bubble ──────────────────────────────────────────────────────────────
 
+function formatElapsed(startMs: number, endMs: number): string {
+  const secs = Math.max(0, Math.round((endMs - startMs) / 1000))
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const rem = secs % 60
+  if (mins < 60) return rem ? `${mins}m ${rem}s` : `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const rmin = mins % 60
+  return rmin ? `${hrs}h ${rmin}m` : `${hrs}h`
+}
+
 type RunBlockState = {
   id: string
   status: "pending" | "running" | "succeeded" | "failed"
@@ -1030,6 +1041,10 @@ function RunBubble({
   // block outputs inline (#1480 PR 9). Refetch on demand if a block the
   // user expands isn't in the cache yet.
   const [runState, setRunState] = useState<Record<string, unknown> | null>(null)
+  const [outcome, setOutcome] = useState<{ type?: string; artifact_url?: string } | null>(null)
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [completedAt, setCompletedAt] = useState<number | null>(null)
+  const [now, setNow] = useState<number>(() => Date.now())
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
@@ -1048,6 +1063,9 @@ function RunBubble({
       .then(data => {
         if (cancelled) return
         if (data?.state) setRunState(data.state as Record<string, unknown>)
+        if (data?.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
+        if (data?.started_at) setStartedAt(new Date(data.started_at as string).getTime())
+        if (data?.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
         if (data?.status && !gotUpdate.current) setStatus(data.status)
       })
       .catch(() => {})
@@ -1055,22 +1073,29 @@ function RunBubble({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId])
 
-  // Refetch state when a block completes so the freshly-added output is
-  // available if the user expands it.
+  // Refetch state + outcome + timing when a block completes / status changes.
   useEffect(() => {
-    // Only refetch when at least one block has completed since last fetch.
     const anyCompleted = Array.from(blocks.values()).some(b => b.status === "succeeded" || b.status === "failed")
-    if (!anyCompleted) return
+    if (!anyCompleted && status !== "succeeded" && status !== "failed") return
     let cancelled = false
     authFetch(`${API}/runs/${runId}`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        if (cancelled || !data?.state) return
-        setRunState(data.state as Record<string, unknown>)
+        if (cancelled || !data) return
+        if (data.state) setRunState(data.state as Record<string, unknown>)
+        if (data.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
+        if (data.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
       })
       .catch(() => {})
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status])
+
+  // Client-side elapsed clock — tick every second while the run is active.
+  useEffect(() => {
+    if (status !== "running" && status !== "pending") return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
   }, [status])
 
   useLensEvent(stream, "run", runId, (evt) => {
@@ -1119,10 +1144,25 @@ function RunBubble({
             fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 999,
             background: pillColor.bg, color: pillColor.fg, textTransform: "capitalize",
           }}>{status}</span>
+          {startedAt && (
+            <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              {formatElapsed(startedAt, completedAt ?? now)}
+            </span>
+          )}
           <a href={`/runs/${runId}`} style={{ fontSize: 13, color: "var(--accent)", textDecoration: "none" }}>
             View run →
           </a>
         </div>
+        {outcome?.artifact_url && (
+          <div style={{ marginBottom: 10, padding: "8px 12px", background: "var(--ok-bg, #dcfce7)", borderRadius: 6, fontSize: 12 }}>
+            <span style={{ color: "var(--ok-text, #166534)", fontWeight: 600 }}>
+              {outcome.type ? outcome.type.replace(/_/g, " ") : "artifact"}:
+            </span>{" "}
+            <a href={outcome.artifact_url} target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none", wordBreak: "break-all" }}>
+              {outcome.artifact_url}
+            </a>
+          </div>
+        )}
         {error && (
           <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
             {error}


### PR DESCRIPTION
## Summary

Final polish for the interactive-SSE Lens surface. Two additions that close the "never leave Lens" loop.

**Depends on** PRs 1, 2, 3, 5, 7, 9. Stacked on PR 9.

## 1. Outcome / artifact link

When a run completes with a detected outcome (PR opened, issue filed, report generated, etc.), the artifact URL renders prominently inside the RunBubble:

\`\`\`
┌────────────────────────────────────────────────────┐
│ Run · autopilot                                    │
│ [succeeded]  2m 14s   View run →                   │
│ pr opened: https://github.com/org/repo/pull/456    │
│ ────────────────────────────────────────────────── │
│ ✓ scan_repo    · click to expand                   │
│ ✓ propose      · click to expand                   │
│ ✓ open_pr      · click to expand                   │
└────────────────────────────────────────────────────┘
\`\`\`

User clicks the artifact link directly from chat — no navigation needed.

**Backend**: \`RunWithWorkflowOut\` now includes \`run.outcome\` (already returned by the workflow-scoped \`/workflows/{wf}/runs/{run_id}\` endpoint; just propagating here). Optional field, backward-compat.

## 2. Elapsed timer

Header pill row now shows elapsed time:
- **While running**: client-side clock ticks every 1s (\`3s\`, \`47s\`, \`2m 14s\`)
- **On completion**: locked to actual duration (\`started_at → completed_at\`)

Uses only client-side \`setInterval\` — no backend load, no polling.

## Regression posture

| Scenario | Behavior |
|----------|----------|
| Flag OFF | RunBubble never mounted → zero surface impact |
| Backend schema addition | Nullable + additive → non-breaking for existing consumers |

## Test plan

- [x] 145 backend tests pass (glens + executor lifecycle + migration round-trip), no failures
- [x] 6 real-Redis integration tests pass end-to-end
- [x] TypeScript clean (\`tsc --noEmit\`)
- [ ] Manual smoke: run an autopilot-style workflow via Lens, verify artifact URL renders + elapsed timer ticks

## Full #1480 pipeline (now complete)

| # | PR | Ship value |
|---|-----|------------|
| #1485 | Publisher + \`runs.session_id\` migration | Foundation |
| #1486 | SSE endpoint + Last-Event-Id replay | Testable |
| #1487 | Actor confirm/cancel tees | Events flow |
| #1489 | Reactive ActionConfirmBubble | First user-visible |
| #1490 | Worker run events + RunBubble | Live status |
| #1492 | Mount-race fix + real-Redis tests | Robust |
| #1493 | Block events + timeline | Step-by-step |
| #1494 | \`list_my_runs\` + \`list_runs_in_session\` | Cross-session view |
| #1495 | Block output expand | Full drill-in |
| **#1496** | **Outcome + elapsed timer** | **Never leave Lens** |

Closes v1 of #1480.