### PR TITLE
fix(lens): retryRun preserves original inputs instead of posting empty

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1291,11 +1291,24 @@ function RunBubble({
   const cancelRun = () => _postAction(`${API}/workflows/${workflowId}/runs/${runId}/cancel`)
   const decideRun = (decision: "approved" | "rejected") =>
     _postAction(`${API}/workflows/${workflowId}/runs/${runId}/approve`, { decision })
-  const retryRun = () =>
-    _postAction(`${API}/workflows/${workflowId}/runs`, {}, (data) => {
+  const retryRun = () => {
+    // #1480 Gap 3 — reuse the original run's inputs. runState + blocks give
+    // us enough to reconstruct: strip out per-block outputs (keys equal to
+    // block IDs) and system-added keys (__foo). What remains is _trigger +
+    // any top-level input fields the workflow was originally started with.
+    const initial_state: Record<string, unknown> = {}
+    if (runState) {
+      for (const [k, v] of Object.entries(runState)) {
+        if (k.startsWith("__")) continue        // system-added
+        if (blocks.has(k)) continue             // block output
+        initial_state[k] = v
+      }
+    }
+    _postAction(`${API}/workflows/${workflowId}/runs`, { initial_state }, (data) => {
       const newId = data.id as string | undefined
       if (newId && onRetry) onRetry(newId, workflowName)
     })
+  }
 
   const pillColor = (() => {
     switch (status) {


### PR DESCRIPTION
Part of #1480 (Gap 3 — retry sends proper inputs).

## Symptom
Click **Retry** on a failed RunBubble → workflows that declare required inputs 422 immediately because the request body was hardcoded to `{}`.

## Fix
Reconstruct `initial_state` from the failed run's own state:
- Strip out block-output keys (using the `blocks` Map RunBubble already tracks from SSE).
- Strip out system keys (`__user_email`, `__dry_run`, `__runtime_persona`, etc.).
- Send what remains — includes `_trigger` and any top-level input fields — as the new run's `initial_state`.

Handles both trigger paths:
- **Webhook / GitHub-triggered** — `_trigger` survives, so the retry replays the same event.
- **Form-triggered** — top-level input fields declared by the workflow survive.

## Fallback
If `runState` hasn't loaded yet (retry clicked on a very fresh bubble), the loop produces `{}`, which is the previous behaviour. No worse than today.

## Test plan
- [ ] Fail a workflow that requires an input.
- [ ] Click Retry in the RunBubble.
- [ ] New run kicks off with the same input, not a 422.
- [ ] Retry a GitHub-triggered failure — new run gets the same `_trigger`.