### PR TITLE
fix(lens): live RunBubble panel — refetch on every block, sync into embedded RunDetailPanel

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1199,9 +1199,12 @@ function RunBubble({
   }, [runId])
 
   // Refetch state + outcome + timing when a block completes / status changes.
+  // #1480 Gap 1 — deps include terminalCount so we refetch on EVERY block
+  // completion, not just the first. That refreshes tokens/cost mid-run so the
+  // embedded RunDetailPanel StatRow updates live (kills #1543 stopgap).
+  const terminalCount = Array.from(blocks.values()).filter(b => b.status === "succeeded" || b.status === "failed").length
   useEffect(() => {
-    const anyCompleted = Array.from(blocks.values()).some(b => b.status === "succeeded" || b.status === "failed")
-    if (!anyCompleted && status !== "succeeded" && status !== "failed") return
+    if (terminalCount === 0 && status !== "succeeded" && status !== "failed") return
     let cancelled = false
     authFetch(`${API}/runs/${runId}`)
       .then(r => (r.ok ? r.json() : null))
@@ -1215,7 +1218,7 @@ function RunBubble({
       .catch(() => {})
     return () => { cancelled = true }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [status])
+  }, [status, terminalCount])
 
   // Client-side elapsed clock — tick every second while the run is active.
   useEffect(() => {

--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -79,6 +79,10 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
   const { authFetch } = useAuthFetch()
 
   const [run, setRun] = useState<RunMeta | null>(initialRun ?? null)
+  // #1480 Gap 1 — re-sync when parent (RunBubble) pushes a fresher initialRun
+  // after block_completed events. Without this the embedded panel is stuck at
+  // whatever run state was seeded at mount and tokens/cost/status don't move.
+  useEffect(() => { if (initialRun) setRun(initialRun) }, [initialRun])
   const [workflowName, setWorkflowName] = useState<string | null>(null)
   const [projectName, setProjectName] = useState<string | null>(null)
   const [projectId, setProjectId] = useState<string | null>(null)


### PR DESCRIPTION
Part of #1480 (Gap 1 — full run trace inline). Complements #1543.

## The bug
Expand a RunBubble on a running workflow, and the embedded `RunDetailPanel` StatRow numbers freeze at whatever was there at mount. Tokens / Est. cost / status stay stale until the run terminates. #1543 killed the flicker but the counters still froze — that was the acknowledged stopgap.

## Root cause — two wiring holes

1. **RunBubble refetches too rarely.** Its state-refetch effect had deps `[status]`, so it only ran on status transitions. Block completions during a `running` status never triggered a refetch → `runData` never updated → nothing fresh to push to the panel.
2. **RunDetailPanel treats `initialRun` as mount-only.** `useState(initialRun ?? null)` — even when the parent DID push a newer `initialRun` prop, the panel ignored it.

## Fix
- **RunBubble**: deps now `[status, terminalCount]`, where `terminalCount` = number of blocks in a terminal (`succeeded` / `failed`) state. Fires exactly once per block completion.
- **RunDetailPanel**: adds `useEffect(() => { if (initialRun) setRun(initialRun) }, [initialRun])` so the parent's fresh fetches actually land.

Net: expand a RunBubble mid-run → StatRow duration ticks (from #1543's `<LiveDuration/>`) + tokens / cost / status update on every `block_completed` event. Still no polling.

## Test plan
- [ ] Trigger a workflow through Lens with 3+ blocks and non-trivial LLM cost.
- [ ] Expand the RunBubble while running.
- [ ] Duration ticks every 1s.
- [ ] After each `block_completed` SSE event, Tokens + Est. cost bump.
- [ ] On terminal, no extra refetch storm — a single final one.