### PR TITLE
feat(#1587 Round 1): A1 ops endpoint + A3 spend alert + A4 atomic cap

### DIFF
--- a/apps/api/app/modules/guard/observability/trial_spend_alert.py
+++ b/apps/api/app/modules/guard/observability/trial_spend_alert.py
@@ -1,0 +1,157 @@
+"""Internal Slack alert on aggregate trial-key spend crossing threshold (#1587 A3).
+
+Fires from the trial-key resolver (`trial_upstream.resolve_trial_key`) when
+a trial call is served. Reuses the same webhook + rate-limit shape as the
+fail-open alerter (`fail_open_alert.py`) — one internal ops channel, one
+env var, no reinvention.
+
+Env config:
+  CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK  — reused; unset = no-op (silent).
+  GUARD_TRIAL_DAILY_ALERT_USD           — threshold; unset = no-op.
+
+Rate limit: one post per hour. Threshold is a "soft" alert — once it
+fires, don't re-fire until spend keeps rising past the last-alerted level.
+"""
+from __future__ import annotations
+
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import structlog
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME
+
+log = structlog.get_logger(__name__)
+
+_ALERT_WEBHOOK_ENV = "CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK"
+_THRESHOLD_ENV = "GUARD_TRIAL_DAILY_ALERT_USD"
+_RATE_LIMIT_SEC = 3600  # one alert per hour
+_HTTP_TIMEOUT_SEC = 3.0
+
+# In-process dedup: (posix-day,) -> (last_post_monotonic, last_spend_alerted)
+# Keyed by day so the counter resets naturally at UTC midnight.
+_dedup: dict[str, tuple[float, float]] = {}
+
+
+def _now() -> float:
+    return time.monotonic()
+
+
+def _today_key() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d")
+
+
+def _within_rate_limit() -> bool:
+    """Cheap pure-timestamp check — used to short-circuit before the SQL
+    query when we know we can't post yet."""
+    prior = _dedup.get(_today_key())
+    return prior is not None and _now() - prior[0] < _RATE_LIMIT_SEC
+
+
+def _should_post(spend_usd: float) -> tuple[bool, float]:
+    """Return (post_now, last_spend_alerted).
+
+    Post iff:
+      - never posted today, OR
+      - past the rate-limit window AND spend has grown at least 25% beyond
+        the last alerted value. Prevents re-alerting on the same $X noise
+        every hour when spend has plateaued.
+    """
+    prior = _dedup.get(_today_key())
+    if prior is None:
+        return True, 0.0
+    last_post, last_alerted = prior
+    if _now() - last_post < _RATE_LIMIT_SEC:
+        return False, last_alerted
+    if spend_usd < last_alerted * 1.25:
+        return False, last_alerted
+    return True, last_alerted
+
+
+def _record_posted(spend_usd: float) -> None:
+    _dedup[_today_key()] = (_now(), spend_usd)
+
+
+def _get_spend_today(db: Session) -> float:
+    """SUM(cost_usd_after) for trial-identity audit rows in the last 24h."""
+    cutoff = datetime.now(timezone.utc) - timedelta(hours=24)
+    return float(
+        db.execute(
+            text("""
+                SELECT COALESCE(SUM(ae.cost_usd_after), 0)
+                FROM guard_audit_events ae
+                JOIN agent_identities ai ON ai.id = ae.agent_identity_id
+                WHERE ai.name = :name AND ae.ts >= :cutoff
+            """),
+            {"name": TRIAL_IDENTITY_NAME, "cutoff": cutoff},
+        ).scalar() or 0.0
+    )
+
+
+def _build_message(*, spend_usd: float, threshold_usd: float, last_alerted: float) -> dict:
+    growth_line = (
+        f"\n*Growth since last alert:* +${spend_usd - last_alerted:.2f} "
+        f"(previous alert at ${last_alerted:.2f})"
+        if last_alerted > 0 else ""
+    )
+    return {
+        "text": (
+            f":money_with_wings: *Trial spend crossed threshold*\n"
+            f"*Today's spend:* ${spend_usd:.2f}\n"
+            f"*Alert threshold:* ${threshold_usd:.2f}"
+            f"{growth_line}\n"
+            f"See `/guard/trial/ops` for the top-10 workspaces."
+        ),
+    }
+
+
+def check_and_alert_trial_spend(db: Session) -> None:
+    """Query today's trial spend and post to the internal ops channel if
+    it exceeds the threshold. Never raises — the trial-key resolver has
+    already decided to serve the key and any exception here must not
+    defeat that decision.
+    """
+    try:
+        webhook = os.environ.get(_ALERT_WEBHOOK_ENV, "").strip()
+        threshold_raw = os.environ.get(_THRESHOLD_ENV, "").strip()
+        if not webhook or not threshold_raw:
+            return
+        try:
+            threshold = float(threshold_raw)
+        except ValueError:
+            log.warning("guard.trial.spend_alert.bad_threshold", value=threshold_raw)
+            return
+
+        # Short-circuit before the SQL query when we know we can't post.
+        # Every trial call runs `resolve_trial_key`, so this dedup gate
+        # matters for perf, not just Slack spam.
+        if _within_rate_limit():
+            return
+
+        spend = _get_spend_today(db)
+        if spend < threshold:
+            return
+
+        post_now, last_alerted = _should_post(spend)
+        if not post_now:
+            return
+
+        payload = _build_message(
+            spend_usd=spend, threshold_usd=threshold, last_alerted=last_alerted,
+        )
+        try:
+            httpx.post(webhook, json=payload, timeout=_HTTP_TIMEOUT_SEC)
+            _record_posted(spend)
+            log.info("guard.trial.spend_alert.posted", spend_usd=spend, threshold_usd=threshold)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("guard.trial.spend_alert.slack_post_failed", err=str(exc))
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.trial.spend_alert.unhandled", err=str(exc))
+
+
+def _reset_dedup_for_tests() -> None:
+    _dedup.clear()

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -12,7 +12,7 @@ identity tokens stay one-shot as before.
 """
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import structlog
 from fastapi import APIRouter, Depends
@@ -138,5 +138,93 @@ def get_trial_session(
         token=token,
         gateway_url=settings.conduct_proxy_url,
         cap_used=get_trial_cap_used(db, workspace_id, str(identity.id)),
+        cap_max=TRIAL_DAILY_CAP,
+    )
+
+
+# ── Trial ops (A1 of #1587) ───────────────────────────────────────────────────
+
+class TrialTopSpender(BaseModel):
+    workspace_id: str
+    workspace_name: str | None
+    spend_usd: float
+    cap_used: int
+
+
+class TrialOpsOut(BaseModel):
+    trial_workspaces_active_24h: int
+    workspaces_at_cap: int
+    spend_today_usd: float
+    top_10_by_spend: list[TrialTopSpender]
+    cap_max: int
+
+
+@router.get("/ops", response_model=TrialOpsOut)
+def get_trial_ops(
+    _perm: str = Depends(require_permission("guard.spend.view_all")),
+    db: Session = Depends(get_db),
+) -> TrialOpsOut:
+    """Platform-ops view of trial-key burn across all workspaces.
+
+    Restricted to `guard.spend.view_all` (security+) — this crosses tenant
+    boundaries by design. Every metric derives from `guard_audit_events`
+    joined against the trial `AgentIdentity` name filter.
+    """
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(hours=24)
+
+    active_24h = db.execute(
+        text("""
+            SELECT COUNT(DISTINCT ae.workspace_id)
+            FROM guard_audit_events ae
+            JOIN agent_identities ai ON ai.id = ae.agent_identity_id
+            WHERE ai.name = :name AND ae.ts >= :cutoff
+        """),
+        {"name": TRIAL_IDENTITY_NAME, "cutoff": cutoff},
+    ).scalar() or 0
+
+    spend_today = db.execute(
+        text("""
+            SELECT COALESCE(SUM(ae.cost_usd_after), 0)
+            FROM guard_audit_events ae
+            JOIN agent_identities ai ON ai.id = ae.agent_identity_id
+            WHERE ai.name = :name AND ae.ts >= :cutoff
+        """),
+        {"name": TRIAL_IDENTITY_NAME, "cutoff": cutoff},
+    ).scalar() or 0.0
+
+    top_rows = db.execute(
+        text("""
+            SELECT
+                ae.workspace_id,
+                w.name AS workspace_name,
+                COALESCE(SUM(ae.cost_usd_after), 0) AS spend,
+                COUNT(*) AS cap_used
+            FROM guard_audit_events ae
+            JOIN agent_identities ai ON ai.id = ae.agent_identity_id
+            JOIN workspaces w ON w.id = ae.workspace_id
+            WHERE ai.name = :name AND ae.ts >= :cutoff
+            GROUP BY ae.workspace_id, w.name
+            ORDER BY spend DESC, cap_used DESC
+            LIMIT 10
+        """),
+        {"name": TRIAL_IDENTITY_NAME, "cutoff": cutoff},
+    ).fetchall()
+
+    at_cap = sum(1 for r in top_rows if r.cap_used >= TRIAL_DAILY_CAP)
+
+    return TrialOpsOut(
+        trial_workspaces_active_24h=int(active_24h),
+        workspaces_at_cap=at_cap,
+        spend_today_usd=float(spend_today),
+        top_10_by_spend=[
+            TrialTopSpender(
+                workspace_id=str(r.workspace_id),
+                workspace_name=r.workspace_name,
+                spend_usd=float(r.spend),
+                cap_used=int(r.cap_used),
+            )
+            for r in top_rows
+        ],
         cap_max=TRIAL_DAILY_CAP,
     )

--- a/apps/api/app/modules/guard/trial_upstream.py
+++ b/apps/api/app/modules/guard/trial_upstream.py
@@ -104,4 +104,11 @@ def resolve_trial_key(
     if get_trial_cap_used(db, workspace_id, agent_identity_id) >= TRIAL_DAILY_CAP:
         return None, "exceeded"
 
+    # #1587 A3: opportunistic Slack alert on aggregate trial-key spend.
+    # Fires from here so the check piggybacks on real trial traffic instead
+    # of needing a cron. Rate-limited + threshold-gated inside the alerter;
+    # never raises (guarded by trial_spend_alert itself).
+    from app.modules.guard.observability.trial_spend_alert import check_and_alert_trial_spend
+    check_and_alert_trial_spend(db)
+
     return env_key, "active"

--- a/apps/api/app/modules/guard/trial_upstream.py
+++ b/apps/api/app/modules/guard/trial_upstream.py
@@ -27,15 +27,57 @@ import os
 from datetime import datetime, timedelta, timezone
 from typing import Literal
 
+import structlog
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
 
+log = structlog.get_logger(__name__)
+
 GUARD_TRIAL_ANTHROPIC_KEY_ENV = "GUARD_TRIAL_ANTHROPIC_KEY"
 TRIAL_DAILY_CAP = 200
 TRIAL_CAP_WINDOW_HOURS = 24
 TrialStatus = Literal["active", "expired", "exceeded", "ineligible"]
+
+
+def _redis_client():
+    """Same shape as `app.modules.guard.rate_limit._redis_client` — lazy
+    import so tests can monkeypatch and the module loads without redis."""
+    import redis as _redis
+    from app.core.config import settings as _settings
+    return _redis.from_url(_settings.redis_url, decode_responses=True)
+
+
+def try_reserve_trial_slot(workspace_id: str, agent_identity_id: str) -> bool:
+    """Atomically reserve a slot in today's trial-cap window.
+
+    Uses Redis INCR (single-command atomic) so two concurrent requests
+    can't both pass the `< CAP` check. Returns True if the request is
+    under cap after the reservation, False if the reservation put us at
+    or over cap (caller should return 'exceeded').
+
+    Fails open when Redis is unreachable: logs a warning and returns True.
+    Rate-limit convention across the codebase (see `rate_limit.py`) — a
+    Redis outage shouldn't defeat trial availability, and the per-workspace
+    `guard_spend_budgets.hard_limit_usd = $2` cap bounds abuse anyway.
+    """
+    day = datetime.now(timezone.utc).strftime("%Y%m%d")
+    key = f"guard:trial:cap:{workspace_id}:{agent_identity_id}:{day}"
+    try:
+        r = _redis_client()
+        pipe = r.pipeline()
+        pipe.incr(key, 1)
+        pipe.expire(key, TRIAL_CAP_WINDOW_HOURS * 3600)
+        count, _ = pipe.execute()
+        return int(count or 0) <= TRIAL_DAILY_CAP
+    except Exception as exc:  # noqa: BLE001
+        log.warning(
+            "guard.trial.reserve_redis_unavailable",
+            workspace_id=workspace_id,
+            err=str(exc),
+        )
+        return True
 
 
 def get_trial_cap_used(db: Session, workspace_id: str, agent_identity_id: str) -> int:
@@ -101,6 +143,15 @@ def resolve_trial_key(
     if row.expires_at is None or row.expires_at <= now:
         return None, "expired"
 
+    # #1587 A4: race-free cap check via Redis atomic INCR. Falls back to
+    # DB count (with the original race) only when Redis is unreachable.
+    if not try_reserve_trial_slot(str(workspace_id), agent_identity_id):
+        return None, "exceeded"
+    # Belt+braces: DB count catches Redis-outage windows AND deliberate
+    # Redis resets (e.g. ops flushed the bucket mid-day). `>= CAP` matches
+    # the original pre-A4 semantic so a workspace that has already
+    # completed CAP requests stays rejected even if the Redis bucket says
+    # otherwise. Cheap SUM against indexed columns.
     if get_trial_cap_used(db, workspace_id, agent_identity_id) >= TRIAL_DAILY_CAP:
         return None, "exceeded"
 

--- a/apps/api/tests/test_trial_ops_endpoint.py
+++ b/apps/api/tests/test_trial_ops_endpoint.py
@@ -1,0 +1,170 @@
+"""Trial ops endpoint self-check (epic #1587 A1)."""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.routers.trial import get_trial_ops  # noqa: E402
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial  # noqa: E402
+from app.modules.guard.trial_upstream import TRIAL_DAILY_CAP  # noqa: E402
+
+
+def _make_workspace(db, plan: str = "free_trial") -> str:
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, :plan, true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"ops-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "plan": plan, "now": now},
+    )
+    db.commit()
+    return ws_id
+
+
+def _seed_and_get_trial_id(db, ws_id: str) -> str:
+    seed_trial(db, ws_id)
+    db.commit()
+    return str(db.execute(
+        text("SELECT id FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar())
+
+
+def _insert_audit(db, ws_id: str, aid: str, cost: float, ts: datetime | None = None):
+    ts = ts or datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO guard_audit_events "
+            "(id, workspace_id, agent_identity_id, ts, source, provider, decision, ai_tool, cost_usd_after) "
+            "VALUES (gen_random_uuid(), :ws, :aid, :ts, 'proxy', 'anthropic', 'allowed', 'cli', :cost)"
+        ),
+        {"ws": ws_id, "aid": aid, "ts": ts, "cost": cost},
+    )
+
+
+@pytest.fixture()
+def workspaces():
+    """Create three trial workspaces with different burn levels; teardown wipes everything."""
+    db = SessionLocal()
+    created: list[str] = []
+    try:
+        ws1 = _make_workspace(db)
+        ws2 = _make_workspace(db)
+        ws3 = _make_workspace(db)
+        created = [ws1, ws2, ws3]
+
+        aid1 = _seed_and_get_trial_id(db, ws1)
+        aid2 = _seed_and_get_trial_id(db, ws2)
+        aid3 = _seed_and_get_trial_id(db, ws3)
+
+        # ws1 = biggest spender ($0.50 total), 5 rows
+        for _ in range(5):
+            _insert_audit(db, ws1, aid1, 0.10)
+        # ws2 = middle spender ($0.20 total), 2 rows
+        for _ in range(2):
+            _insert_audit(db, ws2, aid2, 0.10)
+        # ws3 = at cap (TRIAL_DAILY_CAP rows, tiny cost each)
+        for _ in range(TRIAL_DAILY_CAP):
+            _insert_audit(db, ws3, aid3, 0.001)
+        db.commit()
+
+        yield {"ws1": (ws1, aid1), "ws2": (ws2, aid2), "ws3": (ws3, aid3), "db": db}
+    finally:
+        db.rollback()
+        for ws in created:
+            db.execute(text("DELETE FROM integrations WHERE workspace_id = :id"), {"id": ws})
+            db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws})
+        db.commit()
+        db.close()
+
+
+def _call(db):
+    return get_trial_ops(_perm="security", db=db)
+
+
+def test_reports_active_workspaces_and_total_spend(workspaces):
+    db = workspaces["db"]
+
+    out = _call(db)
+
+    assert out.trial_workspaces_active_24h >= 3
+    # ws1=0.50 + ws2=0.20 + ws3=0.2 = ~0.90 minimum from our fixture
+    assert out.spend_today_usd >= 0.89
+    assert out.cap_max == TRIAL_DAILY_CAP
+
+
+def test_top_10_ranks_by_spend_desc(workspaces):
+    db = workspaces["db"]
+    ws1, _ = workspaces["ws1"]
+
+    out = _call(db)
+
+    assert len(out.top_10_by_spend) >= 3
+    spends = [r.spend_usd for r in out.top_10_by_spend]
+    assert spends == sorted(spends, reverse=True)
+
+    top = out.top_10_by_spend[0]
+    assert top.workspace_id == ws1
+    assert top.spend_usd >= 0.49  # ~$0.50, allow float slack
+
+
+def test_workspaces_at_cap_counted(workspaces):
+    db = workspaces["db"]
+    ws3, _ = workspaces["ws3"]
+
+    out = _call(db)
+
+    assert out.workspaces_at_cap >= 1
+
+    # ws3 landed in top 10 by cap_used (200 rows), verify its row shows at-cap
+    ws3_row = next((r for r in out.top_10_by_spend if r.workspace_id == ws3), None)
+    assert ws3_row is not None
+    assert ws3_row.cap_used == TRIAL_DAILY_CAP
+
+
+def test_stale_audit_rows_excluded_from_24h_window(workspaces):
+    db = workspaces["db"]
+    ws1, aid1 = workspaces["ws1"]
+
+    # Insert a row 48h old — must not count
+    old_ts = datetime.now(timezone.utc) - timedelta(hours=48)
+    _insert_audit(db, ws1, aid1, 99.99, ts=old_ts)
+    db.commit()
+
+    out = _call(db)
+
+    ws1_row = next(r for r in out.top_10_by_spend if r.workspace_id == ws1)
+    assert ws1_row.spend_usd < 10.0, "48h-old $99.99 row should not appear in 24h window"

