### PR TITLE
fix(guard): log fail-open when policy engine errors

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1858,8 +1858,16 @@ def test_trigger(
                 raise HTTPException(status_code=403, detail=f"[ConductGuard] {_r.get('message') or _r.get('rule_id')}")
     except HTTPException:
         raise
-    except Exception:
-        pass  # ponytail: fail-open — Guard engine error must never block a run
+    except Exception as _guard_err:
+        # ponytail: fail-open on engine error so a Guard outage can't wedge every run,
+        # but log the bypass so operators can see when enforcement was silently skipped.
+        log.warning(
+            "guard.engine_error.fail_open",
+            workflow_id=str(workflow_id),
+            workspace_id=str(workspace_id),
+            surface="proxy",
+            error=str(_guard_err),
+        )
 
     workflow = db.query(Workflow).filter(
         Workflow.id == workflow_id,


### PR DESCRIPTION
## Summary

- Guard policy check in `workflows.py:1841-1869` fails open when the policy engine errors — deliberate, so a Redis/DB/policy outage can't wedge every workflow run.
- The bypass was silent (bare `except Exception: pass`). This PR keeps the fail-open behavior but adds a `guard.engine_error.fail_open` structlog line with workflow_id, workspace_id, surface, and error context.
- Operators can now grep and count silent enforcement bypasses.

## What's not in this PR

- No behavior change — enforcement is still fail-open by design.
- No Prometheus counter — tracked in #1520 as rung 2 (5 lines, alertable, no DB surface).
- No `GuardAuditEvent` row — also tracked in #1520; only worth it if compliance/security asks for a queryable per-event bypass record, and it introduces per-workspace lock contention during the exact outages it measures.

## Test plan

- [ ] Trigger a workflow with the Guard policy engine unavailable (mock `compute_policy` to raise, or point at a bad DB URL) and confirm `guard.engine_error.fail_open` appears in logs with workflow_id / workspace_id / error.
- [ ] Trigger a workflow with a healthy Guard: no new log line, no behavior change.
- [ ] Trigger with a `block` rule that matches: still returns HTTP 403 (no regression).

## Background

External researcher flagged the fail-open path via email. Claim was accurate; the `ponytail:` comment already documented the tradeoff, but the bypass produced no observable signal. This PR closes the "silent" half. #1520 tracks the "alertable" half.

Refs #1520.