### PR TITLE
fix(lens): stop RunTrace auto-scroll flicker when embedded (#1513)

### DIFF
--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -376,6 +376,7 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
             }}
             maxTurns={run.max_turns ?? null}
             getToken={getToken}
+            embedded={embedded}
             onSseConnected={() => { setSseActive(true); if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }}
             onSseEnded={() => {
               setSseActive(false)

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -52,6 +52,10 @@ interface Props {
   getToken?: (() => Promise<string | null>) | null
   onSseConnected?: () => void
   onSseEnded?: () => void
+  // #1512 followup — Lens embed lives inside a scrollable chat container.
+  // Auto-scroll on every SSE event yanks the container around and reads as
+  // flicker to the user. Canvas page still uses the auto-scroll default.
+  embedded?: boolean
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -683,7 +687,7 @@ async function buildHeaders(getToken?: (() => Promise<string | null>) | null, wo
   return h
 }
 
-export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, maxTurns, getToken, onSseConnected, onSseEnded }: Props) {
+export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, maxTurns, getToken, onSseConnected, onSseEnded, embedded = false }: Props) {
   const { activeWorkspace } = useWorkspace()
   const [events, setEvents] = useState<RunEvent[]>([])
   const [status, setStatus] = useState(initialStatus)
@@ -787,7 +791,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowId, runId, done])
 
-  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events])
+  useEffect(() => { if (!embedded) bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events, embedded])
 
   // ── Build block rows from events ──────────────────────────────────────────
 


### PR DESCRIPTION
Closes #1513. Follow-up to #1512 which merged before this commit landed.

## Symptom

After #1512, the embedded RunDetailPanel renders inside the Lens ActionConfirmBubble — but flickers during SSE updates (screenshot in #1512 review thread).

## Root cause

\`RunTrace\` calls \`bottomRef.current?.scrollIntoView({ behavior: \"smooth\" })\` on every SSE event (Steps tab):

\`\`\`ts
useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: \"smooth\" }) }, [events])
\`\`\`

On the canvas run detail page this scrolls the whole page — fine. Inside a Lens bubble the enclosing chat container gets yanked around on every event → visible flicker.

## Fix

+6 / -1 across two files:

- \`RunTrace.tsx\`: new \`embedded?: boolean\` prop; gate the auto-scroll on \`!embedded\`.
- \`RunDetailPanel.tsx\`: forward its own \`embedded\` prop down to \`RunTrace\`.

Canvas run detail page unaffected — \`embedded=false\` default keeps the smooth auto-scroll to the bottom on new events.

## Verify

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` — 0 errors
- [ ] Manual: trigger \`self_driving_network_approval_demo\` in Lens → Approve → embedded panel renders and **stays put** during SSE updates
- [ ] Manual: open \`/workflows/<id>/runs/<run_id>\` → SSE events still auto-scroll the page to the latest event