### PR TITLE
fix(lens): embedded panel gets own scroll — smooth streaming (#1518)

### DIFF
--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -173,7 +173,11 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
   // parent (Lens RunBubble, iframe host, etc.) controls the container.
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     embedded
-      ? <>{children}</>
+      // #1518 — own scroll container when embedded. Panel content grows inside
+      // a bounded max-height so streaming block events don't yank the parent
+      // Lens chat around. scrollIntoView({ block: "nearest" }) inside RunTrace
+      // now targets THIS container, not the whole page.
+      ? <div style={{ maxHeight: "70vh", overflowY: "auto", padding: "4px 2px" }}>{children}</div>
       : <div style={{ maxWidth: 1120, margin: "0 auto", padding: "28px 24px" }}>{children}</div>
 
   if (loading) return (

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -801,7 +801,11 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [workflowId, runId, done])
 
-  useEffect(() => { if (!embedded) bottomRef.current?.scrollIntoView({ behavior: "smooth" }) }, [events, embedded])
+  // #1518 — safe on both surfaces. `block: "nearest"` only scrolls the closest
+  // scrollable ancestor, and only if the target is off-screen. On the canvas
+  // page that's the window; inside the embedded panel it's the panel's own
+  // overflow container (#1518). Never touches the parent Lens chat.
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }) }, [events])
 
   // ── Build block rows from events ──────────────────────────────────────────
   // #1516 — memoize so blockRows references are stable across renders that


### PR DESCRIPTION
Follow-up to #1514 + #1517. Both reduced churn but the panel content still lands off-screen and pushes the enclosing Lens chat around as blocks stream in.

## Fix

- **Embedded panel wraps content in \`max-height: 70vh; overflow-y: auto\`** — new content flows inside the bounded container. Parent Lens chat stops moving.
- **\`RunTrace\` scrollIntoView uses \`{ block: \"nearest\" }\`** — only scrolls the nearest scrollable ancestor, only when the target is off-screen. Inside the panel that's the panel; on canvas it's the window. Safe on both.

## Diff

**+6 / -3** across:
- \`apps/web/src/components/runs/RunDetailPanel.tsx\` — Wrapper adds own scroll when embedded
- \`apps/web/src/components/runs/RunTrace.tsx\` — scrollIntoView back on, targets nearest ancestor

## Verify

- [x] tsc clean, eslint clean
- [ ] Lens embedded panel: blocks stream in without whole-page flicker; if content overflows, panel scrolls internally
- [ ] Canvas run detail page: unchanged