### PR TITLE
chore(#1574): drop dead Slack columns (guard_config + security_config)

### DIFF
--- a/apps/api/alembic/versions/0113_drop_dead_slack_columns.py
+++ b/apps/api/alembic/versions/0113_drop_dead_slack_columns.py
@@ -1,0 +1,71 @@
+"""Drop dead Slack columns from guard_config + security_config (#1574 follow-up).
+
+Cleanup pass after PR #1575 shipped the drift alerter on the per-action fanout
+table. Three columns exist on ORM models and DB tables but no code path reads
+them:
+
+1. ``guard_config.slack_integration_id`` — accepted in the token_guardrails
+   PATCH body and echoed back in the GET response, but no UI component
+   renders or sets it, and the drift fanout switched to
+   ``resolve_channels("drift")`` in #1575. The alert_slack_integration_id
+   sibling (used by the settings page Slack card) is untouched.
+
+2. ``security_config.slack_webhook_url`` — the only reader of the
+   security_config table (``_load_security_config_defaults`` in
+   app/routers/security.py) selects three columns, and this isn't one of
+   them. Never referenced elsewhere.
+
+3. ``security_config.slack_integration_id`` — same story as #2.
+
+Revision ID: 0113
+Revises: 0112
+Create Date: 2026-09-03
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+
+revision = "0113"
+down_revision = "0112"
+branch_labels = None
+depends_on = None
+
+
+_DEAD_COLUMNS = (
+    ("guard_config", "slack_integration_id"),
+    ("security_config", "slack_webhook_url"),
+    ("security_config", "slack_integration_id"),
+)
+
+
+def upgrade() -> None:
+    # Log a NOTICE for any workspace that happens to have a non-null value in
+    # a column we're dropping, so operators can see who was writing to a
+    # field nothing read. Same pattern as migration 0112.
+    for table, col in _DEAD_COLUMNS:
+        op.execute(
+            f"DO $$ BEGIN "
+            f"IF EXISTS (SELECT 1 FROM {table} WHERE {col} IS NOT NULL) THEN "
+            f"RAISE NOTICE 'Dropping {table}.{col} with % non-null rows (never read by any code path)', "
+            f"(SELECT COUNT(*) FROM {table} WHERE {col} IS NOT NULL); "
+            f"END IF; END $$;"
+        )
+        op.drop_column(table, col)
+
+
+def downgrade() -> None:
+    op.add_column(
+        "security_config",
+        sa.Column("slack_integration_id", UUID(as_uuid=True), nullable=True),
+    )
+    op.add_column(
+        "security_config",
+        sa.Column("slack_webhook_url", sa.String(500), nullable=True),
+    )
+    op.add_column(
+        "guard_config",
+        sa.Column("slack_integration_id", UUID(as_uuid=True), nullable=True),
+    )

--- a/apps/api/app/models/security_config.py
+++ b/apps/api/app/models/security_config.py
@@ -23,8 +23,6 @@ class SecurityConfig(Base):
     security_emit_enabled = sa.Column(sa.Boolean(), nullable=False, server_default="true")
     security_slack_alerts_enabled = sa.Column(sa.Boolean(), nullable=False, server_default="false")
     security_slack_channel = sa.Column(sa.String(100), nullable=True)
-    slack_webhook_url = sa.Column(sa.String(500), nullable=True)
-    slack_integration_id = sa.Column(UUID(as_uuid=True), nullable=True)
     autopilot_enabled = sa.Column(sa.Boolean(), nullable=False, server_default="false")
     automation_workflow_on_finding = sa.Column(sa.Boolean(), nullable=False, server_default="false")
     automation_finding_severity = sa.Column(sa.String(20), nullable=False, server_default="critical")

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -49,7 +49,6 @@ class GuardConfig(Base):
     resync_requested_at = Column(DateTime(timezone=True), nullable=True)
     token_guardrails = Column(JSONB, nullable=True)
     guardrail_snapshot = Column(JSONB, nullable=True)
-    slack_integration_id = Column(UUID(as_uuid=True), nullable=True)
     alert_slack_integration_id = Column(UUID(as_uuid=True), nullable=True)
     automation_security_scan = Column(Boolean, nullable=False, default=False)
     automation_workflow_trigger = Column(Boolean, nullable=False, default=False)

--- a/apps/api/app/modules/guard/routers/token_guardrails.py
+++ b/apps/api/app/modules/guard/routers/token_guardrails.py
@@ -1,6 +1,6 @@
 """
 GET   /guard/token-guardrails?workspace_id=...  — unified guardrail state (auto-detected + manual)
-PATCH /guard/token-guardrails                   — update manual flags and/or slack_webhook_url
+PATCH /guard/token-guardrails                   — update manual flags
 """
 import json
 import urllib.request
@@ -36,7 +36,6 @@ class TokenGuardrailsOut(BaseModel):
     structured_retrieval: bool
     metrics_budgets: bool
     manual_keys: list[str]
-    slack_integration_id: Optional[str] = None
 
 
 class TokenGuardrailsPatch(BaseModel):
@@ -44,7 +43,6 @@ class TokenGuardrailsPatch(BaseModel):
     prompt_caching: Optional[bool] = None
     model_routing: Optional[bool] = None
     prompt_splitting: Optional[bool] = None
-    slack_integration_id: Optional[str] = None
 
 
 # ── Drift helpers ─────────────────────────────────────────────────────────────
@@ -152,7 +150,6 @@ def _build_guardrail_state(db: Session, workspace_id: str) -> dict:
             structured_retrieval=has_booster,
             metrics_budgets=metrics_budgets,
             manual_keys=_MANUAL_KEYS,
-            slack_integration_id=str(team.slack_integration_id) if team.slack_integration_id else None,
         ),
     }
 
@@ -185,9 +182,6 @@ def patch_token_guardrails(
     if body.prompt_splitting is not None:
         manual["prompt_splitting"] = body.prompt_splitting
     team.token_guardrails = manual
-
-    if body.slack_integration_id is not None:
-        team.slack_integration_id = uuid.UUID(body.slack_integration_id)
 
     db.commit()
     db.refresh(team)

--- a/apps/api/app/routers/security.py
+++ b/apps/api/app/routers/security.py
@@ -127,8 +127,8 @@ class TriggerFixResponse(BaseModel):
 
 # ── Internal helpers ──────────────────────────────────────────────────────────
 
-# ponytail: raw text() because security_config has no ORM model; add a model when we
-# need more than 3 fields.
+# ponytail: raw text() — SecurityConfig ORM model exists (models/security_config.py)
+# purely for Base.metadata registration; not worth wiring for a 3-column read.
 _SECURITY_CFG_SQL = text(
     "SELECT autopilot_enabled, security_slack_alerts_enabled, security_slack_channel "
     "FROM security_config WHERE workspace_id = :ws"

--- a/apps/web/src/hooks/useTokenGuardrails.ts
+++ b/apps/web/src/hooks/useTokenGuardrails.ts
@@ -13,7 +13,6 @@ export interface TokenGuardrails {
   structured_retrieval: boolean
   metrics_budgets: boolean
   manual_keys: string[]
-  slack_integration_id: string | null
 }
 
 const DEFAULTS: TokenGuardrails = {
@@ -25,7 +24,6 @@ const DEFAULTS: TokenGuardrails = {
   structured_retrieval: true,
   metrics_budgets: true,
   manual_keys: ["prompt_caching", "model_routing", "prompt_splitting"],
-  slack_integration_id: null,
 }
 
 interface UseTokenGuardrailsResult {
@@ -65,9 +63,7 @@ export async function patchTokenGuardrails(
   workspaceId: string,
   token: string,
   apiUrl: string,
-  patch: Partial<Pick<TokenGuardrails, "prompt_caching" | "model_routing" | "prompt_splitting">> & {
-    slack_integration_id?: string | null
-  },
+  patch: Partial<Pick<TokenGuardrails, "prompt_caching" | "model_routing" | "prompt_splitting">>,
 ): Promise<TokenGuardrails> {
   const res = await fetch(`${apiUrl}/guard/token-guardrails?workspace_id=${workspaceId}`, {
     method: "PATCH",


### PR DESCRIPTION
Cleanup pass after PR #1575 shipped the drift alerter on the per-action fanout table. Three columns declared on ORM models with zero readers anywhere in the codebase:

| Column | Why it's dead |
|---|---|
| `guard_config.slack_integration_id` | Accepted in the token_guardrails PATCH body, echoed in the GET response, but zero `.tsx` files read/set it. Drift fanout switched to `resolve_channels("drift")` in #1575. `alert_slack_integration_id` (the actively-used sibling) is untouched. |
| `security_config.slack_webhook_url` | Never read. The only reader of the `security_config` table (`_load_security_config_defaults`) selects three unrelated columns. |
| `security_config.slack_integration_id` | Same story. |

## Summary
- Migration `0113_drop_dead_slack_columns` drops all three columns and logs a NOTICE per table if any non-null values existed at drop time (same pattern as `0112`).
- Removes the columns from `SecurityConfig` + `GuardConfig` ORM models.
- Removes `slack_integration_id` from the `TokenGuardrailsOut` / `TokenGuardrailsPatch` schemas and the PATCH handler in `token_guardrails.py`.
- Removes `slack_integration_id` from the `useTokenGuardrails` hook (type, DEFAULTS, patch signature).
- Corrects the stale `ponytail:` comment in `security.py:130` that claimed "no ORM model" for `security_config` — the model exists, it's just kept for `Base.metadata` registration rather than wired for a 3-column read.

Closes #1574.

## Test plan
- [x] `pytest tests/guard/test_drift_channel_fanout.py tests/guard/test_fail_open_customer_alert.py -q` → 21 passed (both the "webhook column is gone" and "fail_open uses fanout" regressions still hold).
- [x] `pytest -k "token_guardrails or guard_drift or guard_config"` → 5 passed, 2 skipped.
- [x] `pytest -k "slack or drift or notification"` → 36 passed, 4 skipped.
- [x] Runtime import + attribute check confirms the fields are gone from both models and both Pydantic schemas.
- [ ] CI runs `test_alembic_check_no_schema_drift` — expected to pass since ORM and migration drop the same columns.