### PR TITLE
feat(#1520): Guard fail-open observability — counter + internal Slack alert (PR 1/2)

### DIFF
--- a/apps/api/app/guard/policy.py
+++ b/apps/api/app/guard/policy.py
@@ -122,6 +122,11 @@ def evaluate(workspace_id: str, provider: str, model: str, body: dict) -> dict:
             rules = compute_policy(db, uuid.UUID(policy_ws_id), "proxy")
         except Exception as e:
             log.warning("guard.proxy.policy_load_failed", err=str(e))
+            try:
+                from app.modules.guard.observability import record_fail_open
+                record_fail_open(db, workspace_id=policy_ws_id, surface="proxy", error=e)
+            except Exception:
+                pass
             from app.modules.guard.models import GuardConfig as _GuardConfig
             cfg = db.query(_GuardConfig).filter(_GuardConfig.workspace_id == uuid.UUID(policy_ws_id)).first()
             deny = cfg.deny_on_error if cfg else True

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -93,6 +93,13 @@ _STATIC = Path(__file__).parent / "static"
 async def favicon():
     return FileResponse(_STATIC / "favicon.png", media_type="image/png")
 
+
+@app.get("/metrics", include_in_schema=False)
+async def metrics():
+    from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+    from starlette.responses import Response
+    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+
 _origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
 if not _origins:
     log.warning("cors.no_origins_configured", msg="ALLOWED_ORIGINS is empty — all cross-origin requests blocked. Set ALLOWED_ORIGINS in .env to enable CORS.")

--- a/apps/api/app/modules/guard/observability/__init__.py
+++ b/apps/api/app/modules/guard/observability/__init__.py
@@ -1,0 +1,13 @@
+"""Guard fail-open observability (#1520).
+
+Exports the pieces used at every fail-open site:
+
+- ``GUARD_ENGINE_ERRORS``            Prometheus counter
+- ``record_fail_open()``             single call from an except: block
+- ``resolve_workspace_context()``    workspace_id -> (workspace_name, org_name), cached
+"""
+from app.modules.guard.observability.fail_open_alert import record_fail_open
+from app.modules.guard.observability.metrics import GUARD_ENGINE_ERRORS
+from app.modules.guard.observability.name_cache import resolve_workspace_context
+
+__all__ = ["GUARD_ENGINE_ERRORS", "record_fail_open", "resolve_workspace_context"]

--- a/apps/api/app/modules/guard/observability/fail_open_alert.py
+++ b/apps/api/app/modules/guard/observability/fail_open_alert.py
@@ -1,0 +1,142 @@
+"""Internal Slack alerter for Guard fail-open events (#1520).
+
+Posts a single Slack message per (workspace_id, surface) burst so a broken
+policy engine (e.g. Redis outage) can't spam the ops channel thousands of
+times per minute. Reads ``CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK`` from env;
+if unset the alerter no-ops and only the Prometheus counter fires.
+
+Customer-facing WARNING alerts (using the workspace's own Slack config) are
+tracked separately in PR 2 of #1520.
+"""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import httpx
+import structlog
+from sqlalchemy.orm import Session
+
+from app.modules.guard.observability.metrics import GUARD_ENGINE_ERRORS
+from app.modules.guard.observability.name_cache import resolve_workspace_context
+
+log = structlog.get_logger(__name__)
+
+_ALERT_WEBHOOK_ENV = "CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK"
+_RATE_LIMIT_SEC = 300  # 5 minutes per (workspace_id, surface)
+_HTTP_TIMEOUT_SEC = 3.0
+
+# In-process dedup: (workspace_id, surface) -> (first_hit_monotonic, burst_count)
+_dedup: dict[tuple[str, str], tuple[float, int]] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _should_post(key: tuple[str, str]) -> tuple[bool, int]:
+    """Decide whether to emit for this (workspace, surface) key.
+
+    Returns (post_now, burst_count). The first hit posts immediately with
+    burst=1; subsequent hits inside the window increment the burst counter
+    silently. When the window closes, the next hit posts again with the
+    accumulated burst count from the prior window (so the ops channel
+    still sees magnitude).
+    """
+    now = _now()
+    prior = _dedup.get(key)
+    if prior is None:
+        _dedup[key] = (now, 1)
+        return True, 1
+
+    first_hit, burst = prior
+    if now - first_hit < _RATE_LIMIT_SEC:
+        _dedup[key] = (first_hit, burst + 1)
+        return False, burst + 1
+
+    _dedup[key] = (now, 1)
+    return True, burst  # burst from the prior window, included for context
+
+
+def _build_message(
+    *,
+    workspace_id: str,
+    workspace_name: str,
+    org_name: str | None,
+    surface: str,
+    error: BaseException,
+    burst: int,
+) -> dict:
+    org_line = f"*Org:* {org_name}\n" if org_name else ""
+    burst_line = f"\n*Burst:* {burst} events in the last window" if burst > 1 else ""
+    return {
+        "text": (
+            f":rotating_light: *Guard fail-open* — engine errored, requests allowed through\n"
+            f"*Workspace:* {workspace_name} (`{workspace_id}`)\n"
+            f"{org_line}"
+            f"*Surface:* `{surface}`\n"
+            f"*Error:* `{type(error).__name__}: {str(error)[:200]}`"
+            f"{burst_line}"
+        ),
+    }
+
+
+def record_fail_open(
+    db: Session | None,
+    *,
+    workspace_id: str | uuid.UUID,
+    surface: str,
+    error: BaseException,
+) -> None:
+    """Single call-site for every fail-open except: block.
+
+    Always increments the Prometheus counter. Best-effort Slack post to
+    Conduct's internal ops channel, rate-limited per (workspace, surface).
+    Never raises — the caller has already decided to fall open on the
+    original error and any exception here would defeat that decision.
+    """
+    ws_id = str(workspace_id)
+    try:
+        GUARD_ENGINE_ERRORS.labels(workspace_id=ws_id, surface=surface).inc()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.fail_open.counter_failed", err=str(exc))
+
+    webhook = os.environ.get(_ALERT_WEBHOOK_ENV, "").strip()
+    if not webhook:
+        return
+
+    post_now, burst = _should_post((ws_id, surface))
+    if not post_now:
+        return
+
+    if db is not None:
+        try:
+            ctx = resolve_workspace_context(db, ws_id)
+        except Exception as exc:  # noqa: BLE001 — never raise from alert path
+            log.warning("guard.fail_open.context_lookup_failed", err=str(exc))
+            ctx = None
+    else:
+        ctx = None
+
+    workspace_name = ctx.workspace_name if ctx else ws_id
+    org_name = ctx.org_name if ctx else None
+    payload = _build_message(
+        workspace_id=ws_id,
+        workspace_name=workspace_name,
+        org_name=org_name,
+        surface=surface,
+        error=error,
+        burst=burst,
+    )
+
+    try:
+        httpx.post(webhook, json=payload, timeout=_HTTP_TIMEOUT_SEC)
+    except Exception as exc:  # noqa: BLE001
+        # Slack itself failed. Log at WARN; do not retry — the outage that
+        # triggered fail-open may also be affecting outbound network.
+        log.warning("guard.fail_open.slack_post_failed", err=str(exc), surface=surface)
+
+
+def _reset_dedup_for_tests() -> None:
+    _dedup.clear()

--- a/apps/api/app/modules/guard/observability/metrics.py
+++ b/apps/api/app/modules/guard/observability/metrics.py
@@ -1,0 +1,8 @@
+"""Prometheus metric definitions for Guard fail-open observability (#1520)."""
+from prometheus_client import Counter
+
+GUARD_ENGINE_ERRORS = Counter(
+    "guard_engine_errors_total",
+    "Guard policy engine failures that fell open at enforcement time.",
+    ["workspace_id", "surface"],
+)

--- a/apps/api/app/modules/guard/observability/name_cache.py
+++ b/apps/api/app/modules/guard/observability/name_cache.py
@@ -1,0 +1,79 @@
+"""Workspace + org name cache for fail-open alerts (#1520).
+
+The alert path must never depend on a live DB lookup — if Guard is falling
+open because the database is degraded, a lookup that triggers the same
+degradation would silence the alert. This cache is populated best-effort
+and returns the raw workspace_id string on any miss or error.
+"""
+from __future__ import annotations
+
+import time
+import uuid
+from dataclasses import dataclass
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+log = structlog.get_logger(__name__)
+
+_TTL_SEC = 300  # 5 minutes
+
+
+@dataclass(frozen=True)
+class WorkspaceContext:
+    workspace_id: str
+    workspace_name: str
+    org_name: str | None
+
+
+_cache: dict[str, tuple[float, WorkspaceContext]] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def resolve_workspace_context(db: Session, workspace_id: str | uuid.UUID) -> WorkspaceContext:
+    """Return names for the workspace, caching for 5 minutes.
+
+    On any lookup failure (invalid id, missing row, DB error) returns a
+    context with ``workspace_id`` as both id and name so alerts still
+    render something useful. Never raises.
+    """
+    ws_id = str(workspace_id)
+
+    hit = _cache.get(ws_id)
+    if hit and _now() - hit[0] < _TTL_SEC:
+        return hit[1]
+
+    try:
+        row = db.execute(
+            text(
+                "SELECT w.name AS workspace_name, o.name AS org_name "
+                "FROM workspaces w "
+                "LEFT JOIN organizations o ON o.id = w.org_id "
+                "WHERE w.id = :ws"
+            ),
+            {"ws": ws_id},
+        ).fetchone()
+    except Exception as exc:
+        log.warning("guard.name_cache.lookup_failed", workspace_id=ws_id, err=str(exc))
+        row = None
+
+    if row is None:
+        ctx = WorkspaceContext(workspace_id=ws_id, workspace_name=ws_id, org_name=None)
+    else:
+        ctx = WorkspaceContext(
+            workspace_id=ws_id,
+            workspace_name=row.workspace_name or ws_id,
+            org_name=row.org_name,
+        )
+
+    _cache[ws_id] = (_now(), ctx)
+    return ctx
+
+
+def clear_cache() -> None:
+    """Test hook — drop all cached entries."""
+    _cache.clear()

--- a/apps/api/app/routers/workflows.py
+++ b/apps/api/app/routers/workflows.py
@@ -1868,6 +1868,8 @@ def test_trigger(
             surface="proxy",
             error=str(_guard_err),
         )
+        from app.modules.guard.observability import record_fail_open
+        record_fail_open(db, workspace_id=workspace_id, surface="proxy", error=_guard_err)
 
     workflow = db.query(Workflow).filter(
         Workflow.id == workflow_id,

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -26,3 +26,4 @@ structlog==24.4.0
 sentry-sdk[fastapi]==2.68.1
 mcp>=1.28,<2  # v2 requires client rewrite — see #1169 for the migration plan
 pgvector==0.3.6
+prometheus-client==0.20.0

--- a/apps/api/tests/guard/test_fail_open_observability.py
+++ b/apps/api/tests/guard/test_fail_open_observability.py
@@ -1,0 +1,134 @@
+"""Guard fail-open observability tests (#1520).
+
+Covers:
+  - Counter increments every fail-open event
+  - Slack alert posts once per (workspace, surface) burst inside the window
+  - Rate-limit dedupes subsequent events silently
+  - Unset webhook env var → no post attempted, counter still increments
+  - Slack post failure logs WARN, does not raise
+"""
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.guard.observability import fail_open_alert as foa
+from app.modules.guard.observability.metrics import GUARD_ENGINE_ERRORS
+
+
+WS = "fd4b6608-f320-44b8-af22-fc579bd53600"
+WEBHOOK = "https://hooks.slack.com/services/T00/B00/XXX"
+
+
+def _counter_value(workspace_id: str, surface: str) -> float:
+    return GUARD_ENGINE_ERRORS.labels(workspace_id=workspace_id, surface=surface)._value.get()
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    foa._reset_dedup_for_tests()
+    yield
+    foa._reset_dedup_for_tests()
+
+
+def test_counter_increments_and_posts_once(monkeypatch):
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+    before = _counter_value(WS, "proxy")
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        with patch("app.modules.guard.observability.fail_open_alert.resolve_workspace_context") as rwc:
+            rwc.return_value = MagicMock(workspace_name="Acme Robotics", org_name="Acme Inc.")
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("redis down"))
+
+    assert _counter_value(WS, "proxy") == before + 1
+    assert post.call_count == 1
+    payload = post.call_args.kwargs["json"]
+    assert "Acme Robotics" in payload["text"]
+    assert "Acme Inc." in payload["text"]
+    assert "proxy" in payload["text"]
+    assert "RuntimeError" in payload["text"]
+
+
+def test_rate_limit_dedupes_second_event_within_window(monkeypatch):
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+    before = _counter_value(WS, "proxy")
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        with patch("app.modules.guard.observability.fail_open_alert.resolve_workspace_context") as rwc:
+            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("y"))
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("z"))
+
+    # Counter fires every time, but Slack posts only once per window.
+    assert _counter_value(WS, "proxy") == before + 3
+    assert post.call_count == 1
+
+
+def test_different_surface_does_not_dedup(monkeypatch):
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        with patch("app.modules.guard.observability.fail_open_alert.resolve_workspace_context") as rwc:
+            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="mcp", error=RuntimeError("y"))
+
+    assert post.call_count == 2
+
+
+def test_unset_webhook_skips_post_but_still_increments(monkeypatch):
+    monkeypatch.delenv(foa._ALERT_WEBHOOK_ENV, raising=False)
+    before = _counter_value(WS, "proxy")
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+
+    assert _counter_value(WS, "proxy") == before + 1
+    assert post.call_count == 0
+
+
+def test_slack_post_failure_does_not_raise(monkeypatch):
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post", side_effect=RuntimeError("slack down")):
+        with patch("app.modules.guard.observability.fail_open_alert.resolve_workspace_context") as rwc:
+            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+            # Must not raise — fail-open path already tolerated the original error.
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+
+
+def test_burst_count_included_after_window_flip(monkeypatch):
+    """After the rate-limit window closes, the next post surfaces how many
+    events were suppressed so ops can see burst magnitude."""
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+
+    # Force the window to appear expired by shrinking it for this test.
+    monkeypatch.setattr(foa, "_RATE_LIMIT_SEC", 0)
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        with patch("app.modules.guard.observability.fail_open_alert.resolve_workspace_context") as rwc:
+            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("y"))
+
+    # With RATE_LIMIT_SEC=0 the window is always considered closed, so both post.
+    assert post.call_count == 2
+
+
+def test_context_lookup_failure_falls_back_to_workspace_id(monkeypatch):
+    monkeypatch.setenv(foa._ALERT_WEBHOOK_ENV, WEBHOOK)
+
+    with patch("app.modules.guard.observability.fail_open_alert.httpx.post") as post:
+        with patch(
+            "app.modules.guard.observability.fail_open_alert.resolve_workspace_context",
+            side_effect=RuntimeError("db down"),
+        ):
+            foa.record_fail_open(MagicMock(), workspace_id=WS, surface="proxy", error=RuntimeError("x"))
+
+    # Post still happens; message falls back to workspace_id as name.
+    assert post.call_count == 1
+    payload = post.call_args.kwargs["json"]
+    assert WS in payload["text"]


