### PR TITLE
feat(lens): canvas Run → Lens session with RunBubble (#1515 P1)

### DIFF
--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1881,6 +1881,11 @@ def test_trigger(
     # __manual: True signals a manual/schedule trigger — bypasses trigger-shape validation.
     run_inputs: dict = payload.pop("inputs", {})
     is_manual_flag: bool = bool(payload.pop("__manual", False))
+    # #1515 P1 — canvas Run → Lens session convergence.
+    # lens_attach=True auto-mints a bare Lens session (or reuses lens_session_id)
+    # so the run appears as a RunBubble in that session. Silent no-op for CLI/webhook.
+    lens_attach: bool = bool(payload.pop("lens_attach", False))
+    lens_session_id_raw = payload.pop("lens_session_id", None)
 
     # Always load the playbook's built-in test_trigger.payload, then merge any
     # caller-supplied overrides on top. This lets --repo override the repo fields
@@ -2014,6 +2019,33 @@ def test_trigger(
             },
         )
 
+    # #1515 P1 — resolve the Lens session (existing or fresh) before insert
+    # so Run.session_id is set at creation. Publisher no-ops on NULL, so this
+    # is the seam that makes RunBubble receive SSE events.
+    lens_session_id: _uuid.UUID | None = None
+    if lens_attach or lens_session_id_raw:
+        from app.modules.glens.models import GlensChatSession
+        if lens_session_id_raw:
+            try:
+                lens_session_id = _uuid.UUID(str(lens_session_id_raw))
+            except ValueError:
+                raise HTTPException(status_code=422, detail="lens_session_id must be a UUID")
+            sess = db.query(GlensChatSession).filter(
+                GlensChatSession.id == lens_session_id,
+                GlensChatSession.workspace_id == _uuid.UUID(workspace_id),
+            ).first()
+            if not sess:
+                raise HTTPException(status_code=404, detail="lens_session_id not found in workspace")
+        else:
+            sess = GlensChatSession(
+                workspace_id=_uuid.UUID(workspace_id),
+                title=f"Run: {workflow.name}"[:120],
+                messages="[]",
+            )
+            db.add(sess)
+            db.flush()
+            lens_session_id = sess.id
+
     run = Run(
         workflow_version_id=version.id,
         workspace_id=workflow.workspace_id,
@@ -2021,9 +2053,39 @@ def test_trigger(
         status="pending",
         state=_initial_state,
         max_turns=suggested_turns,
+        session_id=lens_session_id,
     )
     db.add(run)
     db.commit()
+
+    # #1515 P1 — append run_started envelope so RunBubble rehydrates on
+    # session load (matches the actor helpers.py path). Fail-open: envelope
+    # failure must not fail the run creation.
+    if lens_session_id is not None:
+        try:
+            import json as _json_env
+            from app.modules.glens.models import GlensChatSession as _GCS
+            _sess = db.query(_GCS).filter(_GCS.id == lens_session_id).first()
+            if _sess is not None:
+                _messages = _json_env.loads(_sess.messages or "[]")
+                _messages.append({
+                    "role": "assistant",
+                    "content": _json_env.dumps({
+                        "run_started": {
+                            "run_id": str(run.id),
+                            "workflow_name": workflow.name,
+                            "status": run.status,
+                        }
+                    }),
+                })
+                _sess.messages = _json_env.dumps(_messages)
+                db.commit()
+        except Exception as _env_err:
+            db.rollback()
+            log.warning(
+                "workflow.test_triggered.envelope_failed",
+                run_id=str(run.id), session_id=str(lens_session_id), error=str(_env_err),
+            )
 
     try:
         r = _redis_mod.from_url(_settings.redis_url, decode_responses=True)
@@ -2036,7 +2098,12 @@ def test_trigger(
         raise HTTPException(status_code=503, detail="Run created but queue is unavailable")
 
     log.info("workflow.test_triggered", workflow_id=str(workflow_id), run_id=str(run.id), playbook_slug=workflow.playbook_slug)
-    return {"ok": True, "run_id": str(run.id), "max_turns": suggested_turns}
+    return {
+        "ok": True,
+        "run_id": str(run.id),
+        "max_turns": suggested_turns,
+        "session_id": str(lens_session_id) if lens_session_id else None,
+    }
 
 
 class SyncRequest(BaseModel):

--- a/apps/api/tests/test_workflow_trigger_lens_attach.py
+++ b/apps/api/tests/test_workflow_trigger_lens_attach.py
@@ -1,0 +1,181 @@
+"""#1515 P1 — canvas Run trigger with lens_attach=True.
+
+Verifies the trigger endpoint auto-mints a Lens session, sets
+Run.session_id, and appends a run_started envelope to session messages
+so RunBubble rehydrates on session load.
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from fastapi.testclient import TestClient
+
+from app.core.database import get_db
+from app.main import app
+
+
+class _DummyRedis:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str]] = []
+
+    def rpush(self, key: str, value: str) -> None:
+        self.calls.append((key, value))
+
+
+class _FakeQuery:
+    def __init__(self, result=None) -> None:
+        self._result = result
+
+    def filter(self, *_a, **_kw):
+        return self
+
+    def first(self):
+        return self._result
+
+
+class _FakeDB:
+    """Routes queries by model class — Workflow lookup returns the stub;
+    GlensChatSession lookup returns whatever was last added of that type."""
+
+    def __init__(self, workflow) -> None:
+        self.workflow = workflow
+        self.added: list[object] = []
+        self._by_type: dict[str, list] = {}
+
+    def add(self, obj) -> None:
+        if getattr(obj, "id", None) is None:
+            obj.id = uuid.uuid4()
+        if getattr(obj, "created_at", None) is None:
+            obj.created_at = datetime.now(timezone.utc)
+        self.added.append(obj)
+        self._by_type.setdefault(type(obj).__name__, []).append(obj)
+
+    def commit(self) -> None:
+        return None
+
+    def flush(self) -> None:
+        return None
+
+    def refresh(self, obj) -> None:
+        return None
+
+    def rollback(self) -> None:
+        return None
+
+    def execute(self, *_a, **_kw):
+        return None
+
+    def query(self, model):
+        name = getattr(model, "__name__", "")
+        if name == "Workflow":
+            return _FakeQuery(result=self.workflow)
+        # GlensChatSession — return the last one added (matches the .id filter).
+        rows = self._by_type.get(name, [])
+        return _FakeQuery(result=rows[-1] if rows else None)
+
+
+def _workflow_stub(workflow_id: str, workspace_id: str) -> SimpleNamespace:
+    version_id = uuid.uuid4()
+    return SimpleNamespace(
+        id=uuid.UUID(workflow_id),
+        workspace_id=uuid.UUID(workspace_id),
+        current_version_id=version_id,
+        current_version=SimpleNamespace(
+            id=version_id,
+            graph={"nodes": [{"id": "t1", "data": {"type": "trigger", "config": {"repo_allowlist": "my-org/my-repo"}}}]},
+            yaml_source=None,
+        ),
+        playbook_slug=None,
+        github_hook_repo=None,
+        default_max_turns=None,
+        name="Test Workflow",
+    )
+
+
+def test_trigger_with_lens_attach_mints_session_and_sets_run_session_id(monkeypatch):
+    from app.routers import workflows as workflows_router
+    import redis
+
+    workspace_id = "00000000-0000-0000-0000-000000000001"
+    workflow_id = "44444444-4444-4444-4444-444444444444"
+    workflow = _workflow_stub(workflow_id, workspace_id)
+    db = _FakeDB(workflow=workflow)
+    redis_stub = _DummyRedis()
+
+    monkeypatch.setattr(workflows_router, "_estimate_turns_for_graph", lambda *a, **kw: {"suggested_max_turns": 12})
+    monkeypatch.setattr(redis, "from_url", lambda *_a, **_kw: redis_stub)
+
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            f"/workflows/{workflow_id}/trigger",
+            json={
+                "lens_attach": True,
+                "issue": {"number": 1, "title": "t", "body": "", "html_url": "", "user": {"login": "u"}, "labels": []},
+                "repository": {"full_name": "my-org/my-repo", "name": "my-repo", "owner": {"login": "my-org"}, "default_branch": "main", "clone_url": "", "_caller_set": True},
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["session_id"], "response must include session_id when lens_attach=true"
+
+    # Exactly one GlensChatSession minted, exactly one Run added.
+    sessions = [o for o in db.added if type(o).__name__ == "GlensChatSession"]
+    runs = [o for o in db.added if type(o).__name__ == "Run"]
+    assert len(sessions) == 1, f"expected 1 session, got {len(sessions)}"
+    assert len(runs) == 1, f"expected 1 run, got {len(runs)}"
+
+    # Run.session_id must match the minted session id (this is the seam the
+    # SSE publisher needs — publish no-ops on session_id=NULL).
+    assert runs[0].session_id == sessions[0].id
+    assert body["session_id"] == str(sessions[0].id)
+
+    # Session must carry a run_started envelope so RunBubble rehydrates.
+    messages = json.loads(sessions[0].messages)
+    assert len(messages) == 1
+    envelope = json.loads(messages[0]["content"])
+    assert envelope["run_started"]["run_id"] == str(runs[0].id)
+    assert envelope["run_started"]["workflow_name"] == "Test Workflow"
+
+
+def test_trigger_without_lens_attach_omits_session(monkeypatch):
+    """Baseline: CLI/webhook callers don't set lens_attach — session_id stays None."""
+    from app.routers import workflows as workflows_router
+    import redis
+
+    workspace_id = "00000000-0000-0000-0000-000000000001"
+    workflow_id = "55555555-5555-5555-5555-555555555555"
+    workflow = _workflow_stub(workflow_id, workspace_id)
+    db = _FakeDB(workflow=workflow)
+    redis_stub = _DummyRedis()
+
+    monkeypatch.setattr(workflows_router, "_estimate_turns_for_graph", lambda *a, **kw: {"suggested_max_turns": 12})
+    monkeypatch.setattr(redis, "from_url", lambda *_a, **_kw: redis_stub)
+
+    app.dependency_overrides[get_db] = lambda: db
+    try:
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.post(
+            f"/workflows/{workflow_id}/trigger",
+            json={
+                "issue": {"number": 1, "title": "t", "body": "", "html_url": "", "user": {"login": "u"}, "labels": []},
+                "repository": {"full_name": "my-org/my-repo", "name": "my-repo", "owner": {"login": "my-org"}, "default_branch": "main", "clone_url": "", "_caller_set": True},
+            },
+        )
+    finally:
+        app.dependency_overrides.pop(get_db, None)
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["session_id"] is None
+    sessions = [o for o in db.added if type(o).__name__ == "GlensChatSession"]
+    assert sessions == []
+    runs = [o for o in db.added if type(o).__name__ == "Run"]
+    assert runs and runs[0].session_id is None

--- a/apps/web/src/components/canvas/CanvasEditor.tsx
+++ b/apps/web/src/components/canvas/CanvasEditor.tsx
@@ -899,7 +899,9 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false, isAdmin = f
 
   const performTestTrigger = useCallback(async (payload: Record<string, unknown>, headers: Record<string, string>) => {
     const authFetch: AuthFetch = (url, opts) => fetch(url, { ...opts, headers: { ...headers, ...(opts?.headers as Record<string, string> | undefined) } })
-    const res = await workflows.trigger(authFetch, workflowId, payload)
+    // #1515 P1 — canvas Run lands in a Lens session with RunBubble.
+    // Backend auto-mints a session when lens_attach=true and no lens_session_id is supplied.
+    const res = await workflows.trigger(authFetch, workflowId, { ...payload, lens_attach: true })
     if (res.status === 422) {
       const errBody = await res.json().catch(() => null)
       if (errBody?.detail?.error === "missing_required_inputs") {
@@ -914,7 +916,11 @@ function CanvasEditorInner({ workflowId, getToken, isViewer = false, isAdmin = f
     setTestRunStatus("pending")
     setLastRunSummary({ status: "pending", created_at: new Date().toISOString(), run_id: data.run_id })
     setActiveView("definition")
-  }, [workflowId, TEST_RUN_KEY])
+    // #1515 P1 — redirect to the Lens session so the RunBubble renders with live SSE.
+    if (data.session_id) {
+      router.push(`/lens/${data.session_id}`)
+    }
+  }, [workflowId, TEST_RUN_KEY, router])
 
   const startTestTrigger = useCallback(async () => {
     setTestTriggerModal(false)


### PR DESCRIPTION
## Summary

Canvas Run button now lands in a Lens session with a live RunBubble (P1 slice of #1515).

- Backend `/workflows/{id}/trigger` accepts optional `lens_attach: bool` and `lens_session_id: UUID`. When `lens_attach=true` and no id supplied, auto-mints a bare `GlensChatSession` titled `Run: <workflow.name>`.
- Sets `Run.session_id` so the SSE publisher fans events to the RunBubble (publisher no-ops on NULL — see #1480 PR 14 memory).
- Appends a `run_started` envelope to session messages so `RunBubble` rehydrates on refresh (matches the `_persist_run_started_envelope` path used by the actor substrate).
- Frontend `CanvasEditor` passes `lens_attach: true` and redirects to `/lens/{session_id}` on success.
- CLI / webhook / any caller that omits `lens_attach` — zero behavior change.

## Why one endpoint change unlocks four more paths

Same backend seam works for #1515's P2/P3 stories (webhook, CLI, cron, chain). Each remaining path is a **client-side** change to set `lens_attach=true` — no more backend work required.

## Test plan

Automated:
- [x] `apps/api/tests/test_workflow_trigger_lens_attach.py` — 2 tests: lens_attach mints session + sets `Run.session_id` + writes envelope; no flag = no session (baseline).
- [x] `apps/api/tests/test_phase2_integration_contracts.py` still green (9 tests) — verifies existing trigger contract untouched.
- [x] `tsc --noEmit` clean.

Manual smoke:
- [ ] Open any workflow in canvas, click **⚗ Dry Run**
- [ ] Verify redirect to `/lens/<session_id>`
- [ ] Verify RunBubble renders with the run in it
- [ ] Verify block-timeline events stream (SSE) into the bubble
- [ ] Refresh the page — RunBubble rehydrates from persisted `run_started` envelope
- [ ] Open a second tab on the same session — bubble state stays in sync
- [ ] Run `conduct run <workflow>` from CLI — verify no session minted (baseline preserved)

## Depends on

- #1502 (RunBubble rehydrator) — merged
- #1480 (SSE surface + session_id column) — merged

Closes P1 of #1515.