### PR TITLE
feat(lens): embed RunDetailPanel inside ActionConfirmBubble (#1511) — demo blocker

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -854,9 +854,44 @@ function ActionConfirmBubble({
   // showing active Confirm/Cancel buttons for something that already ran.
   const [serverStatus, setServerStatus] = useState<"pending" | "approved" | "rejected" | "timed_out" | null>(null)
   const [serverResult, setServerResult] = useState<Record<string, unknown> | null>(null)
+  // #1511 — expand toggle + fetched workflow_id so we can embed <RunDetailPanel>
+  // when the action resolved into a run. localStorage keeps expand state across
+  // refresh, keyed by approvalRequestId (per-bubble).
+  const [panelOpen, setPanelOpen] = useState(() => {
+    try { return typeof window !== "undefined" && window.localStorage.getItem(`lens:actionPanelOpen:${approvalRequestId}`) === "1" }
+    catch { return false }
+  })
+  const [runData, setRunData] = useState<RunMeta | null>(null)
   // Dedupe: whichever source (POST response or SSE event) reports resolution
   // first wins. Race is fine because the payload shape is identical.
   const handledRef = useRef(false)
+
+  // #1511 — mirror panelOpen to localStorage so refresh restores expand state.
+  useEffect(() => {
+    try { window.localStorage.setItem(`lens:actionPanelOpen:${approvalRequestId}`, panelOpen ? "1" : "0") }
+    catch { /* best-effort */ }
+  }, [panelOpen, approvalRequestId])
+
+  // #1511 — once we know the run_id (via server snapshot or dispatch), fetch
+  // /runs/{id} to grab workflow_id + a full run seed. RunDetailPanel needs
+  // workflowId, and passing runData as initialRun skips its own initial fetch.
+  const resolvedRunId = (serverResult?.run_id as string | undefined) ?? null
+  useEffect(() => {
+    if (!resolvedRunId) return
+    let cancelled = false
+    authFetch(`${API}/runs/${resolvedRunId}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => { if (!cancelled && data) setRunData(data as RunMeta) })
+      .catch(() => {})
+    return () => { cancelled = true }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [resolvedRunId])
+
+  // #1511 — auto-open the panel when a decided-approved bubble with a run
+  // becomes visible, so the demo flow drops straight into the run detail.
+  useEffect(() => {
+    if (serverStatus === "approved" && resolvedRunId) setPanelOpen(true)
+  }, [serverStatus, resolvedRunId])
 
   // On mount, fetch the current status from the server. Skip when a
   // decision has already been dispatched in this render (handledRef set).
@@ -1007,6 +1042,16 @@ function ActionConfirmBubble({
                 View run →
               </a>
             )}
+          </div>
+        )}
+        {panelOpen && serverStatus === "approved" && runData?.workflow_id && resolvedRunId && (
+          <div style={{ marginTop: 14, borderTop: "1px solid var(--border)", paddingTop: 14 }}>
+            <RunDetailPanel
+              workflowId={runData.workflow_id as string}
+              runId={resolvedRunId}
+              embedded
+              initialRun={runData}
+            />
           </div>
         )}
         {status === "pending" && (serverStatus === null || serverStatus === "pending") && (

--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -44,6 +44,10 @@ export interface RunMeta {
   paused_at: string | null
   current_block_id: string | null
   workflow_version_id: string
+  // Optional convenience field — /runs/{id} returns it (RunWithWorkflowOut),
+  // /workflows/{wf}/runs/{id} does not. Used by ActionConfirmBubble (#1511)
+  // to embed <RunDetailPanel> without a redundant workflow_id lookup.
+  workflow_id?: string
   state?: Record<string, unknown> | null
   max_turns?: number | null
   actual_turns?: number | null


### PR DESCRIPTION
Closes #1511. **Demo blocker for 2026-08-31 HPE Venky meeting.**

## Symptom

When \`self_driving_network_approval_demo\` (or any approvals-gated workflow) is triggered from Lens, the ActionConfirmBubble decides → shows \"Approved\" pill + \"View run →\" link, but **the run detail never appears inside the Lens conversation**. The user has to click the link and navigate out.

The \`RunBubble\` embed shipped in #1508 only fires for the natural-language path (\`run <wf>\` without confirmation). Approvals-gated workflows never reach that path — the ActionConfirmBubble is the terminal bubble.

## Fix

Wire the same expand mechanism into \`ActionConfirmBubble\` when \`serverStatus === \"approved\"\` and a \`run_id\` is present:

1. **Fetch \`/runs/{run_id}\`** once the approval resolves — grabs \`workflow_id\` + a full \`RunMeta\` seed passed to \`RunDetailPanel\` as \`initialRun\` (skips its own initial fetch — same optimization as #1508).
2. **Auto-open** the panel on approval — the demo flow drops straight into the run detail without an extra click.
3. **▸ Expand / ▾ Collapse** button next to \"View run →\".
4. **Persist** \`panelOpen\` to \`localStorage\` keyed by \`approvalRequestId\` so refresh restores state.
5. Render \`<RunDetailPanel workflowId runId embedded initialRun />\` below the decided-state block.

Also adds optional \`workflow_id?: string\` to the \`RunMeta\` interface — \`/runs/{id}\` returns it (RunWithWorkflowOut); \`/workflows/{wf}/runs/{id}\` does not. Only the ActionConfirmBubble embed needs it.

## Diff

**+49 / -0** across 2 files:
- \`apps/web/src/components/glens/GLensChatPage.tsx\` — +45 in ActionConfirmBubble
- \`apps/web/src/components/runs/RunDetailPanel.tsx\` — +4 (optional \`workflow_id\` on \`RunMeta\`)

## Verify

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` — 0 errors on all changed files
- [ ] **Demo path**: Lens → \`run self_driving_network_approval_demo\` → Confirm → Approved → panel auto-opens with Summary / Steps / AI Trace / Files / Approvals / Cost tabs inline
- [ ] Refresh mid-run → panel state restored from localStorage
- [ ] Rejected / timed_out bubbles unaffected (only \"approved\" gets the expand)