### PR DESCRIPTION
Refs #1520. This is PR 1 of 2 per the revised scope on the issue.

## What ships

- **Prometheus counter** \`guard_engine_errors_total{workspace_id, surface}\` — labels are \`workspace_id\` and \`surface\` (\`proxy\`/\`mcp\`/\`workflow\`).
- **\`/metrics\` endpoint** on the API so Prometheus/Alertmanager can scrape.
- **Workspace + org name cache** (5-min TTL) — read-through cache backed by a single JOIN across \`workspaces\` and \`organizations\`. Alert path never fails when Clerk/DB is degraded (the same outage that likely triggered the fail-open in the first place); falls back to the raw \`workspace_id\` string on any miss/error.
- **Internal Slack poster** — reads \`CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK\` env var. No-ops silently if unset (counter still fires, external Alertmanager can be wired). Rate-limited to 1 post per \`(workspace_id, surface)\` per 5 min so a Redis outage cannot spam the ops channel. Subsequent hits inside the window are silently aggregated; the next post after the window flip includes the burst count.
- **Wired at two fail-open sites**:
  - \`apps/api/app/routers/workflows.py:1862\` — the outer proxy-path wrapper (matches the exact log line the issue cited).
  - \`apps/api/app/guard/policy.py:127\` — the deeper engine-error path.

## What does NOT ship (PR 2)

- Customer-facing WARNING post using the workspace's own \`GuardConfig.slack_webhook_url\`.
- New \`guard_config.notify_on_fail_open\` bool + migration.
- Settings UI toggle.
- Wording review with product.

Rationale: two audiences want different severity + framing (see #1520 comment thread). Keeping them in separate PRs so this one merges without wording debate blocking metrics.

## Test plan

7 unit tests in \`apps/api/tests/guard/test_fail_open_observability.py\`, all passing locally (0.04s):

- [x] counter increments on every fail-open event
- [x] Slack post fires once per \`(workspace_id, surface)\` burst
- [x] second event inside window is silently deduped
- [x] different surface on same workspace posts separately
- [x] unset env var → no post attempted, counter still increments
- [x] Slack post failure (network / 5xx) logs WARN, does not raise
- [x] name-cache lookup failure falls back to workspace_id in the message

## Operator action needed

Set \`CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK\` on the API Render service pointing at \`#conduct-alerts\` (already done per screenshot on issue thread).

## Verification post-deploy

1. \`curl https://api.conductai.ai/metrics | grep guard_engine_errors_total\` → should be present with zero events initially.
2. Trigger an artificial engine error on staging → counter increments + one Slack post in \`#conduct-alerts\` with workspace name, org name, surface, error class, burst count.
3. Trigger 5 more within 5 min → counter increments 5×, Slack silent.
4. Wait 5 min, trigger again → new post with burst=5 from prior window.