### PR TITLE
fix(lens): dedupe duplicate block rows in Steps tab

### DIFF
--- a/apps/web/src/components/runs/RunTrace.tsx
+++ b/apps/web/src/components/runs/RunTrace.tsx
@@ -824,6 +824,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
     if (!ev.block_id) continue
 
     if (ev.kind === "block_started") {
+      if (blockMap[ev.block_id]) continue
       const row: BlockRow = {
         blockId: ev.block_id,
         label: (ev.payload.label as string) || ev.block_id,
@@ -872,6 +873,7 @@ export default function RunTrace({ workflowId, runId, initialStatus, initialMeta
       blockMap[ev.block_id].failure = failure
       blockMap[ev.block_id].nextAction = nextAction
     } else if (ev.kind === "block_skipped") {
+      if (blockMap[ev.block_id]) continue
       const row: BlockRow = {
         blockId: ev.block_id,
         label: (ev.payload.label as string) || ev.block_id,


### PR DESCRIPTION
## Problem
Approval-demo run showed the same block (\"Report outcome\") twice in the embedded Steps tab. Playbook only defines one \"Report outcome\" block, so this was a UI aggregation bug.

## Root cause
`RunTrace.tsx` aggregates events into block rows keyed by `block_id`. The `block_started` handler always did:

```ts
blockMap[ev.block_id] = row
rows.push(row)
```

If a second `block_started` arrived for the same `block_id` (SSE reconnect + replay, runtime retry, or bootstrap-fetch overlap), it overwrote the map entry but pushed a **second** row into the array. Same for `block_skipped`.

## Fix
Guard both branches: if we already have a row for this block, skip the duplicate.

```ts
if (blockMap[ev.block_id]) continue
```

Two lines. No schema change, no API change.

## Test plan
- [ ] Run `self-driving-network-approval-demo` through Lens → approve → verify Steps shows one \"Report outcome\" row, not two
- [ ] Verify normal canvas run detail still renders correctly