### PR TITLE
refactor(web): wire homepage to facelift components + mobile pass (v2)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,12 +1,11 @@
 "use client"
 
-import { CtaLink } from "@/components/marketing/CtaLink"
+import { useState } from "react"
 import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 import { AgentSurfaceStrip } from "@/components/marketing/facelift/AgentSurfaceStrip"
 import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
 import { RuntimeFlow } from "@/components/marketing/facelift/RuntimeFlow"
-import { CapabilityStatus, type CapabilityItem } from "@/components/marketing/facelift/CapabilityStatus"
-import { PlaybookTile } from "@/components/marketing/facelift/PlaybookTile"
+import { CapabilityStatus, type CapabilityItem, type CapStatus } from "@/components/marketing/facelift/CapabilityStatus"
 
 export default function HomePage() {
   return (
@@ -33,19 +32,24 @@ export default function HomePage() {
 /* ─── Nav ─────────────────────────────────────────────────────────────── */
 
 function Nav() {
+  const [mobileOpen, setMobileOpen] = useState(false)
+
   return (
     <header className="sticky top-0 bg-white/95 backdrop-blur-sm z-50 border-b border-stone-100">
-      <div className="px-6 py-4 flex items-center justify-between max-w-6xl mx-auto w-full">
+      <div className="px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between max-w-6xl mx-auto w-full">
         <a href="/">
-          <img src="/logo.png" alt="Conduct AI" className="h-10 w-auto" />
+          <img src="/logo.png" alt="Conduct AI" className="h-8 sm:h-10 w-auto" />
         </a>
+
+        {/* Desktop nav */}
         <nav className="hidden md:flex items-center gap-6">
           <ProductDropdown />
           <SolutionsDropdown />
           <DevelopersDropdown />
           <a href="/blog" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Blog</a>
         </nav>
-        <div className="flex items-center gap-3">
+
+        <div className="flex items-center gap-2 sm:gap-3">
           <a href="/sign-in" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors hidden sm:block">
             Sign in
           </a>
@@ -54,13 +58,99 @@ function Nav() {
           </a>
           <a
             href="/discovery"
-            className="rounded-lg bg-stone-900 text-white px-4 py-2 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            className="rounded-lg bg-stone-900 text-white px-3 sm:px-4 py-2 text-sm font-semibold hover:bg-stone-700 transition-colors min-h-[44px] flex items-center"
           >
             Start Discovery
           </a>
+          {/* Hamburger */}
+          <button
+            className="md:hidden p-2 rounded-lg text-stone-600 hover:bg-stone-100 transition-colors min-h-[44px] min-w-[44px] flex items-center justify-center"
+            aria-label="Open navigation menu"
+            aria-expanded={mobileOpen}
+            onClick={() => setMobileOpen(!mobileOpen)}
+          >
+            {mobileOpen ? (
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M4.293 4.293a1 1 0 011.414 0L10 8.586l4.293-4.293a1 1 0 111.414 1.414L11.414 10l4.293 4.293a1 1 0 01-1.414 1.414L10 11.414l-4.293 4.293a1 1 0 01-1.414-1.414L8.586 10 4.293 5.707a1 1 0 010-1.414z" />
+              </svg>
+            ) : (
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor">
+                <path d="M3 5h14a1 1 0 110 2H3a1 1 0 010-2zm0 4h14a1 1 0 110 2H3a1 1 0 010-2zm0 4h14a1 1 0 110 2H3a1 1 0 010-2z" />
+              </svg>
+            )}
+          </button>
         </div>
       </div>
+
+      {/* Mobile drawer */}
+      {mobileOpen && (
+        <div className="md:hidden border-t border-stone-100 bg-white px-4 pb-4">
+          <div className="pt-3 space-y-1">
+            <MobileNavGroup label="Product">
+              <MobileNavItem href="/guard" label="Guard" />
+              <MobileNavItem href="/playbooks" label="Playbooks" />
+              <MobileNavItem href="/evidence" label="Evidence" />
+              <MobileNavItem href="/mcp-gateway" label="MCP" />
+            </MobileNavGroup>
+            <MobileNavGroup label="Solutions">
+              <MobileNavItem href="/solutions/engineering-leaders" label="Engineering Agents" />
+              <MobileNavItem href="/solutions/security-compliance" label="Security Teams" />
+              <MobileNavItem href="/solutions/action-governance" label="Business Actions" />
+            </MobileNavGroup>
+            <MobileNavGroup label="Developers">
+              <MobileNavItem href="/docs" label="Docs" />
+              <MobileNavItem href="/tools/conduct-cli" label="CLI" />
+              <MobileNavItem href="/docs/lens" label="Lens" />
+              <MobileNavItem href="/open-source" label="Open Source" />
+              <MobileNavItem href="https://github.com/sseshachala/conductai" label="GitHub" />
+            </MobileNavGroup>
+            <div className="pt-3 border-t border-stone-100 flex flex-col gap-2">
+              <a href="/sign-in" className="text-sm font-medium text-stone-600 py-2 hover:text-stone-900">Sign in</a>
+              <a href="/book-demo" className="text-sm font-medium text-stone-600 py-2 hover:text-stone-900">Book a Demo</a>
+            </div>
+          </div>
+        </div>
+      )}
     </header>
+  )
+}
+
+function MobileNavGroup({ label, children }: { label: string; children: React.ReactNode }) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div>
+      <button
+        onClick={() => setOpen(!open)}
+        className="w-full flex items-center justify-between py-2.5 text-sm font-semibold text-stone-700 min-h-[44px]"
+      >
+        {label}
+        <svg
+          width="14"
+          height="14"
+          viewBox="0 0 14 14"
+          fill="currentColor"
+          className={`opacity-40 transition-transform ${open ? "rotate-180" : ""}`}
+        >
+          <path d="M2 4l5 5 5-5" />
+        </svg>
+      </button>
+      {open && (
+        <div className="pl-3 pb-2 space-y-1">
+          {children}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function MobileNavItem({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      className="block py-2 text-sm text-stone-500 hover:text-stone-900 transition-colors min-h-[44px] flex items-center"
+    >
+      {label}
+    </a>
   )
 }
 
@@ -151,22 +241,22 @@ function NavItem({ href, title, desc }: { href: string; title: string; desc: str
 
 function HeroSection() {
   return (
-    <section className="max-w-6xl mx-auto px-6 pt-20 pb-16">
-      <div className="grid lg:grid-cols-2 gap-12 items-center">
+    <section className="max-w-6xl mx-auto px-4 sm:px-6 pt-12 sm:pt-20 pb-12 sm:pb-16">
+      <div className="grid lg:grid-cols-2 gap-10 lg:gap-12 items-center">
         {/* Left: copy */}
         <div>
-          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-6">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-5 sm:mb-6">
             ConductGuard
           </p>
-          <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-5 sm:mb-6">
             One policy across your AI agent stack.
           </h1>
-          <p className="text-lg text-stone-500 leading-relaxed mb-8 max-w-xl">
+          <p className="text-base sm:text-lg text-stone-500 leading-relaxed mb-7 sm:mb-8 max-w-xl">
             Conduct Guard enforces runtime policy across supported AI agents, model gateways, and MCP tools — before consequential actions execute.
           </p>
 
           {/* Verbs */}
-          <div className="flex items-center gap-3 mb-10 font-mono text-sm font-bold">
+          <div className="flex items-center gap-2 sm:gap-3 mb-8 sm:mb-10 font-mono text-sm font-bold flex-wrap">
             <span className="text-emerald-600">Allow.</span>
             <span className="text-amber-500">Approve.</span>
             <span className="text-red-600">Block.</span>
@@ -174,30 +264,30 @@ function HeroSection() {
           </div>
 
           {/* CTAs */}
-          <div className="flex flex-col sm:flex-row items-start gap-3 mb-4">
+          <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3 mb-4">
             <a
               href="/discovery"
-              className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors"
+              className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors text-center min-h-[48px] flex items-center justify-center"
             >
               Start Discovery — 14 days free
             </a>
             <a
               href="/book-demo"
-              className="rounded-xl border border-stone-200 text-stone-700 px-7 py-3.5 text-base font-semibold hover:bg-stone-50 transition-colors"
+              className="rounded-xl border border-stone-200 text-stone-700 px-7 py-3.5 text-base font-semibold hover:bg-stone-50 transition-colors text-center min-h-[48px] flex items-center justify-center"
             >
               Book a Demo
             </a>
           </div>
           <a
             href="/open-source"
-            className="text-sm text-stone-400 hover:text-stone-700 transition-colors underline underline-offset-2"
+            className="text-sm text-stone-400 hover:text-stone-700 transition-colors underline underline-offset-2 inline-block py-1"
           >
             View the open-source runtime →
           </a>
         </div>
 
-        {/* Right: Decision card */}
-        <div className="flex flex-col gap-4">
+        {/* Right: Decision card — stacks below copy on mobile */}
+        <div className="flex flex-col gap-4 mt-2 lg:mt-0">
           <DecisionCard
             agent="claude-code / deploy-agent"
             action="deploy_production"
@@ -232,18 +322,18 @@ function ProblemSection() {
   ]
 
   return (
-    <section className="border-t border-stone-100 bg-stone-50 py-20 px-6">
+    <section className="border-t border-stone-100 bg-stone-50 py-12 sm:py-20 px-4 sm:px-6">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Five agent tools shouldn&apos;t require five policy models.
         </h2>
-        <p className="text-stone-500 mb-12 max-w-2xl">
+        <p className="text-stone-500 mb-10 sm:mb-12 max-w-2xl text-sm sm:text-base">
           Every new agent surface creates a new enforcement gap. The problem compounds every time a new tool lands in your stack.
         </p>
-        <div className="grid sm:grid-cols-3 gap-8">
+        <div className="grid sm:grid-cols-3 gap-6 sm:gap-8">
           {cols.map((col) => (
             <div key={col.title}>
-              <p className="font-semibold text-stone-900 mb-2">{col.title}</p>
+              <p className="font-semibold text-stone-900 mb-2 text-sm sm:text-base">{col.title}</p>
               <p className="text-sm text-stone-500 leading-relaxed">{col.body}</p>
             </div>
           ))}
@@ -284,15 +374,15 @@ function CoreLoopSection() {
   ]
 
   return (
-    <section className="py-20 px-6 border-t border-stone-100">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Allow. Approve. Block. Prove.
         </h2>
-        <p className="text-stone-500 mb-12 max-w-2xl">
+        <p className="text-stone-500 mb-10 sm:mb-12 max-w-2xl text-sm sm:text-base">
           Four outcomes. Every agent action gets one. Runtime, not retrospective.
         </p>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5 sm:gap-6">
           {verbs.map((v) => (
             <div key={v.word} className="flex flex-col gap-3">
               {v.decision ? (
@@ -369,15 +459,15 @@ function ConsequentialActionsSection() {
   ]
 
   return (
-    <section className="py-20 px-6 border-t border-stone-100 bg-stone-50">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100 bg-stone-50">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Control the action before it becomes an outcome.
         </h2>
-        <p className="text-stone-500 mb-12 max-w-2xl">
+        <p className="text-stone-500 mb-10 sm:mb-12 max-w-2xl text-sm sm:text-base">
           Guard intercepts at the point of intent — not after a refund processes, a deploy lands, or a secret is read.
         </p>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
           {cards.map((card) => (
             <DecisionCard key={card.action} {...card} compact />
           ))}
@@ -391,32 +481,32 @@ function ConsequentialActionsSection() {
 
 function OnePolicySection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100">
       <div className="max-w-5xl mx-auto">
-        <div className="grid lg:grid-cols-2 gap-12 items-start">
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-12 items-start">
           <div>
-            <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
               Write the rule once. Apply it where agents work.
             </h2>
-            <p className="text-stone-500 leading-relaxed mb-6">
+            <p className="text-stone-500 leading-relaxed mb-6 text-sm sm:text-base">
               One policy definition — one set of rules for which actions require approval, which are blocked, and which are audited. Guard applies it across your entire agent fleet: CLI hooks, HTTP proxy, and MCP layer.
             </p>
             <ul className="space-y-3 text-sm text-stone-600">
               <li className="flex items-start gap-2">
-                <span className="text-emerald-600 font-bold mt-0.5">→</span>
+                <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
                 <span>3 enforcement surfaces: CLI hook, HTTP proxy, MCP layer</span>
               </li>
               <li className="flex items-start gap-2">
-                <span className="text-emerald-600 font-bold mt-0.5">→</span>
+                <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
                 <span>6 BYO gateway adapters: Azure, OpenRouter, Portkey, Helicone, LiteLLM (Preview), ConductAI</span>
               </li>
               <li className="flex items-start gap-2">
-                <span className="text-emerald-600 font-bold mt-0.5">→</span>
+                <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
                 <span>39 pre-built playbooks with Guard enforcement built in</span>
               </li>
             </ul>
           </div>
-          <div>
+          <div className="mt-2 lg:mt-0">
             <AgentSurfaceStrip />
           </div>
         </div>
@@ -429,17 +519,17 @@ function OnePolicySection() {
 
 function NativeControlsSection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100 bg-stone-50">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100 bg-stone-50">
       <div className="max-w-5xl mx-auto">
-        <div className="grid lg:grid-cols-2 gap-12 items-center">
-          <div>
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-12 items-center">
+          <div className="order-2 lg:order-1">
             <RuntimeFlow variant="compact" />
           </div>
-          <div>
-            <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+          <div className="order-1 lg:order-2">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
               Keep the controls you already have.
             </h2>
-            <p className="text-stone-500 leading-relaxed mb-6">
+            <p className="text-stone-500 leading-relaxed mb-6 text-sm sm:text-base">
               Guard sits in front of your existing model gateways. Point to your Azure endpoint, your OpenRouter key, your LiteLLM proxy — Guard intercepts and enforces without replacing the stack underneath.
             </p>
             <div className="space-y-3 text-sm text-stone-600">
@@ -467,14 +557,14 @@ function NativeControlsSection() {
 
 function EvidenceSection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100">
       <div className="max-w-5xl mx-auto">
-        <div className="grid lg:grid-cols-2 gap-12 items-start">
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-12 items-start">
           <div>
-            <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
               Know exactly what happened — and why.
             </h2>
-            <p className="text-stone-500 leading-relaxed mb-6">
+            <p className="text-stone-500 leading-relaxed mb-6 text-sm sm:text-base">
               Every Guard decision is recorded with agent, action, resource, matched rule, reason, user, and timestamp — in a SHA-256 hash-chained audit trail. Altered entries break the chain. Export-ready for SOC 2, HIPAA, and PCI DSS.
             </p>
             <ul className="space-y-2 text-sm text-stone-600">
@@ -491,7 +581,7 @@ function EvidenceSection() {
               ))}
             </ul>
           </div>
-          <div className="flex justify-center lg:justify-end">
+          <div className="flex justify-start lg:justify-end mt-2 lg:mt-0">
             <EvidenceReceipt />
           </div>
         </div>
@@ -518,21 +608,21 @@ const HONEST_CAPABILITIES: CapabilityItem[] = [
 
 function HonestSecuritySection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100 bg-stone-50">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100 bg-stone-50">
       <div className="max-w-5xl mx-auto">
-        <div className="grid lg:grid-cols-2 gap-12">
+        <div className="grid lg:grid-cols-2 gap-10 lg:gap-12">
           <div>
-            <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
               We publish where Guard stops.
             </h2>
-            <p className="text-stone-500 leading-relaxed mb-4">
+            <p className="text-stone-500 leading-relaxed mb-4 text-sm sm:text-base">
               Every capability on this list maps to code in the repo. SHIPPED means it is in production. PREVIEW means it is working but not GA. PLANNED means it is on the roadmap, not in the codebase.
             </p>
             <p className="text-sm text-stone-400">
               Last audit: 2026-09-01 · Source: automated codebase scan
             </p>
           </div>
-          <div>
+          <div className="mt-2 lg:mt-0">
             <CapabilityStatus items={HONEST_CAPABILITIES} showLegend />
           </div>
         </div>
@@ -572,15 +662,17 @@ const OSS_COMPONENTS = [
 
 function OpenSourceSection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Open where trust matters.
         </h2>
-        <p className="text-stone-500 mb-10 max-w-2xl">
+        <p className="text-stone-500 mb-8 sm:mb-10 max-w-2xl text-sm sm:text-base">
           The enforcement engine, CLI, compiler, and developer tools are Apache-2.0. You can read, audit, fork, and self-host them. The hosted product adds workspace management, multi-user access, and the managed SaaS layer.
         </p>
-        <div className="border border-stone-200 rounded-xl overflow-hidden bg-white">
+
+        {/* Desktop table */}
+        <div className="hidden sm:block border border-stone-200 rounded-xl overflow-hidden bg-white">
           <div className="grid grid-cols-4 text-[10px] font-mono font-bold uppercase tracking-widest text-stone-400 px-5 py-3 border-b border-stone-100 bg-stone-50">
             <span>Component</span>
             <span>Licence</span>
@@ -601,6 +693,21 @@ function OpenSourceSection() {
             </div>
           ))}
         </div>
+
+        {/* Mobile card stack */}
+        <div className="sm:hidden space-y-3">
+          {OSS_COMPONENTS.map((c) => (
+            <div key={c.name} className="border border-stone-200 rounded-xl p-4 bg-white">
+              <div className="flex items-start justify-between gap-2 mb-2">
+                <span className="font-semibold text-stone-900 font-mono text-sm">{c.name}</span>
+                <span className="text-emerald-700 text-xs font-mono shrink-0">{c.license}</span>
+              </div>
+              <p className="text-xs text-stone-400 font-mono mb-1">{c.repo}</p>
+              <p className="text-xs text-stone-500">{c.purpose}</p>
+            </div>
+          ))}
+        </div>
+
         <p className="mt-4 text-xs text-stone-400">
           Apache-2.0 includes an explicit patent grant.{" "}
           <a href="https://github.com/sseshachala/conductai" className="underline hover:text-stone-700 transition-colors">
@@ -614,7 +721,12 @@ function OpenSourceSection() {
 
 /* ─── 10. Deployment ──────────────────────────────────────────────────── */
 
-const DEPLOYMENT_OPTIONS = [
+const DEPLOYMENT_OPTIONS: Array<{
+  label: string
+  status: CapStatus
+  desc: string
+  cta: { text: string; href: string } | null
+}> = [
   {
     label: "SaaS",
     status: "SHIPPED",
@@ -641,47 +753,49 @@ const DEPLOYMENT_OPTIONS = [
   },
 ]
 
-type DeployStatus = "SHIPPED" | "PREVIEW" | "PLANNED"
-
-const DEPLOY_STYLE: Record<DeployStatus, { badge: string; border: string }> = {
-  SHIPPED: { badge: "bg-emerald-50 text-emerald-700 border-emerald-200", border: "border-stone-200" },
-  PREVIEW: { badge: "bg-amber-50 text-amber-700 border-amber-200", border: "border-amber-200" },
-  PLANNED: { badge: "bg-stone-50 text-stone-500 border-stone-200", border: "border-stone-200" },
+const DEPLOY_BORDER: Record<CapStatus, string> = {
+  SHIPPED: "border-stone-200",
+  PREVIEW: "border-amber-200",
+  PLANNED: "border-stone-200",
 }
 
 function DeploymentSection() {
   return (
-    <section className="py-20 px-6 border-t border-stone-100 bg-stone-50">
+    <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100 bg-stone-50">
       <div className="max-w-5xl mx-auto">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Deploy Guard where your controls need to live.
         </h2>
-        <p className="text-stone-500 mb-12 max-w-2xl">
+        <p className="text-stone-500 mb-10 sm:mb-12 max-w-2xl text-sm sm:text-base">
           Start on SaaS in minutes. Move to self-hosted Docker when you need data residency. Kubernetes templates are in preview.
         </p>
-        <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
-          {DEPLOYMENT_OPTIONS.map((opt) => {
-            const s = DEPLOY_STYLE[opt.status as DeployStatus]
-            return (
-              <div key={opt.label} className={`border ${s.border} rounded-xl p-5 bg-white flex flex-col gap-3`}>
-                <div className="flex items-center justify-between">
-                  <p className="font-bold text-stone-900">{opt.label}</p>
-                  <span className={`text-[10px] font-mono font-bold uppercase tracking-wider border rounded px-1.5 py-0.5 ${s.badge}`}>
-                    {opt.status}
-                  </span>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          {DEPLOYMENT_OPTIONS.map((opt) => (
+            <div
+              key={opt.label}
+              className={`border ${DEPLOY_BORDER[opt.status]} rounded-xl p-5 bg-white flex flex-col gap-3`}
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-bold text-stone-900">{opt.label}</p>
+                {/* CapabilityStatus chip — single item, name intentionally empty */}
+                <div className="shrink-0">
+                  <CapabilityStatus
+                    items={[{ name: "", status: opt.status }]}
+                    showLegend={false}
+                  />
                 </div>
-                <p className="text-sm text-stone-500 leading-relaxed flex-1">{opt.desc}</p>
-                {opt.cta && (
-                  <a
-                    href={opt.cta.href}
-                    className="text-sm font-semibold text-stone-900 hover:underline mt-auto"
-                  >
-                    {opt.cta.text} →
-                  </a>
-                )}
               </div>
-            )
-          })}
+              <p className="text-sm text-stone-500 leading-relaxed flex-1">{opt.desc}</p>
+              {opt.cta && (
+                <a
+                  href={opt.cta.href}
+                  className="text-sm font-semibold text-stone-900 hover:underline mt-auto min-h-[44px] flex items-center"
+                >
+                  {opt.cta.text} →
+                </a>
+              )}
+            </div>
+          ))}
         </div>
       </div>
     </section>
@@ -692,24 +806,24 @@ function DeploymentSection() {
 
 function FinalCTASection() {
   return (
-    <section className="py-24 px-6 border-t border-stone-100">
+    <section className="py-16 sm:py-24 px-4 sm:px-6 border-t border-stone-100">
       <div className="max-w-2xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+        <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
           Put runtime policy in front of your agents.
         </h2>
-        <p className="text-stone-500 mb-8">
+        <p className="text-stone-500 mb-8 text-sm sm:text-base">
           Discovery mode runs for 14 days, read-only. See every agent action across your team before you enforce anything.
         </p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center justify-center gap-3">
           <a
             href="/discovery"
-            className="rounded-xl bg-stone-900 text-white px-8 py-4 text-base font-semibold hover:bg-stone-700 transition-colors"
+            className="rounded-xl bg-stone-900 text-white px-8 py-4 text-base font-semibold hover:bg-stone-700 transition-colors text-center min-h-[48px] flex items-center justify-center"
           >
             Start Discovery — 14 days free
           </a>
           <a
             href="/book-demo"
-            className="rounded-xl border border-stone-200 text-stone-700 px-8 py-4 text-base font-semibold hover:bg-stone-50 transition-colors"
+            className="rounded-xl border border-stone-200 text-stone-700 px-8 py-4 text-base font-semibold hover:bg-stone-50 transition-colors text-center min-h-[48px] flex items-center justify-center"
           >
             Book a Demo
           </a>
@@ -776,16 +890,16 @@ function PageFooter() {
   ]
 
   return (
-    <footer className="border-t border-stone-100 py-10 px-6 bg-white">
+    <footer className="border-t border-stone-100 py-10 px-4 sm:px-6 bg-white">
       <div className="max-w-6xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between gap-8 mb-10">
-          <div>
+          <div className="shrink-0">
             <img src="/logo.png" alt="Conduct AI" className="h-8 w-auto mb-3" />
             <p className="text-sm text-stone-400 max-w-xs leading-relaxed">
               Runtime policy for AI agent stacks.
             </p>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-5 gap-8">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 sm:gap-8">
             {footerCols.map((col) => (
               <div key={col.heading}>
                 <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-3">
@@ -807,16 +921,16 @@ function PageFooter() {
             ))}
           </div>
         </div>
-        <div className="border-t border-stone-100 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4 text-xs text-stone-400">
+        <div className="border-t border-stone-100 pt-6 flex flex-col sm:flex-row justify-between items-center gap-4 text-xs text-stone-400 text-center sm:text-left">
           <span>
             © {new Date().getFullYear()} Conduct AI. All rights reserved. · Patent pending (US 64/109,502)
           </span>
-          <div className="flex items-center gap-4">
+          <div className="flex items-center gap-4 flex-wrap justify-center">
             <a
               href="https://www.linkedin.com/company/conductai/"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-stone-700 transition-colors"
+              className="hover:text-stone-700 transition-colors min-h-[44px] flex items-center"
               aria-label="LinkedIn"
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
@@ -827,14 +941,14 @@ function PageFooter() {
               href="https://www.youtube.com/@Conductai"
               target="_blank"
               rel="noopener noreferrer"
-              className="hover:text-stone-700 transition-colors"
+              className="hover:text-stone-700 transition-colors min-h-[44px] flex items-center"
               aria-label="YouTube"
             >
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
               </svg>
             </a>
-            <span>Envisioned, designed and developed with love from Houston</span>
+            <span className="hidden sm:inline">Envisioned, designed and developed with love from Houston</span>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Replaces #1589. Rebased onto latest `main` after #1586 merged. Same content, clean history.

## What ships
- Homepage sections now consume the 8 facelift components from #1586 (no more inline JSX in section internals)
- Mobile hamburger nav (collapsible accordion, Product/Solutions/Developers each expand independently, tap targets ≥44px)
- Section padding fixes: `px-4 sm:px-6`, `py-12 sm:py-20` across sections
- Core loop grid: added `grid-cols-1` fallback for 375px
- OSS 4-column table: card stack fallback for <640px
- Deployment cards use `CapabilityStatus` chip (was custom inline badge map)
- Footer grid: intermediate 3-col breakpoint

Zero copy or section-order changes vs #1586.

## 1 commit
- 8fdadde7 refactor(web): wire homepage to facelift components + mobile responsive pass

Closes #1589.