### PR TITLE
feat(#1567 PR 2 redo): trial platform upstream in Guard Gateway

### DIFF
--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -498,6 +498,24 @@ async def _proxy(
         _vault_key_val = _vault_key(db, workspace_id, provider, _environment_id)
         real_key = _upstream_key or _vault_key_val
         if not real_key:
+            # #1567 PR 2: trial workspaces with no BYO key fall through to a
+            # platform-funded env key, fenced by plan + provider + identity + daily cap.
+            from app.modules.guard.trial_upstream import resolve_trial_key
+            _trial_key, _trial_status = resolve_trial_key(
+                db, workspace_id, provider, str(_agent_identity_id) if _agent_identity_id else None,
+            )
+            if _trial_status == "expired":
+                return _fail_closed(
+                    401,
+                    "trial_expired: 7-day trial ended. Add your own key in Settings → Environments.",
+                )
+            if _trial_status == "exceeded":
+                return _fail_closed(
+                    429,
+                    "trial_exceeded: daily trial quota hit. Add your own key in Settings → Environments.",
+                )
+            real_key = _trial_key
+        if not real_key:
             return _fail_closed(
                 503,
                 f"No API key configured — add {provider.upper()}_API_KEY in Settings → Environments, "

--- a/apps/api/app/modules/guard/trial_upstream.py
+++ b/apps/api/app/modules/guard/trial_upstream.py
@@ -1,0 +1,92 @@
+"""Trial-only platform upstream fallback (epic #1567 PR 2).
+
+When a workspace on `plan='free_trial'` sends a proxy request authenticated by
+its trial `AgentIdentity` and has no vault key, this module returns the
+platform-funded key from `GUARD_TRIAL_ANTHROPIC_KEY` (Render env). Any other
+empty-vault case stays fail-closed at proxy.py.
+
+The trial branch is fenced by:
+- workspace.plan == 'free_trial'
+- provider == 'anthropic'  (only provider funded today; add later if needed)
+- agent_identity is the trial identity (name matches, unexpired, active)
+- vault is empty (caller already checked; enforced by call-site position)
+- request-count cap: at most `TRIAL_DAILY_CAP` proxy requests per workspace
+  per 24h, counted from `guard_audit_events` (cheap; post-response but the
+  fence is checked *before* handing out the key)
+
+Returns `(key, status)`:
+- `("<env-key>", "active")` — hand this to the caller as `real_key`
+- `(None, "expired")`      — trial identity past `expires_at`
+- `(None, "exceeded")`     — trial cap already hit for today
+- `(None, "ineligible")`   — any gate not met (wrong plan, wrong provider,
+                              not the trial identity, env var missing)
+"""
+from __future__ import annotations
+
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Literal
+
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
+
+GUARD_TRIAL_ANTHROPIC_KEY_ENV = "GUARD_TRIAL_ANTHROPIC_KEY"
+TRIAL_DAILY_CAP = 200
+TrialStatus = Literal["active", "expired", "exceeded", "ineligible"]
+
+
+def resolve_trial_key(
+    db: Session,
+    workspace_id: str,
+    provider: str,
+    agent_identity_id: str | None,
+) -> tuple[str | None, TrialStatus]:
+    """Trial-only platform upstream key resolver. See module docstring."""
+    if provider != "anthropic":
+        return None, "ineligible"
+
+    env_key = os.environ.get(GUARD_TRIAL_ANTHROPIC_KEY_ENV) or ""
+    if not env_key:
+        return None, "ineligible"
+
+    if not agent_identity_id:
+        return None, "ineligible"
+
+    row = db.execute(
+        text("""
+            SELECT ai.expires_at, ai.lifecycle_state, ai.name, w.plan
+            FROM agent_identities ai
+            JOIN workspaces w ON w.id = ai.workspace_id
+            WHERE ai.id = :aid AND ai.workspace_id = :ws
+            LIMIT 1
+        """),
+        {"aid": agent_identity_id, "ws": str(workspace_id)},
+    ).fetchone()
+    if row is None:
+        return None, "ineligible"
+    if row.plan != TRIAL_PLAN:
+        return None, "ineligible"
+    if row.name != TRIAL_IDENTITY_NAME:
+        return None, "ineligible"
+    if row.lifecycle_state != "active":
+        return None, "ineligible"
+
+    now = datetime.now(timezone.utc)
+    if row.expires_at is None or row.expires_at <= now:
+        return None, "expired"
+
+    used = db.execute(
+        text("""
+            SELECT COUNT(*) FROM guard_audit_events
+            WHERE workspace_id = :ws
+              AND agent_identity_id = :aid
+              AND ts >= :cutoff
+        """),
+        {"ws": str(workspace_id), "aid": agent_identity_id, "cutoff": now - timedelta(hours=24)},
+    ).scalar() or 0
+    if used >= TRIAL_DAILY_CAP:
+        return None, "exceeded"
+
+    return env_key, "active"

--- a/apps/api/tests/test_trial_upstream.py
+++ b/apps/api/tests/test_trial_upstream.py
@@ -1,0 +1,148 @@
+"""Trial upstream resolver self-check (epic #1567 PR 2)."""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.trial_seed import (  # noqa: E402
+    TRIAL_IDENTITY_NAME,
+    seed_trial,
+)
+from app.modules.guard.trial_upstream import (  # noqa: E402
+    GUARD_TRIAL_ANTHROPIC_KEY_ENV,
+    TRIAL_DAILY_CAP,
+    resolve_trial_key,
+)
+
+# Not a real Anthropic key format — kept generic so the credential-leak rule
+# doesn't fire on this test file.
+_KEY = "TRIAL-KEY-PLACEHOLDER-" + uuid.uuid4().hex
+
+
+@pytest.fixture()
+def seeded_ws(monkeypatch):
+    """Fresh workspace + seeded trial identity. Yields (ws_id, trial_id, db)."""
+    monkeypatch.setenv(GUARD_TRIAL_ANTHROPIC_KEY_ENV, _KEY)
+    db = SessionLocal()
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, 'free', true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"trial-up-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "now": now},
+    )
+    db.commit()
+    seed_trial(db, ws_id)
+    db.commit()
+    trial_id = db.execute(
+        text("SELECT id FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    try:
+        yield ws_id, str(trial_id), db
+    finally:
+        db.rollback()
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+        db.commit()
+        db.close()
+
+
+def test_returns_key_when_all_gates_pass(seeded_ws):
+    ws_id, trial_id, db = seeded_ws
+    key, status = resolve_trial_key(db, ws_id, "anthropic", trial_id)
+    assert status == "active"
+    assert key == _KEY
+
+
+def test_wrong_provider_is_ineligible(seeded_ws):
+    ws_id, trial_id, db = seeded_ws
+    key, status = resolve_trial_key(db, ws_id, "openai", trial_id)
+    assert status == "ineligible"
+    assert key is None
+
+
+def test_missing_env_var_is_ineligible(seeded_ws, monkeypatch):
+    ws_id, trial_id, db = seeded_ws
+    monkeypatch.delenv(GUARD_TRIAL_ANTHROPIC_KEY_ENV, raising=False)
+    key, status = resolve_trial_key(db, ws_id, "anthropic", trial_id)
+    assert status == "ineligible"
+    assert key is None
+
+
+def test_non_trial_plan_is_ineligible(seeded_ws):
+    ws_id, trial_id, db = seeded_ws
+    db.execute(text("UPDATE workspaces SET plan = 'free' WHERE id = :ws"), {"ws": ws_id})
+    db.commit()
+    key, status = resolve_trial_key(db, ws_id, "anthropic", trial_id)
+    assert status == "ineligible"
+    assert key is None
+
+
+def test_expired_identity_returns_expired(seeded_ws):
+    ws_id, trial_id, db = seeded_ws
+    past = datetime.now(timezone.utc) - timedelta(days=1)
+    db.execute(
+        text("UPDATE agent_identities SET expires_at = :past WHERE id = :aid"),
+        {"past": past, "aid": trial_id},
+    )
+    db.commit()
+    key, status = resolve_trial_key(db, ws_id, "anthropic", trial_id)
+    assert status == "expired"
+    assert key is None
+
+
+def test_daily_cap_returns_exceeded(seeded_ws):
+    ws_id, trial_id, db = seeded_ws
+    now = datetime.now(timezone.utc)
+    for _ in range(TRIAL_DAILY_CAP):
+        db.execute(
+            text(
+                "INSERT INTO guard_audit_events (id, workspace_id, agent_identity_id, ts, source, provider, decision, ai_tool) "
+                "VALUES (gen_random_uuid(), :ws, :aid, :ts, 'proxy', 'anthropic', 'allowed', 'cli')"
+            ),
+            {"ws": ws_id, "aid": trial_id, "ts": now},
+        )
+    db.commit()
+    key, status = resolve_trial_key(db, ws_id, "anthropic", trial_id)
+    assert status == "exceeded"
+    assert key is None
+
+
+def test_no_agent_identity_is_ineligible(seeded_ws):
+    ws_id, _trial_id, db = seeded_ws
+    key, status = resolve_trial_key(db, ws_id, "anthropic", None)
+    assert status == "ineligible"
+    assert key is None


### PR DESCRIPTION
Redo of #1581. That PR was squashed into its stacked base (`feat/trial-seed-1567-pr1`) instead of main, so its code never reached main even though GitHub marked it MERGED. This PR reopens the same commit against `main`.

Cherry-picked commit: `01dad81e feat(#1567 PR 2): trial-only platform upstream fallback in Guard Gateway (#1581)` — no code changes.

## What lands

- `apps/api/app/modules/guard/trial_upstream.py` — `resolve_trial_key(db, ws, provider, agent_identity_id) -> (key|None, status)`
- `apps/api/app/modules/guard/routers/proxy.py` — one branch (+22) at the key resolution point, emits 401 `trial_expired` / 429 `trial_exceeded`
- `apps/api/tests/test_trial_upstream.py` — 7 tests, all green locally against docker Postgres

## Env var

Set `GUARD_TRIAL_ANTHROPIC_KEY` in Render (prod + preview) after merge. Without it, the trial branch stays `ineligible` and behaviour is identical to today's fail-closed 503.

See #1581 for full context.