### PR TITLE
fix(lens): persist run_started envelope on button-click confirm

### DIFF
--- a/apps/api/app/modules/glens/actor/helpers.py
+++ b/apps/api/app/modules/glens/actor/helpers.py
@@ -372,6 +372,12 @@ def dispatch_confirm(
 
     _publish_action_event(row, "action.confirmed", result=result)
 
+    # #1480 Gap 2 — persist a run_started envelope to the originating chat
+    # session so RunBubble rehydrates on refresh. Natural-language confirm
+    # path does this via chat.py's _extract_run_started_envelope; the
+    # button-click path (this function) needs it done explicitly.
+    _persist_run_started_envelope(db, row, result)
+
     return {
         "executed": True,
         "cached": False,
@@ -416,3 +422,35 @@ def dispatch_cancel(
         "action_id": str(row.id),
         "tool_name": row.tool_name,
     }
+
+
+def _persist_run_started_envelope(db: Session, row, result: Any) -> None:
+    """Append a run_started envelope to the originating Lens chat session so
+    the RunBubble rehydrates on refresh. No-op unless the row has a session_id
+    and the execute result contains a run_id. Fail-open — persistence must not
+    break the confirm.
+    """
+    if not row.session_id or not isinstance(result, dict) or not result.get("run_id"):
+        return
+    import json as _json
+    import uuid as _uuid
+    from app.modules.glens.models import GlensChatSession
+    try:
+        sess = db.query(GlensChatSession).filter(
+            GlensChatSession.id == _uuid.UUID(str(row.session_id))
+        ).first()
+        if sess is None:
+            return
+        messages = _json.loads(sess.messages or "[]")
+        envelope = {
+            "run_started": {
+                "run_id": str(result["run_id"]),
+                "workflow_name": result.get("workflow_name") or row.tool_name or "workflow",
+                "status": result.get("status") or "pending",
+            }
+        }
+        messages.append({"role": "assistant", "content": _json.dumps(envelope)})
+        sess.messages = _json.dumps(messages)
+        db.commit()
+    except Exception:
+        db.rollback()

--- a/apps/api/tests/glens/test_persist_run_started.py
+++ b/apps/api/tests/glens/test_persist_run_started.py
@@ -1,0 +1,69 @@
+"""#1480 Gap 2 — `_persist_run_started_envelope` appends a run_started
+message to the originating Lens chat session so RunBubble rehydrates on
+refresh (button-click confirm path only; NL path already covered by
+_extract_run_started_envelope in chat.py)."""
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.glens.actor.helpers import _persist_run_started_envelope
+
+
+def _row(session_id: str | None = "sess-1") -> SimpleNamespace:
+    return SimpleNamespace(session_id=session_id, tool_name="run_workflow")
+
+
+def _fake_db_with_session(messages: str = "[]"):
+    sess = SimpleNamespace(messages=messages, id=uuid.uuid4())
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = sess
+    return db, sess
+
+
+def test_persists_when_row_has_session_and_result_has_run_id():
+    db, sess = _fake_db_with_session()
+    with patch("uuid.UUID", side_effect=lambda s: sess.id):
+        _persist_run_started_envelope(
+            db, _row("sess-1"),
+            {"run_id": "run-abc", "workflow_name": "ship_it", "status": "pending"},
+        )
+    msgs = json.loads(sess.messages)
+    assert len(msgs) == 1
+    envelope = json.loads(msgs[0]["content"])
+    assert envelope["run_started"]["run_id"] == "run-abc"
+    assert envelope["run_started"]["workflow_name"] == "ship_it"
+    assert envelope["run_started"]["status"] == "pending"
+    db.commit.assert_called_once()
+
+
+def test_noop_when_row_has_no_session_id():
+    db = MagicMock()
+    _persist_run_started_envelope(db, _row(session_id=None), {"run_id": "r1"})
+    db.query.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_noop_when_result_has_no_run_id():
+    db = MagicMock()
+    _persist_run_started_envelope(db, _row("sess-1"), {"status": "pending"})
+    db.query.assert_not_called()
+    db.commit.assert_not_called()
+
+
+def test_falls_open_on_missing_session():
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    # Should not raise, should not commit
+    _persist_run_started_envelope(db, _row("sess-1"), {"run_id": "r1"})
+    db.commit.assert_not_called()
+
+
+def test_falls_open_on_exception():
+    db = MagicMock()
+    db.query.side_effect = RuntimeError("db exploded")
+    # Must not raise — persistence is a nice-to-have
+    _persist_run_started_envelope(db, _row("sess-1"), {"run_id": "r1"})
+    db.rollback.assert_called_once()


### PR DESCRIPTION
Part of #1480 (Gap 2 — button-click RunBubble persistence).

## Symptom
Click Confirm on an ActionConfirmBubble → RunBubble renders inline → refresh the tab → RunBubble is **gone**.

## Root cause
Two confirm paths, only one persists:

- **Natural-language "yes"** → chat.py's `_extract_run_started_envelope` pulls the run_id out of the tool result, and the outer stream loop appends `{"role": "assistant", "content": json.dumps({"run_started": {...}})}` to `session.messages`. Frontend rehydrator (line ~1655) picks it up on refresh.
- **Button-click** → `dispatch_confirm` publishes an `action.confirmed` SSE event and returns. Session messages never updated. Refresh → nothing to rehydrate.

## Fix
`dispatch_confirm` now calls `_persist_run_started_envelope(db, row, result)` after a successful execute. When `row.session_id` is set AND `result.run_id` is present, it appends the same `{"run_started": {...}}` envelope to `GlensChatSession.messages` and commits.

Fail-open: any exception during persistence is caught + rolled back. The run is already kicked off — dropping a chat bubble on refresh is a degraded state, not a failure.

## Tests
5 new unit tests in `test_persist_run_started.py`:
- happy path (envelope appended, commit called)
- no-op when row has no `session_id`
- no-op when result has no `run_id`
- fail-open when session not found
- fail-open when DB throws

## Test plan
- [ ] Trigger a workflow via Lens ActionConfirmBubble (button-click path).
- [ ] Confirm the RunBubble appears.
- [ ] Refresh the browser.
- [ ] RunBubble reappears with the correct run.