### PR TITLE
feat(guard-activity): show short agent_identity_id next to AGENT badge

### DIFF
--- a/apps/web/src/components/guard/ActivityRow.tsx
+++ b/apps/web/src/components/guard/ActivityRow.tsx
@@ -353,8 +353,13 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
                 <a href={href}
                    title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
                    onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
-                   style={{ textDecoration: "none" }}>
+                   style={{ textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}>
                   {pill}
+                  {ev.agent_identity_id && (
+                    <span className="mono" style={{ fontSize: 9.5, color: "var(--text-muted)" }}>
+                      {ev.agent_identity_id.slice(0, 10)}
+                    </span>
+                  )}
                 </a>
               )
             }
@@ -415,8 +420,13 @@ export function ActivityRow({ ev, compact = false, isLast = false }: {
             <a href={href}
                title={ev.agent_identity_id ? `View agent identity ${ev.agent_identity_id}` : "View agent identities"}
                onClick={(e: ReactMouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
-               style={{ textDecoration: "none" }}>
+               style={{ textDecoration: "none", display: "inline-flex", alignItems: "center", gap: 4 }}>
               {pill}
+              {ev.agent_identity_id && (
+                <span className="mono" style={{ fontSize: 9, color: "var(--text-muted)" }}>
+                  {ev.agent_identity_id.slice(0, 10)}
+                </span>
+              )}
             </a>
           )
         })()}


### PR DESCRIPTION
## Summary

- Adds a 10-char mono preview of \`agent_identity_id\` next to the AGENT pill in the activity feed
- Applied in both spots: actor column (proxy path) and tool column (brain_block path)
- No new data — the id was already on the event payload; it was only visible in the badge \`title\` before
- Anchor wraps pill + id-preview so the whole chip is one click target into \`/agent-identity?tab=identities&id=<uuid>\`

## Why

Users looking at the activity feed can't distinguish AGENT rows without hovering each one. With multiple framework demos (langchain-sql-agent, langchain-rag-chatbot, crewai-stock-analysis) hitting the proxy simultaneously, the AGENT column becomes visually indistinguishable — every row just says "AGENT". A short id preview restores at-a-glance identity while keeping the layout tight.

## Test plan

- [ ] Load \`/guard/activity\` with mixed AGENT + HUMAN rows
- [ ] AGENT rows now show \`AGENT <10-char>\` — click either the pill or the id text → navigates to that agent's identity page
- [ ] HUMAN rows unchanged (no id, since \`user_email\` is set)
- [ ] brain_block rows in the tool column also show the id next to the purple AGENT pill
- [ ] No layout regressions in narrow columns (id truncates cleanly at 10 chars)