### PR TITLE
fix(lens): kill panel poll + smooth-scroll when embedded (#1519)

### DIFF
--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -160,7 +160,12 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
         if (brainNode?.data?.model) setAgentModel(brainNode.data.model)
       }
       setLoading(false)
-      if (runData && !isTerminal(runData.status)) {
+      // #1519 — skip the 4s poll when embedded. Each poll rewrites `run`
+      // which re-renders StatRow + block timeline and reads as flicker inside
+      // the Lens bubble. RunTrace has its own SSE for block-level updates;
+      // StatRow (tokens/cost/duration) stays with mount-time values until the
+      // user reopens the panel or the run finishes.
+      if (runData && !isTerminal(runData.status) && !embedded) {
         pollRef.current = setInterval(async () => { await fetchRun() }, 4000)
       }
     }
@@ -385,7 +390,9 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
             onSseEnded={() => {
               setSseActive(false)
               if (!run || isTerminal(run.status)) return
-              if (!pollRef.current) {
+              // #1519 — don't restart the fallback poll when embedded; same
+              // flicker source as the mount poll above.
+              if (!pollRef.current && !embedded) {
                 pollRef.current = setInterval(async () => { await fetchRun() }, 4000)
               }
             }}

--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -805,7 +805,10 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
   // scrollable ancestor, and only if the target is off-screen. On the canvas
   // page that's the window; inside the embedded panel it's the panel's own
   // overflow container (#1518). Never touches the parent Lens chat.
-  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "smooth", block: "nearest" }) }, [events])
+  // #1519 — instant, no smooth animation. Each SSE event snapped the
+  // container smoothly which read as constant motion / flicker inside the
+  // embedded panel. Instant snap = new content visible, no perceived motion.
+  useEffect(() => { bottomRef.current?.scrollIntoView({ behavior: "auto", block: "nearest" }) }, [events])
 
   // ── Build block rows from events ──────────────────────────────────────────
   // #1516 — memoize so blockRows references are stable across renders that


### PR DESCRIPTION
Follow-up to #1518. Panel now has own scroll but two flicker sources still active inside it:

1. **RunDetailPanel polls every 4s** → \`setRun\` rewrites whole panel → StatRow re-renders → Duration ticks, tokens/cost may flash between \"—\" and values.
2. **\`scrollIntoView({ behavior: \"smooth\" })\`** → animates the own-scroll container on every SSE event → constant motion inside the bubble.

## Fix

- Skip the 4s poll when \`embedded=true\` (mount interval + SSE-ended fallback). Trade-off: StatRow values freeze at mount-time — no live tokens/cost ticker inside the bubble. Block-level SSE via RunTrace still updates the Steps tab.
- \`scrollIntoView\` uses \`behavior: \"auto\"\` (instant snap). \`block: \"nearest\"\` still contains the scroll to the panel's own container.

## Diff

**+10 / -3** across:
- \`apps/web/src/components/runs/RunDetailPanel.tsx\` — two poll gates
- \`apps/web/src/components/runs/RunTrace.tsx\` — smooth → auto

## Verify

- [x] tsc + eslint clean
- [ ] Lens embedded panel: StatRow stays put, Steps tab shows block rows appearing without container motion
- [ ] Canvas run detail: unchanged (embedded=false → poll runs, StatRow ticks live)