### PR TITLE
fix(runs): canvas standalone page pushes fresh RunMeta into panel

### DIFF
--- a/apps/web/src/app/(app)/workflows/[id]/runs/[run_id]/page.tsx
+++ b/apps/web/src/app/(app)/workflows/[id]/runs/[run_id]/page.tsx
@@ -4,16 +4,54 @@
  * Full run-detail page. Renders <RunDetailPanel> inside the standard AppShell.
  * The panel is the shared implementation — same component is embedded inside
  * Lens RunBubble with the `embedded` prop.
+ *
+ * #1543 removed the poll inside RunDetailPanel to kill flicker in the Lens
+ * embedded surface. In Lens the panel gets fresh state pushed from RunBubble's
+ * SSE subscription (#1544). Standalone canvas has no such parent — this page
+ * owns a low-frequency poll and pushes fresh RunMeta via `initialRun`, which
+ * RunDetailPanel's #1544 useEffect syncs into its own `run` state.
  */
+import { useEffect, useState } from "react"
 import { useParams } from "next/navigation"
 import AppShell from "@/components/AppShell"
-import RunDetailPanel from "@/components/runs/RunDetailPanel"
+import RunDetailPanel, { type RunMeta } from "@/components/runs/RunDetailPanel"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { API } from "@/lib/api"
+import { isTerminal } from "@/lib/runUtils"
 
 export default function RunDetailPage() {
   const { id: workflowId, run_id: runId } = useParams<{ id: string; run_id: string }>()
+  const { authFetch } = useAuthFetch()
+  const [runData, setRunData] = useState<RunMeta | null>(null)
+
+  useEffect(() => {
+    if (!workflowId || !runId) return
+    let cancelled = false
+
+    async function fetchOnce() {
+      try {
+        const res = await authFetch(`${API}/workflows/${workflowId}/runs/${runId}`)
+        if (!cancelled && res.ok) setRunData(await res.json() as RunMeta)
+      } catch { /* transient — next tick will retry */ }
+    }
+    fetchOnce()
+
+    const id = setInterval(async () => {
+      // Stop polling once terminal — the panel keeps its final state.
+      if (runData && isTerminal(runData.status)) return
+      await fetchOnce()
+    }, 4000)
+    return () => { cancelled = true; clearInterval(id) }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workflowId, runId, runData?.status])
+
   return (
     <AppShell>
-      <RunDetailPanel workflowId={workflowId} runId={runId} />
+      <RunDetailPanel
+        workflowId={workflowId}
+        runId={runId}
+        initialRun={runData ?? undefined}
+      />
     </AppShell>
   )
 }


### PR DESCRIPTION
Post-#1543 regression fix.

## Symptom
Open `/workflows/<wf>/runs/<run>` directly (not embedded in Lens) and the StatRow tokens / cost / status freeze mid-run. Only Duration ticks (from #1543's `LiveDuration`). Waited for a run to finish before any of the aggregates moved.

## Cause
#1543 removed the 4s poll from `RunDetailPanel` to kill flicker in the Lens embedded surface. #1544 added a `useEffect` in the panel that syncs `run <= initialRun`, but only Lens RunBubble was pushing fresh `initialRun`. The standalone canvas page had no parent doing that.

## Fix
Standalone page owns a 4s poll while the run is non-terminal and pushes fresh `RunMeta` via `initialRun`. `RunDetailPanel`'s #1544 sync `useEffect` picks it up. No polling re-introduced in the shared component. Lens surface unchanged.

## Test plan
- [ ] Trigger a long-running workflow. Open `/workflows/<wf>/runs/<run>` in a new tab.
- [ ] Duration ticks (from #1543).
- [ ] Tokens / Est. cost / status update mid-run — no need to refresh.
- [ ] Poll stops once run terminates (verify via network tab: no more `/runs/<id>` requests).
- [ ] Open the same run inside Lens RunBubble — no double-polling (RunBubble still owns its own refetch).