### PR TITLE
chore(guard): rename "Slack channels by action" panel to "Notifications"

### DIFF
--- a/apps/api/app/modules/guard/observability/customer_alert.py
+++ b/apps/api/app/modules/guard/observability/customer_alert.py
@@ -13,7 +13,7 @@ were not enforced and where to change the fail-mode.
 
 Skipped when:
   - ``GuardConfig.notify_on_fail_open`` is False (customer opt-out)
-  - no ``fail_open`` channels configured in the "Slack channels by action" UI
+  - no ``fail_open`` channels configured in the "Notifications" UI
   - inside the 15-min rate-limit window
 """
 from __future__ import annotations
@@ -120,7 +120,7 @@ def notify_customer_fail_open(
 
     # Resolve channels via the same mechanism block/warn/audit/approval use.
     # If nothing is configured for `fail_open`, silently skip — customers
-    # opt in by adding a channel in "Slack channels by action".
+    # opt in by adding a channel in "Notifications".
     try:
         from app.modules.guard.routers.notifications import resolve_channels
         channels = resolve_channels(db, ws_id, "fail_open")

--- a/apps/web/src/app/(app)/theguard/settings/page.tsx
+++ b/apps/web/src/app/(app)/theguard/settings/page.tsx
@@ -183,7 +183,7 @@ function NotificationsCard({
             <path d="M14.5 2v20M9.5 2v20M2 14.5h20M2 9.5h20" />
           </svg>
         </span>
-        <div style={{ fontWeight: 650, fontSize: 14.5 }}>Slack channels by action</div>
+        <div style={{ fontWeight: 650, fontSize: 14.5 }}>Notifications</div>
         {environments.length > 0 && (
           <label style={{ marginLeft: "auto", display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-3)" }}>
             Vault


### PR DESCRIPTION
Shorter, cleaner label. Matches how the panel is actually used — it routes any alert type (block / warn / audit / approval / fail_open / drift) to any transport (slack / webhook / pagerduty / email), not just Slack.

## Changed

- \`apps/web/src/app/(app)/theguard/settings/page.tsx\` — panel header: **"Slack channels by action"** → **"Notifications"**
- \`apps/api/app/modules/guard/observability/customer_alert.py\` — two comment references updated to match

## Not changed

No behavior, no API, no schema. Pure UI copy.

## Verification

Load \`/theguard/settings > Notifications\`, confirm panel header now reads "Notifications" with the hash icon and Vault picker intact.