--- a/apps/api/tests/test_trial_reserve_slot.py
+++ b/apps/api/tests/test_trial_reserve_slot.py
@@ -1,0 +1,99 @@
+"""Race-free trial cap reservation self-check (epic #1587 A4)."""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _redis_is_reachable() -> bool:
+    try:
+        import redis
+        from app.core.config import settings
+        r = redis.from_url(settings.redis_url, socket_connect_timeout=1)
+        r.ping()
+        return True
+    except Exception:
+        return False
+
+
+if not _redis_is_reachable():
+    pytest.skip("Redis unreachable", allow_module_level=True)
+
+
+from app.modules.guard.trial_upstream import (  # noqa: E402
+    TRIAL_DAILY_CAP,
+    _redis_client,
+    try_reserve_trial_slot,
+)
+
+
+@pytest.fixture()
+def ws_and_aid():
+    ws = str(uuid.uuid4())
+    aid = str(uuid.uuid4())
+    yield ws, aid
+    # Clean up today's cap key so a repeated test doesn't leak.
+    day = datetime.now(timezone.utc).strftime("%Y%m%d")
+    _redis_client().delete(f"guard:trial:cap:{ws}:{aid}:{day}")
+
+
+def test_first_reservation_passes(ws_and_aid):
+    ws, aid = ws_and_aid
+    assert try_reserve_trial_slot(ws, aid) is True
+
+
+def test_cap_is_atomic_at_exactly_TRIAL_DAILY_CAP(ws_and_aid):
+    """Reserve exactly TRIAL_DAILY_CAP times — all True; the next one False."""
+    ws, aid = ws_and_aid
+    for _ in range(TRIAL_DAILY_CAP):
+        assert try_reserve_trial_slot(ws, aid) is True
+    assert try_reserve_trial_slot(ws, aid) is False
+
+
+def test_falls_open_when_redis_unreachable(ws_and_aid):
+    """A Redis outage must not defeat trial availability."""
+    ws, aid = ws_and_aid
+
+    class _Boom:
+        def pipeline(self):
+            raise ConnectionError("simulated redis outage")
+
+    with patch("app.modules.guard.trial_upstream._redis_client", return_value=_Boom()):
+        # Any number of calls all pass — the fallback is fail-open.
+        assert try_reserve_trial_slot(ws, aid) is True
+        assert try_reserve_trial_slot(ws, aid) is True
+
+
+def test_separate_workspaces_do_not_share_a_bucket(ws_and_aid):
+    """One workspace hitting cap must not block another."""
+    ws1, aid1 = ws_and_aid
+    ws2, aid2 = str(uuid.uuid4()), str(uuid.uuid4())
+    try:
+        for _ in range(TRIAL_DAILY_CAP):
+            assert try_reserve_trial_slot(ws1, aid1) is True
+        assert try_reserve_trial_slot(ws1, aid1) is False
+        # Different workspace — first call still passes.
+        assert try_reserve_trial_slot(ws2, aid2) is True
+    finally:
+        day = datetime.now(timezone.utc).strftime("%Y%m%d")
+        _redis_client().delete(f"guard:trial:cap:{ws2}:{aid2}:{day}")
+
+
+def test_key_expires_after_window(ws_and_aid):
+    """The Redis key must have a TTL so buckets don't accumulate forever."""
+    ws, aid = ws_and_aid
+    try_reserve_trial_slot(ws, aid)
+    day = datetime.now(timezone.utc).strftime("%Y%m%d")
+    ttl = _redis_client().ttl(f"guard:trial:cap:{ws}:{aid}:{day}")
+    # TTL should be positive and no larger than the 24h window.
+    assert 0 < ttl <= 24 * 3600

