### PR TITLE
fix(nav): remove duplicate Observability sidebar entry

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -1005,13 +1005,6 @@ function AppShellInnerContent({
                 })}
               </div>
             )}
-            <SideNavItem
-              href="/observability"
-              label="Observability"
-              icon={<Icons.Spark />}
-              active={pathname === "/observability" || pathname.startsWith("/observability/")}
-              collapsed={collapsed}
-            />
           </div>
         </nav>
 


### PR DESCRIPTION
## Summary

Two entries in the sidebar both pointed at the same page. The top-level \`/observability\` route is just a redirect to \`/logs/observability\`, and the Logs sub-nav already surfaces Observability. Two rows with identical label + destination = confusing UX.

Keeping the sub-nav entry as the single source of truth. Redirect route stays in place so external links pointing at \`/observability\` still work.

## Test plan

- [x] \`tsc --noEmit\` clean
- [ ] Verify sidebar shows one "Observability" (under Logs), not two
- [ ] Verify \`/observability\` URL still redirects to \`/logs/observability\`