### PR TITLE
feat(lens): interactive SSE surface — cumulative merge of PRs 2-10 (#1480)

### DIFF
--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -37,6 +37,7 @@ from app.modules.glens.routers import config as glens_config
 from app.modules.glens.routers import feedback as glens_feedback
 from app.modules.glens.routers import opener as glens_opener
 from app.modules.glens.routers import policy as glens_policy
+from app.modules.glens.routers import session_stream as glens_session_stream
 from app.modules.glens.routers import sessions as glens_sessions
 from app.modules.glens.actor import routes as glens_actor_routes
 from app.modules.glens.routers import lens_sessions as glens_lens_sessions
@@ -162,6 +163,7 @@ app.include_router(guard_verify.router)
 app.include_router(guard_knowledge_search.router)
 app.include_router(glens_chat.router)
 app.include_router(glens_sessions.router)
+app.include_router(glens_session_stream.router)
 app.include_router(glens_feedback.router)
 app.include_router(glens_opener.router)
 app.include_router(glens_policy.router)

--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -18,6 +18,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from app.modules.glens.actor.types import ActionCtx, ActionSpec
+from app.modules.glens.events import publish_session_event
 from app.modules.guard.approval import (
     apply_decision,
     can_decide,
@@ -25,6 +26,32 @@ from app.modules.guard.approval import (
     sweep_if_timed_out,
 )
 from app.modules.guard.models import GuardApprovalRequest
+
+
+def _publish_action_event(row: GuardApprovalRequest, event_type: str, *, result: Any = None, cached: bool = False) -> None:
+    """Tee an action.* event to the row's originating Lens session so any
+    open session-stream connection can update its bubble reactively.
+
+    No-op when the row has no session_id (HTTP actor calls without chat
+    context — nothing to route to). Fail-open inside publish_session_event
+    means Redis outages never fail the decide operation.
+    """
+    if not row.session_id:
+        return
+    payload: dict[str, Any] = {
+        "tool_name": row.tool_name,
+        "status": row.status,
+    }
+    if result is not None:
+        payload["result"] = result
+    if cached:
+        payload["cached"] = True
+    publish_session_event(
+        row.session_id,
+        event_type,
+        entity={"type": "approval", "id": str(row.id)},
+        payload=payload,
+    )
 
 
 def _idempotency_key(tool_name: str, resolved_input: dict[str, Any]) -> str:
@@ -285,13 +312,17 @@ def dispatch_confirm(
 
     # Idempotent success — already executed, return cached result.
     if row.status == "approved" and (row.tool_input or {}).get("_execute_result") is not None:
+        cached_result = row.tool_input.get("_execute_result")
+        # Re-publish so cross-tab subscribers that missed the first event
+        # (e.g. tab opened after the confirm) still see the resolution.
+        _publish_action_event(row, "action.confirmed", result=cached_result, cached=True)
         return {
             "executed": True,
             "cached": True,
             "action_id": str(row.id),
             "tool_name": row.tool_name,
             "status": row.status,
-            "result": row.tool_input.get("_execute_result"),
+            "result": cached_result,
         }
 
     if row.status != "pending":
@@ -339,6 +370,8 @@ def dispatch_confirm(
     row.tool_input = {**(row.tool_input or {}), "_execute_result": result}
     db.commit()
 
+    _publish_action_event(row, "action.confirmed", result=result)
+
     return {
         "executed": True,
         "cached": False,
@@ -375,6 +408,9 @@ def dispatch_cancel(
         decider_user_id=clerk_user_id,
         reason=reason or f"lens.actor.cancelled:{row.tool_name}",
     )
+
+    _publish_action_event(row, "action.cancelled")
+
     return {
         "cancelled": True,
         "action_id": str(row.id),

--- a/apps/api/app/modules/glens/routers/session_stream.py
+++ b/apps/api/app/modules/glens/routers/session_stream.py
@@ -53,6 +53,82 @@ def _sse_frame(entry_id: str, data: str) -> str:
     return f"data: {data}\n\n"
 
 
+async def _stream_events(
+    session_id: str,
+    last_event_id: str | None,
+    is_disconnected,
+):
+    """Async generator that drives the SSE body for one Lens session.
+
+    Extracted from the endpoint so it can be unit-tested against a real
+    Redis without going through httpx / ASGITransport (which buffers
+    streaming responses — see PR 6 for the incident).
+
+    Ordering: subscribe FIRST so events published during replay queue on
+    pub/sub — otherwise a race can drop events landing between the
+    XREAD and the SUBSCRIBE.
+
+    `is_disconnected` is a zero-arg awaitable returning bool — the
+    endpoint passes `request.is_disconnected` from FastAPI's Request;
+    tests pass a stub.
+    """
+    stream_key = _stream_key(session_id)
+    channel_key = _channel_key(session_id)
+
+    r = aioredis.from_url(settings.redis_url, decode_responses=True)
+    pubsub = r.pubsub()
+    try:
+        await pubsub.subscribe(channel_key)
+
+        if last_event_id:
+            try:
+                replay = await r.xread({stream_key: last_event_id})
+                for _, entries in replay:
+                    for entry_id, fields in entries:
+                        body = fields.get("body")
+                        if not body:
+                            continue
+                        envelope = json.dumps({"id": entry_id, **json.loads(body)})
+                        yield _sse_frame(entry_id, envelope)
+            except Exception as exc:
+                log.warning(
+                    "glens.stream.replay_failed",
+                    session_id=session_id,
+                    last_event_id=last_event_id,
+                    error=str(exc),
+                )
+
+        loop = asyncio.get_event_loop()
+        last_activity = loop.time()
+
+        while True:
+            if await is_disconnected():
+                break
+
+            msg = await pubsub.get_message(
+                ignore_subscribe_messages=True,
+                timeout=PUBSUB_POLL_SECONDS,
+            )
+            if msg is not None:
+                raw = msg.get("data") or ""
+                try:
+                    envelope = json.loads(raw)
+                    yield _sse_frame(envelope.get("id", ""), raw)
+                except Exception:
+                    pass
+                last_activity = loop.time()
+            elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
+                yield ": keepalive\n\n"
+                last_activity = loop.time()
+    finally:
+        try:
+            await pubsub.unsubscribe(channel_key)
+            await pubsub.close()
+            await r.close()
+        except Exception:
+            pass
+
+
 @router.get("/sessions/{session_id}/stream")
 async def glens_session_stream(
     session_id: str,
@@ -72,75 +148,8 @@ async def glens_session_stream(
     ws_uuid = _parse_workspace_id(workspace_id)
     _get_session(db, session_id, ws_uuid)  # 404 if not in workspace
 
-    stream_key = _stream_key(session_id)
-    channel_key = _channel_key(session_id)
-
-    async def event_stream():
-        r = aioredis.from_url(settings.redis_url, decode_responses=True)
-        pubsub = r.pubsub()
-        try:
-            # Subscribe FIRST so events published during replay queue on
-            # pub/sub — otherwise a race can drop events landing between
-            # the XREAD and the SUBSCRIBE.
-            await pubsub.subscribe(channel_key)
-
-            # Replay from Last-Event-Id if the client is reconnecting.
-            if last_event_id:
-                try:
-                    replay = await r.xread({stream_key: last_event_id})
-                    for _, entries in replay:
-                        for entry_id, fields in entries:
-                            body = fields.get("body")
-                            if not body:
-                                continue
-                            # Wrap the stored body with the stream id so
-                            # the client sees the same envelope shape it
-                            # gets from live pub/sub messages.
-                            envelope = json.dumps({"id": entry_id, **json.loads(body)})
-                            yield _sse_frame(entry_id, envelope)
-                except Exception as exc:
-                    log.warning(
-                        "glens.stream.replay_failed",
-                        session_id=session_id,
-                        last_event_id=last_event_id,
-                        error=str(exc),
-                    )
-
-            # Live pub/sub loop.
-            loop = asyncio.get_event_loop()
-            last_activity = loop.time()
-
-            while True:
-                if await request.is_disconnected():
-                    break
-
-                msg = await pubsub.get_message(
-                    ignore_subscribe_messages=True,
-                    timeout=PUBSUB_POLL_SECONDS,
-                )
-                if msg is not None:
-                    raw = msg.get("data") or ""
-                    try:
-                        envelope = json.loads(raw)
-                        yield _sse_frame(envelope.get("id", ""), raw)
-                    except Exception:
-                        # Malformed publish — skip, don't crash the stream.
-                        pass
-                    last_activity = loop.time()
-                elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
-                    # Comment frame — clients ignore, proxies see traffic.
-                    yield ": keepalive\n\n"
-                    last_activity = loop.time()
-        finally:
-            try:
-                await pubsub.unsubscribe(channel_key)
-                await pubsub.close()
-                await r.close()
-            except Exception:
-                pass
-
     return StreamingResponse(
-        event_stream(),
+        _stream_events(session_id, last_event_id, request.is_disconnected),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",

--- a/apps/api/app/modules/glens/routers/session_stream.py
+++ b/apps/api/app/modules/glens/routers/session_stream.py
@@ -1,0 +1,149 @@
+"""SSE endpoint for the Lens session event stream — PR 2 of #1480.
+
+    GET /glens/sessions/{session_id}/stream
+
+Long-lived Server-Sent Events connection scoped to one Lens chat session.
+Subscribes to Redis pub/sub `chan:session:<id>` for real-time fan-out.
+If the client sends a `Last-Event-Id` header, first replays events from
+the Redis Stream `stream:session:<id>` starting AFTER that id, then
+attaches to pub/sub.
+
+Ordering guarantee: subscribe → replay → forward pub/sub. Subscribe
+first so any event published during the replay phase is queued on
+pub/sub, not lost.
+
+Producers are wired in later PRs; this endpoint only READS. Publisher
+lives in `apps/api/app/modules/glens/events.py` (PR 1).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import redis.asyncio as aioredis
+import structlog
+from fastapi import APIRouter, Depends, Header, Request
+from fastapi.responses import StreamingResponse
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.config import settings
+from app.core.database import get_db
+
+from ..events import _channel_key, _stream_key
+from ._helpers import _get_session, _parse_workspace_id
+
+log = structlog.get_logger(__name__)
+router = APIRouter(prefix="/glens", tags=["glens"])
+
+
+# Send an SSE comment every N seconds during idle so intermediary proxies
+# (nginx, cloudflare) don't drop the connection as stale.
+IDLE_KEEPALIVE_SECONDS = 30
+# Short pub/sub poll timeout — lets us check request.is_disconnected() and
+# emit keepalives without holding a blocking call for minutes.
+PUBSUB_POLL_SECONDS = 5
+
+
+def _sse_frame(entry_id: str, data: str) -> str:
+    """Format one SSE frame with the entry id as the `id:` line so clients
+    can resume via `Last-Event-Id` after reconnect."""
+    if entry_id:
+        return f"id: {entry_id}\ndata: {data}\n\n"
+    return f"data: {data}\n\n"
+
+
+@router.get("/sessions/{session_id}/stream")
+async def glens_session_stream(
+    session_id: str,
+    request: Request,
+    last_event_id: str | None = Header(default=None, alias="Last-Event-Id"),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+):
+    """SSE stream of events for one Lens session.
+
+    Auth: same permission as chat/stream + we assert the session belongs
+    to the caller's workspace (`_get_session` 404s otherwise). This is
+    the only door out — anyone opening it subscribes to every event on
+    the session, so cross-workspace leakage must be impossible.
+    """
+    ws_uuid = _parse_workspace_id(workspace_id)
+    _get_session(db, session_id, ws_uuid)  # 404 if not in workspace
+
+    stream_key = _stream_key(session_id)
+    channel_key = _channel_key(session_id)
+
+    async def event_stream():
+        r = aioredis.from_url(settings.redis_url, decode_responses=True)
+        pubsub = r.pubsub()
+        try:
+            # Subscribe FIRST so events published during replay queue on
+            # pub/sub — otherwise a race can drop events landing between
+            # the XREAD and the SUBSCRIBE.
+            await pubsub.subscribe(channel_key)
+
+            # Replay from Last-Event-Id if the client is reconnecting.
+            if last_event_id:
+                try:
+                    replay = await r.xread({stream_key: last_event_id})
+                    for _, entries in replay:
+                        for entry_id, fields in entries:
+                            body = fields.get("body")
+                            if not body:
+                                continue
+                            # Wrap the stored body with the stream id so
+                            # the client sees the same envelope shape it
+                            # gets from live pub/sub messages.
+                            envelope = json.dumps({"id": entry_id, **json.loads(body)})
+                            yield _sse_frame(entry_id, envelope)
+                except Exception as exc:
+                    log.warning(
+                        "glens.stream.replay_failed",
+                        session_id=session_id,
+                        last_event_id=last_event_id,
+                        error=str(exc),
+                    )
+
+            # Live pub/sub loop.
+            loop = asyncio.get_event_loop()
+            last_activity = loop.time()
+
+            while True:
+                if await request.is_disconnected():
+                    break
+
+                msg = await pubsub.get_message(
+                    ignore_subscribe_messages=True,
+                    timeout=PUBSUB_POLL_SECONDS,
+                )
+                if msg is not None:
+                    raw = msg.get("data") or ""
+                    try:
+                        envelope = json.loads(raw)
+                        yield _sse_frame(envelope.get("id", ""), raw)
+                    except Exception:
+                        # Malformed publish — skip, don't crash the stream.
+                        pass
+                    last_activity = loop.time()
+                elif loop.time() - last_activity > IDLE_KEEPALIVE_SECONDS:
+                    # Comment frame — clients ignore, proxies see traffic.
+                    yield ": keepalive\n\n"
+                    last_activity = loop.time()
+        finally:
+            try:
+                await pubsub.unsubscribe(channel_key)
+                await pubsub.close()
+                await r.close()
+            except Exception:
+                pass
+
+    return StreamingResponse(
+        event_stream(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",  # nginx: disable proxy buffering
+        },
+    )

--- a/apps/api/app/modules/glens/run_events.py
+++ b/apps/api/app/modules/glens/run_events.py
@@ -1,4 +1,4 @@
-"""Publish run.* events on the Lens session channel (#1480 PR 5).
+"""Publish run.* events on the Lens session channel (#1480 PR 5 + PR 7).
 
 Only Lens-originated runs (run.session_id is not NULL) push events —
 every other run trigger (workflow UI, CLI, webhooks, scheduler) leaves
@@ -8,10 +8,8 @@ Runtime call sites:
 - executor.py at status → "running"  (worker picks up the run)
 - executor.py at status → "failed"   (worker crash / uncaught exception)
 - dag_runner.py at status → "succeeded" | "failed" (normal completion)
-
-Block-level events (run.block_started / run.block_completed) are a
-follow-up — this PR wires the coarse status transitions only, which
-already unlocks live pill updates on the <RunBubble>.
+- dag_runner.py at each block start / complete / fail (#1480 PR 7 —
+  timeline surface inside <RunBubble>)
 """
 from __future__ import annotations
 
@@ -40,4 +38,32 @@ def publish_run_status(run: Run, *, error: str | None = None) -> None:
         "run.status_changed",
         entity={"type": "run", "id": str(run.id)},
         payload=payload,
+    )
+
+
+def publish_run_block_event(
+    run: Run,
+    block_id: str,
+    event_type: str,
+    payload: dict[str, Any] | None = None,
+) -> None:
+    """Tee a block-level event to the Lens session stream so the <RunBubble>
+    timeline (#1480 PR 7) can render step-by-step progress inline.
+
+    event_type is one of `run.block_started`, `run.block_completed`, or
+    `run.block_failed`. `block_id` is always included in the payload so
+    subscribers can key on it in their per-block reducer.
+
+    No-op when the run has no session_id (non-Lens runs). Fail-open via
+    publish_session_event."""
+    if not getattr(run, "session_id", None):
+        return
+    body: dict[str, Any] = {"block_id": block_id}
+    if payload:
+        body.update(payload)
+    publish_session_event(
+        str(run.session_id),
+        event_type,
+        entity={"type": "run", "id": str(run.id)},
+        payload=body,
     )

--- a/apps/api/app/modules/glens/run_events.py
+++ b/apps/api/app/modules/glens/run_events.py
@@ -1,0 +1,43 @@
+"""Publish run.* events on the Lens session channel (#1480 PR 5).
+
+Only Lens-originated runs (run.session_id is not NULL) push events —
+every other run trigger (workflow UI, CLI, webhooks, scheduler) leaves
+session_id NULL and this module skips silently.
+
+Runtime call sites:
+- executor.py at status → "running"  (worker picks up the run)
+- executor.py at status → "failed"   (worker crash / uncaught exception)
+- dag_runner.py at status → "succeeded" | "failed" (normal completion)
+
+Block-level events (run.block_started / run.block_completed) are a
+follow-up — this PR wires the coarse status transitions only, which
+already unlocks live pill updates on the <RunBubble>.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.models.run import Run
+from app.modules.glens.events import publish_session_event
+
+
+def publish_run_status(run: Run, *, error: str | None = None) -> None:
+    """Emit run.status_changed with the run's current status.
+
+    No-op when the run has no session_id — nothing to route to.
+    Fail-open inside publish_session_event (Redis outage never breaks
+    the worker).
+    """
+    if not getattr(run, "session_id", None):
+        return
+    payload: dict[str, Any] = {
+        "status": run.status,
+    }
+    if error:
+        payload["error"] = error
+    publish_session_event(
+        str(run.session_id),
+        "run.status_changed",
+        entity={"type": "run", "id": str(run.id)},
+        payload=payload,
+    )

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -853,4 +853,5 @@ def get_workspace_run(
         project_id=str(proj_id) if proj_id else None,
         project_name=proj_name,
         state=run.state,
+        outcome=run.outcome,
     )

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -852,4 +852,5 @@ def get_workspace_run(
         workflow_name=wf_name,
         project_id=str(proj_id) if proj_id else None,
         project_name=proj_name,
+        state=run.state,
     )

--- a/apps/api/app/runtime/dag_runner.py
+++ b/apps/api/app/runtime/dag_runner.py
@@ -1254,6 +1254,13 @@ def _execute_dag(
     except Exception:
         pass
 
+    # #1480 PR 5 — tee terminal transition to Lens session stream when Lens-originated.
+    try:
+        from app.modules.glens.run_events import publish_run_status
+        publish_run_status(run, error=fail_error if failed else None)
+    except Exception:
+        pass
+
     if failed and not fail_summary and fail_error:
         fail_summary = _classify_failure(RuntimeError(fail_error), None)
 

--- a/apps/api/app/runtime/dag_runner.py
+++ b/apps/api/app/runtime/dag_runner.py
@@ -27,6 +27,19 @@ from app.runtime.exceptions import ApprovalRequired, ClarificationRequired  # no
 from app.runtime.llm_client import GuardProxyBlocked, LLMUpstreamError
 
 
+def _tee_block(run, block_id: str, event_type: str, extra: dict | None = None) -> None:
+    """Tee a block-level event to the Lens session stream (#1480 PR 7).
+
+    No-op when run.session_id is None (non-Lens runs). Fail-open so a
+    Redis outage or import glitch never breaks the worker.
+    """
+    try:
+        from app.modules.glens.run_events import publish_run_block_event
+        publish_run_block_event(run, block_id, event_type, extra)
+    except Exception:
+        pass
+
+
 def _classify_failure(
     exc: Exception,
     block_id: str | None = None,
@@ -1020,6 +1033,10 @@ def _execute_dag(
             "label": block["data"].get("label", ""),
             "attempt_id": _attempt_id,
         })
+        _tee_block(run, block_id, "run.block_started", {
+            "type": block_type,
+            "label": block["data"].get("label", ""),
+        })
 
         compiled = version.compiled_artifacts or {}
 
@@ -1066,6 +1083,10 @@ def _execute_dag(
                     "for_each": True,
                     "items_count": len(results_list),
                 })
+                _tee_block(run, block_id, "run.block_completed", {
+                    "for_each": True,
+                    "items_count": len(results_list),
+                })
                 continue  # skip the normal single-execution path
 
             # ── per-block retry + fallback_block ─────────────────────────────
@@ -1088,6 +1109,7 @@ def _execute_dag(
                         log.error("block.output_failed", block_id=block_id, error=str(out_err))
                         result = {"sent": False, "error": str(out_err)}
                         _emit(db, run_id, block_id, "block_completed", {"output": result, "warning": str(out_err)})
+                        _tee_block(run, block_id, "run.block_completed", {"warning": str(out_err)})
                         state[block_id] = result
                         state["__last_output"] = json.dumps(result, default=str)
                         _logic_routes_version = _lrv_ref[0]
@@ -1103,6 +1125,9 @@ def _execute_dag(
                                 fallback=fallback_block_id, error=str(_block_err))
                     _emit(db, run_id, block_id, "block_failed", {
                         "error": str(_block_err), "fallback_block": fallback_block_id
+                    })
+                    _tee_block(run, block_id, "run.block_failed", {
+                        "error": str(_block_err), "fallback_block": fallback_block_id,
                     })
                     state[block_id] = {"error": str(_block_err), "fallback_triggered": True}
                     state["__next_block"] = fallback_block_id
@@ -1127,6 +1152,7 @@ def _execute_dag(
                 "output": result,
                 "attempt_id": _attempt_id,
             })
+            _tee_block(run, block_id, "run.block_completed", None)
 
             # Visibility: if any {{block.field}} refs in this block's inputs
             # failed to resolve, surface them so users don't only find out
@@ -1195,6 +1221,11 @@ def _execute_dag(
                 "reason_code": fail_summary["code"],
                 "next_action": fail_summary["next_action"],
             })
+            _tee_block(run, block_id, "run.block_failed", {
+                "error": fail_summary["message"],
+                "reason_code": fail_summary["code"],
+                "next_action": fail_summary["next_action"],
+            })
             break
 
         except Exception as e:
@@ -1212,6 +1243,11 @@ def _execute_dag(
             _emit(db, run_id, block_id, "block_failed", {
                 "error": fail_summary["message"],
                 "failure": fail_summary,
+                "reason_code": fail_summary["code"],
+                "next_action": fail_summary["next_action"],
+            })
+            _tee_block(run, block_id, "run.block_failed", {
+                "error": fail_summary["message"],
                 "reason_code": fail_summary["code"],
                 "next_action": fail_summary["next_action"],
             })

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -231,6 +231,9 @@ def execute_run(run_id: str):
         run.attempt_count = (run.attempt_count or 0) + 1
         db.commit()
         _emit(db, run_id, None, "run_started", {"node_count": len((version.graph or {}).get("nodes", []))})
+        # #1480 PR 5 — tee to Lens session stream when Lens-originated.
+        from app.modules.glens.run_events import publish_run_status
+        publish_run_status(run)
 
         # Accumulated state — includes previous run segment outputs on resume
         state: dict[str, Any] = dict(run.state or {})
@@ -427,6 +430,12 @@ def execute_run(run_id: str):
                 db.commit()
                 _emit_run_analytics(run, None, {}, db, outcome="failed", error=str(e))
                 _enqueue_online_eval(str(run.id))
+                # #1480 PR 5 — surface worker crash on Lens session stream.
+                try:
+                    from app.modules.glens.run_events import publish_run_status
+                    publish_run_status(run, error=str(e))
+                except Exception:
+                    pass
         except Exception:
             pass
     finally:

--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -209,3 +209,7 @@ class RunWithWorkflowOut(RunOut):
     # expand a block inline without a second fetch. Same auth boundary
     # already applies (require_permission("platform.runs.view")).
     state: Optional[dict[str, Any]] = None
+    # {type, artifact_url} written at run completion (#1480 PR 10) — the
+    # Lens <RunBubble> renders artifact_url as a prominent link so users
+    # see the produced PR / issue / report without leaving chat.
+    outcome: Optional[dict[str, Any]] = None

--- a/apps/api/app/schemas/run.py
+++ b/apps/api/app/schemas/run.py
@@ -204,3 +204,8 @@ class RunWithWorkflowOut(RunOut):
     workflow_name: str
     project_id: Optional[str] = None
     project_name: Optional[str] = None
+    # Accumulated block outputs — populated by the dag_runner as each block
+    # completes. Included here (#1480 PR 9) so the Lens <RunBubble> can
+    # expand a block inline without a second fetch. Same auth boundary
+    # already applies (require_permission("platform.runs.view")).
+    state: Optional[dict[str, Any]] = None

--- a/apps/api/app/tools/registrations/lens/__init__.py
+++ b/apps/api/app/tools/registrations/lens/__init__.py
@@ -36,6 +36,7 @@ from app.tools.registrations.lens import (
     ops,
     policies,
     primitives,
+    runs,
     workflows,
     workspace,
 )
@@ -45,6 +46,7 @@ _ALL_TOOLS = [
     *guard_core.TOOLS,
     *policies.TOOLS,
     *workflows.TOOLS,
+    *runs.TOOLS,
     *workspace.TOOLS,
     *marketplace.TOOLS,
     *ops.TOOLS,

--- a/apps/api/app/tools/registrations/lens/runs.py
+++ b/apps/api/app/tools/registrations/lens/runs.py
@@ -1,0 +1,169 @@
+"""Lens tool registrations — run history (#1480 PR 8).
+
+Two tools that let Lens surface a user's / a session's run history without
+leaving the chat surface:
+
+- `list_my_runs` — cross-session, workspace-scoped, filtered by the calling
+  user's clerk_user_id (from `ctx`). Answers "what did I run today?"
+- `list_runs_in_session` — filter by the SSE session id introduced in PR 1.
+  Answers "what did we run in this conversation?"
+
+Both are read-only free-function tools (not routed through Executor) so
+we can read the current user + session directly from ctx.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+from app.tools.types import ToolDef
+from app.tools.registrations.lens._shared import (
+    _LIMIT,
+    _LENS_TAGS,
+    _READ_ONLY,
+)
+
+
+_RUN_STATUS_ENUM = ["pending", "running", "paused", "succeeded", "failed", "cancelled"]
+
+
+def _serialize_row(row) -> dict[str, Any]:
+    """Common row shape — matches list_runs so consumers can share rendering."""
+    r = row.Run
+    return {
+        "run_id": str(r.id),
+        "workflow_id": str(row.workflow_id),
+        "workflow_name": row.workflow_name,
+        "status": r.status,
+        "triggered_by": r.triggered_by,
+        "started_at": r.started_at.isoformat() if r.started_at else None,
+        "completed_at": r.completed_at.isoformat() if r.completed_at else None,
+        "created_at": r.created_at.isoformat() if r.created_at else None,
+        "actual_turns": r.actual_turns,
+    }
+
+
+def list_my_runs(ctx, status: str | None = None, limit: int = 20):
+    """Recent runs triggered by the current user across the workspace org.
+
+    Only returns runs where `triggered_by` matches the caller's
+    clerk_user_id — auth is enforced by ctx, not by the LLM. Same as
+    list_runs but scoped to me.
+    """
+    from app.core.database import SessionLocal
+    from app.models.run import Run
+    from app.models.workflow import Workflow, WorkflowVersion
+    from app.modules.glens.executor import _org_ws_subquery
+
+    clerk_user_id = getattr(ctx, "clerk_user_id", None)
+    if not clerk_user_id or clerk_user_id.startswith("system:"):
+        return {"error": "list_my_runs requires a real user context (not system/lens actor)"}
+
+    db = SessionLocal()
+    try:
+        org_ws = _org_ws_subquery(db, ctx.workspace_id)
+        q = (
+            db.query(Run, Workflow.name.label("workflow_name"), Workflow.id.label("workflow_id"))
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, WorkflowVersion.workflow_id == Workflow.id)
+            .filter(Run.workspace_id.in_(org_ws))
+            .filter(Run.triggered_by == clerk_user_id)
+        )
+        if status:
+            q = q.filter(Run.status == status)
+        rows = q.order_by(Run.created_at.desc()).limit(min(limit, 100)).all()
+        return [_serialize_row(row) for row in rows]
+    finally:
+        db.close()
+
+
+def list_runs_in_session(ctx, session_id: str | None = None, status: str | None = None, limit: int = 20):
+    """Runs triggered from a Lens chat session (populated by PR 1's
+    runs.session_id column). Defaults to the current session in ctx.
+    """
+    from app.core.database import SessionLocal
+    from app.models.run import Run
+    from app.models.workflow import Workflow, WorkflowVersion
+    from app.modules.glens.executor import _org_ws_subquery
+
+    sid = session_id or getattr(ctx, "session_id", None)
+    if not sid:
+        return {"error": "session_id required (no current session in ctx)"}
+    try:
+        sid_uuid = uuid.UUID(sid)
+    except (ValueError, TypeError):
+        return {"error": "session_id must be a UUID"}
+
+    db = SessionLocal()
+    try:
+        org_ws = _org_ws_subquery(db, ctx.workspace_id)
+        q = (
+            db.query(Run, Workflow.name.label("workflow_name"), Workflow.id.label("workflow_id"))
+            .join(WorkflowVersion, Run.workflow_version_id == WorkflowVersion.id)
+            .join(Workflow, WorkflowVersion.workflow_id == Workflow.id)
+            .filter(Run.workspace_id.in_(org_ws))
+            .filter(Run.session_id == sid_uuid)
+        )
+        if status:
+            q = q.filter(Run.status == status)
+        rows = q.order_by(Run.created_at.desc()).limit(min(limit, 100)).all()
+        return [_serialize_row(row) for row in rows]
+    finally:
+        db.close()
+
+
+TOOLS: list[ToolDef] = [
+    ToolDef(
+        name="list_my_runs",
+        description=(
+            "Recent workflow runs triggered by the CURRENT user in this workspace org. "
+            "Use for 'what did I run today', 'my recent runs', 'show my last workflow'. "
+            "Returns run_id, workflow_name, status, timings. Cross-session — spans "
+            "every Lens conversation the user has had. For a single-session view "
+            "use list_runs_in_session instead."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "status": {
+                    "type": "string",
+                    "enum": _RUN_STATUS_ENUM,
+                    "description": "Filter to one lifecycle state",
+                },
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=list_my_runs,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="list_runs_in_session",
+        description=(
+            "Runs triggered from THIS Lens chat session (or a specific session_id). "
+            "Use for 'what did we run here', 'runs from this conversation', 'show "
+            "everything I've kicked off in this session'. Only lists Lens-originated "
+            "runs — runs triggered from the workflow UI or CLI won't appear."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "session_id": {
+                    "type": "string",
+                    "description": "Session UUID; defaults to current session in ctx",
+                },
+                "status": {
+                    "type": "string",
+                    "enum": _RUN_STATUS_ENUM,
+                    "description": "Filter to one lifecycle state",
+                },
+                "limit": _LIMIT,
+            },
+            "required": [],
+        },
+        impl=list_runs_in_session,
+        annotations=_READ_ONLY,
+        tags=_LENS_TAGS,
+    ),
+]

--- a/apps/api/tests/glens/test_actor_publish_tee.py
+++ b/apps/api/tests/glens/test_actor_publish_tee.py
@@ -1,0 +1,80 @@
+"""Verify actor helpers tee action.confirmed / action.cancelled events to
+the row's originating Lens session (#1480 PR 3).
+
+Focus: the _publish_action_event helper. Its contract:
+  - No-op when row.session_id is None (HTTP calls without chat context)
+  - Publishes action.confirmed with entity=approval + payload=result/cached
+  - Publishes action.cancelled with entity=approval, no result
+  - Uses row.session_id + row.id for routing
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.modules.glens.actor.helpers import _publish_action_event
+
+
+def _row(session_id="sess-abc", row_id="row-xyz", tool_name="run_workflow", status="approved"):
+    return SimpleNamespace(
+        id=row_id,
+        session_id=session_id,
+        tool_name=tool_name,
+        status=status,
+    )
+
+
+def test_no_publish_when_row_has_no_session_id() -> None:
+    """HTTP actor calls without chat context leave session_id NULL — nothing
+    to route to, so publish is skipped entirely."""
+    row = _row(session_id=None)
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"run_id": "r1"})
+    mock_pub.assert_not_called()
+
+
+def test_confirmed_event_shape() -> None:
+    row = _row()
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"run_id": "r1"})
+    mock_pub.assert_called_once()
+    session_id, event_type = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == "sess-abc"
+    assert event_type == "action.confirmed"
+    assert kwargs["entity"] == {"type": "approval", "id": "row-xyz"}
+    assert kwargs["payload"] == {
+        "tool_name": "run_workflow",
+        "status": "approved",
+        "result": {"run_id": "r1"},
+    }
+
+
+def test_confirmed_event_marks_cached_when_flagged() -> None:
+    row = _row()
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed", result={"foo": "bar"}, cached=True)
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"]["cached"] is True
+
+
+def test_cancelled_event_omits_result() -> None:
+    row = _row(status="rejected")
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.cancelled")
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"] == {"tool_name": "run_workflow", "status": "rejected"}
+    assert "result" not in kwargs["payload"]
+    assert "cached" not in kwargs["payload"]
+
+
+def test_row_id_stringified_for_entity() -> None:
+    """entity.id must be a string — approval rows carry UUID; the publisher
+    contract expects string ids."""
+    import uuid
+    row_uuid = uuid.uuid4()
+    row = _row(row_id=row_uuid)
+    with patch("app.modules.glens.actor.helpers.publish_session_event") as mock_pub:
+        _publish_action_event(row, "action.confirmed")
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["entity"]["id"] == str(row_uuid)

--- a/apps/api/tests/glens/test_events_publisher_integration.py
+++ b/apps/api/tests/glens/test_events_publisher_integration.py
@@ -1,0 +1,143 @@
+"""Real-Redis round-trip tests for the session event publisher (#1480 PR 6).
+
+Bring Redis up with `docker compose up redis` — these auto-skip when the
+port isn't reachable, so they run locally on the dev machine and no-op
+in CI without a Redis service.
+
+Two properties exercised end-to-end (not just against MagicMock):
+
+1. `publish_session_event` XADDs a real entry to the session Stream and
+   PUBLISHes a real message on the session channel. Both are readable
+   with a plain redis client.
+2. Stream entries survive across the reconnect window (used by the SSE
+   endpoint's `Last-Event-Id` replay).
+"""
+from __future__ import annotations
+
+import json
+import uuid
+
+import pytest
+import redis
+
+from app.core.config import settings
+from app.modules.glens.events import (
+    STREAM_MAXLEN,
+    _channel_key,
+    _stream_key,
+    publish_session_event,
+)
+
+
+@pytest.fixture
+def real_redis():
+    """Yield a real Redis client if reachable; skip test otherwise.
+
+    Auto-cleans keys created during the test so the fixture is
+    self-contained — no cross-test pollution."""
+    try:
+        r = redis.from_url(settings.redis_url, decode_responses=True, socket_timeout=1)
+        r.ping()
+    except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+        pytest.skip("Redis not reachable — start with `docker compose up redis`")
+    created_keys: list[str] = []
+    yield r, created_keys
+    if created_keys:
+        r.delete(*created_keys)
+
+
+def _fresh_session_id() -> str:
+    """One session id per test — no cross-test collision on the Stream key."""
+    return str(uuid.uuid4())
+
+
+def test_publish_writes_readable_stream_entry(real_redis) -> None:
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    entry_id = publish_session_event(
+        sid,
+        "action.confirmed",
+        entity={"type": "approval", "id": "row-1"},
+        payload={"tool_name": "run_workflow", "status": "approved"},
+    )
+    assert entry_id  # non-empty stream id like "1699999999999-0"
+
+    entries = r.xrange(_stream_key(sid))
+    assert len(entries) == 1
+    stream_id, fields = entries[0]
+    assert stream_id == entry_id
+    body = json.loads(fields["body"])
+    assert body["type"] == "action.confirmed"
+    assert body["entity"] == {"type": "approval", "id": "row-1"}
+    assert body["payload"]["tool_name"] == "run_workflow"
+
+
+def test_publish_reaches_pub_sub_subscribers(real_redis) -> None:
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    ps = r.pubsub()
+    ps.subscribe(_channel_key(sid))
+    # Consume the subscribe confirmation so the next get_message returns the
+    # real event only.
+    ack = ps.get_message(timeout=1)
+    assert ack is not None and ack["type"] == "subscribe"
+
+    entry_id = publish_session_event(
+        sid, "run.status_changed",
+        entity={"type": "run", "id": "run-xyz"},
+        payload={"status": "running"},
+    )
+
+    msg = ps.get_message(timeout=1, ignore_subscribe_messages=True)
+    assert msg is not None, "no fanout message received on channel"
+    envelope = json.loads(msg["data"])
+    assert envelope["id"] == entry_id
+    assert envelope["type"] == "run.status_changed"
+    assert envelope["entity"] == {"type": "run", "id": "run-xyz"}
+    assert envelope["payload"] == {"status": "running"}
+
+    ps.unsubscribe()
+    ps.close()
+
+
+def test_last_event_id_replay_returns_events_after_id(real_redis) -> None:
+    """The SSE endpoint replays via `XREAD {stream: last_event_id}`. Sanity-
+    check the underlying primitive: XREAD from a mid-stream id returns only
+    entries STRICTLY after it."""
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    first_id = publish_session_event(sid, "action.confirmed")
+    second_id = publish_session_event(sid, "run.status_changed")
+    third_id = publish_session_event(sid, "run.status_changed")
+
+    # Client had first_id last — should receive second + third only.
+    replay = r.xread({_stream_key(sid): first_id})
+    assert len(replay) == 1
+    _key, entries = replay[0]
+    ids = [e[0] for e in entries]
+    assert ids == [second_id, third_id]
+
+
+def test_stream_bounded_by_maxlen(real_redis) -> None:
+    """Publishing more than STREAM_MAXLEN events must trim the stream so
+    Redis memory stays bounded per session."""
+    r, cleanup = real_redis
+    sid = _fresh_session_id()
+    cleanup.append(_stream_key(sid))
+
+    # Push a bit past the cap — approximate=True means Redis may keep a few
+    # extra entries but won't grow unboundedly.
+    for i in range(STREAM_MAXLEN + 50):
+        publish_session_event(sid, f"test.event.{i}")
+
+    length = r.xlen(_stream_key(sid))
+    # Approximate trim can leave up to ~STREAM_MAXLEN + a small tail. Allow
+    # 2x the cap as the guardrail — anything higher means MAXLEN isn't
+    # taking effect.
+    assert length <= STREAM_MAXLEN * 2

--- a/apps/api/tests/glens/test_lens_run_tools.py
+++ b/apps/api/tests/glens/test_lens_run_tools.py
@@ -1,0 +1,87 @@
+"""Unit tests for list_my_runs + list_runs_in_session Lens tools (#1480 PR 8).
+
+Focus: registration + input/error paths. DB-touching query paths auto-skip
+without Postgres, same as the sibling test_run_tools.py.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.tools import registrations as _tool_registrations  # noqa: F401 populate
+from app.tools.registrations.lens.runs import list_my_runs, list_runs_in_session
+from app.tools.registry import default_registry
+
+
+# ── Registration ───────────────────────────────────────────────────────────
+
+def test_list_my_runs_registered() -> None:
+    tool = default_registry.get("list_my_runs")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert tool.annotations.read_only is True
+
+
+def test_list_runs_in_session_registered() -> None:
+    tool = default_registry.get("list_runs_in_session")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert tool.annotations.read_only is True
+
+
+# ── list_my_runs input validation ─────────────────────────────────────────
+
+def test_list_my_runs_rejects_missing_user() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", clerk_user_id=None)
+    out = list_my_runs(ctx)
+    assert "error" in out
+    assert "real user" in out["error"]
+
+
+def test_list_my_runs_rejects_system_user() -> None:
+    """system:lens is the actor's synthetic id, not a real user — the tool
+    is 'what did I run', not 'what did the agent run'."""
+    ctx = SimpleNamespace(workspace_id="ws-1", clerk_user_id="system:lens")
+    out = list_my_runs(ctx)
+    assert "error" in out
+    assert "real user" in out["error"]
+
+
+# ── list_runs_in_session input validation ─────────────────────────────────
+
+def test_list_runs_in_session_requires_session() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", session_id=None)
+    out = list_runs_in_session(ctx)
+    assert "error" in out
+    assert "session_id" in out["error"]
+
+
+def test_list_runs_in_session_rejects_non_uuid() -> None:
+    ctx = SimpleNamespace(workspace_id="ws-1", session_id="not-a-uuid")
+    out = list_runs_in_session(ctx, session_id="not-a-uuid")
+    assert "error" in out
+    assert "UUID" in out["error"]
+
+
+def test_list_runs_in_session_defaults_to_ctx_session_id() -> None:
+    """When no session_id arg passed, tool reads ctx.session_id.
+
+    We stub SessionLocal + query so no DB is required — the goal is
+    to prove the ctx fallback path resolves the session_id correctly
+    before the query attempts to run.
+    """
+    ctx = SimpleNamespace(
+        workspace_id="00000000-0000-0000-0000-000000000000",
+        session_id="11111111-1111-1111-1111-111111111111",
+    )
+    with patch("app.core.database.SessionLocal") as mock_sl, \
+         patch("app.modules.glens.executor._org_ws_subquery", return_value=[]):
+        mock_db = MagicMock()
+        mock_db.query.return_value.join.return_value.join.return_value \
+            .filter.return_value.filter.return_value.order_by.return_value \
+            .limit.return_value.all.return_value = []
+        mock_sl.return_value = mock_db
+        out = list_runs_in_session(ctx)
+    assert out == []  # empty list — no error, ctx fallback worked

--- a/apps/api/tests/glens/test_run_events_publisher.py
+++ b/apps/api/tests/glens/test_run_events_publisher.py
@@ -1,0 +1,70 @@
+"""Verify publish_run_status tees run.status_changed to the run's session
+channel — foundation for the <RunBubble> live status (#1480 PR 5).
+
+Contract:
+- No-op when run.session_id is None (non-Lens-originated runs)
+- Publishes entity=run + payload={status} on happy path
+- Includes error when passed
+- session_id and run.id stringified for the publisher
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from app.modules.glens.run_events import publish_run_status
+
+
+def _run(session_id="sess-abc", run_id="run-xyz", status="running"):
+    return SimpleNamespace(id=run_id, session_id=session_id, status=status)
+
+
+def test_no_publish_when_run_has_no_session_id() -> None:
+    """Runs from workflow UI / CLI / webhooks leave session_id NULL and
+    must not touch the session channel — nothing to route to."""
+    run = _run(session_id=None)
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    mock_pub.assert_not_called()
+
+
+def test_publishes_run_status_changed_with_entity_and_status() -> None:
+    run = _run(status="running")
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    session_id, event_type = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == "sess-abc"
+    assert event_type == "run.status_changed"
+    assert kwargs["entity"] == {"type": "run", "id": "run-xyz"}
+    assert kwargs["payload"] == {"status": "running"}
+
+
+def test_error_included_when_provided() -> None:
+    run = _run(status="failed")
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run, error="boom")
+    assert mock_pub.call_args.kwargs["payload"] == {"status": "failed", "error": "boom"}
+
+
+def test_uuid_ids_stringified() -> None:
+    import uuid
+    session_uuid = uuid.uuid4()
+    run_uuid = uuid.uuid4()
+    run = _run(session_id=session_uuid, run_id=run_uuid)
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    session_id, _ = mock_pub.call_args.args
+    kwargs = mock_pub.call_args.kwargs
+    assert session_id == str(session_uuid)
+    assert kwargs["entity"]["id"] == str(run_uuid)
+
+
+def test_no_publish_when_session_id_attr_missing() -> None:
+    """Defensive: SimpleNamespace without session_id at all — getattr default
+    catches this. Real Run rows always have the column post-PR-1 but tests
+    with dummy objects should still be safe."""
+    run = SimpleNamespace(id="r1", status="running")  # no session_id attr
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_status(run)
+    mock_pub.assert_not_called()

--- a/apps/api/tests/glens/test_run_events_publisher.py
+++ b/apps/api/tests/glens/test_run_events_publisher.py
@@ -68,3 +68,44 @@ def test_no_publish_when_session_id_attr_missing() -> None:
     with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
         publish_run_status(run)
     mock_pub.assert_not_called()
+
+
+
+# ── publish_run_block_event (#1480 PR 7 — block-level timeline) ────────────
+
+from app.modules.glens.run_events import publish_run_block_event
+
+
+def test_block_event_no_op_when_run_has_no_session_id() -> None:
+    run = _run(session_id=None)
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_block_event(run, "b-1", "run.block_started")
+    mock_pub.assert_not_called()
+
+
+def test_block_event_puts_block_id_in_payload() -> None:
+    run = _run()
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_block_event(run, "b-1", "run.block_started", {"label": "discover"})
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"] == {"block_id": "b-1", "label": "discover"}
+    assert kwargs["entity"] == {"type": "run", "id": "run-xyz"}
+
+
+def test_block_event_defaults_payload_to_block_id_only() -> None:
+    run = _run()
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_block_event(run, "b-1", "run.block_completed")
+    assert mock_pub.call_args.kwargs["payload"] == {"block_id": "b-1"}
+
+
+def test_block_event_error_payload_shape() -> None:
+    run = _run()
+    with patch("app.modules.glens.run_events.publish_session_event") as mock_pub:
+        publish_run_block_event(run, "b-1", "run.block_failed", {
+            "error": "boom", "reason_code": "EXECUTION_ERROR",
+        })
+    kwargs = mock_pub.call_args.kwargs
+    assert kwargs["payload"] == {
+        "block_id": "b-1", "error": "boom", "reason_code": "EXECUTION_ERROR",
+    }

--- a/apps/api/tests/glens/test_session_stream_endpoint.py
+++ b/apps/api/tests/glens/test_session_stream_endpoint.py
@@ -1,0 +1,87 @@
+"""Verify GET /glens/sessions/{id}/stream — auth, response type, replay wrapper.
+
+Focus: the auth boundary + SSE response shape. The pub/sub read loop
+requires a live Redis; we do NOT exercise it here — PR 3 wires actor
+endpoints as publishers and covers the round-trip in an integration
+test if we ever add one. Env vars come from tests/conftest.py.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock
+
+import app.models.run          # noqa: F401
+import app.models.workspace    # noqa: F401
+
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.database import get_db
+from app.main import app
+from app.modules.glens.routers.session_stream import _sse_frame
+
+
+WS_ID = str(uuid.uuid4())
+SESSION_ID = str(uuid.uuid4())
+
+
+def _make_client(session_lookup_ok: bool = True):
+    def _noop_permission(perm):
+        async def _check():
+            return "admin"
+        return _check
+
+    if session_lookup_ok:
+        def _stub_session(db, session_id, ws_uuid):
+            s = MagicMock()
+            s.id = uuid.UUID(session_id)
+            s.workspace_id = ws_uuid
+            return s
+    else:
+        def _stub_session(db, session_id, ws_uuid):
+            raise HTTPException(status_code=404, detail="Session not found")
+
+    app.dependency_overrides[get_db] = lambda: iter([MagicMock()])
+    app.dependency_overrides[get_workspace_id] = lambda: WS_ID
+    app.dependency_overrides[require_permission] = _noop_permission
+    import app.modules.glens.routers.session_stream as mod
+    mod._get_session = _stub_session
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _teardown():
+    app.dependency_overrides.clear()
+    import app.modules.glens.routers.session_stream as mod
+    from app.modules.glens.routers._helpers import _get_session as real
+    mod._get_session = real
+
+
+def test_returns_404_when_session_not_in_workspace() -> None:
+    client = _make_client(session_lookup_ok=False)
+    try:
+        resp = client.get(f"/glens/sessions/{SESSION_ID}/stream")
+        assert resp.status_code == 404
+    finally:
+        _teardown()
+
+
+def test_sse_frame_includes_id_line_when_entry_id_present() -> None:
+    frame = _sse_frame("1699999999999-0", '{"foo":"bar"}')
+    assert frame.startswith("id: 1699999999999-0\n")
+    assert 'data: {"foo":"bar"}' in frame
+    assert frame.endswith("\n\n")
+
+
+def test_sse_frame_omits_id_line_when_entry_id_blank() -> None:
+    frame = _sse_frame("", '{"foo":"bar"}')
+    assert not frame.startswith("id:")
+    assert frame == 'data: {"foo":"bar"}\n\n'
+
+
+def test_endpoint_is_registered_on_app() -> None:
+    """FastAPI does not always expose sub-router routes via app.routes at
+    the top level; the openapi schema is the authoritative source."""
+    schema = app.openapi()
+    assert "/glens/sessions/{session_id}/stream" in schema["paths"]
+    assert "get" in schema["paths"]["/glens/sessions/{session_id}/stream"]

--- a/apps/api/tests/glens/test_session_stream_generator.py
+++ b/apps/api/tests/glens/test_session_stream_generator.py
@@ -1,0 +1,147 @@
+"""Real-Redis round-trip test of the SSE async generator (#1480 PR 6.5).
+
+We bypass HTTP entirely — httpx's ASGITransport buffers streaming
+responses (well-known FastAPI+httpx quirk), so a full endpoint test
+hangs. Instead we drive `_stream_events()` directly and verify the
+pub/sub → yield pipeline.
+
+Coverage:
+- Live pub/sub: publish an event, the next yielded frame carries it
+- Last-Event-Id replay: connect with a prior stream id, replay frames
+  strictly after that id BEFORE any live event
+
+Auto-skips when Redis unreachable (same fixture as
+test_events_publisher_integration.py).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+import redis
+
+from app.core.config import settings
+from app.modules.glens.events import _stream_key, publish_session_event
+from app.modules.glens.routers.session_stream import _stream_events
+
+
+def _redis_reachable() -> bool:
+    try:
+        redis.from_url(settings.redis_url, decode_responses=True, socket_timeout=1).ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_reachable(),
+    reason="Redis not reachable — start with `docker compose up redis`",
+)
+
+
+@pytest.fixture
+def redis_cleanup():
+    """Yield a callback that registers keys to delete after the test."""
+    r = redis.from_url(settings.redis_url, decode_responses=True)
+    keys: list[str] = []
+    yield keys.append
+    if keys:
+        r.delete(*keys)
+
+
+class _Disconnect:
+    """Awaitable stub for FastAPI's request.is_disconnected — flip .value
+    to unwedge the generator's while-loop from tests."""
+    def __init__(self) -> None:
+        self.value = False
+
+    async def __call__(self) -> bool:
+        return self.value
+
+
+async def _first_data_frame(gen) -> dict:
+    """Pull frames from the async generator until we find a `data:` frame
+    (skipping keepalive comments). Returns the parsed JSON envelope."""
+    async for frame in gen:
+        if not frame or frame.startswith(":"):
+            continue
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+    raise AssertionError("generator ended without yielding a data frame")
+
+
+@pytest.mark.asyncio
+async def test_generator_yields_frame_from_live_publish(redis_cleanup) -> None:
+    """publish_session_event → subscribe queue → _stream_events yields
+    the frame with the right envelope."""
+    sid = str(uuid.uuid4())
+    redis_cleanup(_stream_key(sid))
+
+    disconnect = _Disconnect()
+    gen = _stream_events(sid, None, disconnect)
+
+    # Kick the generator once to let it SUBSCRIBE before we publish. The
+    # first `async for` step advances the generator into the subscribe +
+    # into the pub/sub poll — at that point the subscriber is live.
+    reader = asyncio.create_task(_first_data_frame(gen))
+    await asyncio.sleep(0.2)
+
+    entry_id = publish_session_event(
+        sid, "action.confirmed",
+        entity={"type": "approval", "id": "approval-xyz"},
+        payload={"status": "approved"},
+    )
+    assert entry_id  # publish succeeded
+
+    envelope = await asyncio.wait_for(reader, timeout=3.0)
+    assert envelope["id"] == entry_id
+    assert envelope["type"] == "action.confirmed"
+    assert envelope["entity"] == {"type": "approval", "id": "approval-xyz"}
+    assert envelope["payload"] == {"status": "approved"}
+
+    disconnect.value = True
+    # Let the generator observe the disconnect and clean up.
+    try:
+        await asyncio.wait_for(gen.aclose(), timeout=2.0)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_generator_replays_from_last_event_id_before_live(redis_cleanup) -> None:
+    """When connecting with Last-Event-Id, the generator MUST yield the
+    Stream entries AFTER that id first, before it starts forwarding
+    live pub/sub messages."""
+    sid = str(uuid.uuid4())
+    redis_cleanup(_stream_key(sid))
+
+    first_id = publish_session_event(sid, "action.confirmed", payload={"n": 1})
+    second_id = publish_session_event(sid, "run.status_changed", payload={"n": 2})
+    third_id = publish_session_event(sid, "run.status_changed", payload={"n": 3})
+    assert first_id and second_id and third_id
+
+    disconnect = _Disconnect()
+    gen = _stream_events(sid, first_id, disconnect)
+
+    replayed: list[dict] = []
+    async for frame in gen:
+        if not frame or frame.startswith(":"):
+            continue
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                replayed.append(json.loads(line[6:]))
+        # Replay of two entries done — flip disconnect to end the generator.
+        if len(replayed) >= 2:
+            disconnect.value = True
+            break
+
+    assert [e["id"] for e in replayed] == [second_id, third_id]
+    assert [e["payload"]["n"] for e in replayed] == [2, 3]
+
+    try:
+        await asyncio.wait_for(gen.aclose(), timeout=2.0)
+    except (asyncio.TimeoutError, StopAsyncIteration):
+        pass

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -998,6 +998,17 @@ function ActionConfirmBubble({
 
 // ─── Run bubble ──────────────────────────────────────────────────────────────
 
+function formatElapsed(startMs: number, endMs: number): string {
+  const secs = Math.max(0, Math.round((endMs - startMs) / 1000))
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  const rem = secs % 60
+  if (mins < 60) return rem ? `${mins}m ${rem}s` : `${mins}m`
+  const hrs = Math.floor(mins / 60)
+  const rmin = mins % 60
+  return rmin ? `${hrs}h ${rmin}m` : `${hrs}h`
+}
+
 type RunBlockState = {
   id: string
   status: "pending" | "running" | "succeeded" | "failed"
@@ -1030,6 +1041,10 @@ function RunBubble({
   // block outputs inline (#1480 PR 9). Refetch on demand if a block the
   // user expands isn't in the cache yet.
   const [runState, setRunState] = useState<Record<string, unknown> | null>(null)
+  const [outcome, setOutcome] = useState<{ type?: string; artifact_url?: string } | null>(null)
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [completedAt, setCompletedAt] = useState<number | null>(null)
+  const [now, setNow] = useState<number>(() => Date.now())
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
@@ -1048,6 +1063,9 @@ function RunBubble({
       .then(data => {
         if (cancelled) return
         if (data?.state) setRunState(data.state as Record<string, unknown>)
+        if (data?.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
+        if (data?.started_at) setStartedAt(new Date(data.started_at as string).getTime())
+        if (data?.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
         if (data?.status && !gotUpdate.current) setStatus(data.status)
       })
       .catch(() => {})
@@ -1055,22 +1073,29 @@ function RunBubble({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId])
 
-  // Refetch state when a block completes so the freshly-added output is
-  // available if the user expands it.
+  // Refetch state + outcome + timing when a block completes / status changes.
   useEffect(() => {
-    // Only refetch when at least one block has completed since last fetch.
     const anyCompleted = Array.from(blocks.values()).some(b => b.status === "succeeded" || b.status === "failed")
-    if (!anyCompleted) return
+    if (!anyCompleted && status !== "succeeded" && status !== "failed") return
     let cancelled = false
     authFetch(`${API}/runs/${runId}`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        if (cancelled || !data?.state) return
-        setRunState(data.state as Record<string, unknown>)
+        if (cancelled || !data) return
+        if (data.state) setRunState(data.state as Record<string, unknown>)
+        if (data.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
+        if (data.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
       })
       .catch(() => {})
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status])
+
+  // Client-side elapsed clock — tick every second while the run is active.
+  useEffect(() => {
+    if (status !== "running" && status !== "pending") return
+    const id = setInterval(() => setNow(Date.now()), 1000)
+    return () => clearInterval(id)
   }, [status])
 
   useLensEvent(stream, "run", runId, (evt) => {
@@ -1119,10 +1144,25 @@ function RunBubble({
             fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 999,
             background: pillColor.bg, color: pillColor.fg, textTransform: "capitalize",
           }}>{status}</span>
+          {startedAt && (
+            <span style={{ fontSize: 11, color: "var(--text-muted)" }}>
+              {formatElapsed(startedAt, completedAt ?? now)}
+            </span>
+          )}
           <a href={`/runs/${runId}`} style={{ fontSize: 13, color: "var(--accent)", textDecoration: "none" }}>
             View run →
           </a>
         </div>
+        {outcome?.artifact_url && (
+          <div style={{ marginBottom: 10, padding: "8px 12px", background: "var(--ok-bg, #dcfce7)", borderRadius: 6, fontSize: 12 }}>
+            <span style={{ color: "var(--ok-text, #166534)", fontWeight: 600 }}>
+              {outcome.type ? outcome.type.replace(/_/g, " ") : "artifact"}:
+            </span>{" "}
+            <a href={outcome.artifact_url} target="_blank" rel="noopener noreferrer" style={{ color: "var(--accent)", textDecoration: "none", wordBreak: "break-all" }}>
+              {outcome.artifact_url}
+            </a>
+          </div>
+        )}
         {error && (
           <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
             {error}

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -997,6 +997,13 @@ function ActionConfirmBubble({
 }
 
 // ─── Run bubble ──────────────────────────────────────────────────────────────
+
+type RunBlockState = {
+  id: string
+  status: "pending" | "running" | "succeeded" | "failed"
+  label?: string
+  error?: string
+}
 // #1480 PR 5 — live run status inline in chat. Subscribes to run.status_changed
 // events on the session stream and updates its pill in place. Always renders
 // the "View run →" link so the user can jump to the run detail page.
@@ -1016,6 +1023,9 @@ function RunBubble({
 }) {
   const [status, setStatus] = useState(initialStatus)
   const [error, setError] = useState<string | null>(null)
+  // Per-block timeline (#1480 PR 7). Order is insertion order (Map preserves
+  // it), which matches the DAG execution order the worker publishes in.
+  const [blocks, setBlocks] = useState<Map<string, RunBlockState>>(new Map())
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
   const gotUpdate = useRef(false)
@@ -1040,12 +1050,31 @@ function RunBubble({
   }, [runId])
 
   useLensEvent(stream, "run", runId, (evt) => {
-    if (evt.type !== "run.status_changed") return
     gotUpdate.current = true
-    const nextStatus = (evt.payload?.status as string | undefined) ?? status
-    setStatus(nextStatus)
-    const evtErr = evt.payload?.error as string | undefined
-    if (evtErr) setError(evtErr)
+    if (evt.type === "run.status_changed") {
+      const nextStatus = (evt.payload?.status as string | undefined) ?? status
+      setStatus(nextStatus)
+      const evtErr = evt.payload?.error as string | undefined
+      if (evtErr) setError(evtErr)
+      return
+    }
+    // Block-level events (#1480 PR 7 timeline)
+    const blockId = evt.payload?.block_id as string | undefined
+    if (!blockId) return
+    const label = evt.payload?.label as string | undefined
+    const errMsg = evt.payload?.error as string | undefined
+    setBlocks(prev => {
+      const next = new Map(prev)
+      const cur = next.get(blockId) ?? { id: blockId, status: "pending" }
+      if (evt.type === "run.block_started") {
+        next.set(blockId, { ...cur, status: "running", label: label ?? cur.label })
+      } else if (evt.type === "run.block_completed") {
+        next.set(blockId, { ...cur, status: "succeeded" })
+      } else if (evt.type === "run.block_failed") {
+        next.set(blockId, { ...cur, status: "failed", error: errMsg ?? cur.error })
+      }
+      return next
+    })
   })
 
   const pillColor = (() => {
@@ -1073,6 +1102,29 @@ function RunBubble({
         {error && (
           <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
             {error}
+          </div>
+        )}
+        {blocks.size > 0 && (
+          <div style={{ marginTop: 10, borderTop: "1px solid var(--border)", paddingTop: 10 }}>
+            {Array.from(blocks.values()).map(b => (
+              <div key={b.id} style={{ display: "flex", alignItems: "flex-start", gap: 8, fontSize: 12, padding: "4px 0", color: "var(--text-2)" }}>
+                <span style={{
+                  display: "inline-block", width: 14, textAlign: "center",
+                  color: b.status === "succeeded" ? "var(--ok-text, #166534)"
+                       : b.status === "failed"    ? "var(--err-text, #991b1b)"
+                       : b.status === "running"   ? "var(--accent-text, #2563eb)"
+                       : "var(--text-muted)",
+                }}>{b.status === "succeeded" ? "✓" : b.status === "failed" ? "✗" : b.status === "running" ? "●" : "○"}</span>
+                <div style={{ flex: 1, minWidth: 0 }}>
+                  <div style={{ fontWeight: 500, color: "var(--text)" }}>{b.label ?? b.id}</div>
+                  {b.error && (
+                    <div style={{ fontSize: 11, color: "var(--err-text, #991b1b)", marginTop: 2 }}>
+                      {b.error}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
           </div>
         )}
       </div>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -3,6 +3,8 @@ import { API } from "@/lib/api"
 
 import { useEffect, useRef, useState } from "react"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { useLensEvent } from "@/hooks/useLensEvent"
+import { useLensSessionStream, type LensSessionStream } from "@/hooks/useLensSessionStream"
 import { GlensDashboard } from "@/components/glens/GlensDashboard"
 import type { GlensDashboardSpec } from "@/components/glens/GlensDashboard"
 import { GlensPageBubble } from "@/components/glens/GlensPageBubble"
@@ -829,6 +831,7 @@ function ActionConfirmBubble({
   warnings,
   expiresAt,
   authFetch,
+  stream,
   onResult,
 }: {
   toolName: string
@@ -837,10 +840,44 @@ function ActionConfirmBubble({
   warnings?: string[]
   expiresAt?: string
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
+  stream: LensSessionStream | null
   onResult: (text: string) => void
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
   const [idCopied, setIdCopied] = useState(false)
+  // Dedupe: whichever source (POST response or SSE event) reports resolution
+  // first wins. Race is fine because the payload shape is identical.
+  const handledRef = useRef(false)
+
+  const finish = (text: string) => {
+    if (handledRef.current) return
+    handledRef.current = true
+    setStatus("done")
+    onResult(text)
+  }
+
+  const messageForConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string): string => {
+    const result = (payload?.result ?? {}) as Record<string, unknown>
+    const label = (payload?.tool_name as string | undefined) ?? fallbackTool
+    const runId = result.run_id as string | undefined
+    if (runId) {
+      const wfName = (result.workflow_name as string | undefined) ?? label
+      return `Run started for **${wfName}**. [View run →](/runs/${runId})`
+    }
+    return `${label} executed successfully.`
+  }
+
+  // #1480 PR 4 — react to action.confirmed / action.cancelled events on the
+  // session stream. Fires for cross-tab confirms, Slack-side approvals, or
+  // any decide path that touches this row. `stream` is null when the SSE
+  // feature flag is off — subscription is a silent no-op then.
+  useLensEvent(stream, "approval", approvalRequestId, (evt) => {
+    if (evt.type === "action.confirmed") {
+      finish(messageForConfirmed(evt.payload, toolName))
+    } else if (evt.type === "action.cancelled") {
+      finish("Action cancelled.")
+    }
+  })
 
   async function post(action: "confirm" | "cancel") {
     setStatus("loading")
@@ -851,26 +888,22 @@ function ActionConfirmBubble({
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        onResult(`Failed to ${action}: ${err.detail ?? res.status}`)
+        finish(`Failed to ${action}: ${err.detail ?? res.status}`)
+        return
+      }
+      // When the SSE stream is live, it will call `finish` with the
+      // event-derived message; the POST body is redundant then. When SSE
+      // is off (flag disabled) or subscribed too late, fall through and
+      // use the response body directly. `finish` deduplicates either way.
+      const data = await res.json()
+      if (action === "confirm") {
+        finish(messageForConfirmed(data as Record<string, unknown>, toolName))
       } else {
-        const data = await res.json()
-        if (action === "confirm") {
-          const label = data.tool_name ?? toolName
-          const runId = data.result?.run_id as string | undefined
-          if (runId) {
-            const wfName = data.result?.workflow_name ?? label
-            onResult(`Run started for **${wfName}**. [View run →](/runs/${runId})`)
-          } else {
-            onResult(`${label} executed successfully.`)
-          }
-        } else {
-          onResult(`Action cancelled.`)
-        }
+        finish("Action cancelled.")
       }
     } catch {
-      onResult("Network error. Please try again.")
+      finish("Network error. Please try again.")
     }
-    setStatus("done")
   }
 
   const isMutation = toolName !== "decide_approval"  // heuristic — decide is itself an approve/reject
@@ -1028,6 +1061,10 @@ export function GLensChatPage() {
 
   const [sessions, setSessions] = useState<GLensSession[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
+  // #1480 PR 4 — SSE session stream. Returns null when the feature flag
+  // (NEXT_PUBLIC_LENS_SSE_SURFACE) is off or no active session yet; bubbles
+  // that opt in via useLensEvent silently degrade to the existing REST flow.
+  const lensStream = useLensSessionStream(activeId)
   const [messages, setMessages] = useState<Message[]>([])
   const [loading, setLoading] = useState(false)
   const [suggestions, setSuggestions] = useState<string[]>(DEFAULT_SUGGESTIONS)
@@ -1369,6 +1406,7 @@ export function GLensChatPage() {
                       warnings={msg.warnings}
                       expiresAt={msg.expiresAt}
                       authFetch={authFetch}
+                      stream={lensStream}
                       onResult={text => setMessages(prev => [
                         ...prev.slice(0, i),
                         { role: "assistant", kind: "answer", text },

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1026,6 +1026,11 @@ function RunBubble({
   // Per-block timeline (#1480 PR 7). Order is insertion order (Map preserves
   // it), which matches the DAG execution order the worker publishes in.
   const [blocks, setBlocks] = useState<Map<string, RunBlockState>>(new Map())
+  // Cached run.state from /runs/{id} — populated on mount, used to render
+  // block outputs inline (#1480 PR 9). Refetch on demand if a block the
+  // user expands isn't in the cache yet.
+  const [runState, setRunState] = useState<Record<string, unknown> | null>(null)
+  const [expanded, setExpanded] = useState<Set<string>>(new Set())
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
   const gotUpdate = useRef(false)
@@ -1041,13 +1046,32 @@ function RunBubble({
     authFetch(`${API}/runs/${runId}`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
-        if (cancelled || !data?.status || gotUpdate.current) return
-        setStatus(data.status)
+        if (cancelled) return
+        if (data?.state) setRunState(data.state as Record<string, unknown>)
+        if (data?.status && !gotUpdate.current) setStatus(data.status)
       })
       .catch(() => {})
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [runId])
+
+  // Refetch state when a block completes so the freshly-added output is
+  // available if the user expands it.
+  useEffect(() => {
+    // Only refetch when at least one block has completed since last fetch.
+    const anyCompleted = Array.from(blocks.values()).some(b => b.status === "succeeded" || b.status === "failed")
+    if (!anyCompleted) return
+    let cancelled = false
+    authFetch(`${API}/runs/${runId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data?.state) return
+        setRunState(data.state as Record<string, unknown>)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status])
 
   useLensEvent(stream, "run", runId, (evt) => {
     gotUpdate.current = true
@@ -1106,25 +1130,61 @@ function RunBubble({
         )}
         {blocks.size > 0 && (
           <div style={{ marginTop: 10, borderTop: "1px solid var(--border)", paddingTop: 10 }}>
-            {Array.from(blocks.values()).map(b => (
-              <div key={b.id} style={{ display: "flex", alignItems: "flex-start", gap: 8, fontSize: 12, padding: "4px 0", color: "var(--text-2)" }}>
-                <span style={{
-                  display: "inline-block", width: 14, textAlign: "center",
-                  color: b.status === "succeeded" ? "var(--ok-text, #166534)"
-                       : b.status === "failed"    ? "var(--err-text, #991b1b)"
-                       : b.status === "running"   ? "var(--accent-text, #2563eb)"
-                       : "var(--text-muted)",
-                }}>{b.status === "succeeded" ? "✓" : b.status === "failed" ? "✗" : b.status === "running" ? "●" : "○"}</span>
-                <div style={{ flex: 1, minWidth: 0 }}>
-                  <div style={{ fontWeight: 500, color: "var(--text)" }}>{b.label ?? b.id}</div>
-                  {b.error && (
-                    <div style={{ fontSize: 11, color: "var(--err-text, #991b1b)", marginTop: 2 }}>
-                      {b.error}
+            {Array.from(blocks.values()).map(b => {
+              const isExpanded = expanded.has(b.id)
+              const blockOutput = runState?.[b.id]
+              const hasOutput = blockOutput !== undefined && b.status !== "pending" && b.status !== "running"
+              return (
+                <div key={b.id} style={{ padding: "4px 0" }}>
+                  <div
+                    onClick={hasOutput ? () => setExpanded(prev => {
+                      const next = new Set(prev)
+                      if (next.has(b.id)) next.delete(b.id); else next.add(b.id)
+                      return next
+                    }) : undefined}
+                    style={{
+                      display: "flex", alignItems: "flex-start", gap: 8, fontSize: 12,
+                      color: "var(--text-2)", cursor: hasOutput ? "pointer" : "default",
+                    }}
+                  >
+                    <span style={{
+                      display: "inline-block", width: 14, textAlign: "center",
+                      color: b.status === "succeeded" ? "var(--ok-text, #166534)"
+                           : b.status === "failed"    ? "var(--err-text, #991b1b)"
+                           : b.status === "running"   ? "var(--accent-text, #2563eb)"
+                           : "var(--text-muted)",
+                    }}>{b.status === "succeeded" ? "✓" : b.status === "failed" ? "✗" : b.status === "running" ? "●" : "○"}</span>
+                    <div style={{ flex: 1, minWidth: 0 }}>
+                      <div style={{ fontWeight: 500, color: "var(--text)" }}>
+                        {b.label ?? b.id}
+                        {hasOutput && (
+                          <span style={{ marginLeft: 8, fontSize: 10, color: "var(--text-muted)" }}>
+                            {isExpanded ? "▾" : "▸"}
+                          </span>
+                        )}
+                      </div>
+                      {b.error && (
+                        <div style={{ fontSize: 11, color: "var(--err-text, #991b1b)", marginTop: 2 }}>
+                          {b.error}
+                        </div>
+                      )}
                     </div>
+                  </div>
+                  {isExpanded && hasOutput && (
+                    <pre style={{
+                      margin: "6px 0 6px 22px", padding: "8px 10px",
+                      background: "var(--surface-3, rgba(0,0,0,0.03))",
+                      border: "1px solid var(--border)", borderRadius: 6,
+                      fontSize: 11, overflow: "auto", maxHeight: 240,
+                      fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace",
+                      color: "var(--text-2)",
+                    }}>
+                      {JSON.stringify(blockOutput, null, 2)}
+                    </pre>
                   )}
                 </div>
-              </div>
-            ))}
+              )
+            })}
           </div>
         )}
       </div>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1006,17 +1006,42 @@ function RunBubble({
   workflowName,
   initialStatus,
   stream,
+  authFetch,
 }: {
   runId: string
   workflowName: string
   initialStatus: string
   stream: LensSessionStream | null
+  authFetch: (url: string, options?: RequestInit) => Promise<Response>
 }) {
   const [status, setStatus] = useState(initialStatus)
   const [error, setError] = useState<string | null>(null)
+  // If an SSE update lands before the bootstrap fetch resolves, the fetch
+  // result is stale — don't overwrite the fresher event.
+  const gotUpdate = useRef(false)
+
+  // Mount-race fix: the worker publishes run.status_changed as soon as it
+  // picks up the run — often BEFORE this component mounts and subscribes.
+  // On short runs both "running" and terminal events can fire before the
+  // subscription attaches, leaving the pill stuck at "pending" forever.
+  // Fetch current status once on mount so the pill catches up regardless
+  // of when SSE events landed.
+  useEffect(() => {
+    let cancelled = false
+    authFetch(`${API}/runs/${runId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data?.status || gotUpdate.current) return
+        setStatus(data.status)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [runId])
 
   useLensEvent(stream, "run", runId, (evt) => {
     if (evt.type !== "run.status_changed") return
+    gotUpdate.current = true
     const nextStatus = (evt.payload?.status as string | undefined) ?? status
     setStatus(nextStatus)
     const evtErr = evt.payload?.error as string | undefined
@@ -1503,6 +1528,7 @@ export function GLensChatPage() {
                       workflowName={msg.workflowName}
                       initialStatus={msg.initialStatus}
                       stream={lensStream}
+                      authFetch={authFetch}
                     />
                   )}
                   {msg.kind === "policy_confirm" && (

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -36,6 +36,7 @@ type Message =
   | { role: "assistant"; kind: "page"; answer: string; pageKind: string; pageData: Record<string, unknown>; warning?: string; skill: string }
   | { role: "assistant"; kind: "policy_confirm"; answer: string; action: string; draft: Record<string, unknown>; mapping: PolicyMapping[]; targetRuleId?: string; sessionId: string; skill: string; warning?: string }
   | { role: "assistant"; kind: "action_confirm"; toolName: string; approvalRequestId: string; summary: string; warnings?: string[]; expiresAt?: string }
+  | { role: "assistant"; kind: "run"; runId: string; workflowName: string; initialStatus: string }
   | { role: "assistant"; kind: "blocks"; answer: string; blocks: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
   | { role: "assistant"; kind: "table"; answer: string; columns?: unknown[]; rows: unknown[]; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> }; understoodAs?: string }
 
@@ -833,6 +834,7 @@ function ActionConfirmBubble({
   authFetch,
   stream,
   onResult,
+  onRunStarted,
 }: {
   toolName: string
   approvalRequestId: string
@@ -842,6 +844,7 @@ function ActionConfirmBubble({
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
   stream: LensSessionStream | null
   onResult: (text: string) => void
+  onRunStarted?: (runId: string, workflowName: string, initialStatus: string) => void
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
   const [idCopied, setIdCopied] = useState(false)
@@ -849,22 +852,38 @@ function ActionConfirmBubble({
   // first wins. Race is fine because the payload shape is identical.
   const handledRef = useRef(false)
 
-  const finish = (text: string) => {
+  const finishText = (text: string) => {
     if (handledRef.current) return
     handledRef.current = true
     setStatus("done")
     onResult(text)
   }
 
-  const messageForConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string): string => {
+  const finishRun = (runId: string, workflowName: string, initialStatus: string) => {
+    if (handledRef.current) return
+    handledRef.current = true
+    setStatus("done")
+    if (onRunStarted) {
+      onRunStarted(runId, workflowName, initialStatus)
+    } else {
+      // Flag OFF or no run-bubble callback wired — fall back to text link.
+      onResult(`Run started for **${workflowName}**. [View run →](/runs/${runId})`)
+    }
+  }
+
+  const dispatchConfirmed = (payload: Record<string, unknown> | undefined, fallbackTool: string) => {
     const result = (payload?.result ?? {}) as Record<string, unknown>
     const label = (payload?.tool_name as string | undefined) ?? fallbackTool
     const runId = result.run_id as string | undefined
     if (runId) {
       const wfName = (result.workflow_name as string | undefined) ?? label
-      return `Run started for **${wfName}**. [View run →](/runs/${runId})`
+      // Initial status from the run row when we have it; "pending" otherwise
+      // (the worker will emit run.status_changed within seconds).
+      const initialStatus = (result.status as string | undefined) ?? "pending"
+      finishRun(runId, wfName, initialStatus)
+    } else {
+      finishText(`${label} executed successfully.`)
     }
-    return `${label} executed successfully.`
   }
 
   // #1480 PR 4 — react to action.confirmed / action.cancelled events on the
@@ -873,9 +892,9 @@ function ActionConfirmBubble({
   // feature flag is off — subscription is a silent no-op then.
   useLensEvent(stream, "approval", approvalRequestId, (evt) => {
     if (evt.type === "action.confirmed") {
-      finish(messageForConfirmed(evt.payload, toolName))
+      dispatchConfirmed(evt.payload, toolName)
     } else if (evt.type === "action.cancelled") {
-      finish("Action cancelled.")
+      finishText("Action cancelled.")
     }
   })
 
@@ -888,21 +907,21 @@ function ActionConfirmBubble({
       })
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
-        finish(`Failed to ${action}: ${err.detail ?? res.status}`)
+        finishText(`Failed to ${action}: ${err.detail ?? res.status}`)
         return
       }
-      // When the SSE stream is live, it will call `finish` with the
+      // When the SSE stream is live, it will call `finish*` with the
       // event-derived message; the POST body is redundant then. When SSE
       // is off (flag disabled) or subscribed too late, fall through and
-      // use the response body directly. `finish` deduplicates either way.
+      // use the response body directly. `handledRef` deduplicates either way.
       const data = await res.json()
       if (action === "confirm") {
-        finish(messageForConfirmed(data as Record<string, unknown>, toolName))
+        dispatchConfirmed(data as Record<string, unknown>, toolName)
       } else {
-        finish("Action cancelled.")
+        finishText("Action cancelled.")
       }
     } catch {
-      finish("Network error. Please try again.")
+      finishText("Network error. Please try again.")
     }
   }
 
@@ -972,6 +991,65 @@ function ActionConfirmBubble({
           </div>
         )}
         {status === "loading" && <div style={{ fontSize: 13, color: "var(--text-muted)" }}>Working…</div>}
+      </div>
+    </div>
+  )
+}
+
+// ─── Run bubble ──────────────────────────────────────────────────────────────
+// #1480 PR 5 — live run status inline in chat. Subscribes to run.status_changed
+// events on the session stream and updates its pill in place. Always renders
+// the "View run →" link so the user can jump to the run detail page.
+
+function RunBubble({
+  runId,
+  workflowName,
+  initialStatus,
+  stream,
+}: {
+  runId: string
+  workflowName: string
+  initialStatus: string
+  stream: LensSessionStream | null
+}) {
+  const [status, setStatus] = useState(initialStatus)
+  const [error, setError] = useState<string | null>(null)
+
+  useLensEvent(stream, "run", runId, (evt) => {
+    if (evt.type !== "run.status_changed") return
+    const nextStatus = (evt.payload?.status as string | undefined) ?? status
+    setStatus(nextStatus)
+    const evtErr = evt.payload?.error as string | undefined
+    if (evtErr) setError(evtErr)
+  })
+
+  const pillColor = (() => {
+    switch (status) {
+      case "succeeded": return { bg: "var(--ok-bg, #dcfce7)", fg: "var(--ok-text, #166534)" }
+      case "failed":    return { bg: "var(--err-bg, #fee2e2)", fg: "var(--err-text, #991b1b)" }
+      case "running":   return { bg: "var(--accent-weak, rgba(59,130,246,0.12))", fg: "var(--accent-text, #2563eb)" }
+      default:          return { bg: "var(--surface-3, #f3f4f6)", fg: "var(--text-muted)" }
+    }
+  })()
+
+  return (
+    <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
+      <div style={{ maxWidth: "80%", background: "var(--surface-2)", border: "1px solid var(--border)", borderRadius: "4px 14px 14px 14px", padding: "16px 20px" }}>
+        <div style={{ fontSize: 10, fontWeight: 700, color: "var(--text-muted)", textTransform: "uppercase", letterSpacing: ".06em", marginBottom: 8 }}>Run · {workflowName}</div>
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 10 }}>
+          <span style={{
+            fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 999,
+            background: pillColor.bg, color: pillColor.fg, textTransform: "capitalize",
+          }}>{status}</span>
+          <a href={`/runs/${runId}`} style={{ fontSize: 13, color: "var(--accent)", textDecoration: "none" }}>
+            View run →
+          </a>
+        </div>
+        {error && (
+          <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
+            {error}
+          </div>
+        )}
       </div>
     </div>
   )
@@ -1412,6 +1490,19 @@ export function GLensChatPage() {
                         { role: "assistant", kind: "answer", text },
                         ...prev.slice(i + 1),
                       ])}
+                      onRunStarted={lensStream ? (runId, wfName, initialStatus) => setMessages(prev => [
+                        ...prev.slice(0, i),
+                        { role: "assistant", kind: "run", runId, workflowName: wfName, initialStatus },
+                        ...prev.slice(i + 1),
+                      ]) : undefined}
+                    />
+                  )}
+                  {msg.kind === "run" && (
+                    <RunBubble
+                      runId={msg.runId}
+                      workflowName={msg.workflowName}
+                      initialStatus={msg.initialStatus}
+                      stream={lensStream}
                     />
                   )}
                   {msg.kind === "policy_confirm" && (

--- a/apps/web/src/hooks/useLensEvent.ts
+++ b/apps/web/src/hooks/useLensEvent.ts
@@ -1,0 +1,35 @@
+"use client"
+
+/**
+ * Subscribe a component to Lens session events for one entity (#1480 PR 4).
+ *
+ * Component-level entity subscription — no global reducer, no coupled state.
+ * Each bubble subscribes to its own approval_id or run_id and reacts when
+ * events arrive from the session stream.
+ *
+ * Silent no-op when `stream` is null (feature flag off, or no active session).
+ */
+import { useEffect, useRef } from "react"
+
+import type { LensEvent, LensSessionStream } from "./useLensSessionStream"
+
+
+export function useLensEvent(
+  stream: LensSessionStream | null,
+  entityType: string,
+  entityId: string | null | undefined,
+  handler: (evt: LensEvent) => void,
+): void {
+  // Keep the latest handler in a ref so we don't tear down + re-subscribe
+  // every time the parent re-renders with a new closure.
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+
+  useEffect(() => {
+    if (!stream || !entityId) return
+    return stream.subscribe(
+      (evt) => evt.entity?.type === entityType && evt.entity?.id === entityId,
+      (evt) => handlerRef.current(evt),
+    )
+  }, [stream, entityType, entityId])
+}

--- a/apps/web/src/hooks/useLensSessionStream.ts
+++ b/apps/web/src/hooks/useLensSessionStream.ts
@@ -1,0 +1,159 @@
+"use client"
+
+/**
+ * Client for the Lens session SSE stream (#1480 PR 4).
+ *
+ *   GET /glens/sessions/{id}/stream  →  SSE frames of session events
+ *
+ * We use fetch + ReadableStream instead of the browser's EventSource so we
+ * can attach the Clerk Bearer token + X-Workspace-ID header (EventSource
+ * only supports cookies). The wire format is standard SSE; we parse it in
+ * ~30 lines below.
+ *
+ * Consumers use `useLensEvent(stream, entityType, entityId, handler)` from
+ * `useLensEvent.ts` to react to events for one entity (approval/run) without
+ * building a global reducer.
+ *
+ * Reconnect: on network error / stream end, wait 3s and reconnect with the
+ * last-seen event id so the server replays anything we missed.
+ *
+ * Feature flag: NEXT_PUBLIC_LENS_SSE_SURFACE === "true" — off by default.
+ */
+import { useEffect, useRef, useState } from "react"
+
+import { API } from "@/lib/api"
+
+import { useAuthFetch } from "./useAuthFetch"
+
+export type LensEvent = {
+  id: string
+  type: string
+  at: string
+  entity?: { type: string; id: string }
+  payload?: Record<string, unknown>
+}
+
+type Subscriber = {
+  predicate: (evt: LensEvent) => boolean
+  handler: (evt: LensEvent) => void
+}
+
+export type LensSessionStream = {
+  subscribe: (
+    predicate: (evt: LensEvent) => boolean,
+    handler: (evt: LensEvent) => void,
+  ) => () => void
+}
+
+const SSE_ENABLED = process.env.NEXT_PUBLIC_LENS_SSE_SURFACE === "true"
+const RECONNECT_DELAY_MS = 3000
+
+
+export function useLensSessionStream(sessionId: string | null): LensSessionStream | null {
+  const { authFetch } = useAuthFetch()
+  const subsRef = useRef<Subscriber[]>([])
+  const [stream, setStream] = useState<LensSessionStream | null>(null)
+
+  useEffect(() => {
+    if (!SSE_ENABLED || !sessionId) {
+      setStream(null)
+      return
+    }
+
+    let cancelled = false
+    let lastEventId: string | null = null
+    let controller = new AbortController()
+
+    const streamHandle: LensSessionStream = {
+      subscribe(predicate, handler) {
+        const sub = { predicate, handler }
+        subsRef.current.push(sub)
+        return () => {
+          subsRef.current = subsRef.current.filter((s) => s !== sub)
+        }
+      },
+    }
+    setStream(streamHandle)
+
+    const dispatch = (evt: LensEvent) => {
+      for (const sub of subsRef.current) {
+        try {
+          if (sub.predicate(evt)) sub.handler(evt)
+        } catch {
+          // Subscriber threw — swallow so one bad bubble doesn't nuke the stream.
+        }
+      }
+    }
+
+    const connect = async () => {
+      while (!cancelled) {
+        controller = new AbortController()
+        try {
+          const headers: Record<string, string> = {}
+          if (lastEventId) headers["Last-Event-Id"] = lastEventId
+          const res = await authFetch(`${API}/glens/sessions/${sessionId}/stream`, {
+            method: "GET",
+            headers,
+            signal: controller.signal,
+          })
+          if (!res.ok || !res.body) {
+            throw new Error(`stream open failed: ${res.status}`)
+          }
+
+          const reader = res.body.getReader()
+          const decoder = new TextDecoder()
+          let buf = ""
+
+          while (!cancelled) {
+            const { done, value } = await reader.read()
+            if (done) break
+            buf += decoder.decode(value, { stream: true })
+
+            // SSE frames are separated by a blank line.
+            const parts = buf.split("\n\n")
+            buf = parts.pop() ?? ""
+            for (const raw of parts) {
+              // Ignore SSE comments (keepalives) — they start with ":".
+              if (raw.startsWith(":") || raw.trim() === "") continue
+
+              let idLine = ""
+              let dataLine = ""
+              for (const line of raw.split("\n")) {
+                if (line.startsWith("id: ")) idLine = line.slice(4)
+                else if (line.startsWith("data: ")) dataLine = line.slice(6)
+              }
+              if (!dataLine) continue
+
+              try {
+                const parsed = JSON.parse(dataLine) as LensEvent
+                if (idLine) lastEventId = idLine
+                else if (parsed.id) lastEventId = parsed.id
+                dispatch(parsed)
+              } catch {
+                // Malformed frame — skip, don't crash the stream.
+              }
+            }
+          }
+        } catch (err) {
+          if (cancelled) return
+          if (err instanceof Error && err.name === "AbortError") return
+          // Fall through to reconnect after delay.
+        }
+        if (cancelled) return
+        await new Promise((r) => setTimeout(r, RECONNECT_DELAY_MS))
+      }
+    }
+
+    connect()
+
+    return () => {
+      cancelled = true
+      controller.abort()
+      subsRef.current = []
+      setStream(null)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionId])
+
+  return stream
+}


### PR DESCRIPTION
## Why one big PR

PRs #1486, #1487, #1489, #1490, #1492, #1493, #1494, #1495, #1496 all merged as **MERGED** in GitHub but landed in **each other's branches** (stacked base misconfiguration), never on main. Only #1485 (PR 1) reached main. This PR cherry-picks all 9 accumulated commits onto a fresh branch off main so everything lands atomically.

## Included commits (in order)

1. \`feat(lens): SSE session-stream endpoint with Last-Event-Id replay\` — was #1486
2. \`feat(lens): tee action.confirmed / action.cancelled to session stream\` — was #1487
3. \`feat(lens): reactive ActionConfirmBubble via SSE session stream\` — was #1489
4. \`feat(lens): worker run.status_changed events + live <RunBubble>\` — was #1490
5. \`fix(lens): RunBubble mount-race + real-Redis publisher integration tests\` — was #1492
6. \`test(lens): extract SSE generator + real-Redis round-trip test\` — was #1492 hotfix
7. \`feat(lens): block-level run events + inline timeline in RunBubble\` — was #1493
8. \`feat(lens): list_my_runs + list_runs_in_session tools\` — was #1494
9. \`feat(lens): expand blocks inline to view outputs\` — was #1495
10. \`feat(lens): outcome artifact link + elapsed timer in RunBubble\` — was #1496

## What this ships end-to-end

The full interactive SSE surface — user runs a workflow via Lens Confirm button, gets:
- Live \`<RunBubble>\` with pill (\`pending → running → succeeded/failed\`)
- Elapsed timer ticking during the run
- Block-by-block timeline (\`○ ● ✓ ✗\` glyphs) in DAG order
- Click a completed block → JSON output expands inline
- Artifact URL (PR opened, issue filed, etc.) renders in a green box when detected
- \`list_my_runs\` / \`list_runs_in_session\` tools for cross-session run history

Behind flag \`NEXT_PUBLIC_LENS_SSE_SURFACE\` — off = byte-for-byte identical to today.

## Regression evidence

- **140 backend tests pass** (glens + real Postgres + migration 0108)
- **TypeScript clean** (\`tsc --noEmit\`)
- **6 real-Redis integration tests pass** (publisher + SSE generator)
- **Same evidence as the 9 individual PRs** — this is the same code, just correctly targeted at main this time

## Note on the stacked-PR bug

For future stacked PR series: GitHub does NOT auto-flip child bases to main when parents merge. Either use merge queue (correct fix) or rebase each child onto main manually before merging. This series merged fast without rebasing → 9 PRs landed in dangling branches instead of main.

Closes the same scope as: #1486, #1487, #1489, #1490, #1492, #1493, #1494, #1495, #1496.

Part of #1480.