### PR TITLE
docs: goal-first landing, personas, reference, root README pointer (#1525)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,9 +8,12 @@ Docs are organized **by goal, not by file shape**. Pick a section below.
 
 ## Start by goal
 
-- **I want to run Conduct locally** → [Operate → Developer setup](modules/conductguard/developer_setup.md)
+- **I'm brand new — get me running** → [Start](start.md)
+- **I want to run Conduct locally on the codebase** → [Operate → Developer setup](modules/conductguard/developer_setup.md)
 - **I want to write a playbook** → [Concepts → Playbooks](mental-models/08-playbooks.md) + [Playbook DSL ADR](adr/ADR-0004-playbook-dsl-versus-external-orchestration-frameworks.md)
+- **I want to see 37 working examples** → [Examples](examples.md)
 - **I want to govern AI tool usage on my team** → [Operate → ConductGuard Quickstart](modules/conductguard/QUICKSTART.md)
+- **I want to wire Conduct into CI, MCP, or my own tools** → [Automate](automate.md)
 - **I want to understand the architecture** → [Orientation → ARCHITECTURE](ARCHITECTURE.md)
 - **I want to add a policy rule / compliance pack** → [Policy → Enforcement coverage](modules/conductguard/enforcement_coverage.generated.md)
 - **I want to integrate a third-party tool** → [Integrations](#integrations)
@@ -21,9 +24,9 @@ Docs are organized **by goal, not by file shape**. Pick a section below.
 
 New to Conduct. Get from zero to a working install.
 
-- [Developer setup](modules/conductguard/developer_setup.md) — local dev environment, dependencies, first run
+- [Start](start.md) — install `conduct-cli`, log in, install 30+ playbooks, first agent run, first `playbook.yaml`
+- [Developer setup](modules/conductguard/developer_setup.md) — local dev environment, dependencies, first run against the Conduct codebase
 - [ConductGuard Quickstart](modules/conductguard/QUICKSTART.md) — install Guard, sync policy, first governed AI tool call
-- *(planned)* Install, first playbook — see #1523 for CLI local-first work
 
 ---
 
@@ -87,8 +90,8 @@ Running Conduct. Day-two ops: onboard a team, respond to an incident, tune a rul
 
 Wire Conduct into your other tools. CI, MCP, agents.
 
-- [ConductGuard MCP](modules/conductguard/conductguard_mcp.md) — MCP server for AI clients (Claude Code, Cursor, Codex)
-- *(planned)* CLI JSON output, exit codes, agent integration — see #1523
+- [Automate](automate.md) — CLI, MCP, CI, hooks, HTTP API, webhooks
+- [ConductGuard MCP](modules/conductguard/conductguard_mcp.md) — MCP server spec (Claude Code, Cursor, Codex)
 
 ---
 
@@ -118,7 +121,7 @@ Third-party systems Conduct plugs into.
 
 ## Examples
 
-*(gap — planned)* One card per playbook in [`apps/api/playbooks/`](../apps/api/playbooks/). For now, browse the directory directly — 22 playbooks covering GitHub PR review, Slack triage, incident response, CI security, and more.
+- [Examples](examples.md) — 37 pre-built playbooks grouped by what they do: code review, security scan + auto-fix, dependencies, incidents, releases, AI governance, autopilot, testing, docs, NetOps.
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,145 @@
+# Conduct Documentation
+
+Conduct is a YAML playbook platform that turns AI agents into reusable team automations — with a FastAPI backend, Next.js canvas UI, Redis worker, cross-provider LLM proxy (Guard), and 22+ pre-built playbooks covering GitHub, Slack, CI/CD, and incident response.
+
+Docs are organized **by goal, not by file shape**. Pick a section below.
+
+---
+
+## Start by goal
+
+- **I want to run Conduct locally** → [Operate → Developer setup](modules/conductguard/developer_setup.md)
+- **I want to write a playbook** → [Concepts → Playbooks](mental-models/08-playbooks.md) + [Playbook DSL ADR](adr/ADR-0004-playbook-dsl-versus-external-orchestration-frameworks.md)
+- **I want to govern AI tool usage on my team** → [Operate → ConductGuard Quickstart](modules/conductguard/QUICKSTART.md)
+- **I want to understand the architecture** → [Orientation → ARCHITECTURE](ARCHITECTURE.md)
+- **I want to add a policy rule / compliance pack** → [Policy → Enforcement coverage](modules/conductguard/enforcement_coverage.generated.md)
+- **I want to integrate a third-party tool** → [Integrations](#integrations)
+
+---
+
+## Start
+
+New to Conduct. Get from zero to a working install.
+
+- [Developer setup](modules/conductguard/developer_setup.md) — local dev environment, dependencies, first run
+- [ConductGuard Quickstart](modules/conductguard/QUICKSTART.md) — install Guard, sync policy, first governed AI tool call
+- *(planned)* Install, first playbook — see #1523 for CLI local-first work
+
+---
+
+## Reference
+
+Stable contracts and vocabulary. Read these when you need the *exact* answer.
+
+- [Vocabulary](vocabulary.md) — canonical terms used across the codebase
+- [API versioning](api-versioning.md) — how API versions are declared, deprecated, and served
+- [Policy decision contract](policy-decision-contract.md) — allow / warn / block / audit semantics
+- [Guard token model](specs/GUARD_TOKEN_MODEL.md) — token types (`cond_agt_*`, `cond_run_*`, `cond_cred_*`), lifetimes, scopes
+- [Guard capability inventory](modules/conductguard/CAPABILITY_INVENTORY.md) — what Guard does, mapped to controls
+
+---
+
+## Concepts
+
+Mental models. How the pieces fit together. Read these once, refer back rarely.
+
+- [1. Execution engine](mental-models/01-execution-engine.md)
+- [2. Brain block](mental-models/02-brain-block.md)
+- [3. Guard proxy](mental-models/03-guard-proxy.md)
+- [4. Policy engine](mental-models/04-policy-engine.md)
+- [5. Memory](mental-models/05-memory.md)
+- [6. DSL compiler](mental-models/06-dsl-compiler.md)
+- [7. Agent identity](mental-models/07-agent-identity.md)
+- [8. Playbooks](mental-models/08-playbooks.md)
+- [9. Pricing](mental-models/09-pricing.md)
+- [10. Auth & crypto](mental-models/10-auth-crypto.md)
+- [11. Database schema](mental-models/11-database-schema.md)
+- [12. Data flow](mental-models/12-data-flow.md)
+
+---
+
+## Orientation
+
+Where things sit. Trust boundaries. Failure modes. Read before making architectural changes.
+
+- [ARCHITECTURE](ARCHITECTURE.md) — top-down system view
+- [Guard mental model](guard-mental-model.md) — how Guard thinks about tool calls
+- [Guard false-positive strategy](guard-fp-strategy.md) — how we tune rule precision
+- [Threat model](threat-model.md) — attack surface, mitigations
+- [Module security threat model](modules/security/threat-model.md) — per-module threat analysis
+
+---
+
+## Operate
+
+Running Conduct. Day-two ops: onboard a team, respond to an incident, tune a rule.
+
+- [ConductGuard overview](modules/conductguard/overview.md) — what Guard is, who it's for
+- [ConductGuard README](modules/conductguard/README.md) — module entry point
+- [Runbook](modules/conductguard/RUNBOOK.md) — incident response, common ops
+- [Team onboarding](modules/conductguard/team_onboarding.md) — bring a team onto Guard
+- [Audit log verification](audit-log-verification.md) — verify the hash-chained audit trail
+- [Guard module spec](modules/guard.md) — v0.3 fleet-management model
+
+---
+
+## Automate
+
+Wire Conduct into your other tools. CI, MCP, agents.
+
+- [ConductGuard MCP](modules/conductguard/conductguard_mcp.md) — MCP server for AI clients (Claude Code, Cursor, Codex)
+- *(planned)* CLI JSON output, exit codes, agent integration — see #1523
+
+---
+
+## Policy
+
+Ship policy. Compliance mappings, coverage evidence, permission model, spend controls.
+
+- [AI governance playbooks](modules/conductguard/ai_governance_playbooks.md) — how Guard implements common governance patterns
+- [Enforcement coverage](modules/conductguard/enforcement_coverage.generated.md) — generated evidence: which surface enforces which rule
+- [Hook coverage](modules/conductguard/hook_coverage.md) — PreToolUse / PostToolUse hook matrix
+- [Roles & permissions](modules/conductguard/roles_permissions.md) — RBAC seed data, permission names
+- [Spend controls](modules/conductguard/spend_controls.md) — budgets, hard caps, alerts
+
+---
+
+## Integrations
+
+Third-party systems Conduct plugs into.
+
+- [Proliferate](integrations/proliferate.md) — LLM key distribution + rotation
+- [Cedar adapter — spec](cedar-adapter-spec.md) — Cedar policy import contract
+- [Cedar adapter — usage](cedar-adapter-usage.md) — how to import Cedar policies
+- [Okta + Conduct](reference/okta-plus-conduct.md) — SSO / SCIM / group sync
+- [Okta tracking](reference/okta-tracking.md) — audit trail for Okta-provisioned identities
+
+---
+
+## Examples
+
+*(gap — planned)* One card per playbook in [`apps/api/playbooks/`](../apps/api/playbooks/). For now, browse the directory directly — 22 playbooks covering GitHub PR review, Slack triage, incident response, CI security, and more.
+
+---
+
+## ADRs
+
+Decisions with tradeoffs written down. Read before proposing to change the same thing.
+
+- [Index](adr/README.md)
+- [ADR-0001 — Guard enforcement surfaces & trust boundaries](adr/ADR-0001-guard-enforcement-surfaces-and-trust-boundaries.md)
+- [ADR-0002 — Policy pack schema & applicability contract](adr/ADR-0002-policy-pack-schema-and-applicability-contract.md)
+- [ADR-0003 — Fail-open vs fail-closed semantics](adr/ADR-0003-fail-open-versus-fail-closed-semantics.md)
+- [ADR-0004 — Playbook DSL vs external orchestration frameworks](adr/ADR-0004-playbook-dsl-versus-external-orchestration-frameworks.md)
+
+---
+
+## Not in this index
+
+- `docs/demo-scripts/` — marketing/demo scripts, not user docs
+- `docs/team-os/` — internal team standards (auth, migrations, security)
+- `docs/mental-models/` files that don't yet exist in this list — none; all 12 are indexed above
+
+## Contributing
+
+New page? Add it to the section that matches the **goal** it serves, not the file type. If your page doesn't fit any section, that's a signal the taxonomy needs a new section — open an issue against #1525 rather than adding an "Other" pile.

--- a/docs/automate.md
+++ b/docs/automate.md
@@ -1,0 +1,115 @@
+# Automate
+
+Wire Conduct into your other tools. CLI, MCP, CI, HTTP.
+
+---
+
+## CLI
+
+`conduct-cli` is the primary programmatic entrypoint. Install with `pip install conduct-cli`; full command reference in the [CLI README](../packages/conduct-cli/README.md).
+
+**Command groups:**
+
+| Group | Purpose |
+|---|---|
+| `login`, `whoami`, `token` | Auth |
+| `projects`, `create`, `delete`, `reset`, `switch` | Workspace/project management |
+| `playbooks`, `install`, `install-all`, `agents` | Playbook catalog + installation |
+| `test`, `run`, `emit` | Execution + event emission |
+| `environments`, `credentials`, `set` | Secrets |
+| `guard sync`, `guard status`, `guard audit`, `guard approvals`, `guard discover`, `guard watch` | Guard governance |
+| `mcp install` | Register Conduct's MCP server in AI clients |
+| `skill list`, `skill install`, `skill uninstall` | Guard policy skill packs |
+| `verify`, `test-guard`, `test-security` | Governance evidence + rule testing |
+
+**Exit codes:** `0` success, `1` user/config error, `2` blocked by Guard policy. Machine-parseable output via `--json` flag on most commands.
+
+---
+
+## MCP (Model Context Protocol)
+
+Conduct exposes an MCP server so Claude Code, Cursor, Codex, and any MCP-compatible AI client can call Guard directly. Full spec: [ConductGuard MCP](modules/conductguard/conductguard_mcp.md).
+
+**Install:**
+
+```bash
+conduct mcp install
+```
+
+Writes MCP server registration into your AI client's config files (`~/.claude/`, `~/.cursor/`, etc.).
+
+**Tools exposed to the AI client:**
+
+- `guard_status` — team, active rules, policy version
+- `guard_check` — pre-flight check before executing a tool call
+- `guard_sync` — refresh policy from the API
+- `guard_activity` — log what the AI is currently doing
+
+**Endpoint (remote):** `https://api.conductai.ai/guard/mcp` — spawned via `npx -y mcp-remote https://api.conductai.ai/guard/mcp` if you prefer no local binary.
+
+---
+
+## CI integration
+
+`conduct-cli` is stateless per-invocation (reads token from `~/.conduct/config.json` or `CONDUCT_TOKEN` env var). Drop it into any pipeline.
+
+**GitHub Actions example:**
+
+```yaml
+- name: Install Conduct CLI
+  run: pip install conduct-cli
+
+- name: Trigger release-readiness agent
+  env:
+    CONDUCT_TOKEN: ${{ secrets.CONDUCT_TOKEN }}
+    CONDUCT_WORKSPACE: ${{ secrets.CONDUCT_WORKSPACE }}
+  run: conduct test "Release Readiness Reviewer" --json
+```
+
+**Emit findings from any scanner into Conduct's security loop:**
+
+```bash
+conduct emit finding \
+  --severity critical \
+  --type hardcoded_secret \
+  --description "AWS key at src/config.py:42"
+```
+
+Findings flow into the [Security Loop](../apps/api/playbooks/security_loop.yaml) playbook for auto-triage.
+
+---
+
+## Hooks (Claude Code, Cursor, Codex)
+
+`conduct guard sync` installs a PreToolUse hook at `~/.conductguard/hook.py` that fires before every AI tool call. Local policy evaluation (no API round-trip), async audit event to the API, exit code 0/2 for allow/block.
+
+Details: [Hook coverage matrix](modules/conductguard/hook_coverage.md).
+
+---
+
+## HTTP API
+
+Every CLI command is a thin wrapper over the HTTP API. Base URL: `https://api.conductai.ai` (or your self-hosted server). Auth: `Authorization: Bearer <token>`.
+
+- **Versioning contract** → [API versioning](api-versioning.md)
+- **Interactive schema** → `https://<your-api>/docs` (OpenAPI/Swagger)
+- **Machine schema** → `https://<your-api>/openapi.json`
+
+---
+
+## Programmatic execution
+
+For custom orchestration outside the CLI:
+
+- **REST**: hit `POST /workflows/<id>/run` with inputs; poll `GET /runs/<id>` for status.
+- **Webhooks (inbound)**: every playbook auto-exposes `https://<your-api>/webhooks/inbound/<workflow-id>` — POST any JSON payload to trigger.
+- **Webhooks (outbound)**: subscribe to run lifecycle events under workspace settings.
+- **SSE**: `GET /runs/<id>/events` streams live run events.
+
+---
+
+## Next steps
+
+- **Understand the runtime** → [Execution engine](mental-models/01-execution-engine.md), [Brain block](mental-models/02-brain-block.md)
+- **Tune governance** → [Policy](README.md#policy)
+- **Add a custom Guard rule** → [Enforcement coverage](modules/conductguard/enforcement_coverage.generated.md)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,127 @@
+# Examples
+
+37 pre-built playbooks. Every one is a working YAML file under [`apps/api/playbooks/`](../apps/api/playbooks/) — copy, tweak, install. Grouped by what they *do*, not by which tool they call.
+
+Install one directly:
+
+```bash
+conduct install pr-reviewer --project MyProject --repo owner/repo
+```
+
+Install all 37:
+
+```bash
+conduct install-all --project MyProject --repo owner/repo
+```
+
+---
+
+## Code review
+
+Every PR gets a first-pass AI review before a human looks at it.
+
+- **[PR Reviewer](../apps/api/playbooks/pr-reviewer.yaml)** — Every PR reviewed for bugs, security issues, and style. Review comment posted automatically.
+- **[Bulk PR Reviewer](../apps/api/playbooks/bulk-pr-reviewer.yaml)** — Review all open PRs in a repo in one run. Posts a fleet summary to Slack.
+- **[Copilot / AI PR Reviewer](../apps/api/playbooks/copilot-reviewer.yaml)** — AI-authored PRs get a second AI review — catches what Copilot and Cursor miss before humans touch it.
+- **[Terraform Plan Reviewer](../apps/api/playbooks/terraform-reviewer.yaml)** — Terraform PRs reviewed for security misconfigs, cost anomalies, and drift.
+
+---
+
+## Security scanning
+
+Catch known-bad patterns before they land.
+
+- **[Security Scanner](../apps/api/playbooks/security-scanner.yaml)** — Every PR scanned for OWASP Top 10, hardcoded secrets, vulnerable dependencies.
+- **[Multi-Repo Scanner](../apps/api/playbooks/multi-repo-scanner.yaml)** — Fleet-wide security scan across many repos in parallel; ranked findings.
+- **[BugHunter Active Scan](../apps/api/playbooks/bughunter-active-scan.yaml)** — Dynamically loads skills from a configurable GitHub repo (default: `elementalsouls/Claude-BugHunter`).
+- **[Threat Modeler](../apps/api/playbooks/threat-modeler.yaml)** — Auto-drafts a STRIDE threat model on every PR that changes architecture, services, endpoints, or trust boundaries.
+- **[Codebase Guard Monitor](../apps/api/playbooks/codebase-guard-monitor.yaml)** — Every PR scanned for security violations before merge.
+
+---
+
+## Security auto-fix
+
+Turn a finding into a merged PR.
+
+- **[Security Autopilot Fix](../apps/api/playbooks/security-autopilot-fix.yaml)** — Reads the affected file, writes a targeted patch, opens a PR.
+- **[Security Patch Updater](../apps/api/playbooks/security-patch-updater.yaml)** — Dependabot alerts patched, tested, and PR'd with a clear CVE reference.
+- **[Security Loop](../apps/api/playbooks/security_loop.yaml)** — Auto-triage security findings from any AI tool or scanner that posts to the findings endpoint.
+- **[Third-Party Autopilot Fix](../apps/api/playbooks/thirdparty-autopilot-fix.yaml)** — Fork any third-party repo, apply the fix, open a PR back to upstream.
+
+---
+
+## Dependencies
+
+- **[Dependency Audit](../apps/api/playbooks/dependency-audit.yaml)** — Iterate outdated deps, assess risk per package, open GitHub issues for major upgrades. Supports npm, pip, cargo, go modules.
+- **[Dependency Updater](../apps/api/playbooks/dependency-updater.yaml)** — Outdated deps bumped and PR'd automatically every week.
+
+---
+
+## Incidents & alerts
+
+Alert fires → root cause hypothesis is in Slack in under 60 seconds.
+
+- **[Incident Responder](../apps/api/playbooks/incident-responder.yaml)** — Reads the alert, correlates recent commits + deploys, posts a structured hypothesis to `#incidents`.
+- **[CI Failure Alert](../apps/api/playbooks/ci-notify.yaml)** — Failed builds diagnosed and explained in Slack before anyone opens a terminal.
+- **[Postmortem Drafter](../apps/api/playbooks/postmortem-drafter.yaml)** — Structured postmortem drafted automatically when an incident closes.
+- **[Flaky Test Detective](../apps/api/playbooks/flaky-test-detective.yaml)** — Flaky tests identified, traced to the offending commit, fix recommendation lands in Slack + GitHub.
+
+---
+
+## Releases
+
+- **[Release Gating](../apps/api/playbooks/release-gating.yaml)** — Readiness checks + HITL approval + auto-tag + release notes on approval.
+- **[Release Readiness Reviewer](../apps/api/playbooks/release-readiness.yaml)** — Go/no-go in Slack — open blockers, failed CI, pending reviews, unresolved incidents.
+- **[Release Notes Drafter](../apps/api/playbooks/release-notes.yaml)** — Tag a release → notes drafted automatically.
+
+---
+
+## AI governance
+
+Governance for the AI tools your team uses.
+
+- **[AI Drift Detector](../apps/api/playbooks/ai-drift-detector.yaml)** — Daily check for AI governance drift.
+- **[AI Output Auditor](../apps/api/playbooks/ai-output-auditor.yaml)** — Weekly audit of AI tool outputs. Samples the Guard audit log, checks accuracy/bias/quality, posts a scorecard to Slack.
+- **[AI Risk Assessment](../apps/api/playbooks/ai-risk-assessment.yaml)** — Pre-deploy checklist for any new AI tool. Surfaces risks, sets data boundaries, defines human controls, generates a one-page incident response plan.
+- **[AI Incident Drill](../apps/api/playbooks/ai-incident-drill.yaml)** — Quarterly simulation of an AI governance incident.
+- **[Compromised Support Agent](../apps/api/playbooks/compromised-support-agent.yaml)** — Autonomous support agent picks up a ticket containing a prompt injection — Guard blocks, audit trail captures.
+
+---
+
+## Autopilot & issue automation
+
+Label an issue, walk away, come back to a merged PR.
+
+- **[Autopilot — GitHub Issues](../apps/api/playbooks/autopilot.yaml)** — Label an issue `autopilot ready`. Claude implements the fix, runs tests with inline retry, opens the PR.
+- **[Autopilot Approved](../apps/api/playbooks/autopilot-approved.yaml)** — Same, but waits for your approval before opening the PR.
+- **[OSS Issue Sweep](../apps/api/playbooks/oss-issue-sweep.yaml)** — Every open issue mapped for cross-issue deps, ordered by blast radius, then fixed and PR'd in order.
+- **[Issue Triage](../apps/api/playbooks/issue-triage.yaml)** — New issues labeled, prioritized, clarified automatically.
+
+---
+
+## Testing
+
+- **[Smoke Test — Pipeline Ping](../apps/api/playbooks/smoke-test.yaml)** — Prove the full pipeline is healthy in under 30 seconds.
+- **[Multi-Env Smoke Test](../apps/api/playbooks/multi-env-smoke-test.yaml)** — Smoke tests across multiple environments in one run.
+- **[Acme Onboarding E2E](../apps/api/playbooks/acme-onboarding-e2e.yaml)** — Full role-coverage E2E test using Peekaboo (macOS GUI automation via MCP).
+
+---
+
+## Docs
+
+- **[Docs Drift Detector](../apps/api/playbooks/docs-drift-detector.yaml)** — Merged PRs that break the docs get a follow-up PR automatically.
+
+---
+
+## NetOps
+
+- **[Network Diagnosis Agent](../apps/api/playbooks/network-diagnosis-agent.yaml)** — Autonomous NetOps agent diagnoses a branch incident, correlates telemetry + config changes, proposes remediation, executes only the reversible parts.
+- **[Self-Driving Network — Prod Config Push (HITL)](../apps/api/playbooks/self-driving-network-approval-demo.yaml)** — Multi-fabric NetOps (Juniper Mist + Aruba Central) — synchronized config push with human approval gate.
+
+---
+
+## Writing your own
+
+Every playbook above is a self-contained YAML file — 100 to 500 lines each — and they compose from the same block types (`brain`, `http_call`, `slack_post`, `github_*`, `run_shell`, `for_each`, `plan_fix`, `clarify`, `record_outcome`, ...). Pick the closest existing playbook, copy it, edit inputs and blocks.
+
+See [Concepts → Playbooks](mental-models/08-playbooks.md) for the block-type reference and [ADR-0004](adr/ADR-0004-playbook-dsl-versus-external-orchestration-frameworks.md) for the design rationale.

--- a/docs/start.md
+++ b/docs/start.md
@@ -1,0 +1,113 @@
+# Start
+
+New to Conduct. Zero to a first working automation.
+
+---
+
+## Install
+
+```bash
+pip install conduct-cli
+```
+
+Requires Python 3.9+. Runs on Linux, macOS, and Windows.
+
+Verify:
+
+```bash
+conduct --version
+```
+
+For local development against the Conduct codebase (docker-compose, migrations, seeded data), see [Developer setup](modules/conductguard/developer_setup.md) instead.
+
+---
+
+## Quickstart
+
+Five commands from install to a first agent run against your own GitHub repo.
+
+### 1. Log in
+
+```bash
+conduct login
+```
+
+Opens a browser, authenticates against `api.conductai.ai` (or your self-hosted server), and stores the token at `~/.conduct/config.json`. Token starts with `cond_agt_`.
+
+Prefer manual? Issue a token from **Settings → Agents → Issue token** in the dashboard, then:
+
+```bash
+conduct login --server https://api.conductai.ai --token cond_agt_xxx --workspace <workspace-id>
+```
+
+### 2. Browse playbooks
+
+```bash
+conduct playbooks
+```
+
+Lists the 30+ pre-built playbooks (PR review, incident response, security scanning, dependency updates, etc.). See the full catalog in [Examples](examples.md).
+
+### 3. Install all playbooks into a project
+
+```bash
+conduct install-all --project DevOps --repo owner/repo
+```
+
+Creates the project if it doesn't exist. Instantiates every playbook, pointed at your GitHub repo. Use `--input key=value` to override any playbook input.
+
+### 4. List installed agents
+
+```bash
+conduct agents
+```
+
+### 5. Fire a test run
+
+```bash
+conduct test "PR Reviewer"
+```
+
+Streams the agent's execution live. Use `conduct test --all` to fire every agent in sequence.
+
+That's it. Your repo now has 30+ AI agents watching for PRs, incidents, dependency updates, and security issues — governed by Guard and logged to a hash-chained audit trail.
+
+---
+
+## Your first `playbook.yaml`
+
+A playbook is a YAML file describing an agent's inputs, trigger, and block sequence. Minimum viable:
+
+```yaml
+name: My First Agent
+version: 1
+description: >
+  Says hello in Slack when triggered.
+
+inputs:
+  slack_channel:
+    label: Slack channel
+    default: "#general"
+
+trigger:
+  type: webhook
+
+blocks:
+  - id: greet
+    type: slack_post
+    channel: {{ inputs.slack_channel }}
+    text: "hello from conduct"
+```
+
+Save as `hello.yaml`, drop into `apps/api/playbooks/` (self-hosted) or upload via the dashboard (hosted). Trigger by POSTing to `https://<your-api>/webhooks/inbound/<workflow-id>`.
+
+Next: read [Playbooks](mental-models/08-playbooks.md) for the full block reference, or browse [Examples](examples.md) for 37 working playbooks to copy from.
+
+---
+
+## Next steps
+
+- **Understand what just happened** → [Concepts](README.md#concepts) (start with [Execution engine](mental-models/01-execution-engine.md))
+- **Add governance** → [ConductGuard Quickstart](modules/conductguard/QUICKSTART.md)
+- **Wire into CI, MCP, or your own tools** → [Automate](automate.md)
+- **Run Conduct on your own infrastructure** → [Developer setup](modules/conductguard/developer_setup.md)


### PR DESCRIPTION
## Summary

Multi-audience docs reorg (#1525 Phase 1 + gap-fill + persona/reference nav). Zero file moves, so no back-reference churn.

### New pages
- `docs/README.md` — goal-first landing (all sections), now with a **By persona** nav block on top (solo dev / team lead / security buyer)
- `docs/start.md` — pip install, 5-command quickstart, first `playbook.yaml`
- `docs/automate.md` — CLI groups, MCP, CI (GitHub Actions), hooks, HTTP API, webhooks
- `docs/examples.md` — 37 playbook cards grouped by outcome
- `docs/reference/blocks.md` — every playbook block type with required fields + examples (from `apps/api/app/dsl/schema.py`)
- `docs/reference/guard-rule-packs.md` — 183 rules across 15 packs, grouped by tier (auto-gen from pack JSON)

### Edits
- Root `README.md` — new **Documentation** section with quick-path links; first time the repo home points at the docs landing.

### Audience coverage
Every persona has a documented path:
- **Solo dev evaluating** → Start → Examples → Automate
- **Team lead onboarding** → Guard Quickstart → Team onboarding → Automate → Examples
- **Security buyer due diligence** → Threat model → Audit verification → Rule packs → Enforcement coverage → ADR-0001 → ADR-0003

Closes #1525 Phase 1 in full. Phase 2 (physical `git mv` into per-section folders) stays deferred — only worth it if the flat layout becomes a real friction after use.

## Test plan
- [x] All internal links across `README.md`, landing, and new pages verified programmatically — none broken.
- [x] Rule pack reference generator run against live pack JSON — 183 rules across 15 packs match.
- [x] Block reference cross-checked against `dsl/schema.py` block type enum + validators.
- [ ] Skim after merge — confirm the persona nav reads right on GitHub.