### PR TITLE
fix(guard): fail_open + drift fan out to all 4 transports, not just Slack

### DIFF
--- a/apps/api/app/modules/guard/observability/customer_alert.py
+++ b/apps/api/app/modules/guard/observability/customer_alert.py
@@ -143,9 +143,48 @@ def notify_customer_fail_open(
 
     text_msg = _build_message(workspace_name=workspace_name, count=count)
 
+    # Fanout to every transport the workspace has configured for `fail_open`.
+    # Mirrors the block/warn/audit/approval split in events.py:230-250 so a
+    # customer who configured a webhook or PagerDuty for fail_open actually
+    # receives the alert there, not just Slack.
+    by_type: dict[str, list] = {"slack": [], "webhook": [], "pagerduty": [], "email": []}
+    for c in channels:
+        by_type.setdefault(c.channel_type, []).append(c)
+
     try:
-        from app.modules.guard.routers.events import _fanout_slack
-        _fanout_slack(db, ws_id, channels, text_msg)
+        from app.modules.guard.routers.events import (
+            _fanout_slack,
+            _fanout_webhook,
+            _fanout_pagerduty,
+            _fanout_email,
+        )
+
+        if by_type["slack"]:
+            _fanout_slack(db, ws_id, by_type["slack"], text_msg)
+        if by_type["webhook"]:
+            _fanout_webhook(by_type["webhook"], {
+                "event": "guard.fail_open",
+                "workspace_id": ws_id,
+                "workspace_name": workspace_name,
+                "count": count,
+                "message": text_msg,
+            })
+        if by_type["pagerduty"]:
+            _fanout_pagerduty(by_type["pagerduty"], "fail_open", "guard.engine_error", text_msg)
+        if by_type["email"]:
+            _fanout_email(
+                db, ws_id, by_type["email"],
+                subject=f"[Guard fail-open] Policy not evaluated in {workspace_name}",
+                html=(
+                    f"<p><strong>Guard could not evaluate policy</strong> on "
+                    f"<strong>{count}</strong> request(s) in the last 15 min in "
+                    f"<strong>{workspace_name}</strong>.</p>"
+                    f"<p>Per your fail-open default, these requests were allowed through. "
+                    f"Guard rules were not enforced for the affected calls.</p>"
+                    f"<p>To change this behavior, set your workspace to fail-closed in "
+                    f"Guard Settings.</p>"
+                ),
+            )
     except Exception as exc:  # noqa: BLE001
         log.warning("guard.fail_open.customer_fanout_failed", err=str(exc))
 

--- a/apps/api/app/modules/guard/routers/savings.py
+++ b/apps/api/app/modules/guard/routers/savings.py
@@ -162,12 +162,42 @@ def record_savings(
                     f"*ConductGuard drift detected* in workspace *{body.workspace_id}*:\n"
                     + "\n".join(drifts)
                 )
-                # Route via the per-action fanout — customers configure
-                # the drift channel in /theguard/settings > Notifications.
-                # Silent when no channels are set (opt-in model).
+                # Fanout to every transport configured for `drift`. Same
+                # 4-way split events.py:230-250 uses for block/warn/audit/
+                # approval, so webhook / PagerDuty / email are equal
+                # citizens with Slack.
                 channels = resolve_channels(db, body.workspace_id, "drift")
                 if channels:
-                    _fanout_slack(db, body.workspace_id, channels, text)
+                    from app.modules.guard.routers.events import (
+                        _fanout_webhook,
+                        _fanout_pagerduty,
+                        _fanout_email,
+                    )
+                    by_type: dict[str, list] = {"slack": [], "webhook": [], "pagerduty": [], "email": []}
+                    for c in channels:
+                        by_type.setdefault(c.channel_type, []).append(c)
+
+                    if by_type["slack"]:
+                        _fanout_slack(db, body.workspace_id, by_type["slack"], text)
+                    if by_type["webhook"]:
+                        _fanout_webhook(by_type["webhook"], {
+                            "event": "guard.drift_detected",
+                            "workspace_id": body.workspace_id,
+                            "drifts": drifts,
+                            "message": text,
+                        })
+                    if by_type["pagerduty"]:
+                        _fanout_pagerduty(by_type["pagerduty"], "drift", "guard.token_drift", text)
+                    if by_type["email"]:
+                        _fanout_email(
+                            db, body.workspace_id, by_type["email"],
+                            subject=f"[Guard drift] Guardrail state changed in {body.workspace_id}",
+                            html=(
+                                f"<p><strong>ConductGuard drift detected</strong> in workspace "
+                                f"<code>{body.workspace_id}</code>.</p>"
+                                + "<ul>" + "".join(f"<li>{d}</li>" for d in drifts) + "</ul>"
+                            ),
+                        )
 
             team.guardrail_snapshot = {
                 **prev_snap,

--- a/apps/api/tests/guard/test_fail_open_customer_alert.py
+++ b/apps/api/tests/guard/test_fail_open_customer_alert.py
@@ -33,11 +33,11 @@ def _mk_db(notify_on_fail_open: bool = True):
     return db
 
 
-def _mk_channel(channel_ref: str = "#security"):
-    """One slack channel record — matches shape returned by resolve_channels."""
+def _mk_channel(channel_ref: str = "#security", channel_type: str = "slack"):
+    """One channel record — matches shape returned by resolve_channels."""
     return SimpleNamespace(
-        id="ch-1",
-        channel_type="slack",
+        id=f"ch-{channel_type}",
+        channel_type=channel_type,
         channel_ref=channel_ref,
         integration_id=None,
         enabled=True,
@@ -199,3 +199,103 @@ def test_customer_message_omits_error_class_and_trace_id():
     assert "trace_id" not in text_msg
     assert "RuntimeError" not in text_msg
     assert "Exception" not in text_msg
+
+
+# ── Multi-transport fanout (all 4 channels equal citizens) ────────────────
+
+def test_fanout_hits_slack_when_slack_channel_configured():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels",
+               return_value=[_mk_channel(channel_type="slack")]), \
+         patch("app.modules.guard.routers.events._fanout_slack") as slack, \
+         patch("app.modules.guard.routers.events._fanout_webhook") as webhook, \
+         patch("app.modules.guard.routers.events._fanout_pagerduty") as pd, \
+         patch("app.modules.guard.routers.events._fanout_email") as email, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert slack.call_count == 1
+    assert webhook.call_count == 0
+    assert pd.call_count == 0
+    assert email.call_count == 0
+
+
+def test_fanout_hits_webhook_when_webhook_channel_configured():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels",
+               return_value=[_mk_channel(channel_ref="https://x.example/hook", channel_type="webhook")]), \
+         patch("app.modules.guard.routers.events._fanout_slack") as slack, \
+         patch("app.modules.guard.routers.events._fanout_webhook") as webhook, \
+         patch("app.modules.guard.routers.events._fanout_pagerduty") as pd, \
+         patch("app.modules.guard.routers.events._fanout_email") as email, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert slack.call_count == 0
+    assert webhook.call_count == 1
+    payload = webhook.call_args.args[1]
+    assert payload["event"] == "guard.fail_open"
+    assert payload["workspace_name"] == "Acme"
+    assert payload["count"] == 1
+
+
+def test_fanout_hits_pagerduty_when_pd_channel_configured():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels",
+               return_value=[_mk_channel(channel_ref="pd-routing-key", channel_type="pagerduty")]), \
+         patch("app.modules.guard.routers.events._fanout_slack") as slack, \
+         patch("app.modules.guard.routers.events._fanout_webhook") as webhook, \
+         patch("app.modules.guard.routers.events._fanout_pagerduty") as pd, \
+         patch("app.modules.guard.routers.events._fanout_email") as email, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert pd.call_count == 1
+    # _fanout_pagerduty(channels, action, rule_id, message)
+    args = pd.call_args.args
+    assert args[1] == "fail_open"
+    assert args[2] == "guard.engine_error"
+
+
+def test_fanout_hits_email_when_email_channel_configured():
+    db = _mk_db()
+    with patch("app.modules.guard.routers.notifications.resolve_channels",
+               return_value=[_mk_channel(channel_ref="alerts@acme.example", channel_type="email")]), \
+         patch("app.modules.guard.routers.events._fanout_slack") as slack, \
+         patch("app.modules.guard.routers.events._fanout_webhook") as webhook, \
+         patch("app.modules.guard.routers.events._fanout_pagerduty") as pd, \
+         patch("app.modules.guard.routers.events._fanout_email") as email, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert email.call_count == 1
+    kwargs = email.call_args.kwargs
+    assert "Guard fail-open" in kwargs["subject"]
+    assert "Acme" in kwargs["html"]
+
+
+def test_fanout_hits_all_when_mixed_channels_configured():
+    db = _mk_db()
+    mixed = [
+        _mk_channel(channel_ref="#s", channel_type="slack"),
+        _mk_channel(channel_ref="https://x", channel_type="webhook"),
+        _mk_channel(channel_ref="rk", channel_type="pagerduty"),
+        _mk_channel(channel_ref="a@x", channel_type="email"),
+    ]
+    with patch("app.modules.guard.routers.notifications.resolve_channels", return_value=mixed), \
+         patch("app.modules.guard.routers.events._fanout_slack") as slack, \
+         patch("app.modules.guard.routers.events._fanout_webhook") as webhook, \
+         patch("app.modules.guard.routers.events._fanout_pagerduty") as pd, \
+         patch("app.modules.guard.routers.events._fanout_email") as email, \
+         patch("app.modules.guard.observability.customer_alert.resolve_workspace_context") as rwc:
+        rwc.return_value = MagicMock(workspace_name="Acme", org_name=None)
+        ca.notify_customer_fail_open(db, workspace_id=WS)
+
+    assert slack.call_count == 1
+    assert webhook.call_count == 1
+    assert pd.call_count == 1
+    assert email.call_count == 1


