### PR TITLE
feat(#1520): PR 3 — fail-open alert routes through channels-by-action UI

### DIFF
--- a/apps/api/alembic/versions/0111_guard_notif_fail_open_action.py
+++ b/apps/api/alembic/versions/0111_guard_notif_fail_open_action.py
@@ -1,0 +1,52 @@
+"""Widen guard_notification_channels.action CHECK to allow 'fail_open' (#1520 PR 3).
+
+Migration 0092 seeded the check with the four action tiers Guard had at
+the time: block / warn / audit / approval. #1520 PR 3 adds a fifth tier —
+fail_open — so customers can route the fail-open WARNING to a channel of
+their choice via the same UI they already use for the other tiers.
+
+Postgres does not support ALTER CHECK CONSTRAINT in place; drop + recreate
+under the same name.
+
+Revision ID: 0111
+Revises: 0110
+Create Date: 2026-09-02
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0111"
+down_revision = "0110"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_guard_notif_channel_action",
+        "guard_notification_channels",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_guard_notif_channel_action",
+        "guard_notification_channels",
+        "action IN ('block', 'warn', 'audit', 'approval', 'fail_open')",
+    )
+
+
+def downgrade() -> None:
+    # Downgrade path: remove any fail_open rows first so the narrower
+    # constraint can be re-applied without violating existing data.
+    op.execute("DELETE FROM guard_notification_channels WHERE action = 'fail_open'")
+    op.drop_constraint(
+        "ck_guard_notif_channel_action",
+        "guard_notification_channels",
+        type_="check",
+    )
+    op.create_check_constraint(
+        "ck_guard_notif_channel_action",
+        "guard_notification_channels",
+        "action IN ('block', 'warn', 'audit', 'approval')",
+    )

--- a/apps/api/app/modules/guard/observability/customer_alert.py
+++ b/apps/api/app/modules/guard/observability/customer_alert.py
@@ -1,9 +1,10 @@
-"""Customer-facing WARNING alert when Guard falls open (#1520 PR 2).
+"""Customer-facing WARNING alert when Guard falls open (#1520 PR 2 + PR 3).
 
 Companion to the internal ERROR alert in ``fail_open_alert.py``:
 
 - Internal alert  → Conduct ops, `CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK`, per-surface
-- Customer alert  → workspace's own `GuardConfig.slack_webhook_url`, per-workspace
+- Customer alert  → workspace's own Slack, routed through the
+  ``guard_notification_channels`` table under action="fail_open"
 
 The customer post is intentionally quieter than the internal one — 15-min
 aggregate window, no error class or trace_id, no per-surface split. The
@@ -11,9 +12,8 @@ audience can't act on which surface failed; they need to know their rules
 were not enforced and where to change the fail-mode.
 
 Skipped when:
-  - `GuardConfig.notify_on_fail_open` is False (customer opt-out)
-  - `GuardConfig.slack_webhook_url` is empty (no channel configured)
-  - the config row itself is missing
+  - ``GuardConfig.notify_on_fail_open`` is False (customer opt-out)
+  - no ``fail_open`` channels configured in the "Slack channels by action" UI
   - inside the 15-min rate-limit window
 """
 from __future__ import annotations
@@ -22,7 +22,6 @@ import os
 import time
 import uuid
 
-import httpx
 import structlog
 from sqlalchemy.orm import Session
 
@@ -31,7 +30,6 @@ from app.modules.guard.observability.name_cache import resolve_workspace_context
 log = structlog.get_logger(__name__)
 
 _RATE_LIMIT_SEC = 900  # 15 minutes per workspace
-_HTTP_TIMEOUT_SEC = 3.0
 
 # (workspace_id,) -> (window_start_monotonic, event_count_in_window)
 _dedup: dict[str, tuple[float, int]] = {}
@@ -68,40 +66,37 @@ def _should_post(workspace_id: str) -> tuple[bool, int]:
     return True, count  # carry the prior window's count in the message
 
 
-def _build_message(*, workspace_name: str, count: int) -> dict:
+def _build_message(*, workspace_name: str, count: int) -> str:
     settings_url = f"{_settings_base_url()}/theguard/settings"
     events_line = (
         f"*{count} requests* in the last 15 min"
         if count > 1
         else "*1 request* just now"
     )
-    return {
-        "text": (
-            f":warning: *Guard could not evaluate policy* on {events_line} in *{workspace_name}*.\n"
-            f"Per your fail-open default, these requests were allowed through. "
-            f"Guard rules were not enforced for the affected calls.\n"
-            f"To change this behavior, set your workspace to fail-closed in "
-            f"<{settings_url}|Guard Settings>."
-        ),
-    }
+    return (
+        f":warning: *Guard could not evaluate policy* on {events_line} in *{workspace_name}*.\n"
+        f"Per your fail-open default, these requests were allowed through. "
+        f"Guard rules were not enforced for the affected calls.\n"
+        f"To change this behavior, set your workspace to fail-closed in "
+        f"<{settings_url}|Guard Settings>."
+    )
 
 
-def _load_config(db: Session, workspace_id: str):
-    """Load GuardConfig with only the fields we need. Returns None on any
-    failure so the alert path never raises from the customer branch."""
+def _notify_on_fail_open_enabled(db: Session, workspace_id: str) -> bool:
+    """Read the per-workspace opt-out flag. Defaults to True so a config
+    lookup failure never silences transparency."""
     from sqlalchemy import text
     try:
         row = db.execute(
-            text(
-                "SELECT notify_on_fail_open, slack_webhook_url "
-                "FROM guard_config WHERE workspace_id = :ws"
-            ),
+            text("SELECT notify_on_fail_open FROM guard_config WHERE workspace_id = :ws"),
             {"ws": workspace_id},
         ).fetchone()
     except Exception as exc:  # noqa: BLE001
         log.warning("guard.fail_open.customer_config_lookup_failed", err=str(exc))
-        return None
-    return row
+        return True  # fail-open on the opt-out check itself
+    if row is None:
+        return True
+    return bool(getattr(row, "notify_on_fail_open", True))
 
 
 def notify_customer_fail_open(
@@ -112,20 +107,27 @@ def notify_customer_fail_open(
     """Best-effort customer WARNING post. Never raises.
 
     Rate-limited per workspace (not per surface) — the customer sees one
-    channel, one message, aggregated.
+    channel, one message, aggregated. Routes through the per-action Slack
+    fanout the workspace already configures for block/warn/audit/approval.
     """
     if db is None:
         return
 
     ws_id = str(workspace_id)
 
-    cfg = _load_config(db, ws_id)
-    if cfg is None:
+    if not _notify_on_fail_open_enabled(db, ws_id):
         return
-    if not getattr(cfg, "notify_on_fail_open", True):
+
+    # Resolve channels via the same mechanism block/warn/audit/approval use.
+    # If nothing is configured for `fail_open`, silently skip — customers
+    # opt in by adding a channel in "Slack channels by action".
+    try:
+        from app.modules.guard.routers.notifications import resolve_channels
+        channels = resolve_channels(db, ws_id, "fail_open")
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.fail_open.customer_resolve_channels_failed", err=str(exc))
         return
-    webhook = (getattr(cfg, "slack_webhook_url", None) or "").strip()
-    if not webhook:
+    if not channels:
         return
 
     post_now, count = _should_post(ws_id)
@@ -139,12 +141,13 @@ def notify_customer_fail_open(
         log.warning("guard.fail_open.customer_context_failed", err=str(exc))
         workspace_name = ws_id
 
-    payload = _build_message(workspace_name=workspace_name, count=count)
+    text_msg = _build_message(workspace_name=workspace_name, count=count)
 
     try:
-        httpx.post(webhook, json=payload, timeout=_HTTP_TIMEOUT_SEC)
+        from app.modules.guard.routers.events import _fanout_slack
+        _fanout_slack(db, ws_id, channels, text_msg)
     except Exception as exc:  # noqa: BLE001
-        log.warning("guard.fail_open.customer_slack_post_failed", err=str(exc))
+        log.warning("guard.fail_open.customer_fanout_failed", err=str(exc))
 
 
 def _reset_dedup_for_tests() -> None:

--- a/apps/api/app/modules/guard/routers/notifications.py
+++ b/apps/api/app/modules/guard/routers/notifications.py
@@ -41,7 +41,7 @@ log = structlog.get_logger(__name__)
 router = APIRouter(prefix="/guard/notifications", tags=["guard-notifications"])
 
 
-ACTIONS = ("block", "warn", "audit", "approval")
+ACTIONS = ("block", "warn", "audit", "approval", "fail_open")
 CHANNEL_TYPES = ("slack", "email", "pagerduty", "webhook")
 
 
@@ -62,7 +62,7 @@ class ChannelOut(BaseModel):
 
 
 class ChannelCreate(BaseModel):
-    action: Literal["block", "warn", "audit", "approval"]
+    action: Literal["block", "warn", "audit", "approval", "fail_open"]
     channel_type: Literal["slack", "webhook", "pagerduty", "email"] = "slack"
     integration_id: str | None = None
     channel_ref: str = Field(..., min_length=1, max_length=2048)

--- a/apps/api/tests/guard/test_fail_open_customer_alert.py
+++ b/apps/api/tests/guard/test_fail_open_customer_alert.py
@@ -1,9 +1,9 @@
-"""Customer-facing WARNING alert tests (#1520 PR 2).
+"""Customer-facing WARNING alert tests (#1520 PR 3).
 
-Companion to test_fail_open_observability.py which covers the internal
-ERROR alert. This file covers the customer WARNING path — different
-audience, different framing, opt-out via guard_config.notify_on_fail_open,
-15-min rate-limit per workspace.
+The customer alerter now routes through the same
+``guard_notification_channels`` fanout the workspace already uses for
+block / warn / audit / approval. The old single-webhook path
+(``GuardConfig.slack_webhook_url``) is no longer read from here.
 """
 from __future__ import annotations
 
@@ -25,122 +25,151 @@ def _reset_state():
     ca._reset_dedup_for_tests()
 
 
-def _mk_db(*, notify_on_fail_open: bool = True, slack_webhook_url: str | None = "https://hooks.slack.com/x/y/z"):
+def _mk_db(notify_on_fail_open: bool = True):
+    """Build a MagicMock db whose SELECT returns the opt-out row."""
     db = MagicMock()
-    row = SimpleNamespace(notify_on_fail_open=notify_on_fail_open, slack_webhook_url=slack_webhook_url)
+    row = SimpleNamespace(notify_on_fail_open=notify_on_fail_open)
     db.execute.return_value.fetchone.return_value = row
     return db
 
 
-def test_posts_when_notify_on_and_webhook_set():
+def _mk_channel(channel_ref: str = "#security"):
+    """One slack channel record — matches shape returned by resolve_channels."""
+    return SimpleNamespace(
+        id="ch-1",
+        channel_type="slack",
+        channel_ref=channel_ref,
+        integration_id=None,
+        enabled=True,
+    )
+
+
+# ── Happy path ──────────────────────────────────────────────────────────────
+
+def test_fanout_called_when_channel_configured_and_opted_in():
     db = _mk_db()
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        with patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
-            rwc.return_value = MagicMock(workspace_name="Acme Robotics", org_name="Acme Inc.")
-            ca.notify_customer_fail_open(db, workspace_id=WS)
+    channels = [_mk_channel()]
 
-    assert post.call_count == 1
-    payload = post.call_args.kwargs["json"]
-    # WARNING framing, no error class, no trace_id
-    assert ":warning:" in payload["text"]
-    assert "Acme Robotics" in payload["text"]
-    assert "fail-open default" in payload["text"]
-    # Settings link included
-    assert "/theguard/settings" in payload["text"]
-    # Never leak internal error details
-    assert "RuntimeError" not in payload["text"]
-    assert "trace_id" not in payload["text"]
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=channels) as rc, \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme Robotics", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
 
+    rc.assert_called_once_with(db, WS, "fail_open")
+    assert fanout.call_count == 1
+    # _fanout_slack signature: (db, workspace_id, channels, text_msg)
+    args = fanout.call_args.args
+    assert args[1] == WS
+    assert args[2] == channels
+    text_msg = args[3]
+    assert ":warning:" in text_msg
+    assert "Acme Robotics" in text_msg
+    assert "/theguard/settings" in text_msg
+
+
+# ── Opt-out ──────────────────────────────────────────────────────────────
 
 def test_skips_when_notify_on_fail_open_false():
     db = _mk_db(notify_on_fail_open=False)
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
+    with patch("app.modules.guard.routers.notifications.resolve_channels") as rc, \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout:
         ca.notify_customer_fail_open(db, workspace_id=WS)
-    assert post.call_count == 0
+    # Never even resolves channels when opted out — cheap short-circuit
+    assert rc.call_count == 0
+    assert fanout.call_count == 0
 
 
-def test_skips_when_webhook_url_empty():
-    db = _mk_db(slack_webhook_url="")
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
+def test_skips_when_no_channels_configured():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=[]), \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout:
         ca.notify_customer_fail_open(db, workspace_id=WS)
-    assert post.call_count == 0
+    assert fanout.call_count == 0
 
 
-def test_skips_when_webhook_url_null():
-    db = _mk_db(slack_webhook_url=None)
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        ca.notify_customer_fail_open(db, workspace_id=WS)
-    assert post.call_count == 0
+def test_none_db_is_safe():
+    with patch("app.modules.guard.routers.events._fanout_slack") as fanout:
+        ca.notify_customer_fail_open(None, workspace_id=WS)
+    assert fanout.call_count == 0
 
+
+# ── Rate limit ──────────────────────────────────────────────────────────────
 
 def test_rate_limit_dedupes_within_15min_window():
     db = _mk_db()
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        with patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
-            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
-            ca.notify_customer_fail_open(db, workspace_id=WS)
-            ca.notify_customer_fail_open(db, workspace_id=WS)
-            ca.notify_customer_fail_open(db, workspace_id=WS)
+    channels = [_mk_channel()]
 
-    # First post fires; next two silently deduped inside the 15-min window.
-    assert post.call_count == 1
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=channels), \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert fanout.call_count == 1
 
 
 def test_burst_count_surfaces_after_window_flip(monkeypatch):
     monkeypatch.setattr(ca, "_RATE_LIMIT_SEC", 0)
     db = _mk_db()
+    channels = [_mk_channel()]
 
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        with patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
-            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
-            ca.notify_customer_fail_open(db, workspace_id=WS)
-            ca.notify_customer_fail_open(db, workspace_id=WS)
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=channels), \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
 
-    assert post.call_count == 2
+    assert fanout.call_count == 2
 
 
-def test_slack_post_failure_does_not_raise():
+# ── Defensive / never-raises ─────────────────────────────────────────────
+
+def test_fanout_failure_does_not_raise():
     db = _mk_db()
-    with patch("app.modules.guard.observability.customer_alert.httpx.post", side_effect=RuntimeError("slack down")):
-        with patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
-            rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
-            # Must not raise — the caller has already fallen open.
-            ca.notify_customer_fail_open(db, workspace_id=WS)
+    channels = [_mk_channel()]
+
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=channels), \
+         patch("app.modules.guard.routers.events._fanout_slack", side_effect=RuntimeError("slack down")), \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        # Must not raise
+        ca.notify_customer_fail_open(db, workspace_id=WS)
 
 
-def test_db_lookup_failure_skips_silently():
+def test_resolve_channels_failure_skips_silently():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels", side_effect=RuntimeError("db down")), \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout:
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+    assert fanout.call_count == 0
+
+
+def test_config_lookup_failure_defaults_to_opted_in():
+    """A DB error reading the opt-out flag must not silence transparency.
+    The lookup treats an error as opted-in and continues to channel resolution."""
     db = MagicMock()
     db.execute.side_effect = RuntimeError("db down")
 
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=[]) as rc, \
+         patch("app.modules.guard.routers.events._fanout_slack") as fanout:
         ca.notify_customer_fail_open(db, workspace_id=WS)
 
-    # Config could not be loaded → no post, no raise.
-    assert post.call_count == 0
+    # opt-in defaulted → still tried to resolve channels
+    assert rc.call_count == 1
+    # ... but no channels → no fanout
+    assert fanout.call_count == 0
 
 
-def test_config_missing_row_skips_silently():
-    db = MagicMock()
-    db.execute.return_value.fetchone.return_value = None
-
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        ca.notify_customer_fail_open(db, workspace_id=WS)
-
-    assert post.call_count == 0
-
-
-def test_none_db_is_safe():
-    with patch("app.modules.guard.observability.customer_alert.httpx.post") as post:
-        ca.notify_customer_fail_open(None, workspace_id=WS)
-    assert post.call_count == 0
-
+# ── Wire-through + message shape ─────────────────────────────────────────
 
 def test_record_fail_open_wires_through_to_customer_notify():
-    """Integrated wire-through: one record_fail_open() call must delegate
-    to the customer notify path (via _also_notify_customer). Uses a spy
-    pattern on _also_notify_customer so the assertion is independent of
-    the shared-httpx-module patching gotcha — per-module isolated tests
-    already cover the httpx.post fanout for each poster in depth."""
+    """One record_fail_open() call must delegate to the customer notify
+    path (via _also_notify_customer). Spy pattern keeps the assertion
+    deterministic and independent of the shared-httpx patch gotcha."""
     from app.modules.guard.observability import fail_open_alert as foa
 
     foa._reset_dedup_for_tests()
@@ -151,24 +180,22 @@ def test_record_fail_open_wires_through_to_customer_notify():
     with patch("app.modules.guard.observability.fail_open_alert._also_notify_customer") as spy:
         foa.record_fail_open(db, workspace_id=WS, surface="proxy", error=RuntimeError("boom"))
 
-    assert spy.call_count == 1, "record_fail_open must delegate to customer notify path exactly once"
+    assert spy.call_count == 1
     called_db, called_ws = spy.call_args.args
     assert called_db is db
     assert called_ws == WS
 
 
 def test_customer_message_omits_error_class_and_trace_id():
-    """Audience-defining regression guard. The customer WARNING must never
-    leak internal error details or a trace id — that's what makes it
-    different from the internal ERROR alert."""
-    payload = ca._build_message(workspace_name="Acme", count=3)
-    text = payload["text"]
+    """Audience-defining regression guard. The customer WARNING must
+    never leak internal error details or a trace id — that's what makes
+    it different from the internal ERROR alert."""
+    text_msg = ca._build_message(workspace_name="Acme", count=3)
 
-    assert ":warning:" in text
-    assert "Acme" in text
-    assert "3 requests" in text
-    assert "/theguard/settings" in text
-    # These MUST NOT leak into a customer-facing post
-    assert "trace_id" not in text
-    assert "RuntimeError" not in text
-    assert "Exception" not in text
+    assert ":warning:" in text_msg
+    assert "Acme" in text_msg
+    assert "3 requests" in text_msg
+    assert "/theguard/settings" in text_msg
+    assert "trace_id" not in text_msg
+    assert "RuntimeError" not in text_msg
+    assert "Exception" not in text_msg

--- a/apps/web/src/app/(app)/theguard/settings/page.tsx
+++ b/apps/web/src/app/(app)/theguard/settings/page.tsx
@@ -48,16 +48,18 @@ const GUARD_SETTINGS_TABS: readonly SettingsTab<GuardSettingsTab>[] = [
 
 // ─── #1142 Phase 1 — per-action notifications card ────────────────────────────
 
-const NOTIF_ACTIONS: Array<{ k: "block" | "warn" | "audit" | "approval"; label: string; hint: string }> = [
-  { k: "block",    label: "Block",    hint: "loud by default — send to a security channel" },
-  { k: "warn",     label: "Warn",     hint: "quiet — a heads-up to a dev channel" },
-  { k: "audit",    label: "Audit",    hint: "silent by default — leave empty to skip" },
-  { k: "approval", label: "Approval", hint: "notify approvers when a rule requires human sign-off" },
+type NotifActionKey = "block" | "warn" | "audit" | "approval" | "fail_open"
+const NOTIF_ACTIONS: Array<{ k: NotifActionKey; label: string; hint: string }> = [
+  { k: "block",     label: "Block",     hint: "loud by default — send to a security channel" },
+  { k: "warn",      label: "Warn",      hint: "quiet — a heads-up to a dev channel" },
+  { k: "audit",     label: "Audit",     hint: "silent by default — leave empty to skip" },
+  { k: "approval",  label: "Approval",  hint: "notify approvers when a rule requires human sign-off" },
+  { k: "fail_open", label: "Fail-open", hint: "customer heads-up when Guard could not evaluate policy (allowed through per your default)" },
 ]
 
 interface NotifChannel {
   id: string
-  action: "block" | "warn" | "audit" | "approval"
+  action: NotifActionKey
   channel_type: string
   channel_ref: string
   enabled: boolean
@@ -111,7 +113,7 @@ function NotificationsCard({
 
   useEffect(() => { void load() }, [load])
 
-  async function handleAdd(action: "block" | "warn" | "audit" | "approval") {
+  async function handleAdd(action: NotifActionKey) {
     if (!workspaceId || !addChannel.trim()) return
     try {
       let body: {

--- a/apps/web/src/lib/api/guard.ts
+++ b/apps/web/src/lib/api/guard.ts
@@ -71,7 +71,7 @@ export interface GuardEnforcementCoverage {
   exception_expired: boolean
 }
 
-export type NotificationAction = "block" | "warn" | "audit" | "approval"
+export type NotificationAction = "block" | "warn" | "audit" | "approval" | "fail_open"
 export type NotificationChannelType = "slack" | "email" | "pagerduty" | "webhook"
 
 export interface NotificationChannel {


### PR DESCRIPTION
Refs #1520. PR 3 of the fail-open observability arc. Closes the design gap surfaced in review of #1571: customers couldn't see or configure the fail-open Slack channel in the "Slack channels by action" UI on \`/theguard/settings\`.

## What ships

- **Migration 0111** widens the \`ck_guard_notif_channel_action\` CHECK on \`guard_notification_channels\` to include \`fail_open\`.
- **notifications.py** — \`ACTIONS\` tuple + Pydantic Literal extended with \`fail_open\`. Existing POST/GET/DELETE endpoints accept it with zero other changes.
- **customer_alert.py** — rewired from \`GuardConfig.slack_webhook_url\` (legacy single-webhook column) to \`resolve_channels(db, ws, "fail_open")\` + shared \`_fanout_slack\` helper. Same code path block/warn/audit/approval already use — the customer's OAuth Slack bot token, per-integration, no webhook URL involved.
- **NotificationsCard UI** — adds a fifth row:
  > **Fail-open** — customer heads-up when Guard could not evaluate policy (allowed through per your default)
  Same shape as the other rows including the Test button.
- **guard.ts** — \`NotificationAction\` type widened.

## Migration order

Depends on \`0110\` (from #1571 which is already merged). Deploys in-place with no downtime.

## Backward compatibility

\`GuardConfig.slack_webhook_url\` is untouched by this PR — the column stays. Only the customer fail-open alerter stops reading it. Token guardrails still use it (see follow-up).

## Follow-up

- **PR 4** — migrate \`token_guardrails._post_slack_drift\` from webhook URL to \`resolve_channels("token_drift")\` + \`_fanout_slack\`, matching this PR's pattern. Adds a sixth row to NotificationsCard. Backfill migration copies existing \`slack_webhook_url\` values into the new channel rows.
- **PR 5** — DROP COLUMN \`guard_config.slack_webhook_url\` and \`slack_integration_id\` (once no code reads them).

## Test plan

- 11 tests in \`apps/api/tests/guard/test_fail_open_customer_alert.py\` rewritten for the new shape:
  - [x] Fanout called when channels resolve + opt-in
  - [x] Skips when \`notify_on_fail_open=False\` (cheap short-circuit before channel resolve)
  - [x] Skips when no channels configured for \`fail_open\`
  - [x] Skips when db is None
  - [x] 15-min rate-limit dedupes subsequent events
  - [x] Burst count surfaces after window flip
  - [x] Fanout failure logs WARN, never raises
  - [x] resolve_channels failure skips silently
  - [x] Config lookup failure defaults to opted-in (never silences transparency)
  - [x] \`record_fail_open()\` wire-through (spy pattern, deterministic)
  - [x] Customer message omits error class / trace_id (audience-defining regression guard)
- **1266/1266** guard suite passes locally
- Frontend TypeScript clean

## Verification post-deploy

1. On \`/theguard/settings > Notifications\`, confirm new "Fail-open" row appears.
2. Click **+ Add channel**, pick a Slack channel, save. Confirm it renders.
3. Click **Test** → get the standard test message in that channel.
4. Trigger an actual fail-open (temporarily poison policy cache) → customer WARNING lands in the configured channel with the approved wording.