### PR TITLE
refactor(#1567 PR 5): self-review fixes — dedup cap query, fix plan mismatch, drop dead import

### DIFF
--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -12,7 +12,7 @@ identity tokens stay one-shot as before.
 """
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
 import structlog
 from fastapi import APIRouter, Depends
@@ -24,13 +24,8 @@ from app.core.auth import get_workspace_id, require_permission
 from app.core.config import settings
 from app.core.crypto import decrypt
 from app.core.database import get_db
-from app.modules.guard.trial_seed import (
-    TRIAL_DAYS,
-    TRIAL_IDENTITY_NAME,
-    TRIAL_PLAN,
-    seed_trial,
-)
-from app.modules.guard.trial_upstream import TRIAL_DAILY_CAP
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial
+from app.modules.guard.trial_upstream import TRIAL_DAILY_CAP, get_trial_cap_used
 
 log = structlog.get_logger(__name__)
 
@@ -80,19 +75,6 @@ def _load_trial_identity(db: Session, workspace_id: str):
     ).fetchone()
 
 
-def _cap_used_today(db: Session, workspace_id: str, agent_identity_id: str) -> int:
-    now = datetime.now(timezone.utc)
-    return db.execute(
-        text("""
-            SELECT COUNT(*) FROM guard_audit_events
-            WHERE workspace_id = :ws
-              AND agent_identity_id = :aid
-              AND ts >= :cutoff
-        """),
-        {"ws": workspace_id, "aid": agent_identity_id, "cutoff": now - timedelta(hours=24)},
-    ).scalar() or 0
-
-
 @router.get("/session", response_model=TrialSessionOut)
 def get_trial_session(
     workspace_id: str = Depends(get_workspace_id),
@@ -121,7 +103,13 @@ def get_trial_session(
         seed_trial(db, workspace_id)
         db.commit()
         identity = _load_trial_identity(db, workspace_id)
-        plan = TRIAL_PLAN
+        # PR 5: re-read plan from DB — `seed_trial` only flips `free`, so a
+        # paid empty workspace stays on its actual plan (e.g. 'pro').
+        plan_row = db.execute(
+            text("SELECT plan FROM workspaces WHERE id = :ws"),
+            {"ws": workspace_id},
+        ).fetchone()
+        plan = plan_row.plan if plan_row else plan
         log.info("guard.trial.seed_on_demand", workspace_id=workspace_id)
 
     if identity is None:
@@ -149,6 +137,6 @@ def get_trial_session(
         days_remaining=days_remaining if not expired else 0,
         token=token,
         gateway_url=settings.conduct_proxy_url,
-        cap_used=_cap_used_today(db, workspace_id, str(identity.id)),
+        cap_used=get_trial_cap_used(db, workspace_id, str(identity.id)),
         cap_max=TRIAL_DAILY_CAP,
     )

--- a/apps/api/app/modules/guard/trial_upstream.py
+++ b/apps/api/app/modules/guard/trial_upstream.py
@@ -34,7 +34,31 @@ from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
 
 GUARD_TRIAL_ANTHROPIC_KEY_ENV = "GUARD_TRIAL_ANTHROPIC_KEY"
 TRIAL_DAILY_CAP = 200
+TRIAL_CAP_WINDOW_HOURS = 24
 TrialStatus = Literal["active", "expired", "exceeded", "ineligible"]
+
+
+def get_trial_cap_used(db: Session, workspace_id: str, agent_identity_id: str) -> int:
+    """Count trial-identity audit rows in the last `TRIAL_CAP_WINDOW_HOURS`.
+
+    Single source of truth for the trial cap counter — the proxy fence in
+    `resolve_trial_key` and the read-out in `/guard/trial/session` both call
+    this so the window/columns can't drift between call sites.
+    """
+    now = datetime.now(timezone.utc)
+    return db.execute(
+        text("""
+            SELECT COUNT(*) FROM guard_audit_events
+            WHERE workspace_id = :ws
+              AND agent_identity_id = :aid
+              AND ts >= :cutoff
+        """),
+        {
+            "ws": str(workspace_id),
+            "aid": str(agent_identity_id),
+            "cutoff": now - timedelta(hours=TRIAL_CAP_WINDOW_HOURS),
+        },
+    ).scalar() or 0
 
 
 def resolve_trial_key(
@@ -77,16 +101,7 @@ def resolve_trial_key(
     if row.expires_at is None or row.expires_at <= now:
         return None, "expired"
 
-    used = db.execute(
-        text("""
-            SELECT COUNT(*) FROM guard_audit_events
-            WHERE workspace_id = :ws
-              AND agent_identity_id = :aid
-              AND ts >= :cutoff
-        """),
-        {"ws": str(workspace_id), "aid": agent_identity_id, "cutoff": now - timedelta(hours=24)},
-    ).scalar() or 0
-    if used >= TRIAL_DAILY_CAP:
+    if get_trial_cap_used(db, workspace_id, agent_identity_id) >= TRIAL_DAILY_CAP:
         return None, "exceeded"
 
     return env_key, "active"

--- a/apps/api/tests/test_trial_session_endpoint.py
+++ b/apps/api/tests/test_trial_session_endpoint.py
@@ -154,6 +154,25 @@ def test_cap_used_reflects_recent_audit_rows(empty_ws):
     assert second.token == first.token
 
 
+def test_paid_empty_workspace_plan_not_overwritten(empty_ws):
+    """PR 5: a paid workspace with no runs/keys must keep its plan when the
+    Try-It endpoint on-demand-seeds. seed_trial only flips `free`, and the
+    endpoint must re-fetch instead of assuming the flip happened."""
+    ws_id, db = empty_ws
+
+    db.execute(text("UPDATE workspaces SET plan = 'pro' WHERE id = :ws"), {"ws": ws_id})
+    db.commit()
+
+    out = _call(ws_id, db)
+    assert out.plan == "pro"
+    assert out.token and out.token.startswith("cond_agt_")
+
+    plan_now = db.execute(
+        text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id},
+    ).scalar()
+    assert plan_now == "pro"
+
+
 def test_active_workspace_with_integration_is_ineligible(empty_ws):
     """PR 4 B: workspace already has a vault key → refuse to seed a trial identity."""
     ws_id, db = empty_ws


### PR DESCRIPTION
Stacked on #1584. Self-review of the four merged PRs surfaced three real issues; this PR addresses them.

## 1. Dedup — cap-used query

Same `SELECT COUNT(*) FROM guard_audit_events` (24h window, workspace+identity filter) was written twice: once in \`trial_upstream.resolve_trial_key\` (proxy fence) and once in \`trial.py._cap_used_today\` (session read-out). Next change to cap logic would drift.

Promoted to \`get_trial_cap_used(db, ws, aid) -> int\` in \`trial_upstream.py\`; both call sites now use it. Added \`TRIAL_CAP_WINDOW_HOURS = 24\` constant so the window can't diverge.

## 2. Bug — plan mismatch on paid empty workspace

\`/guard/trial/session\` set \`plan = TRIAL_PLAN\` locally after \`seed_trial()\`. With PR 4's guard, \`seed_trial\` only flips when the DB plan is \`'free'\`. A \`plan='pro'\` workspace with zero runs and zero integrations (rare but real, e.g. fresh paid signup) would then get an API response of \`plan='free_trial'\` while the DB still said \`'pro'\`.

Fixed by re-reading the plan from the DB after \`seed_trial()\` instead of assuming the flip happened.

## 3. Dead import

Dropped \`TRIAL_DAYS\` from \`trial.py\` — \`days_remaining\` is computed from \`expires_at - now\`, never from the constant.

## Test

- \`test_paid_empty_workspace_plan_not_overwritten\` — pre-sets \`plan='pro'\`, calls Try-It, verifies both the response and the DB row remain \`'pro'\` and a trial identity is still minted.
- All 16 trial tests (PR 1 + PR 2 + PR 3 + PR 4 + PR 5) green together on docker Postgres.

## Not fixed here

- Test-inline duplication for inserting stub \`guard_audit_events\` rows across two tests. Deferred — extract to a shared helper when we add a third similar test.
- Race condition on the trial cap check (two concurrent requests can each read \`used < CAP\` and overshoot by a few). For a 200/day cap with $2 hard limit, overshoot is a cent of noise. Fix with a Redis counter or \`SELECT ... FOR UPDATE\` when a user actually hits the cap.