### PR TITLE
feat(#1567 PR 1): trial seed on Clerk user.created

### DIFF
--- a/apps/api/app/modules/guard/trial_seed.py
+++ b/apps/api/app/modules/guard/trial_seed.py
@@ -1,0 +1,97 @@
+"""Trial seed for new signups (epic #1567).
+
+Called from the Clerk `user.created` webhook and from `/theguard/try` first-hit
+(shipped in a later PR). Idempotent — safe to replay.
+
+Sets `workspaces.plan='free_trial'`, inserts a workspace-default
+`guard_rate_limits` row, inserts a workspace-default `guard_spend_budgets`
+row, and mints a 7-day trial `AgentIdentity`.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.crypto import encrypt
+from app.modules.agent_identity.models import AgentIdentity
+from app.modules.agent_identity.router import _generate_token
+
+TRIAL_PLAN = "free_trial"
+TRIAL_RPM = 60
+TRIAL_TPM = 100_000
+TRIAL_MONTHLY_USD = 2.0
+TRIAL_HARD_USD = 2.0
+TRIAL_DAYS = 7
+TRIAL_IDENTITY_NAME = "Trial (7 days)"
+
+
+def seed_trial(db: Session, workspace_id: str) -> str | None:
+    """Seed trial guardrails on `workspace_id`. Idempotent.
+
+    Returns the plaintext trial token if a new identity was minted, else None.
+    Caller commits.
+    """
+    now = datetime.now(timezone.utc)
+    ws = str(workspace_id)
+
+    db.execute(
+        text("UPDATE workspaces SET plan = :plan WHERE id = :ws"),
+        {"plan": TRIAL_PLAN, "ws": ws},
+    )
+
+    # ponytail: NULLs are distinct in the guard_rate_limits unique constraint,
+    # so ON CONFLICT won't fire for workspace-default rows. Use WHERE NOT EXISTS.
+    db.execute(
+        text("""
+            INSERT INTO guard_rate_limits (id, workspace_id, agent_identity_id, rpm, tpm, created_at, updated_at)
+            SELECT gen_random_uuid(), :ws, NULL, :rpm, :tpm, :now, :now
+            WHERE NOT EXISTS (
+                SELECT 1 FROM guard_rate_limits
+                WHERE workspace_id = :ws AND agent_identity_id IS NULL
+            )
+        """),
+        {"ws": ws, "rpm": TRIAL_RPM, "tpm": TRIAL_TPM, "now": now},
+    )
+
+    db.execute(
+        text("""
+            INSERT INTO guard_spend_budgets (id, workspace_id, clerk_user_id, monthly_limit_usd, hard_limit_usd, alert_threshold_pct, created_at, updated_at)
+            SELECT gen_random_uuid(), :ws, NULL, :monthly, :hard, 80, :now, :now
+            WHERE NOT EXISTS (
+                SELECT 1 FROM guard_spend_budgets
+                WHERE workspace_id = :ws AND clerk_user_id IS NULL
+            )
+        """),
+        {"ws": ws, "monthly": TRIAL_MONTHLY_USD, "hard": TRIAL_HARD_USD, "now": now},
+    )
+
+    existing = db.execute(
+        text("""
+            SELECT 1 FROM agent_identities
+            WHERE workspace_id = :ws AND name = :name
+              AND lifecycle_state = 'active'
+              AND (expires_at IS NULL OR expires_at > :now)
+            LIMIT 1
+        """),
+        {"ws": ws, "name": TRIAL_IDENTITY_NAME, "now": now},
+    ).fetchone()
+    if existing:
+        return None
+
+    plaintext, prefix = _generate_token()
+    db.add(AgentIdentity(
+        id=str(uuid.uuid4()),
+        workspace_id=workspace_id,
+        name=TRIAL_IDENTITY_NAME,
+        provider="conduct",
+        token_prefix=prefix,
+        token_encrypted=encrypt({"token": plaintext}),
+        environment_id=None,
+        created_at=now,
+        last_used_at=None,
+        expires_at=now + timedelta(days=TRIAL_DAYS),
+    ))
+    return plaintext

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -1336,6 +1336,10 @@ async def clerk_webhook(request: Request, db: Session = Depends(get_db)):
     from app.routers.projects import _seed_starter_policies
     _seed_starter_policies(db, workspace_id, now)
 
+    # Trial seed (#1567): rate/budget caps + 7-day trial agent identity.
+    from app.modules.guard.trial_seed import seed_trial
+    seed_trial(db, str(workspace_id))
+
     db.commit()
     log.info("clerk_webhook.workspace_created", user_id=user_id, workspace_id=str(workspace_id))
     return {"ok": True, "workspace_id": str(workspace_id)}

--- a/apps/api/tests/test_trial_seed.py
+++ b/apps/api/tests/test_trial_seed.py
@@ -1,0 +1,147 @@
+"""Trial seed self-check (epic #1567 PR 1).
+
+conftest.py sets DATABASE_URL and ENCRYPTION_KEY defaults before this file
+imports, so the test just skips the module if Postgres is unreachable.
+"""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.trial_seed import (  # noqa: E402
+    TRIAL_HARD_USD,
+    TRIAL_IDENTITY_NAME,
+    TRIAL_MONTHLY_USD,
+    TRIAL_PLAN,
+    TRIAL_RPM,
+    TRIAL_TPM,
+    seed_trial,
+)
+
+
+@pytest.fixture()
+def ws():
+    """Create a bare workspace, yield (id, db), delete on teardown (cascade removes seeded rows)."""
+    db = SessionLocal()
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, 'free', true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"trial-seed-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "now": now},
+    )
+    db.commit()
+    try:
+        yield ws_id, db
+    finally:
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+        db.commit()
+        db.close()
+
+
+def _count(db, sql: str, params: dict) -> int:
+    return db.execute(text(sql), params).scalar() or 0
+
+
+def test_seed_trial_inserts_expected_rows(ws):
+    ws_id, db = ws
+
+    plaintext = seed_trial(db, ws_id)
+    db.commit()
+
+    assert plaintext and plaintext.startswith("cond_agt_")
+
+    plan = db.execute(
+        text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id},
+    ).scalar()
+    assert plan == TRIAL_PLAN
+
+    rl = db.execute(
+        text(
+            "SELECT rpm, tpm FROM guard_rate_limits "
+            "WHERE workspace_id = :ws AND agent_identity_id IS NULL"
+        ),
+        {"ws": ws_id},
+    ).fetchone()
+    assert rl is not None
+    assert rl.rpm == TRIAL_RPM
+    assert rl.tpm == TRIAL_TPM
+
+    bg = db.execute(
+        text(
+            "SELECT monthly_limit_usd, hard_limit_usd FROM guard_spend_budgets "
+            "WHERE workspace_id = :ws AND clerk_user_id IS NULL"
+        ),
+        {"ws": ws_id},
+    ).fetchone()
+    assert bg is not None
+    assert float(bg.monthly_limit_usd) == TRIAL_MONTHLY_USD
+    assert float(bg.hard_limit_usd) == TRIAL_HARD_USD
+
+    ai = db.execute(
+        text(
+            "SELECT expires_at, lifecycle_state FROM agent_identities "
+            "WHERE workspace_id = :ws AND name = :name"
+        ),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).fetchone()
+    assert ai is not None
+    assert ai.lifecycle_state == "active"
+    delta_days = (ai.expires_at - datetime.now(timezone.utc)).days
+    assert 6 <= delta_days <= 7
+
+
+def test_seed_trial_is_idempotent(ws):
+    ws_id, db = ws
+
+    first = seed_trial(db, ws_id)
+    db.commit()
+    assert first is not None
+
+    second = seed_trial(db, ws_id)
+    db.commit()
+    assert second is None
+
+    for table, filt in [
+        ("guard_rate_limits", "workspace_id = :ws AND agent_identity_id IS NULL"),
+        ("guard_spend_budgets", "workspace_id = :ws AND clerk_user_id IS NULL"),
+        ("agent_identities", "workspace_id = :ws AND name = :name"),
+    ]:
+        params = {"ws": ws_id}
+        if "name" in filt:
+            params["name"] = TRIAL_IDENTITY_NAME
+        n = _count(db, f"SELECT COUNT(*) FROM {table} WHERE {filt}", params)
+        assert n == 1, f"{table}: expected 1 row, got {n}"


### PR DESCRIPTION
## Summary

First PR of epic #1567 (Signup Try-It). Wires the trial-seed function into the Clerk `user.created` webhook.

New signups now get, in one commit inside `clerk_webhook`:

- `workspaces.plan` flipped to `free_trial`
- workspace-default `guard_rate_limits` row (60 RPM / 100k TPM)
- workspace-default `guard_spend_budgets` row ($2 monthly / $2 hard cap)
- 7-day trial `AgentIdentity` (name "Trial (7 days)")

All idempotent — a replayed webhook (or on-demand seed in a later PR) leaves exactly one row per table. No new tables, no migration; every table already existed.

## Scope

- `apps/api/app/modules/guard/trial_seed.py` — new module, one exported function `seed_trial(db, workspace_id) -> str | None`. Returns the plaintext trial token on first mint, `None` on idempotent replay.
- `apps/api/app/routers/webhooks.py` — one call at the end of the `user.created` branch.
- `apps/api/tests/test_trial_seed.py` — two tests (happy path + idempotency), both green locally against docker Postgres.

Zero ORM changes → schema-drift regression check is guaranteed clean.

## Deferred (see epic #1567)

- **PR 2**: gateway resolver honours `plan='free_trial'` via a new narrow env var `GUARD_TRIAL_ANTHROPIC_KEY`, emits `trial_exceeded` on trial-scope blocks. Includes the cost-fence verification checklist added to the epic on 2026-09-03.
- **PR 3**: `/theguard/try` page + on-demand seed for existing empty workspaces + empty-state CTA on `/theguard`.

## Test plan

- [x] `pytest apps/api/tests/test_trial_seed.py` — both tests pass on docker Postgres.
- [x] `python -c "from app.modules.guard.trial_seed import seed_trial"` — module imports.
- [x] `python -c "from app.routers.webhooks import clerk_webhook"` — webhooks router still imports.
- [ ] CI: schema-drift check (no ORM changes; should be a no-op).
- [ ] After merge on staging: trigger a Clerk `user.created` webhook, verify the four seed effects on the resulting workspace.