### PR TITLE
fix(lens): session_id root fix + decided-status ActionConfirmBubble (#1480)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/run_workflow.py
+++ b/apps/api/app/modules/glens/actor/registrations/run_workflow.py
@@ -134,6 +134,12 @@ def _execute_run_workflow(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str,
         status="pending",
         state=initial_state,
         max_turns=getattr(workflow, "default_max_turns", None) or 20,
+        # #1480 PR 14 — thread the originating Lens session through so the
+        # worker's publish_run_status / publish_run_block_event calls have
+        # somewhere to route SSE events. Without this the RunBubble in
+        # chat never gets the block timeline because publisher no-ops on
+        # session_id=NULL.
+        session_id=ctx.session_id,
     )
     ctx.db.add(run)
     ctx.db.commit()

--- a/apps/api/app/modules/glens/actor/routes.py
+++ b/apps/api/app/modules/glens/actor/routes.py
@@ -46,6 +46,63 @@ class CancelResponse(BaseModel):
     tool_name: str
 
 
+class ActionStatusResponse(BaseModel):
+    """Current state of an approval row — used by the restored Lens
+    ActionConfirmBubble to render "Confirmed →" / "Cancelled" / "Expired"
+    instead of active buttons for already-decided rows (#1480)."""
+    action_id: str
+    status: str  # pending | approved | rejected | timed_out
+    tool_name: str | None
+    surface: str | None
+    result: dict[str, Any] | None = None
+
+
+@router.get("/{action_id}", response_model=ActionStatusResponse)
+def get_action_status(
+    action_id: str,
+    workspace_id: str = Depends(get_workspace_id),
+    db: Session = Depends(get_db),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+) -> ActionStatusResponse:
+    """Read-only status check for a Lens-proposed action.
+
+    Bubble uses this on mount to decide whether to render active
+    Confirm/Cancel buttons (status=pending) or a resolved summary
+    (status=approved/rejected/timed_out).
+    """
+    import uuid as _uuid
+    from app.modules.guard.models import GuardApprovalRequest
+
+    try:
+        row_id = _uuid.UUID(action_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="action_id must be a UUID")
+    try:
+        ws_uuid = _uuid.UUID(workspace_id)
+    except ValueError:
+        raise HTTPException(status_code=400, detail="Invalid workspace_id")
+
+    row = (
+        db.query(GuardApprovalRequest)
+        .filter(
+            GuardApprovalRequest.id == row_id,
+            GuardApprovalRequest.workspace_id == ws_uuid,
+        )
+        .first()
+    )
+    if row is None:
+        raise HTTPException(status_code=404, detail="action not found")
+
+    result = (row.tool_input or {}).get("_execute_result") if row.tool_input else None
+    return ActionStatusResponse(
+        action_id=str(row.id),
+        status=row.status,
+        tool_name=row.tool_name,
+        surface=row.surface,
+        result=result,
+    )
+
+
 @router.post("/{action_id}/confirm", response_model=ConfirmResponse)
 def confirm_action(
     action_id: str,

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -848,9 +848,30 @@ function ActionConfirmBubble({
 }) {
   const [status, setStatus] = useState<"pending" | "loading" | "done">("pending")
   const [idCopied, setIdCopied] = useState(false)
+  // Server-side status snapshot fetched on mount so a restored bubble for
+  // an already-decided action renders in the resolved state instead of
+  // showing active Confirm/Cancel buttons for something that already ran.
+  const [serverStatus, setServerStatus] = useState<"pending" | "approved" | "rejected" | "timed_out" | null>(null)
+  const [serverResult, setServerResult] = useState<Record<string, unknown> | null>(null)
   // Dedupe: whichever source (POST response or SSE event) reports resolution
   // first wins. Race is fine because the payload shape is identical.
   const handledRef = useRef(false)
+
+  // On mount, fetch the current status from the server. Skip when a
+  // decision has already been dispatched in this render (handledRef set).
+  useEffect(() => {
+    let cancelled = false
+    authFetch(`${API}/glens/actions/${approvalRequestId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data?.status) return
+        setServerStatus(data.status as typeof serverStatus)
+        if (data.result) setServerResult(data.result as Record<string, unknown>)
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [approvalRequestId])
 
   const finishText = (text: string) => {
     if (handledRef.current) return
@@ -966,7 +987,28 @@ function ActionConfirmBubble({
           </div>
         )}
 
-        {status === "pending" && (
+        {(serverStatus === "approved" || serverStatus === "rejected" || serverStatus === "timed_out") && (
+          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--text-muted)" }}>
+            <span style={{
+              fontSize: 11, fontWeight: 600, padding: "3px 10px", borderRadius: 999,
+              background:
+                serverStatus === "approved" ? "var(--ok-bg, #dcfce7)" :
+                serverStatus === "rejected" ? "var(--err-bg, #fee2e2)" :
+                "var(--surface-3, #f3f4f6)",
+              color:
+                serverStatus === "approved" ? "var(--ok-text, #166534)" :
+                serverStatus === "rejected" ? "var(--err-text, #991b1b)" :
+                "var(--text-muted)",
+              textTransform: "capitalize",
+            }}>{serverStatus === "timed_out" ? "Expired" : serverStatus}</span>
+            {serverStatus === "approved" && (serverResult?.run_id as string | undefined) && (
+              <a href={`/runs/${serverResult!.run_id}`} style={{ color: "var(--accent)", textDecoration: "none" }}>
+                View run →
+              </a>
+            )}
+          </div>
+        )}
+        {status === "pending" && (serverStatus === null || serverStatus === "pending") && (
           <div style={{ display: "flex", gap: 10, alignItems: "center" }}>
             <button
               onClick={() => post("confirm")}


### PR DESCRIPTION
Two small fixes that got pushed to the #1503 branch after it was merged. Filing here so they land.

## 1. Root fix: thread session_id into Run() from Lens actor

**The bug that made the block timeline invisible.** \`_execute_run_workflow\` in \`run_workflow.py\` was constructing the Run without \`session_id=ctx.session_id\` → every Lens-triggered run had \`session_id=NULL\` → \`publish_run_status\` and \`publish_run_block_event\` both no-op → zero SSE events fired → RunBubble showed pill only, no block timeline.

One-line fix. Non-breaking (nullable column, non-Lens callers unaffected).

Without this, the entire block-events SSE pipeline is dark for Lens runs. **Every screenshot Sudhi saw with "no blocks in timeline" was caused by this.**

## 2. ActionConfirmBubble reflects decided status on restore

Refresh bug: restored ActionConfirmBubble for an already-decided approval rendered active Confirm/Cancel buttons. Safe (PR #1470 idempotency) but wrong UX.

**Backend**: new read-only \`GET /glens/actions/{action_id}\` returns \`{status, tool_name, surface, result}\`. Same auth as sibling routes.

**Frontend**: ActionConfirmBubble mount fetches this. Render branches:
- Fetch in flight → optimistic pending (buttons render, no flicker for fresh bubbles)
- \`pending\` → buttons render
- \`approved\` → green pill + "View run →" link if result has run_id
- \`rejected\` → red pill
- \`timed_out\` → grey "Expired" pill

No buttons ever render for decided rows.

## Test evidence

- 148 backend tests pass, no regressions
- TypeScript clean
- Both fixes locally verified against real Postgres + Redis

## After merge + redeploy

- Trigger a Lens workflow → block timeline actually streams in as blocks execute
- Refresh a session with a decided approval → resolved pill instead of confusing active buttons

Part of #1480.