### PR TITLE
feat(lens): natural-language RunBubble + inline Cancel/Approve/Reject/Retry (#1480 PR 13+14)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -789,6 +789,14 @@ async def glens_chat_stream(
             confirm_envelope = _extract_confirm_envelope(final_msgs)
             run_started_envelope = _extract_run_started_envelope(final_msgs)
 
+            # #1480 PR 14 — skip prose streaming entirely when we have a
+            # run_started envelope. <RunBubble> IS the answer; streaming
+            # "Run triggered successfully!" underneath would flash for
+            # ~500ms before the frontend replaces it with the bubble.
+            if run_started_envelope:
+                await event_q.put({"type": "done", "answer": "", "confirm_envelope": confirm_envelope, "run_started_envelope": run_started_envelope})
+                return
+
             if early_text:
                 answer = early_text
                 tool_results = [msg.get("content", "") for msg in final_msgs if msg.get("role") == "tool"]

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -428,6 +428,53 @@ def _extract_confirm_envelope(final_msgs: list[dict]) -> dict | None:
     return None
 
 
+def _extract_run_started_envelope(final_msgs: list[dict]) -> dict | None:
+    """First tool result whose JSON body reports a successful run kickoff
+    (executed=True + result.run_id set). Surfaces the run metadata to the
+    SSE 'done' event so the frontend can render <RunBubble> inline —
+    same live surface the button-click path gets via ActionConfirmBubble
+    (#1480 PR 11).
+
+    Fires when the LLM took the natural-language confirm path
+    (`confirm_pending_action` tool) instead of the user clicking Confirm.
+
+    Same two shapes as `_extract_confirm_envelope`:
+      OpenAI/Perplexity: {"role": "tool", "content": "<json>"}
+      Anthropic:         {"role": "user", "content": [{"type": "tool_result", "content": "<json>"}, ...]}
+    """
+    def _match(raw) -> dict | None:
+        try:
+            r = json.loads(raw) if isinstance(raw, str) else raw
+        except Exception:
+            return None
+        if not isinstance(r, dict):
+            return None
+        if not r.get("executed"):
+            return None
+        result = r.get("result")
+        if not isinstance(result, dict) or not result.get("run_id"):
+            return None
+        return {
+            "run_id": result["run_id"],
+            "workflow_name": result.get("workflow_name") or r.get("tool_name") or "workflow",
+            "status": result.get("status") or "pending",
+        }
+
+    for m in final_msgs:
+        content = m.get("content", "")
+        if m.get("role") == "tool":
+            hit = _match(content)
+            if hit:
+                return hit
+        elif m.get("role") == "user" and isinstance(content, list):
+            for blk in content:
+                if isinstance(blk, dict) and blk.get("type") == "tool_result":
+                    hit = _match(blk.get("content", ""))
+                    if hit:
+                        return hit
+    return None
+
+
 def _build_drilldown(tool_calls: list[tuple[str, dict]]) -> str | None:
     """Build a grounded drilldown URL from the tool calls the LLM actually made."""
     page = "/logs/guard"
@@ -740,6 +787,7 @@ async def glens_chat_stream(
             final_msgs, early_text, tool_calls = await asyncio.to_thread(_resolve_tools, llm_messages, system, executor)
             drilldown = _build_drilldown(tool_calls) if _has_data(final_msgs) else None
             confirm_envelope = _extract_confirm_envelope(final_msgs)
+            run_started_envelope = _extract_run_started_envelope(final_msgs)
 
             if early_text:
                 answer = early_text
@@ -750,7 +798,7 @@ async def glens_chat_stream(
                 for char in answer:
                     await event_q.put({"type": "token", "text": char})
                     await asyncio.sleep(0)
-                await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope})
+                await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope, "run_started_envelope": run_started_envelope})
                 return
 
             # Phase 2: stream synthesis (tools already resolved)
@@ -766,7 +814,7 @@ async def glens_chat_stream(
                     await event_q.put({"type": "token", "text": char})
                     await asyncio.sleep(0)
                 answer += link
-            await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope})
+            await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope, "run_started_envelope": run_started_envelope})
         except Exception as e:
             # If it's a Guard block, surface the rule_id to logs + telemetry.
             # #1286 wired Lens through the same policy engine as the HTTP
