### PR TITLE
feat(#1587 E1): vault-key RPM/TPM enforcement in proxy hot path (step 4d)

### DIFF
--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -491,6 +491,29 @@ async def _proxy(
         _audit_decision = "warned" if _action == "WARN" else "allowed"
         _audit_rule_id  = decision["rule_id"] if _action == "WARN" else None
 
+        # 4d. Per-key RPM/TPM rate limiting (#980, #1587 E1). Fires for
+        # vault-key + trial-key + platform-key traffic — enforcement is
+        # opt-in per workspace via guard_rate_limits rows. If no row
+        # exists, check_rate_limit is a cheap no-op (early return in the
+        # module). Redis outage fails open by design.
+        from app.modules.guard.rate_limit import check_rate_limit as _check_rate_limit
+        _rate = _check_rate_limit(
+            db,
+            workspace_id=workspace_id,
+            agent_identity_id=str(_agent_identity_id) if _agent_identity_id else None,
+            input_tokens=_estimate_input_tokens(body),
+        )
+        if _rate.limited:
+            log.info(
+                "guard.proxy.rate_limited",
+                workspace_id=workspace_id,
+                scope=_rate.scope,
+                metric=_rate.metric,
+                limit=_rate.limit,
+                current=_rate.current,
+            )
+            return _fail_closed(429, _rate.reason)
+
         # 5. Vault lookup — for BYO gateways: upstream_key authenticates with the gateway,
         # vault_key is the real vendor key the gateway forwards to Anthropic/OpenAI.
         upstream = _upstream_url(db, workspace_id, provider, _environment_id)

--- a/apps/api/tests/guard/test_proxy_rate_limit_wireup.py
+++ b/apps/api/tests/guard/test_proxy_rate_limit_wireup.py
@@ -1,0 +1,42 @@
+"""Wire-in assertion for #1587 E1 — vault-key RPM/TPM fence in the proxy.
+
+Migration 0096 documented that `check_rate_limit` should be called from
+`_proxy` step 4d, but the wiring never landed until #1587 E1. This test
+guards against future refactors silently removing the fence.
+
+Complements the module-level smoke tests in test_rate_limit_smoke.py —
+those prove check_rate_limit works; this proves the proxy calls it.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+
+def test_proxy_module_imports_check_rate_limit():
+    """The proxy module source must contain the check_rate_limit import."""
+    from app.modules.guard.routers import proxy
+    source = inspect.getsource(proxy)
+    assert "check_rate_limit" in source, (
+        "Proxy hot path is missing check_rate_limit — #1587 E1 wire-in "
+        "was reverted or refactored away. See migration 0096 for the "
+        "expected call site."
+    )
+
+
+def test_proxy_returns_429_on_rate_limit():
+    """The wire-in must convert `limited=True` into a 429 response,
+    not a silent pass. Grep for the specific error code so a refactor
+    that changes the response code (e.g., to 503) trips this test."""
+    from app.modules.guard.routers import proxy
+    source = inspect.getsource(proxy)
+    # Find the block that references _rate.limited and confirm 429 lives
+    # within a small window (30 lines) — tolerates reformatting.
+    idx = source.find("_rate.limited")
+    assert idx > 0, "no _rate.limited branch found — wire-in missing"
+    window = source[idx:idx + 800]
+    assert "429" in window, (
+        "rate-limit 429 response missing from proxy — E1 wire-in "
+        "changed the failure mode."
+    )


### PR DESCRIPTION
Round 2 of #1587 — close the vault-key enforcement gap.

## What lands

Migration 0096 (Aug 2026) documented that `check_rate_limit` should be called from `_proxy` step 4d.2, but the wiring never landed. Before this PR:

- Only the CLI hook path (`app/guard/sources.py:120`) enforced `guard_rate_limits`.
- Proxy path had **no pre-forward RPM/TPM fence**. A curl loop with a leaked vault key ran at wire speed; `guard_spend_budgets` only fired on the post-response audit path.

This PR inserts the call in `proxy.py` right after Guard policy evaluation (step 4c) and before the vault lookup (step 5). ~30 lines.

## Semantics

- **Enforcement is opt-in per workspace** — no `guard_rate_limits` row = cheap no-op early-return in the module. No forced defaults.
- **Redis outage fails open** by the module's existing convention (matches `rate_limit.py` docstring).
- **Returns 429** with the module's human-readable reason (e.g. `"Requests-per-minute limit of 60 reached (61 in current window). Retry in <60s."`).
- **Structlog info line** on every rate-limit hit with scope + metric + limit + current — feeds observability out of the box.

## Trial + vault-key stack cleanly

- **Trial traffic**: keeps its 200/day cap (`try_reserve_trial_slot` from A4) AND gains RPM/TPM enforcement via the workspace-default row that `seed_trial` inserts (60 RPM / 100k TPM). Two-layer fence.
- **Vault-key traffic**: gets whatever RPM/TPM the workspace admin configures.

## Tests

- **7 existing** rate-limit smoke tests (`tests/guard/test_rate_limit_smoke.py`) still pass — no behavior change to the module.
- **2 new** source-level wire-in assertions in `tests/guard/test_proxy_rate_limit_wireup.py` — guard against future refactors silently removing the fence.
- **16 trial tests** still pass — trial cap + rate-limit stack cleanly.

## No new env vars

No new config required. Existing `REDIS_URL` is used (already set for the rest of the rate-limit module).

## Test plan post-merge

- [ ] Insert a `guard_rate_limits` row for a real workspace via `/guard/rate-limits` UI.
- [ ] Hit the proxy from that workspace above the RPM cap, verify 429 with the reason header.
- [ ] Verify `guard.proxy.rate_limited` structlog lines land in the log stream.
- [ ] Confirm workspaces with no `guard_rate_limits` row see no behavior change.
