### PR TITLE
fix(#1587): empty-state banner should only show for first-time workspaces

### DIFF
--- a/apps/web/src/app/(app)/theguard/page.tsx
+++ b/apps/web/src/app/(app)/theguard/page.tsx
@@ -427,6 +427,26 @@ export default function GuardPage() {
 function GuardDashboard() {
   const { getToken } = useAuth()
   const { authFetch } = useAuthFetch()
+
+  // #1567 empty-state banner gate: only show the banner for genuinely
+  // eligible first-time workspaces. Session endpoint returns
+  // {ineligible: true} for workspaces with any run or vault key.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const r = await authFetch(`${API}/guard/trial/session`)
+        if (!r.ok) return
+        const data = await r.json()
+        if (!cancelled) setTrialSession({
+          ineligible: !!data.ineligible,
+          expired: !!data.expired,
+          cap_used: data.cap_used ?? 0,
+        })
+      } catch { /* silent — banner just stays hidden on error */ }
+    })()
+    return () => { cancelled = true }
+  }, [authFetch])
   const { user } = useUser()
   const { teamId, loading: teamLoading } = useGuardTeam()
   const { activeWorkspace } = useWorkspace()
@@ -446,6 +466,11 @@ function GuardDashboard() {
   const [chartToken, setChartToken]   = useState<string | null>(null)
   const [agentCount, setAgentCount]   = useState<number | null>(null)
   const [proxyCount, setProxyCount]   = useState<number | null>(null)
+  const [trialSession, setTrialSession] = useState<{
+    ineligible: boolean
+    expired: boolean
+    cap_used: number
+  } | null>(null)
 
   const PAGE_SIZE = 100
 
@@ -746,7 +771,7 @@ function GuardDashboard() {
     <GuardShell live={live} lastFetched={lastUpdated} agentCount={agentCount} proxyCount={proxyCount}>
 
       {/* #1567 empty-state CTA — new workspaces land on Try Guard in one click */}
-      {!loading && (stats?.events_today ?? 0) === 0 && (
+      {!loading && trialSession && !trialSession.ineligible && !trialSession.expired && trialSession.cap_used === 0 && (
         <div style={{
           borderRadius: 8,
           border: "1px solid var(--brand-bd, #0f766e)",


### PR DESCRIPTION
The empty-state banner on `/theguard` was rendering for active workspaces on quiet days, because the gate was `(stats?.events_today ?? 0) === 0`. Then clicking Try Guard landed on the Try-It page which correctly showed the "already active" panel — the mixed signal you screenshotted.

## Fix

Reuse the ineligibility signal the backend already computes. Fetch `/guard/trial/session` on page mount and gate the banner on the same three conditions the Try-It page uses to decide token-card vs "already active" panel:

- `!ineligible` — no runs and no vault keys (mirrors backend `_workspace_is_active` from PR 4)
- `!expired` — 7-day trial hasn't ended
- `cap_used === 0` — no trial calls made yet

Banner and page now agree. If the session fetch fails, the banner just stays hidden (silent).

## Files

- `apps/web/src/app/(app)/theguard/page.tsx` — +26/-1: new state, new fetch effect, tightened gate.

## Test plan

- [ ] Active workspace: banner hidden.
- [ ] Fresh signup workspace (never used): banner shows once. After clicking Try Guard and using one verb (cap_used becomes 1), banner hides on next load.
- [ ] Post-7-day-expiry workspace: banner hidden (expired trial CTA elsewhere).
- [ ] Session endpoint down: banner hidden (no false positive).
