### PR TITLE
feat(lens): session ID badge + share link on /lens/<id>

### DIFF
--- a/apps/web/src/app/(app)/lens/[sessionId]/page.tsx
+++ b/apps/web/src/app/(app)/lens/[sessionId]/page.tsx
@@ -9,6 +9,61 @@ import { API } from "@/lib/api/client"
 import { GlensDashboard } from "@/components/glens/GlensDashboard"
 import type { GlensDashboardSpec } from "@/components/glens/GlensDashboard"
 
+function SessionIdBadge({ sessionId }: { sessionId: string }) {
+  const [copied, setCopied] = useState<"" | "id" | "url">("")
+
+  async function copy(text: string, kind: "id" | "url") {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(kind)
+      setTimeout(() => setCopied(""), 1500)
+    } catch {
+      // ponytail: silent fail on clipboard denial — user sees no state change, can select manually
+    }
+  }
+
+  const shareUrl =
+    typeof window !== "undefined" ? `${window.location.origin}/lens/${sessionId}` : ""
+
+  return (
+    <div style={{ display: "inline-flex", alignItems: "center", gap: 10, marginLeft: 16 }}>
+      <button
+        type="button"
+        onClick={() => copy(sessionId, "id")}
+        title={`Session ID: ${sessionId} (click to copy)`}
+        style={{
+          fontFamily: "var(--font-mono, ui-monospace, monospace)",
+          fontSize: 12,
+          color: "var(--text-muted)",
+          background: "var(--surface-2)",
+          border: "1px solid var(--border-subtle)",
+          borderRadius: 4,
+          padding: "2px 8px",
+          cursor: "pointer",
+        }}
+      >
+        {copied === "id" ? "copied ✓" : sessionId.slice(0, 8)}
+      </button>
+      <button
+        type="button"
+        onClick={() => copy(shareUrl, "url")}
+        title="Copy shareable link"
+        style={{
+          fontSize: 12,
+          color: "var(--text-muted)",
+          background: "transparent",
+          border: "1px solid var(--border-subtle)",
+          borderRadius: 4,
+          padding: "2px 8px",
+          cursor: "pointer",
+        }}
+      >
+        {copied === "url" ? "copied ✓" : "share link"}
+      </button>
+    </div>
+  )
+}
+
 interface LensSessionResponse {
   session_id: string
   ready: boolean
@@ -84,7 +139,7 @@ export default function LensSessionPage() {
           padding: "32px 24px 64px",
         }}
       >
-        <div style={{ marginBottom: 28 }}>
+        <div style={{ marginBottom: 28, display: "flex", alignItems: "center" }}>
           <Link
             href="/lens"
             style={{
@@ -98,6 +153,7 @@ export default function LensSessionPage() {
           >
             ← Back to Lens
           </Link>
+          {sessionId && <SessionIdBadge sessionId={sessionId} />}
         </div>
 
         {loadingSpec && (


### PR DESCRIPTION
## What this PR does

Adds a short 8-char session ID badge (click to copy full UUID) and a **share link** button to the `/lens/<id>` page header. Nothing else changes — dashboard render, back link, and loading states are untouched.

## Type

- [x] Feature

## Why a fresh PR

The parent PR #1561 (`feat/lens-cli-flag-1515-p2`) was squash-merged as PR #1560, but the squash absorbed 5 of the 6 branch commits and left the session-ID / share-link commit orphaned on the branch. Rather than rebase #1561 (noisy history), this cherry-picks the one surviving commit (`75e179c2`) onto a fresh branch off main. Closes #1561 as superseded.

## Checklist

- [x] No new tests needed — pure UI addition, no logic changes.
- [x] `pnpm typecheck` unchanged surface.
- [x] No secrets, no personal data, no customer names in the diff.

## How to test

1. Open any `/lens/<id>` session.
2. Verify the header shows a short 8-char badge next to the title; click it → full UUID copies to clipboard.
3. Click the "share link" button → full `/lens/<id>` URL copies to clipboard.

## Skipped

- Adding IDs to the session-list sidebar — add when users ask for it.