### PR TITLE
fix(lens): stop Steps tab flicker on every SSE event (#1516)

### DIFF
--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -376,6 +376,7 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
             }}
             maxTurns={run.max_turns ?? null}
             getToken={getToken}
+            embedded={embedded}
             onSseConnected={() => { setSseActive(true); if (pollRef.current) { clearInterval(pollRef.current); pollRef.current = null } }}
             onSseEnded={() => {
               setSseActive(false)

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -52,6 +52,10 @@ interface Props {
   getToken?: (() => Promise<string | null>) | null
   onSseConnected?: () => void
   onSseEnded?: () => void
+  // #1512 followup — Lens embed lives inside a scrollable chat container.
+  // Auto-scroll on every SSE event yanks the container around and reads as
+  // flicker to the user. Canvas page still uses the auto-scroll default.
+  embedded?: boolean
 }
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -683,7 +687,7 @@ async function buildHeaders(getToken?: (() => Promise<string | null>) | null, wo
   return h
 }
 
-export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, maxTurns, getToken, onSseConnected, onSseEnded }: Props) {
+export default function RunTrace({ workflowId, runId, initialStatus, initialMeta, maxTurns, getToken, onSseConnected, onSseEnded, embedded = false }: Props) {
   const { activeWorkspace } = useWorkspace()
   const [events, setEvents] = useState<RunEvent[]>([])
   const [status, setStatus] = useState(initialStatus)
@@ -787,7 +791,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowId, runId, done])
 
-  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events])
+  useEffect(() => { if (!embedded) bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events, embedded])
 
   // ── Build block rows from events ──────────────────────────────────────────
 

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useEffect, useRef, useState } from "react"
+import { memo, useEffect, useMemo, useRef, useState } from "react"
 import { duration as formatDuration } from "@/lib/runUtils"
 import { API } from "@/lib/api"
 import { useWorkspace } from "@/lib/WorkspaceContext"
@@ -285,7 +285,7 @@ function cardStyle(row: BlockRow): React.CSSProperties {
   return { flex: 1, padding: "12px 15px" }
 }
 
-function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
+const BlockRowView = memo(function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
   const isTimedOut = row.timedOut === true
   const [expanded, setExpanded] = useState(row.status === "failed")
   const [diffExpanded, setDiffExpanded] = useState(false)
@@ -584,7 +584,17 @@ function BlockRowView({ row, isLast }: { row: BlockRow; isLast: boolean }) {
       </div>
     </div>
   )
-}
+}, (prev, next) => (
+  prev.isLast === next.isLast &&
+  prev.row.blockId === next.row.blockId &&
+  prev.row.status === next.row.status &&
+  prev.row.startedAt === next.row.startedAt &&
+  prev.row.completedAt === next.row.completedAt &&
+  prev.row.error === next.row.error &&
+  prev.row.output === next.row.output &&
+  prev.row.toolCalls === next.row.toolCalls &&
+  prev.row.budgetExhausted === next.row.budgetExhausted
+))
 
 // ── Run terminal row ──────────────────────────────────────────────────────────
 
@@ -794,11 +804,16 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   useEffect(() => { if (!embedded) bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events, embedded])
 
   // ── Build block rows from events ──────────────────────────────────────────
+  // #1516 — memoize so blockRows references are stable across renders that
+  // didn't change events (parent re-render, panel poll). Without this, every
+  // render allocates new BlockRow objects and BlockRowView reruns even when
+  // its content is identical — the CSS pulse animation restarts each time
+  // and the Steps tab visibly flickers on every parent update.
+  const blockRows: BlockRow[] = useMemo(() => {
+    const rows: BlockRow[] = []
+    const blockMap: Record<string, BlockRow> = {}
 
-  const blockRows: BlockRow[] = []
-  const blockMap: Record<string, BlockRow> = {}
-
-  for (const ev of events) {
+    for (const ev of events) {
     if (!ev.block_id) continue
 
     if (ev.kind === "block_started") {
@@ -810,7 +825,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         startedAt: ev.created_at,
       }
       blockMap[ev.block_id] = row
-      blockRows.push(row)
+      rows.push(row)
     } else if (ev.kind === "block_completed" && blockMap[ev.block_id]) {
       const out = ev.payload.output as Record<string, unknown> | undefined
       blockMap[ev.block_id].status = "completed"
@@ -858,7 +873,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
         output: { skipped: true, reason: ev.payload.reason },
       }
       blockMap[ev.block_id] = row
-      blockRows.push(row)
+      rows.push(row)
     } else if (ev.kind === "brain_budget_exhausted" && blockMap[ev.block_id]) {
       blockMap[ev.block_id].budgetExhausted = {
         turns: ev.payload.turns as number,
@@ -883,7 +898,10 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       blockMap[ev.block_id].status = "running"
       blockMap[ev.block_id].output = { status: "approval_required" }
     }
-  }
+    }
+
+    return rows
+  }, [events])
 
   const runFailed = events.find(e => e.kind === "run_failed")
   const runCompleted = events.find(e => e.kind === "run_completed")


### PR DESCRIPTION
Closes #1516. Follow-up to #1514 which killed the scrollIntoView flicker but not this one.

## Symptom

Embedded RunDetailPanel on Steps tab flickers as each block event lands (screenshot in #1512 thread — user reported \"gives an impression of entire page\" jumping).

## Root cause

\`RunTrace\` rebuilds \`blockRows\` with fresh \`BlockRow\` objects on **every** render. \`BlockRowView\` isn't memoized, so it re-renders on every event; its inline \`animation: \"pulse 2s ...\"\` reapplies each time and the **CSS keyframe restarts from frame 0** → visible flicker across the timeline.

The panel's 4s poll compounds this: parent re-render → \`blockRows\` rebuilt → all rows re-rendered → pulse restart.

## Fix

**+29 / -11 in one file** (\`RunTrace.tsx\`):

1. **\`useMemo\`** on the \`blockRows\` build, deps \`[events]\` — stable references when events haven't changed. Kills the parent-triggered re-render churn.
2. **\`React.memo\`** on \`BlockRowView\` with content-aware equality: \`blockId / status / startedAt / completedAt / error / output / toolCalls / budgetExhausted\`. Rows that haven't visibly changed skip re-render entirely, so their CSS animations persist.

Canvas run detail page unaffected — same code path, just fewer wasted renders.

## Verify

- [x] \`tsc --noEmit\` clean
- [x] \`eslint\` clean
- [ ] Manual: trigger \`self_driving_network_approval_demo\` in Lens → Approve → Steps tab → block rows stream in as blocks start/complete without whole-timeline flicker
- [ ] Manual: canvas run detail (\`/workflows/<id>/runs/<run_id>\`) still renders identically
- [ ] Manual: pulse animation on running block stays smooth (doesn't restart per event)