### PR TITLE
feat(lens): embed RunDetailPanel inside RunBubble (#1506)

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -11,7 +11,7 @@ import { GlensPageBubble } from "@/components/glens/GlensPageBubble"
 import { GenericTableBubble } from "@/components/glens/GenericTableBubble"
 import { BlocksBubble } from "@/components/glens/BlocksBubble"
 import { FeedbackButtons } from "@/components/glens/FeedbackButtons"
-import RunDetailPanel from "@/components/runs/RunDetailPanel"
+import RunDetailPanel, { type RunMeta } from "@/components/runs/RunDetailPanel"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1095,7 +1095,15 @@ function RunBubble({
   const [now, setNow] = useState<number>(() => Date.now())
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
   // #1506 — top-level expand toggle for the embedded RunDetailPanel
-  const [panelOpen, setPanelOpen] = useState(false)
+  const [panelOpen, setPanelOpen] = useState(() => {
+    // #1508 follow-up — persist expand state across refresh, per runId.
+    // localStorage (not sessionStorage) so re-opening the tab keeps context.
+    try { return typeof window !== "undefined" && window.localStorage.getItem(`lens:panelOpen:${runId}`) === "1" }
+    catch { return false }
+  })
+  // #1508 follow-up — cache the /runs/{id} response so the embedded
+  // RunDetailPanel can skip its own initial fetch (initialRun prop).
+  const [runData, setRunData] = useState<RunMeta | null>(null)
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
   const gotUpdate = useRef(false)
@@ -1112,6 +1120,7 @@ function RunBubble({
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled) return
+        if (data) setRunData(data as RunMeta)
         if (data?.state) {
           const st = data.state as Record<string, unknown>
           setRunState(st)
@@ -1153,6 +1162,7 @@ function RunBubble({
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled || !data) return
+        setRunData(data as RunMeta)
         if (data.state) setRunState(data.state as Record<string, unknown>)
         if (data.outcome) setOutcome(data.outcome as { type?: string; artifact_url?: string })
         if (data.completed_at) setCompletedAt(new Date(data.completed_at as string).getTime())
@@ -1174,6 +1184,12 @@ function RunBubble({
   useEffect(() => {
     if (status === "paused") setPanelOpen(true)
   }, [status])
+
+  // #1508 follow-up — mirror panelOpen to localStorage so refresh restores it.
+  useEffect(() => {
+    try { window.localStorage.setItem(`lens:panelOpen:${runId}`, panelOpen ? "1" : "0") }
+    catch { /* private-mode / quota — best-effort */ }
+  }, [panelOpen, runId])
 
   useLensEvent(stream, "run", runId, (evt) => {
     gotUpdate.current = true
@@ -1414,7 +1430,7 @@ function RunBubble({
         )}
         {panelOpen && workflowId && (
           <div style={{ marginTop: 14, borderTop: "1px solid var(--border)", paddingTop: 14 }}>
-            <RunDetailPanel workflowId={workflowId} runId={runId} embedded />
+            <RunDetailPanel workflowId={workflowId} runId={runId} embedded initialRun={runData ?? undefined} />
           </div>
         )}
       </div>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -11,6 +11,7 @@ import { GlensPageBubble } from "@/components/glens/GlensPageBubble"
 import { GenericTableBubble } from "@/components/glens/GenericTableBubble"
 import { BlocksBubble } from "@/components/glens/BlocksBubble"
 import { FeedbackButtons } from "@/components/glens/FeedbackButtons"
+import RunDetailPanel from "@/components/runs/RunDetailPanel"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1093,6 +1094,8 @@ function RunBubble({
   const [completedAt, setCompletedAt] = useState<number | null>(null)
   const [now, setNow] = useState<number>(() => Date.now())
   const [expanded, setExpanded] = useState<Set<string>>(new Set())
+  // #1506 — top-level expand toggle for the embedded RunDetailPanel
+  const [panelOpen, setPanelOpen] = useState(false)
   // If an SSE update lands before the bootstrap fetch resolves, the fetch
   // result is stale — don't overwrite the fresher event.
   const gotUpdate = useRef(false)
@@ -1164,6 +1167,12 @@ function RunBubble({
     if (status !== "running" && status !== "pending") return
     const id = setInterval(() => setNow(Date.now()), 1000)
     return () => clearInterval(id)
+  }, [status])
+
+  // #1506 — auto-open the full detail panel when the run pauses for approval,
+  // so the Approvals tab is one click away without hunting for a chevron.
+  useEffect(() => {
+    if (status === "paused") setPanelOpen(true)
   }, [status])
 
   useLensEvent(stream, "run", runId, (evt) => {
@@ -1252,6 +1261,18 @@ function RunBubble({
               {formatElapsed(startedAt, completedAt ?? now)}
             </span>
           )}
+          <button
+            onClick={() => setPanelOpen(o => !o)}
+            aria-label={panelOpen ? "Collapse run detail" : "Expand run detail"}
+            aria-expanded={panelOpen}
+            style={{
+              background: "transparent", border: "1px solid var(--border)",
+              borderRadius: 6, padding: "2px 8px", fontSize: 11,
+              color: "var(--text-2)", cursor: "pointer", lineHeight: 1.4,
+            }}
+          >
+            {panelOpen ? "▾ Collapse" : "▸ Expand"}
+          </button>
           <a href={`/runs/${runId}`} style={{ fontSize: 13, color: "var(--accent)", textDecoration: "none" }}>
             View run →
           </a>
@@ -1276,7 +1297,7 @@ function RunBubble({
             {actionErr}
           </div>
         )}
-        {workflowId && (status === "pending" || status === "running" || status === "paused" || status === "failed") && (
+        {!panelOpen && workflowId && (status === "pending" || status === "running" || status === "paused" || status === "failed") && (
           <div style={{ display: "flex", gap: 8, marginBottom: 10, flexWrap: "wrap" }}>
             {(status === "pending" || status === "running") && (
               <button
@@ -1389,6 +1410,11 @@ function RunBubble({
                 </div>
               )
             })}
+          </div>
+        )}
+        {panelOpen && workflowId && (
+          <div style={{ marginTop: 14, borderTop: "1px solid var(--border)", paddingTop: 14 }}>
+            <RunDetailPanel workflowId={workflowId} runId={runId} embedded />
           </div>
         )}
       </div>

--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -29,7 +29,7 @@ class TabErrorBoundary extends Component<{ children: React.ReactNode }, { hasErr
   }
 }
 
-interface RunMeta {
+export interface RunMeta {
   id: string
   status: string
   governance?: { blocked?: boolean } | null
@@ -57,18 +57,25 @@ export interface RunDetailPanelProps {
    * The parent (e.g. Lens RunBubble) supplies its own container.
    */
   embedded?: boolean
+  /**
+   * Seed the panel with a run record the caller already fetched (e.g. Lens
+   * RunBubble hits /runs/{id} on mount). When provided, the panel skips its
+   * initial fetch and renders immediately. Polling still runs for
+   * non-terminal runs so any missing fields fill in on the next tick.
+   */
+  initialRun?: RunMeta
 }
 
-export default function RunDetailPanel({ workflowId, runId, embedded = false }: RunDetailPanelProps) {
+export default function RunDetailPanel({ workflowId, runId, embedded = false, initialRun }: RunDetailPanelProps) {
   const { getToken, isLoaded } = useAuth()
   const { authFetch } = useAuthFetch()
 
-  const [run, setRun] = useState<RunMeta | null>(null)
+  const [run, setRun] = useState<RunMeta | null>(initialRun ?? null)
   const [workflowName, setWorkflowName] = useState<string | null>(null)
   const [projectName, setProjectName] = useState<string | null>(null)
   const [projectId, setProjectId] = useState<string | null>(null)
   const [agentModel, setAgentModel] = useState<string | null>(null)
-  const [loading, setLoading] = useState(true)
+  const [loading, setLoading] = useState(!initialRun)
   const [fetchError, setFetchError] = useState<string | null>(null)
   const [refreshing, setRefreshing] = useState(false)
   const [stopping, setStopping] = useState(false)
@@ -129,8 +136,10 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false }: 
   useEffect(() => {
     if (!isLoaded) return
     async function load() {
+      // #1508 follow-up — skip the initial fetchRun when the parent seeded us
+      // with a run record; polling still starts below for non-terminal runs.
       const [runData, wfRes] = await Promise.all([
-        fetchRun(),
+        initialRun ? Promise.resolve(initialRun) : fetchRun(),
         authFetch(`${API}/workflows/${workflowId}`),
       ])
       if (wfRes.ok) {


### PR DESCRIPTION
Closes #1506. Follow-up to #1507.

## What

Adds an expand/collapse toggle to Lens \`RunBubble\` that reveals the full run-detail surface — Summary / Steps / AI Trace / Files / Approvals / Cost — inline inside the same chat conversation. No page navigation, no context loss.

**Governance decisions (Approve, Reject, Cancel, Retry) now happen inside the same Lens thread that triggered the run.** The audit trail is the conversation.

## Changes

Single file: \`apps/web/src/components/glens/GLensChatPage.tsx\` — **+27 / -1**.

1. Import \`RunDetailPanel\` (shared with the canvas run detail page since #1507).
2. Add \`panelOpen\` state to \`RunBubble\` (default collapsed).
3. **Auto-open on \`paused\`** — when the run pauses for human approval, the panel opens automatically so the Approvals tab is one click away without hunting for a chevron.
4. Add \`▸ Expand\` / \`▾ Collapse\` button next to \"View run →\".
5. **Hide RunBubble's own Cancel/Approve/Reject/Retry** while the panel is open — the panel owns the actions in embedded mode, avoiding duplicate buttons calling the same endpoints.
6. Render \`<RunDetailPanel workflowId={workflowId} runId={runId} embedded />\` below the block timeline when \`panelOpen\`. The \`embedded\` prop (from #1507) hides breadcrumbs, page-level action buttons, and the outer \`maxWidth\` wrapper.

## Behavior

| State | Collapsed (default) | Expanded |
|---|---|---|
| Header (workflow name, status pill, elapsed, View run) | shown | shown |
| Expand/Collapse button | \`▸ Expand\` | \`▾ Collapse\` |
| Inline Cancel/Approve/Reject/Retry | shown | **hidden** (panel owns actions) |
| Block timeline (per-block glyphs) | shown | shown |
| Full run-detail tabs | hidden | **shown** |

Auto-open trigger: \`status === \"paused\"\` (approval-needed).

## Verify

- [x] \`tsc --noEmit\` — clean
- [x] \`eslint\` — clean (no new warnings)
- [ ] Manual: type \`run <workflow>\` in Lens → click \`▸ Expand\` → all six tabs render
- [ ] Manual: run pauses on approval → panel auto-opens, Approve inside Approvals tab works, run resumes
- [ ] Manual: refresh mid-run → RunBubble rehydrates (state resets to collapsed — persistence of expand state is deferrable, out of scope)
- [ ] Manual: multiple RunBubbles in same session don't collide

## Non-goals / deferred

- **Persist \`panelOpen\` across refresh** — not persisted today. Consistent with the existing per-block \`expanded\` Set (also non-persistent). Add later if it becomes friction.
- **Double-fetch of /runs/{id}** — RunBubble fetches on mount for status + block seeding; RunDetailPanel fetches independently. Two GETs per bubble when expanded. Not optimizing until it measurably hurts (\`ponytail:\` two fetches, coalesce if it becomes a load problem).