### PR TITLE
fix(lens): embedded panel flows at natural height — no internal scroll

### DIFF
--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -169,11 +169,13 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
   // parent (Lens RunBubble, iframe host, etc.) controls the container.
   const Wrapper = ({ children }: { children: React.ReactNode }) =>
     embedded
-      // #1518 — own scroll container when embedded. Panel content grows inside
-      // a bounded max-height so streaming block events don't yank the parent
-      // Lens chat around. scrollIntoView({ block: "nearest" }) inside RunTrace
-      // now targets THIS container, not the whole page.
-      ? <div style={{ maxHeight: "70vh", overflowY: "auto", padding: "4px 2px" }}>{children}</div>
+      // Panel flows at natural height inside the Lens RunBubble — no internal
+      // scroll container, no scrollbar flicker as content grows. The Lens
+      // chat parent already has its own scroll. #1518's bounded scroll box
+      // was there to isolate RunTrace's scrollIntoView({block:"nearest"});
+      // that stays intact — scrollIntoView with nearest is a no-op when the
+      // element is already in view, which it will be as content grows inline.
+      ? <div style={{ padding: "4px 2px" }}>{children}</div>
       : <div style={{ maxWidth: 1120, margin: "0 auto", padding: "28px 24px" }}>{children}</div>
 
   if (loading) return (


### PR DESCRIPTION
Post-merge cleanup — scrollbar flicker on embedded panel.

## Symptom
Scrollbar flickers on the right edge of the RunDetailPanel embedded inside Lens RunBubble as content updates (see attached user screenshots).

## Cause
#1518's \`maxHeight: 70vh + overflowY: auto\` — every re-render (now once per \`block_completed\` after #1544) nudges content across the 70vh threshold, scrollbar pops in/out.

## Fix
Drop the internal scroll container. Embedded panel flows at natural height inside RunBubble; Lens chat owns the parent scroll.

## Kept intact
- Standalone canvas page (\`/workflows/<wf>/runs/<run>\`) unchanged — still \`maxWidth: 1120px\` centered with page-level scroll.
- #1518's original concern (RunTrace's \`scrollIntoView({block: "nearest"})\` yanking the whole page) is still addressed — \`nearest\` is a no-op when the element is already in view, which it will be as content grows inline.

## Test plan
- [ ] Trigger a workflow in Lens, expand the RunBubble.
- [ ] Watch blocks complete — no scrollbar flash on the panel edge.
- [ ] Lens chat scrolls smoothly as panel grows.
- [ ] Open the same run at \`/workflows/<wf>/runs/<run>\` — page layout unchanged.