### PR TITLE
fix(guard): strict-scope _org_ws_subquery — close cross-tenant leak (#1564)

### DIFF
--- a/apps/api/app/modules/guard/routers/discovery.py
+++ b/apps/api/app/modules/guard/routers/discovery.py
@@ -35,16 +35,8 @@ router = APIRouter(prefix="/guard/discover", tags=["guard"])
 
 
 def _org_ws_subquery(db: Session, workspace_id: str):
-    """Return a subquery of all workspace IDs in the same org.
-
-    Resolution: org_id (when set) → owner_id (same person's workspaces) → single workspace.
-    """
+    """Strict single-workspace scoping. See issue #1564."""
     ws_uuid = uuid.UUID(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 

--- a/apps/api/app/modules/guard/routers/events.py
+++ b/apps/api/app/modules/guard/routers/events.py
@@ -29,17 +29,19 @@ SSE_MAX_DURATION  = 300  # reconnect after 5 min
 
 
 def _org_ws_subquery(db, workspace_id: str):
-    """Return a subquery of all workspace IDs in the same org.
+    """Return a subquery containing only the requested workspace_id.
 
-    Falls back to a single-workspace filter when the workspace has no org_id.
+    Historically this helper broadened queries to every workspace in the same
+    org (or every workspace the current user owned when no org was set). That
+    broadening silently mixed data across tenants on every list endpoint — see
+    issue #1564. Strict single-workspace scoping is the only safe default.
+
+    Legitimate cross-workspace rollups (e.g. an org-admin "all workspaces
+    spend" view) must be built as explicit /org/* endpoints gated on
+    `guard.*.view_all` permissions — never as silent broadening here.
     """
     import uuid as _uuid
     ws_uuid = _uuid.UUID(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 

--- a/apps/api/app/modules/guard/routers/policies.py
+++ b/apps/api/app/modules/guard/routers/policies.py
@@ -214,16 +214,14 @@ def _ws_uuid(workspace_id: str) -> uuid.UUID:
 
 
 def _org_ws_subquery(db: Session, workspace_id: str):
-    """Return a subquery of all workspace IDs in the same org.
+    """Strict single-workspace scoping. See issue #1564.
 
-    Falls back to a single-workspace filter when the workspace has no org_id.
+    Previously this broadened queries to every workspace in the same org or
+    (fallback) every workspace the current user owned — silently leaking data
+    across tenants on every list endpoint. Legit org-wide rollups must ship as
+    explicit /org/* endpoints gated on `guard.*.view_all` permissions.
     """
     ws_uuid = _ws_uuid(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 

--- a/apps/api/app/modules/guard/routers/spend.py
+++ b/apps/api/app/modules/guard/routers/spend.py
@@ -24,19 +24,11 @@ router = APIRouter(prefix="/guard/spend", tags=["guard"])
 
 
 def _org_ws_subquery(db: Session, workspace_id: str):
-    """Return a subquery of all workspace IDs in the same org.
-
-    Falls back to a single-workspace filter when the workspace has no org_id.
-    """
+    """Strict single-workspace scoping. See issue #1564."""
     try:
         ws_uuid = uuid.UUID(workspace_id)
     except ValueError:
         return db.query(Workspace.id).filter(Workspace.id == None)  # noqa: E711 — safe empty subquery
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 

--- a/apps/api/app/modules/guard/routers/verify.py
+++ b/apps/api/app/modules/guard/routers/verify.py
@@ -58,12 +58,8 @@ def _grade(score: int) -> str:
 
 
 def _org_ws_subquery(db: Session, workspace_id: str):
+    """Strict single-workspace scoping. See issue #1564."""
     ws_uuid = uuid.UUID(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id).subquery()
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id).subquery()
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid).subquery()
 
 

--- a/apps/api/app/routers/compliance.py
+++ b/apps/api/app/routers/compliance.py
@@ -25,12 +25,8 @@ router = APIRouter(prefix="/compliance", tags=["compliance"])
 
 
 def _org_ws_subquery(db: Session, workspace_id: str):
+    """Strict single-workspace scoping. See issue #1564."""
     ws_uuid = uuid.UUID(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 

--- a/apps/api/app/routers/governance.py
+++ b/apps/api/app/routers/governance.py
@@ -111,12 +111,8 @@ def _split_framework(token: str) -> tuple[str, str | None]:
 # ── Endpoints ─────────────────────────────────────────────────────────────────
 
 def _org_ws_subquery(db: Session, workspace_id: str):
+    """Strict single-workspace scoping. See issue #1564."""
     ws_uuid = uuid.UUID(workspace_id)
-    ws = db.query(Workspace).filter(Workspace.id == ws_uuid).first()
-    if ws and ws.org_id:
-        return db.query(Workspace.id).filter(Workspace.org_id == ws.org_id)
-    if ws and ws.owner_id:
-        return db.query(Workspace.id).filter(Workspace.owner_id == ws.owner_id)
     return db.query(Workspace.id).filter(Workspace.id == ws_uuid)
 
 


### PR DESCRIPTION
## Summary

Closes #1564. Collapses all 7 copies of \`_org_ws_subquery\` to strict single-workspace filtering. Removes the org-wide and owner-wide broadening that silently leaked data across tenants on every list endpoint.

## Scope

7 files, -28 net lines:
- \`guard/routers/events.py\` (activity, cost-trend, unified, correlated)
- \`guard/routers/policies.py\`
- \`guard/routers/spend.py\` (spend summary, budgets, month window)
- \`guard/routers/discovery.py\`
- \`guard/routers/verify.py\` (chain verify — preserves .subquery() wrapper)
- \`routers/compliance.py\`
- \`routers/governance.py\`

## Verified

- 1268 existing API tests pass (guard/*, glens/test_lens_run_tools, test_lens_events_tool, test_guard_spend_month_window, tests/tools/*, tests/guard/*)
- UI audit confirms no page today renders data as org-wide; labels are \"your team\", \"team total\", never \"all workspaces\"

## Deliberately out of scope

- **Consolidating the 7 duplicate copies** into one shared helper — kept as follow-up so the security diff stays small and reviewable
- **Building an /org/* admin section** for legit cross-workspace rollups (Decision 2 from the design chat). Ship when a real admin asks; new endpoints must gate on \`guard.*.view_all\` permissions

## Test plan

- [ ] Deploy to staging
- [ ] Log in as a user owning 2+ workspaces (or seed a test user with two workspaces same owner_id, no org_id)
- [ ] Open \`/logs/guard\` on workspace A — should show only A's events (previously showed A+B)
- [ ] Open \`/theguard\` (spend, activity) on workspace A — same isolation check
- [ ] Open \`/governance\`, \`/theguard/policies\`, \`/theguard/spend\` on workspace B — should show only B's data