@@ -805,6 +853,8 @@ async def glens_chat_stream(
                     persisted: dict[str, Any] = {"answer": answer, "skill": "governance"}
                     if evt.get("confirm_envelope"):
                         persisted["confirm_envelope"] = evt["confirm_envelope"]
+                    if evt.get("run_started_envelope"):
+                        persisted["run_started"] = evt["run_started_envelope"]
                     session_messages.append({
                         "role": "assistant",
                         "content": json.dumps(persisted),
@@ -815,6 +865,8 @@ async def glens_chat_stream(
                     done_payload = {"type": "done", "session_id": session_id_str, "skill": "governance", "answer": answer}
                     if evt.get("confirm_envelope"):
                         done_payload.update(evt["confirm_envelope"])
+                    if evt.get("run_started_envelope"):
+                        done_payload["run_started"] = evt["run_started_envelope"]
                     yield f"data: {json.dumps(done_payload)}\n\n"
                     break
         except asyncio.TimeoutError:

--- a/apps/api/app/runtime/dag_runner.py
+++ b/apps/api/app/runtime/dag_runner.py
@@ -1193,6 +1193,13 @@ def _execute_dag(
                 db.commit()
             except Exception:
                 pass
+            # #1480 PR 14 — surface the pause on the Lens session stream so
+            # <RunBubble> can render Approve/Reject buttons inline.
+            try:
+                from app.modules.glens.run_events import publish_run_status
+                publish_run_status(run)
+            except Exception:
+                pass
             _payload = {
                 "block_id": ap.block_id,
                 "message": ap.message,

--- a/apps/api/tests/glens/test_cross_tab_pubsub.py
+++ b/apps/api/tests/glens/test_cross_tab_pubsub.py
@@ -1,0 +1,106 @@
+"""Cross-tab pubsub smoke test (#1480 PR 14) — two subscribers on the same
+session channel both receive a single published event.
+
+The whole reason the design chose Redis pub/sub for fan-out was cross-tab
+support 'comes free': every tab opens its own SSE connection, both
+subscribe to `chan:session:<id>`, one PUBLISH → every subscriber gets a
+message. This test proves the primitive works so we can trust the
+architectural claim without a browser.
+
+Auto-skips when Redis isn't reachable — same fixture pattern as the
+other integration tests.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import uuid
+
+import pytest
+import redis
+
+from app.core.config import settings
+from app.modules.glens.events import _stream_key, publish_session_event
+from app.modules.glens.routers.session_stream import _stream_events
+
+
+def _redis_reachable() -> bool:
+    try:
+        redis.from_url(settings.redis_url, decode_responses=True, socket_timeout=1).ping()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = pytest.mark.skipif(
+    not _redis_reachable(),
+    reason="Redis not reachable — start with `docker compose up redis`",
+)
+
+
+class _Disconnect:
+    def __init__(self) -> None:
+        self.value = False
+
+    async def __call__(self) -> bool:
+        return self.value
+
+
+async def _next_data_frame(gen) -> dict:
+    async for frame in gen:
+        if not frame or frame.startswith(":"):
+            continue
+        for line in frame.split("\n"):
+            if line.startswith("data: "):
+                return json.loads(line[6:])
+    raise AssertionError("generator ended without yielding a data frame")
+
+
+@pytest.mark.asyncio
+async def test_two_subscribers_on_same_session_both_receive_event() -> None:
+    """Cross-tab: same user, two Lens tabs → two SSE connections →
+    ONE publish should fan out to both."""
+    sid = str(uuid.uuid4())
+    r = redis.from_url(settings.redis_url, decode_responses=True)
+
+    d1 = _Disconnect()
+    d2 = _Disconnect()
+    tab1 = _stream_events(sid, None, d1)
+    tab2 = _stream_events(sid, None, d2)
+
+    # Start both readers before publishing so the SUBSCRIBE inside each
+    # generator has actually attached.
+    reader1 = asyncio.create_task(_next_data_frame(tab1))
+    reader2 = asyncio.create_task(_next_data_frame(tab2))
+    await asyncio.sleep(0.25)
+
+    entry_id = publish_session_event(
+        sid, "action.confirmed",
+        entity={"type": "approval", "id": "approval-xyz"},
+        payload={"status": "approved"},
+    )
+    assert entry_id
+
+    try:
+        envelope1, envelope2 = await asyncio.wait_for(
+            asyncio.gather(reader1, reader2), timeout=3.0,
+        )
+        # Both tabs got the same frame with the same stream id.
+        assert envelope1["id"] == entry_id
+        assert envelope2["id"] == entry_id
+        assert envelope1["type"] == "action.confirmed"
+        assert envelope2["type"] == "action.confirmed"
+        assert envelope1["entity"] == {"type": "approval", "id": "approval-xyz"}
+        assert envelope2["entity"] == {"type": "approval", "id": "approval-xyz"}
+    finally:
+        d1.value = True
+        d2.value = True
+        for gen in (tab1, tab2):
+            try:
+                await asyncio.wait_for(gen.aclose(), timeout=2.0)
+            except (asyncio.TimeoutError, StopAsyncIteration):
+                pass
+        try:
+            r.delete(_stream_key(sid))
+        except Exception:
+            pass

--- a/apps/api/tests/glens/test_extract_run_started_envelope.py
+++ b/apps/api/tests/glens/test_extract_run_started_envelope.py
@@ -1,0 +1,107 @@
+"""#1480 PR 13 — the SSE 'done' event must surface a run_started envelope
+so the frontend renders <RunBubble> instead of the LLM's prose.
+
+_extract_run_started_envelope scans final_msgs for the first tool result
+whose JSON body carries executed=True + result.run_id — that's the shape
+`confirm_pending_action` returns after natural-language "yes"."""
+from __future__ import annotations
+
+import json
+
+from app.modules.glens.routers.chat import _extract_run_started_envelope
+
+
+CONFIRMED = {
+    "executed": True,
+    "cached": False,
+    "action_id": "act_abc",
+    "tool_name": "run_workflow",
+    "status": "approved",
+    "result": {
+        "run_id": "31def331-49d1-49c0-90eb-a00b88c47ea0",
+        "workflow_name": "self_driving_network_approval_demo",
+        "status": "pending",
+    },
+}
+
+
+def test_matches_openai_shape_tool_role() -> None:
+    msgs = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": "calling tool"},
+        {"role": "tool", "content": json.dumps(CONFIRMED)},
+    ]
+    envelope = _extract_run_started_envelope(msgs)
+    assert envelope == {
+        "run_id": "31def331-49d1-49c0-90eb-a00b88c47ea0",
+        "workflow_name": "self_driving_network_approval_demo",
+        "status": "pending",
+    }
+
+
+def test_matches_anthropic_shape_tool_result_in_user_message() -> None:
+    msgs = [
+        {"role": "user", "content": "run it"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "tool_result", "content": json.dumps(CONFIRMED)},
+            ],
+        },
+    ]
+    envelope = _extract_run_started_envelope(msgs)
+    assert envelope is not None
+    assert envelope["run_id"] == "31def331-49d1-49c0-90eb-a00b88c47ea0"
+
+
+def test_returns_none_when_no_tool_result() -> None:
+    msgs = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "hi"}]
+    assert _extract_run_started_envelope(msgs) is None
+
+
+def test_returns_none_when_executed_false() -> None:
+    """cancel_pending_action returns executed=False; must not fire RunBubble."""
+    payload = {"cancelled": True, "action_id": "x", "tool_name": "run_workflow"}
+    msgs = [{"role": "tool", "content": json.dumps(payload)}]
+    assert _extract_run_started_envelope(msgs) is None
+
+
+def test_returns_none_when_no_run_id_in_result() -> None:
+    """Non-run tools (e.g. rules mutations) return executed=True but no
+    run_id — RunBubble must not fire for those."""
+    payload = {
+        "executed": True,
+        "action_id": "x",
+        "tool_name": "apply_policy",
+        "status": "approved",
+        "result": {"policy_id": "pol_123"},
+    }
+    msgs = [{"role": "tool", "content": json.dumps(payload)}]
+    assert _extract_run_started_envelope(msgs) is None
+
+
+def test_falls_back_to_tool_name_when_workflow_name_missing() -> None:
+    payload = {
+        "executed": True,
+        "action_id": "x",
+        "tool_name": "run_workflow",
+        "status": "approved",
+        "result": {"run_id": "r1"},
+    }
+    msgs = [{"role": "tool", "content": json.dumps(payload)}]
+    envelope = _extract_run_started_envelope(msgs)
+    assert envelope == {
+        "run_id": "r1",
+        "workflow_name": "run_workflow",
+        "status": "pending",
+    }
+
+
+def test_skips_unparseable_content() -> None:
+    msgs = [
+        {"role": "tool", "content": "not-json"},
+        {"role": "tool", "content": json.dumps(CONFIRMED)},
+    ]
+    envelope = _extract_run_started_envelope(msgs)
+    assert envelope is not None
+    assert envelope["run_id"] == "31def331-49d1-49c0-90eb-a00b88c47ea0"

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1473,6 +1473,17 @@ export function GLensChatPage() {
         skill: (data.skill as string) ?? "rules",
         followups: data.followups as string[] | undefined,
       }])
+    } else if (data.run_started) {
+      // Natural-language confirm path (#1480 PR 11): user typed "yes" and
+      // the LLM called confirm_pending_action which returned a run_id.
+      // Render <RunBubble> — same live surface the button-click path gets.
+      const rs = data.run_started as { run_id: string; workflow_name: string; status: string }
+      setMessages(prev => [...prev.slice(0, -1), {
+        role: "assistant", kind: "run",
+        runId: rs.run_id,
+        workflowName: rs.workflow_name,
+        initialStatus: rs.status ?? "pending",
+      }])
     } else if (data.confirm_required && data.approval_request_id) {
       setMessages(prev => [...prev.slice(0, -1), {
         role: "assistant", kind: "action_confirm",

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1025,12 +1025,14 @@ function RunBubble({
   initialStatus,
   stream,
   authFetch,
+  onRetry,
 }: {
   runId: string
   workflowName: string
   initialStatus: string
   stream: LensSessionStream | null
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
+  onRetry?: (newRunId: string, workflowName: string) => void
 }) {
   const [status, setStatus] = useState(initialStatus)
   const [error, setError] = useState<string | null>(null)
@@ -1042,6 +1044,9 @@ function RunBubble({
   // user expands isn't in the cache yet.
   const [runState, setRunState] = useState<Record<string, unknown> | null>(null)
   const [outcome, setOutcome] = useState<{ type?: string; artifact_url?: string } | null>(null)
+  const [workflowId, setWorkflowId] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+  const [actionErr, setActionErr] = useState<string | null>(null)
   const [startedAt, setStartedAt] = useState<number | null>(null)
   const [completedAt, setCompletedAt] = useState<number | null>(null)
   const [now, setNow] = useState<number>(() => Date.now())
@@ -1083,6 +1088,7 @@ function RunBubble({
             if (seeded.size > 0) setBlocks(prev => prev.size === 0 ? seeded : prev)
           }
         }
+        if (data?.workflow_id) setWorkflowId(data.workflow_id as string)
         if (data?.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
         if (data?.started_at) setStartedAt(new Date(data.started_at as string).getTime())
         if (data?.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
@@ -1146,11 +1152,46 @@ function RunBubble({
     })
   })
 
+  async function _postAction(url: string, body?: unknown, onOk?: (data: Record<string, unknown>) => void) {
+    if (busy || !workflowId) return
+    setBusy(true); setActionErr(null)
+    try {
+      const res = await authFetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: body ? JSON.stringify(body) : undefined,
+      })
+      if (!res.ok) {
+        const err = await res.json().catch(() => ({}))
+        setActionErr((err as { detail?: string }).detail ?? `Request failed (${res.status})`)
+        setBusy(false)
+        return
+      }
+      const data = await res.json().catch(() => ({}))
+      onOk?.(data as Record<string, unknown>)
+    } catch {
+      setActionErr("Network error")
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const cancelRun = () => _postAction(`${API}/workflows/${workflowId}/runs/${runId}/cancel`)
+  const decideRun = (decision: "approved" | "rejected") =>
+    _postAction(`${API}/workflows/${workflowId}/runs/${runId}/approve`, { decision })
+  const retryRun = () =>
+    _postAction(`${API}/workflows/${workflowId}/runs`, {}, (data) => {
+      const newId = data.id as string | undefined
+      if (newId && onRetry) onRetry(newId, workflowName)
+    })
+
   const pillColor = (() => {
     switch (status) {
       case "succeeded": return { bg: "var(--ok-bg, #dcfce7)", fg: "var(--ok-text, #166534)" }
       case "failed":    return { bg: "var(--err-bg, #fee2e2)", fg: "var(--err-text, #991b1b)" }
       case "running":   return { bg: "var(--accent-weak, rgba(59,130,246,0.12))", fg: "var(--accent-text, #2563eb)" }
+      case "paused":    return { bg: "var(--warn-bg, #fef3c7)", fg: "var(--warn, #f59e0b)" }
+      case "cancelled": return { bg: "var(--surface-3, #f3f4f6)", fg: "var(--text-muted)" }
       default:          return { bg: "var(--surface-3, #f3f4f6)", fg: "var(--text-muted)" }
     }
   })()
@@ -1186,6 +1227,67 @@ function RunBubble({
         {error && (
           <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "8px 12px", borderRadius: 6 }}>
             {error}
+          </div>
+        )}
+        {actionErr && (
+          <div style={{ fontSize: 12, color: "var(--err-text, #991b1b)", background: "var(--err-bg, #fee2e2)", padding: "6px 10px", borderRadius: 6, marginBottom: 8 }}>
+            {actionErr}
+          </div>
+        )}
+        {workflowId && (status === "pending" || status === "running" || status === "paused" || status === "failed") && (
+          <div style={{ display: "flex", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
+            {(status === "pending" || status === "running") && (
+              <button
+                onClick={cancelRun}
+                disabled={busy}
+                style={{
+                  padding: "6px 14px", borderRadius: 6, border: "1px solid var(--border)",
+                  background: "transparent", color: "var(--text-2)",
+                  fontSize: 12, cursor: busy ? "wait" : "pointer",
+                }}
+              >
+                Cancel
+              </button>
+            )}
+            {status === "paused" && (
+              <>
+                <button
+                  onClick={() => decideRun("approved")}
+                  disabled={busy}
+                  style={{
+                    padding: "6px 14px", borderRadius: 6, border: "none",
+                    background: "var(--accent)", color: "#fff",
+                    fontSize: 12, fontWeight: 600, cursor: busy ? "wait" : "pointer",
+                  }}
+                >
+                  Approve
+                </button>
+                <button
+                  onClick={() => decideRun("rejected")}
+                  disabled={busy}
+                  style={{
+                    padding: "6px 14px", borderRadius: 6, border: "1px solid var(--border)",
+                    background: "transparent", color: "var(--text-2)",
+                    fontSize: 12, cursor: busy ? "wait" : "pointer",
+                  }}
+                >
+                  Reject
+                </button>
+              </>
+            )}
+            {status === "failed" && onRetry && (
+              <button
+                onClick={retryRun}
+                disabled={busy}
+                style={{
+                  padding: "6px 14px", borderRadius: 6, border: "none",
+                  background: "var(--accent)", color: "#fff",
+                  fontSize: 12, fontWeight: 600, cursor: busy ? "wait" : "pointer",
+                }}
+              >
+                Retry
+              </button>
+            )}
           </div>
         )}
         {blocks.size > 0 && (
@@ -1732,6 +1834,10 @@ export function GLensChatPage() {
                       initialStatus={msg.initialStatus}
                       stream={lensStream}
                       authFetch={authFetch}
+                      onRetry={(newRunId, wfName) => setMessages(prev => [
+                        ...prev,
+                        { role: "assistant", kind: "run", runId: newRunId, workflowName: wfName, initialStatus: "pending" },
+                      ])}
                     />
                   )}
                   {msg.kind === "policy_confirm" && (


### PR DESCRIPTION
## What ships in one merge

**PR 13** (natural-language RunBubble) + **PR 14** (inline lifecycle actions) + **PR 14 polish** (prose flash + cross-tab). After this lands, **Lens is the runtime**, no known gaps.

## Slices

### 1. Natural-language "yes" → RunBubble (was PR 13)

- \`_extract_run_started_envelope\` walks tool results for \`confirm_pending_action\` (\`executed=True\` + \`result.run_id\`)
- Injected into SSE \`done\` payload, persisted alongside \`confirm_envelope\` for restore
- Frontend \`_applyData\` detects → pushes \`{kind: "run"}\` → RunBubble renders instead of prose

### 2. Inline lifecycle actions (was PR 14)

Status-driven buttons on RunBubble:

| status | Buttons |
|--------|---------|
| pending / running | Cancel |
| paused | Approve · Reject |
| failed | Retry |

All POST to existing endpoints. Retry creates a new run and pushes a fresh RunBubble below the failed one. Backend fix: \`dag_runner.py\` publishes \`run.status_changed\` on \`ApprovalRequired\` (was silent before).

### 3. Prose flash suppression

When \`run_started_envelope\` present, backend skips prose streaming entirely — sends \`answer=""\` + envelope in done. No ~500ms flicker before RunBubble takes over.

### 4. Cross-tab pubsub proven

New integration test drives two \`_stream_events\` generators on the same session, publishes once, asserts both receive. Design claim ("cross-tab is free via Redis pubsub") now has a test to back it.

## Test evidence

- 148 backend tests pass, no regressions
- TypeScript clean
- Cross-tab + all 6 integration tests pass against docker redis:7-alpine locally

## Manual smoke checklist (post-merge, flag on)

- [ ] Type "yes" to a Confirm prompt → \`<RunBubble>\` renders immediately, NO prose flash
- [ ] Cancel a running run → pill flips to \`cancelled\`
- [ ] Trigger a workflow with an approval block → \`Approve\` / \`Reject\` buttons render → click Approve → run resumes
- [ ] Fail a run → \`Retry\` button renders → click → new RunBubble appears below
- [ ] Open Lens in two browser tabs on same session → Confirm in tab 1 → tab 2's bubble also updates

Part of #1480.