### PR TITLE
fix(lens): rehydrate ActionConfirmBubble + RunBubble on session restore (#1480 PR 12)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 
 import structlog
 from fastapi import APIRouter, BackgroundTasks, Depends
@@ -797,9 +798,16 @@ async def glens_chat_stream(
 
                 elif evt.get("type") == "done":
                     answer = evt["answer"]
+                    # Persist envelopes alongside the answer so session
+                    # restore (#1480 PR 12) can rehydrate the right bubble
+                    # kind — otherwise refresh loses ActionConfirmBubble /
+                    # RunBubble and shows the LLM's prose only.
+                    persisted: dict[str, Any] = {"answer": answer, "skill": "governance"}
+                    if evt.get("confirm_envelope"):
+                        persisted["confirm_envelope"] = evt["confirm_envelope"]
                     session_messages.append({
                         "role": "assistant",
-                        "content": json.dumps({"answer": answer, "skill": "governance"}),
+                        "content": json.dumps(persisted),
                     })
                     capped = session_messages[-50:]
                     background_tasks.add_task(_bg_save_session, session_id_str, capped, None)

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1062,7 +1062,27 @@ function RunBubble({
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled) return
-        if (data?.state) setRunState(data.state as Record<string, unknown>)
+        if (data?.state) {
+          const st = data.state as Record<string, unknown>
+          setRunState(st)
+          // #1480 PR 12 — seed the block timeline from persisted run.state
+          // so a restored RunBubble shows completed blocks immediately
+          // instead of waiting for new SSE events (which never come for
+          // an already-completed run).
+          if (gotUpdate.current === false) {
+            const seeded = new Map<string, RunBlockState>()
+            for (const [key, val] of Object.entries(st)) {
+              if (key.startsWith("__")) continue
+              const failed = val && typeof val === "object" && "error" in (val as Record<string, unknown>)
+              seeded.set(key, {
+                id: key,
+                status: failed ? "failed" : "succeeded",
+                error: failed ? String((val as Record<string, unknown>).error) : undefined,
+              })
+            }
+            if (seeded.size > 0) setBlocks(prev => prev.size === 0 ? seeded : prev)
+          }
+        }
         if (data?.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
         if (data?.started_at) setStartedAt(new Date(data.started_at as string).getTime())
         if (data?.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
@@ -1386,6 +1406,26 @@ export function GLensChatPage() {
               thread.push({ role: "assistant", kind: "table", rows: rendered.rows, answer: p.answer ?? "", skill: p.skill ?? "governance", columns: p.columns })
             } else if (rendered.blocks?.length) {
               thread.push({ role: "assistant", kind: "blocks", blocks: rendered.blocks, answer: p.answer ?? "", skill: p.skill ?? "governance" })
+            } else if (p.confirm_envelope?.approval_request_id) {
+              // #1480 PR 12 — rehydrate ActionConfirmBubble from persisted envelope
+              const ce = p.confirm_envelope
+              thread.push({
+                role: "assistant", kind: "action_confirm",
+                toolName: ce.tool_name,
+                approvalRequestId: ce.approval_request_id,
+                summary: ce.summary ?? "Confirm this action?",
+                warnings: ce.warnings ?? [],
+                expiresAt: ce.expires_at,
+              })
+            } else if (p.run_started?.run_id) {
+              // #1480 PR 12 — rehydrate RunBubble from persisted envelope
+              const rs = p.run_started
+              thread.push({
+                role: "assistant", kind: "run",
+                runId: rs.run_id,
+                workflowName: rs.workflow_name ?? "workflow",
+                initialStatus: rs.status ?? "pending",
+              })
             } else {
               const text = p.answer || p.question
               if (text) thread.push({ role: "assistant", kind: "answer", text, skill: p.skill })


### PR DESCRIPTION
## Bug

Reload a Lens session that had a Confirm/Run bubble — the bubble is gone, only the LLM's prose text survives.

## Root cause

\`_bg_save_session\` in \`chat.py\` persisted only the answer text:
\`\`\`python
session_messages.append({
    "role": "assistant",
    "content": json.dumps({"answer": answer, "skill": "governance"}),
})
\`\`\`

The \`confirm_envelope\` + \`run_started_envelope\` that trigger \`action_confirm\` / \`run\` message kinds were dropped. On restore, \`GET /glens/sessions/{id}\` returns just \`{answer, skill}\` → frontend falls into the "kind: answer" branch → bubble replaced with plain text.

## Fix

**Backend**: include envelopes in the persisted JSON. Non-breaking — extra keys are optional.

**Frontend \`selectSession\`**: check the restored JSON for envelopes and push the matching message kind.

**Frontend \`<RunBubble>\`**: mount-time \`/runs/{id}\` fetch now also seeds the \`blocks\` timeline Map from \`run.state\` keys. Restored bubbles show the full completed timeline immediately instead of waiting for SSE events that never come for a done run.

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Refresh session with pending confirm | Prose text only | ActionConfirmBubble restored |
| Refresh session mid-run | Text link | RunBubble with live pill |
| Refresh completed run | Text link | RunBubble with full block timeline + outcome |

## Test plan

- [x] 140 backend tests pass (real Postgres + Redis)
- [x] TypeScript clean
- [x] Byte-for-byte parity with pre-PR-12 for sessions without SSE bubbles (existing answer/table/blocks/dashboard restore paths unchanged)
- [ ] Manual smoke: trigger a Confirm bubble, refresh, verify bubble restored
- [ ] Manual smoke: click Confirm, refresh mid-run, verify RunBubble + timeline restored
- [ ] Manual smoke: wait for run to complete, refresh, verify full RunBubble + block outputs + artifact link

Part of #1480.