### PR TITLE
chore(web): W4 polish — root docs, blog rename, /lens URL, docs Lens stub (v2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Releases page.
 - Discovery mode — read-only, promote observed rules into enforcement.
 
 ### 2026-06 · Compliance packs + policy engine
-- 20+ compliance packs shipped (OWASP, SOC 2, HIPAA, PCI, EU AI Act).
+- 15 compliance packs shipped (OWASP, SOC 2, HIPAA, PCI, EU AI Act).
 - Persona-aware rules with `signed_config` verification on every check.
 - Guard Verify v2 — adversarial battery + `conduct verify` CLI.
 
@@ -37,8 +37,7 @@ Releases page.
 - Canvas UI, playbook DSL, YAML loader, workspace-scoped audit.
 - MCP OAuth on Claude.ai — Guard endpoint at
   `https://api.conductai.ai/guard/mcp`.
-- 22 pre-built playbooks covering GitHub, Slack, CI/CD, and incident
-  response workflows.
+- 39 playbooks covering GitHub, Slack, CI/CD, and incident response workflows.
 
 ## Version tag conventions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## About
 **Owner:** Sudhi
-**Purpose:** Building Conduct — a YAML playbook platform that turns AI agents into reusable team automations, with a FastAPI backend, Next.js canvas UI, Redis worker, and 22 pre-built playbooks covering GitHub, Slack, CI/CD, and incident response workflows.
+**Purpose:** Building Conduct — a YAML playbook platform that turns AI agents into reusable team automations, with a FastAPI backend, Next.js canvas UI, Redis worker, and 39 playbooks covering GitHub, Slack, CI/CD, and incident response workflows.
 
 ## Agent Work — Always-On Watchdog
 When working on playbooks (`apps/api/playbooks/`), brain block prompts, turn budgets, or block chaining: activate `/agent-builder` skill. It enforces the review checklist for every agent capability change:

--- a/NORTHSTAR_GOVERNANCE.md
+++ b/NORTHSTAR_GOVERNANCE.md
@@ -273,7 +273,7 @@ Forcing question, asked every Monday:
 
 ### What clones in a weekend
 
-Everything visible in a demo. All dashboard pages (`/governance`, `/guard`, `/secure`, `/spend`), canvas editor, YAML playbook format, the 22 playbooks, brain block prompts, framework matrix, KPI cards, narrative strip, RBAC tables, MCP surface, CLI.
+Everything visible in a demo. All dashboard pages (`/governance`, `/guard`, `/secure`, `/spend`), canvas editor, YAML playbook format, the 39 playbooks, brain block prompts, framework matrix, KPI cards, narrative strip, RBAC tables, MCP surface, CLI.
 
 If it lives on a screen or in a YAML file in the repo, it clones.
 

--- a/UNIFIED_RULE_SPEC.md.bak
+++ b/UNIFIED_RULE_SPEC.md.bak
@@ -316,7 +316,7 @@ preserved contract, only once the facade has proven the model.
 - Three activity pages → one feed view, filtered by lens.
 
 No behaviour is removed. The executor, the queue, the webhook triggers, the CLI
-gate, and all 22 playbooks are untouched.
+gate, and all 39 playbooks are untouched.
 
 ---
 

--- a/apps/web/public/conduct-pages/conduct-landing.html
+++ b/apps/web/public/conduct-pages/conduct-landing.html
@@ -478,7 +478,7 @@ footer { border-top: 1px solid var(--stone-200); padding: 36px 0; }
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="5" r="2"/><circle cx="5" cy="19" r="2"/><circle cx="19" cy="7" r="2"/><path d="M7 5h5a2 2 0 0 1 2 2v3"/><path d="M5 7v10"/></svg>
         </div>
         <h3>Agent Workflows</h3>
-        <p>Stop doing the same work around every PR. 22 pre-built playbooks handle issue triage, code review, incident response, and release notes — with human approval before anything ships. Every agent gets an A–F scorecard and DORA-lite metrics so you know what's actually delivering value.</p>
+        <p>Stop doing the same work around every PR. 39 playbooks handle issue triage, code review, incident response, and release notes — with human approval before anything ships. Every agent gets an A–F scorecard and DORA-lite metrics so you know what's actually delivering value.</p>
         <a href="/marketplace" class="pillar-link">Browse Marketplace →</a>
       </div>
       <div class="pillar guard">

--- a/apps/web/src/app/(marketing)/blog/autonomous-agents-need-an-autonomous-guard/page.tsx
+++ b/apps/web/src/app/(marketing)/blog/autonomous-agents-need-an-autonomous-guard/page.tsx
@@ -12,7 +12,7 @@ export default function BlogPost() {
       <div className="mb-10">
         <div className="flex items-center gap-3 mb-6">
           <span className="text-xs font-semibold text-indigo-700 bg-indigo-50 border border-indigo-200 px-2.5 py-1 rounded-full uppercase tracking-widest">
-            Autonomy
+            Context/Runtime Decisions
           </span>
           <span className="text-xs text-stone-400">August 23, 2026</span>
         </div>

--- a/apps/web/src/app/(marketing)/blog/page.tsx
+++ b/apps/web/src/app/(marketing)/blog/page.tsx
@@ -29,7 +29,7 @@ export default function BlogIndex() {
       title: "Autonomous agents need an autonomous guard.",
       excerpt: "A self-driving network agent detects a BGP flap across two fabrics and proposes a fix. Before that change reaches production, ConductGuard intercepts it, asks a human, records the decision. 90-second demo.",
       date: "August 23, 2026",
-      tag: "Autonomy",
+      tag: "Context/Runtime Decisions",
       tagColor: "text-indigo-700 bg-indigo-50 border-indigo-200",
     },
     {

--- a/apps/web/src/app/(marketing)/docs/lens/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/lens/page.tsx
@@ -1,0 +1,72 @@
+export const metadata = {
+  title: "Lens — Docs | Conduct",
+  description: "Lens is the conversational chat surface built into the Conduct app for querying Guard status, playbooks, and evidence.",
+}
+
+export default function LensDocsPage() {
+  return (
+    <div className="max-w-2xl mx-auto px-6 py-16 w-full">
+      <div className="mb-2">
+        <a href="/docs" className="text-sm text-stone-400 hover:text-stone-600 transition-colors">
+          Docs
+        </a>
+        <span className="text-sm text-stone-300 mx-2">/</span>
+        <span className="text-sm text-stone-600">Lens</span>
+      </div>
+
+      <h1 className="text-3xl font-bold text-stone-900 mt-6 mb-2">Lens</h1>
+      <p className="text-stone-500 mb-10 leading-relaxed">
+        Lens is the conversational interface built into the Conduct app. It is not a standalone product or a separate chat service — it is the in-app surface for querying Guard activity, playbook state, and evidence records.
+      </p>
+
+      <nav className="mb-10 border border-stone-200 rounded-xl px-5 py-4">
+        <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-3">On this page</p>
+        <ol className="flex flex-col gap-1.5 text-sm text-stone-600">
+          <li><a href="#overview" className="hover:text-indigo-600 transition-colors">Overview</a></li>
+          <li><a href="#tool-inventory" className="hover:text-indigo-600 transition-colors">Tool inventory</a></li>
+          <li><a href="#access" className="hover:text-indigo-600 transition-colors">Accessing Lens</a></li>
+        </ol>
+      </nav>
+
+      <section id="overview" className="mb-10">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Overview</h2>
+        <p className="text-stone-600 leading-relaxed">
+          Lens lives inside the Conduct workspace. Developers and security teams use it to ask questions about live Guard state, run lookups across the audit trail, inspect playbook runs, and surface spend data — all without leaving the app. Responses are grounded in workspace data, not trained knowledge.
+        </p>
+      </section>
+
+      <section id="tool-inventory" className="mb-10">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Tool inventory</h2>
+        <p className="text-stone-600 leading-relaxed mb-4">
+          Lens is backed by a registry of workspace-scoped tools. Each tool resolves live data from the API rather than from the language model&apos;s weights. The current registry covers:
+        </p>
+        <ul className="flex flex-col gap-2 text-sm text-stone-600 list-disc pl-5">
+          <li>Guard status and recent activity (blocks, warnings, approvals)</li>
+          <li>Playbook run history and block-level event log</li>
+          <li>Evidence records and hash-chain verification</li>
+          <li>Spend and token usage by agent and workspace</li>
+          <li>Credential and environment status</li>
+        </ul>
+        <p className="text-stone-400 text-sm mt-4">Full tool schema reference: see the source registry at <code className="bg-stone-100 px-1 rounded text-xs">apps/api/app/modules/lens/</code>.</p>
+      </section>
+
+      <section id="access" className="mb-10">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Accessing Lens</h2>
+        <p className="text-stone-600 leading-relaxed">
+          Lens is available to all workspace members with at least viewer role. Open the Conduct app and select <strong>Lens</strong> from the left-hand navigation. There is no separate login or API key — Lens inherits your workspace session.
+        </p>
+      </section>
+
+      <div className="border-t border-stone-100 pt-6 mt-6">
+        <a
+          href="https://github.com/sseshachala/conductai/tree/main/apps/api/app/modules/lens"
+          className="text-sm text-indigo-600 hover:text-indigo-800 transition-colors font-medium"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View Lens source on GitHub
+        </a>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -171,6 +171,7 @@ function MarketingFooter() {
       links: [
         ["Docs", "/docs"],
         ["CLI", "/tools/conduct-cli"],
+        ["Lens", "/docs/lens"],
         ["Open Source", "/open-source"],
         ["GitHub", "https://github.com/sseshachala/conductai"],
       ] as [string, string][],

--- a/apps/web/src/app/(marketing)/lens/page.tsx
+++ b/apps/web/src/app/(marketing)/lens/page.tsx
@@ -1,0 +1,26 @@
+export const metadata = {
+  title: "Lens | Conduct",
+  description: "Lens is the conversational interface built into the Conduct app.",
+}
+
+export default function LensHoldingPage() {
+  return (
+    <div className="min-h-[60vh] flex flex-col items-center justify-center px-6 text-center">
+      <h1 className="text-2xl font-bold text-stone-900 mb-3">Lens</h1>
+      <p className="text-stone-500 max-w-sm leading-relaxed mb-6">
+        Lens is our chat surface for the app. It is not a standalone product.
+        Docs live at{" "}
+        <a href="/docs/lens" className="text-indigo-600 underline underline-offset-2 hover:text-indigo-800">
+          /docs/lens
+        </a>
+        .
+      </p>
+      <a
+        href="/docs/lens"
+        className="text-sm font-semibold text-indigo-600 hover:text-indigo-800 transition-colors"
+      >
+        Go to Lens docs
+      </a>
+    </div>
+  )
+}

--- a/conduct-architecture-braindump.html
+++ b/conduct-architecture-braindump.html
@@ -343,7 +343,7 @@
         <tbody>
           <tr><td><strong>Guard</strong></td><td>Intercepts every AI tool call. Enforces team policies (block rm -rf, require approval for prod deploys, redact secrets). Captures session telemetry.</td><td>Security leads, CTOs, compliance teams</td></tr>
           <tr><td><strong>Agent Booster</strong></td><td>Semantic codebase routing. Returns only the relevant symbols for a task — not the whole file. 5–15× token cost reduction.</td><td>Developers paying per token</td></tr>
-          <tr><td><strong>Conduct Runtime</strong></td><td>YAML playbook automation. 22 pre-built workflows covering GitHub, Slack, CI/CD, incident response. Chain AI brain blocks + tool calls + bash in a visual canvas.</td><td>Engineering leads automating repetitive AI work</td></tr>
+          <tr><td><strong>Conduct Runtime</strong></td><td>YAML playbook automation. 39 playbooks covering GitHub, Slack, CI/CD, incident response. Chain AI brain blocks + tool calls + bash in a visual canvas.</td><td>Engineering leads automating repetitive AI work</td></tr>
         </tbody>
       </table>
     </div>


### PR DESCRIPTION
Replaces #1590. Rebased onto latest `main` after #1586 (facelift P1) merged. Same content, clean history, no force-push needed.

## What ships
- Root docs count sweep (39 playbooks / 15 packs) across CHANGELOG, CLAUDE.md, NORTHSTAR_GOVERNANCE, UNIFIED_RULE_SPEC.md.bak, conduct-architecture-braindump.html, conduct-landing.html
- Blog category rename: `Autonomy` → `Context/Runtime Decisions`
- `/lens` reserved as docs-only holding page (per positioning §16.5 Rule 3)
- Developers → Docs → Lens stub + footer nav link

## 4 commits
- 4c636c7a chore(docs): sweep truth counts in root docs
- 1c4e683c chore(web): rename Autonomy blog category to Context/Runtime Decisions
- e5006429 feat(web): reserve /lens as docs-only holding page
- 1075fcfc feat(web): add Developers → Lens docs stub and footer nav link

Closes #1590.