### PR DESCRIPTION
Fixes an asymmetry surfaced during Notifications-panel walkthrough after #1573 + #1575 landed.

## Bug

The Notifications panel offers **slack / webhook / email / pagerduty** as channel types for every action row. Block/warn/audit/approval correctly fan out to all four (via \`events.py:230-250\`). But the two new tiers **fail_open** and **drift** only called \`_fanout_slack\` — adding a webhook, PagerDuty, or email channel to those rows silently did nothing.

## Fix

Mirror the \`by_type\` split \`events.py\` uses. Each site now:

1. Splits channels by \`channel_type\`
2. Calls the matching \`_fanout_*\` helper per non-empty bucket

### customer_alert.py (\`fail_open\`)

| Transport | Payload |
|---|---|
| Slack | text WARNING — audience-defining copy (no error class, no trace_id) |
| Webhook | \`{event, workspace_id, workspace_name, count, message}\` |
| PagerDuty | action=\`fail_open\`, rule_id=\`guard.engine_error\` |
| Email | HTML body preserving the WARNING framing |

### savings.py (\`drift\`)

| Transport | Payload |
|---|---|
| Slack | drift text |
| Webhook | \`{event, workspace_id, drifts, message}\` |
| PagerDuty | action=\`drift\`, rule_id=\`guard.token_drift\` |
| Email | HTML list of drift items |

## Test plan

- **5 new tests** in \`tests/guard/test_fail_open_customer_alert.py\`:
  - [x] Slack channel alone → only \`_fanout_slack\` fires
  - [x] Webhook channel alone → only \`_fanout_webhook\` fires (with expected payload shape)
  - [x] PagerDuty channel alone → only \`_fanout_pagerduty\` fires with \`action="fail_open"\`
  - [x] Email channel alone → only \`_fanout_email\` fires with WARNING subject + HTML
  - [x] Mixed 4-transport list → all four fire once each
- **1276/1276** guard suite passes (was 1271)
- **33/33** savings tests pass (drift path)

## What's NOT in this PR

No schema change, no migration, no UI change. Pure alerter internals.

## Verification post-deploy

1. On a test workspace with the fail_open row configured, add a webhook channel (any RequestBin URL). Trigger fail-open. Webhook should receive a POST with \`event: guard.fail_open\`.
2. Add a PagerDuty channel to the drift row. Uninstall RTK, POST \`/guard/savings\`. PagerDuty should trigger with \`action: drift\`.
3. Standard **Test** button on each channel type continues to work (unchanged — it's a separate endpoint).