### PR TITLE
feat(#1567 PR 4): guard plan flip + refuse active workspaces on Try-It

### DIFF
--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -40,11 +40,30 @@ router = APIRouter(prefix="/guard/trial", tags=["guard-trial"])
 class TrialSessionOut(BaseModel):
     plan: str
     expired: bool
+    ineligible: bool = False
+    reason: str | None = None
     days_remaining: int
     token: str | None
     gateway_url: str
     cap_used: int
     cap_max: int
+
+
+def _workspace_is_active(db: Session, workspace_id: str) -> bool:
+    """A workspace is 'active' if it has ever run a workflow or wired any
+    integration (vault key). Trial seeding is skipped for these — see PR 4
+    cohort-2 fix."""
+    has_run = db.execute(
+        text("SELECT 1 FROM runs WHERE workspace_id = :ws LIMIT 1"),
+        {"ws": workspace_id},
+    ).fetchone()
+    if has_run:
+        return True
+    has_creds = db.execute(
+        text("SELECT 1 FROM integrations WHERE workspace_id = :ws LIMIT 1"),
+        {"ws": workspace_id},
+    ).fetchone()
+    return bool(has_creds)
 
 
 def _load_trial_identity(db: Session, workspace_id: str):
@@ -88,6 +107,17 @@ def get_trial_session(
 
     identity = _load_trial_identity(db, workspace_id)
     if identity is None:
+        # PR 4: active workspaces (any run or vault key) don't get a trial
+        # identity minted for them. The page renders a "you're past the
+        # trial" panel and points them at the real gateway path.
+        if _workspace_is_active(db, workspace_id):
+            log.info("guard.trial.refused_active_workspace", workspace_id=workspace_id)
+            return TrialSessionOut(
+                plan=plan, expired=False, ineligible=True, reason="active_workspace",
+                days_remaining=0, token=None,
+                gateway_url=settings.conduct_proxy_url,
+                cap_used=0, cap_max=TRIAL_DAILY_CAP,
+            )
         seed_trial(db, workspace_id)
         db.commit()
         identity = _load_trial_identity(db, workspace_id)

--- a/apps/api/app/modules/guard/trial_seed.py
+++ b/apps/api/app/modules/guard/trial_seed.py
@@ -37,8 +37,11 @@ def seed_trial(db: Session, workspace_id: str) -> str | None:
     now = datetime.now(timezone.utc)
     ws = str(workspace_id)
 
+    # Only flip fresh workspaces to `free_trial`. Never overwrite an active
+    # workspace's plan (PR 4 cohort-2 fix). Idempotent replays are a no-op
+    # since the plan is already `free_trial`.
     db.execute(
-        text("UPDATE workspaces SET plan = :plan WHERE id = :ws"),
+        text("UPDATE workspaces SET plan = :plan WHERE id = :ws AND plan = 'free'"),
         {"plan": TRIAL_PLAN, "ws": ws},
     )
 

--- a/apps/api/tests/test_trial_seed.py
+++ b/apps/api/tests/test_trial_seed.py
@@ -145,3 +145,20 @@ def test_seed_trial_is_idempotent(ws):
             params["name"] = TRIAL_IDENTITY_NAME
         n = _count(db, f"SELECT COUNT(*) FROM {table} WHERE {filt}", params)
         assert n == 1, f"{table}: expected 1 row, got {n}"
+
+
+def test_seed_does_not_overwrite_non_free_plan(ws):
+    """PR 4: an active workspace on plan!='free' must keep its plan when
+    seed_trial is called (e.g. curious active user clicks Try)."""
+    ws_id, db = ws
+
+    db.execute(text("UPDATE workspaces SET plan = 'pro' WHERE id = :ws"), {"ws": ws_id})
+    db.commit()
+
+    seed_trial(db, ws_id)
+    db.commit()
+
+    plan_now = db.execute(
+        text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id},
+    ).scalar()
+    assert plan_now == "pro"

--- a/apps/api/tests/test_trial_session_endpoint.py
+++ b/apps/api/tests/test_trial_session_endpoint.py
@@ -58,6 +58,10 @@ def empty_ws():
         yield ws_id, db
     finally:
         db.rollback()
+        # integrations doesn't cascade, so wipe it explicitly. Other trial-owned
+        # tables (agent_identities, guard_rate_limits, guard_spend_budgets,
+        # guard_audit_events) do cascade off workspaces.id.
+        db.execute(text("DELETE FROM integrations WHERE workspace_id = :id"), {"id": ws_id})
         db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
         db.commit()
         db.close()
@@ -148,3 +152,32 @@ def test_cap_used_reflects_recent_audit_rows(empty_ws):
     second = _call(ws_id, db)
     assert second.cap_used == 3
     assert second.token == first.token
+
+
+def test_active_workspace_with_integration_is_ineligible(empty_ws):
+    """PR 4 B: workspace already has a vault key → refuse to seed a trial identity."""
+    ws_id, db = empty_ws
+
+    db.execute(
+        text(
+            "INSERT INTO integrations (id, workspace_id, service, auth_method, handle, created_at) "
+            "VALUES (gen_random_uuid(), :ws, 'anthropic', 'api_key', 'anthropic', NOW())"
+        ),
+        {"ws": ws_id},
+    )
+    db.commit()
+
+    out = _call(ws_id, db)
+    assert out.ineligible is True
+    assert out.reason == "active_workspace"
+    assert out.token is None
+    assert out.days_remaining == 0
+
+    n = db.execute(
+        text(
+            "SELECT COUNT(*) FROM agent_identities "
+            "WHERE workspace_id = :ws AND name = :name"
+        ),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert n == 0, "no trial identity should be minted for active workspaces"

--- a/apps/web/src/app/(app)/theguard/try/page.tsx
+++ b/apps/web/src/app/(app)/theguard/try/page.tsx
@@ -10,6 +10,8 @@ import { API } from "@/lib/api/client"
 interface TrialSession {
   plan: string
   expired: boolean
+  ineligible?: boolean
+  reason?: string | null
   days_remaining: number
   token: string | null
   gateway_url: string
@@ -298,6 +300,27 @@ export default function GuardTryPage() {
               <Link href="/theguard/settings" className="inline-block text-sm px-3 py-1.5 rounded border border-amber-800 bg-amber-900 text-white hover:bg-amber-700">
                 Connect provider
               </Link>
+            </div>
+          )}
+
+          {session?.ineligible && (
+            <div className="rounded-lg border border-sky-200 bg-sky-50 p-4 space-y-3">
+              <p className="font-semibold text-sky-900">This workspace already has activity.</p>
+              <p className="text-sm text-sky-800">
+                The Try-It surface is for new signups. Your workspace already has real runs or vault keys —
+                Guard is already governing it. Two paths from here:
+              </p>
+              <ul className="text-sm text-sky-800 list-disc pl-5 space-y-1">
+                <li>
+                  <Link href="/projects" className="underline">Create a new workspace</Link> to
+                  run the four-verb demo in isolation.
+                </li>
+                <li>
+                  Point your existing traffic through the Guard Gateway — configure it in
+                  <Link href="/theguard/settings" className="underline mx-1">Settings → Proxy</Link>
+                  and every call becomes an audited event.
+                </li>
+              </ul>
             </div>
           )}
 


### PR DESCRIPTION
Stacked on #1583. Two cohort-2 fixes so curious active users don't have their workspace state modified by a Try-It click.

## A — Guard the plan flip in `seed_trial`

The `UPDATE workspaces SET plan='free_trial'` now includes `WHERE plan = 'free'`. Active workspaces (`plan='pro'`, `'free_trial'`, or anything else) keep their plan when `seed_trial()` is called. New workspaces from the Clerk `user.created` webhook still flip cleanly because they land on `plan='free'`.

## B — Refuse active workspaces at `/guard/trial/session`

A workspace is 'active' if it has any run OR any `integrations` row. In that case the endpoint returns `{ineligible: true, reason: "active_workspace"}` and does NOT call `seed_trial` — no trial identity is minted for the curious click.

## Frontend

`/theguard/try` now renders a distinct sky-blue panel when `ineligible=true`, pointing the user at two real paths:

- Create a new workspace to run the four-verb demo in isolation.
- Route existing traffic through Settings → Proxy — every call becomes an audited event.

## Tests

- `test_seed_does_not_overwrite_non_free_plan` — pre-set `plan='pro'`, call `seed_trial`, verify plan is unchanged.
- `test_active_workspace_with_integration_is_ineligible` — insert one integration row, verify `ineligible=true`, `token=None`, and zero trial identities minted.
- All 15 trial tests (PR 1 + PR 2 + PR 3 + PR 4) green together on docker Postgres.

## Not in scope

- C (rename to "Sandbox"): skipped. Ships when a named customer asks for isolated demo envs inside their active workspace.
- Auto-seed on every new-workspace creation via UI: still lazy — user must visit `/theguard/try` in the new workspace to trigger seed. If we ever add a full onboarding wizard, that's when auto-seed on workspace-creation becomes worth wiring.