--- a/apps/api/tests/test_trial_spend_alert.py
+++ b/apps/api/tests/test_trial_spend_alert.py
@@ -1,0 +1,154 @@
+"""Trial spend alert self-check (epic #1587 A3)."""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.observability.trial_spend_alert import (  # noqa: E402
+    _reset_dedup_for_tests,
+    check_and_alert_trial_spend,
+)
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_dedup():
+    _reset_dedup_for_tests()
+    yield
+    _reset_dedup_for_tests()
+
+
+@pytest.fixture()
+def spend_ws():
+    """Trial workspace with $5 of audit rows in the last hour."""
+    db = SessionLocal()
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, 'free', true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"spend-alert-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "now": now},
+    )
+    db.commit()
+    seed_trial(db, ws_id)
+    db.commit()
+    aid = str(db.execute(
+        text("SELECT id FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar())
+    for _ in range(5):
+        db.execute(
+            text(
+                "INSERT INTO guard_audit_events "
+                "(id, workspace_id, agent_identity_id, ts, source, provider, decision, ai_tool, cost_usd_after) "
+                "VALUES (gen_random_uuid(), :ws, :aid, :ts, 'proxy', 'anthropic', 'allowed', 'cli', 1.0)"
+            ),
+            {"ws": ws_id, "aid": aid, "ts": now},
+        )
+    db.commit()
+    try:
+        yield ws_id, db
+    finally:
+        db.rollback()
+        db.execute(text("DELETE FROM integrations WHERE workspace_id = :id"), {"id": ws_id})
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+        db.commit()
+        db.close()
+
+
+def test_noops_when_webhook_env_missing(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.delenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", raising=False)
+    monkeypatch.setenv("GUARD_TRIAL_DAILY_ALERT_USD", "2.0")
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+    mock_post.assert_not_called()
+
+
+def test_noops_when_threshold_env_missing(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.setenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", "https://hooks.slack.com/fake")
+    monkeypatch.delenv("GUARD_TRIAL_DAILY_ALERT_USD", raising=False)
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+    mock_post.assert_not_called()
+
+
+def test_noops_when_below_threshold(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.setenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", "https://hooks.slack.com/fake")
+    monkeypatch.setenv("GUARD_TRIAL_DAILY_ALERT_USD", "100.0")  # $5 in DB, threshold $100
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+    mock_post.assert_not_called()
+
+
+def test_posts_when_over_threshold(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.setenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", "https://hooks.slack.com/fake")
+    monkeypatch.setenv("GUARD_TRIAL_DAILY_ALERT_USD", "2.0")  # $5 in DB, threshold $2
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+    assert mock_post.call_count == 1
+    payload = mock_post.call_args.kwargs["json"]
+    assert "Trial spend crossed threshold" in payload["text"]
+    assert "$5.00" in payload["text"]
+
+
+def test_second_call_within_rate_limit_is_deduped(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.setenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", "https://hooks.slack.com/fake")
+    monkeypatch.setenv("GUARD_TRIAL_DAILY_ALERT_USD", "2.0")
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+        check_and_alert_trial_spend(db)
+    assert mock_post.call_count == 1
+
+
+def test_bad_threshold_env_noops(spend_ws, monkeypatch):
+    _ws, db = spend_ws
+    monkeypatch.setenv("CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK", "https://hooks.slack.com/fake")
+    monkeypatch.setenv("GUARD_TRIAL_DAILY_ALERT_USD", "not-a-number")
+
+    with patch("httpx.post") as mock_post:
+        check_and_alert_trial_spend(db)
+    mock_post.assert_not_called()


### PR DESCRIPTION
Round 1 of #1587 — close the trial cost blind spot. Three commits, three concerns, one PR.

## A1 — \`GET /guard/trial/ops\`

Aggregate cross-tenant view of trial-key burn:
- \`trial_workspaces_active_24h\`, \`workspaces_at_cap\`, \`spend_today_usd\`, \`top_10_by_spend\`, \`cap_max\`
- Auth: \`require_permission(\"guard.spend.view_all\")\` — security+ tier.
- 4 tests (active workspace count, top-10 sort, at-cap detection, 24h window enforcement).

## A3 — internal Slack alert on trial spend threshold

Reuses \`CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK\` (existing pattern from \`fail_open_alert.py\`) — no new webhook, no new pattern.
- New env: \`GUARD_TRIAL_DAILY_ALERT_USD\` (threshold). Unset = no-op.
- Fires opportunistically from \`resolve_trial_key\` on the \"active\" branch — piggybacks on real trial traffic, no cron.
- Dedup: one post per hour AT MOST, keyed by UTC day, with a 25% growth gate to avoid re-firing on plateau.
- Short-circuits before the SQL query when rate-limited so per-trial-call cost is one dict lookup.
- 6 tests.

## A4 — race-free trial cap via atomic Redis reservation

Replaces the racy \`SELECT COUNT >= CAP\` check with \`INCR + EXPIRE(24h)\` via Redis pipeline (single-command atomic). Two concurrent requests each get distinct sequential values from Redis, so at most CAP of them pass.

- Redis outage → fails open (matches codebase rate-limit convention), belt+braces DB \`>= CAP\` fallback catches the case.
- Manual Redis flush → same fallback.
- Redis key \`guard:trial:cap:{ws}:{aid}:{yyyymmdd}\` — auto-expires 24h after first INCR.
- 5 tests (skipped when Redis unreachable): first reservation, exactly-CAP passes then (CAP+1) fails, Redis outage falls open, per-workspace isolation, TTL bound.

## Test summary

- **26 trial tests total** across 6 test files, all green on docker Postgres + Redis.
- No ORM changes → drift regression check unaffected.

## Env vars after merge

- \`GUARD_TRIAL_DAILY_ALERT_USD\` — new (Round 1 wants this set). Suggest \$10-25 as a starting threshold; adjust based on early traffic.
- \`CONDUCT_INTERNAL_ALERT_SLACK_WEBHOOK\` — already exists per fail-open alerter. Reused, no change.

## Next in the epic

- Round 2: E1 — fold \`guard_rate_limits\` RPM/TPM enforcement into the proxy hot path so vault-key traffic gets the same pre-forward fence trial traffic has.
- Round 3: B/D/C (cold-user discovery, multi-provider, lifecycle handoff) when signal arrives.