### PR TITLE
feat(web): W3 per-page rebuilds — 8 marketing pages per facelift plan (v2)

### DIFF
--- a/apps/web/src/app/(marketing)/evidence/page.tsx
+++ b/apps/web/src/app/(marketing)/evidence/page.tsx
@@ -10,62 +10,221 @@ export const metadata = {
 export default function EvidencePage() {
   return (
     <div className="min-h-screen bg-white">
-      <main className="max-w-5xl mx-auto px-6 py-20">
-        <section className="mb-16 text-center">
-          <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-4">
+      <main className="max-w-5xl mx-auto px-6">
+
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
             Evidence
           </p>
           <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
             Know exactly what happened — and why.
           </h1>
-          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed">
-            Every action Guard evaluates leaves a receipt: the decision, the
-            rule it matched, who approved it, and a signed record you can
-            replay. One answer per action, not a log to correlate.
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Every action Guard evaluates leaves a receipt: the decision, the rule it matched,
+            who approved it, and a signed record you can replay. One answer per action, not a log to correlate.
           </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
+          </div>
         </section>
 
+        {/* Receipt */}
         <section className="mb-20 flex justify-center">
           <EvidenceReceipt />
         </section>
 
+        {/* What each receipt contains */}
         <section className="mb-20 grid grid-cols-1 sm:grid-cols-2 gap-8 text-sm text-stone-600">
           <div>
-            <h2 className="text-lg font-bold text-stone-900 mb-2">
-              What each receipt contains
-            </h2>
-            <ul className="list-disc pl-5 space-y-1">
-              <li>Decision (allow / approve / block) and the rule that fired</li>
-              <li>The agent, user, resource, and action attempted</li>
-              <li>Approval chain if human review was required</li>
-              <li>Execution outcome and any downstream effects</li>
-              <li>Integrity marker so tampering is detectable</li>
+            <h2 className="text-lg font-bold text-stone-900 mb-3">What each receipt contains</h2>
+            <ul className="space-y-2 leading-relaxed">
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Decision (allow / approve / block) and the rule that fired
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                The agent, user, resource, and action attempted
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Approval chain if human review was required
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Execution outcome and any downstream effects
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Integrity marker — SHA-256 hash chain so tampering is detectable
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Reference timestamp tied to the canonical reference date
+              </li>
             </ul>
           </div>
           <div>
-            <h2 className="text-lg font-bold text-stone-900 mb-2">
-              What you can do with it
-            </h2>
-            <ul className="list-disc pl-5 space-y-1">
-              <li>Answer a regulator or auditor with a signed record</li>
-              <li>Reconstruct any agent decision after the fact</li>
-              <li>Map decisions to compliance controls (SOC2, HIPAA)</li>
-              <li>Retain and export by policy, not by log volume</li>
+            <h2 className="text-lg font-bold text-stone-900 mb-3">What you can do with it</h2>
+            <ul className="space-y-2 leading-relaxed">
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Answer a regulator or auditor with a signed record
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Reconstruct any agent decision after the fact
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Map decisions to compliance controls (SOC 2, HIPAA, PCI DSS, EU AI Act)
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Retain and export by policy, not by log volume
+              </li>
+              <li className="flex items-start gap-2">
+                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
+                Verify chain integrity via the Guard verification API
+              </li>
             </ul>
           </div>
         </section>
 
-        <section className="text-center border-t border-stone-100 pt-16">
-          <p className="text-sm text-stone-400 mb-4">
-            Full pillar page — mapping, retention, compliance exports — shipping soon.
-          </p>
-          <Link
-            href="/guard"
-            className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-          >
-            See how Guard enforces →
-          </Link>
+        {/* Decision / Approval / Execution */}
+        <section className="mb-16 border-t border-stone-100 pt-16">
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-8">
+            <div>
+              <h3 className="text-base font-bold text-stone-900 mb-2">Decision</h3>
+              <p className="text-sm text-stone-500 leading-relaxed">
+                Every allow, approve, and block is a receipt. The decision is not inferred from logs —
+                it is the primary record. The rule that fired and the reason string are embedded.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-bold text-stone-900 mb-2">Approval</h3>
+              <p className="text-sm text-stone-500 leading-relaxed">
+                When Guard routes an action to human approval, the receipt records who approved it,
+                when they approved it, and on what grounds. The full approval chain is part of the receipt.
+              </p>
+            </div>
+            <div>
+              <h3 className="text-base font-bold text-stone-900 mb-2">Execution</h3>
+              <p className="text-sm text-stone-500 leading-relaxed">
+                After the action executes, the outcome is appended to the same receipt. One record
+                from policy decision through to execution result.
+              </p>
+            </div>
+          </div>
         </section>
+
+        {/* Integrity + Retention */}
+        <section className="mb-16">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
+            <div className="border border-stone-200 rounded-xl p-6 bg-white">
+              <h3 className="text-base font-bold text-stone-900 mb-2">Integrity</h3>
+              <p className="text-sm text-stone-500 leading-relaxed mb-3">
+                Receipts are SHA-256 hash-chained. Each entry includes the hash of the previous entry.
+                Alter any record and the chain breaks at verification. The integrity endpoint lets you
+                verify the full chain on demand.
+              </p>
+              <p className="text-xs font-mono text-stone-400">
+                Guard verification API — get_verify_evidence
+              </p>
+            </div>
+            <div className="border border-stone-200 rounded-xl p-6 bg-white">
+              <h3 className="text-base font-bold text-stone-900 mb-2">Retention</h3>
+              <p className="text-sm text-stone-500 leading-relaxed">
+                Receipts are stored per workspace with configurable retention. Export by time window,
+                agent, policy, or decision type. Retention policy is set in Guard configuration —
+                not in the audit system separately.
+              </p>
+            </div>
+          </div>
+        </section>
+
+        {/* Compliance mapping */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Compliance mapping</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-6 max-w-2xl">
+            Guard ships 15 compliance packs. Each pack maps rules to a compliance standard. When a pack
+            rule fires, the receipt records which standard was enforced and which rule matched. Compliance
+            reports are generated from the audit trail — not from manual assertions.
+          </p>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+            {[
+              "SOC 2 CC7.3",
+              "HIPAA §164.312",
+              "PCI DSS 4.0",
+              "EU AI Act",
+              "NIST AI RMF",
+              "ISO 42001",
+              "OWASP Agentic Top 10",
+              "IRS 1075",
+              "Prompt injection",
+              "Financial services",
+            ].map((standard) => (
+              <div
+                key={standard}
+                className="border border-stone-200 rounded-lg bg-stone-50 px-3 py-2 text-xs font-mono text-stone-600 text-center"
+              >
+                {standard}
+              </div>
+            ))}
+          </div>
+          <p className="text-xs text-stone-400 mt-3">
+            + 5 more packs. See{" "}
+            <Link href="/solutions/security-compliance" className="underline hover:text-stone-600">
+              Security Teams
+            </Link>{" "}
+            for the full list.
+          </p>
+        </section>
+
+        {/* Lens vocab */}
+        <section className="mb-20 border border-stone-200 rounded-xl bg-stone-50 px-6 py-5">
+          <p className="text-xs font-mono text-stone-400 mb-2 uppercase tracking-widest">Lens</p>
+          <p className="text-sm font-mono text-stone-700">
+            &ldquo;Ask Lens: &lsquo;show me every block against{" "}
+            <span className="text-red-600">payments-api</span> this month.&rsquo;&rdquo;
+          </p>
+          <p className="text-xs text-stone-400 mt-3 leading-relaxed">
+            Lens is the workspace chat surface. Ask questions about Guard activity, compliance state,
+            or any agent action — and get answers backed by the audit trail, not log correlation.
+          </p>
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">One receipt per action. Verifiable. Always.</h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/guard"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              See how Guard enforces →
+            </Link>
+          </div>
+        </section>
+
       </main>
     </div>
   )

--- a/apps/web/src/app/(marketing)/guard/page.tsx
+++ b/apps/web/src/app/(marketing)/guard/page.tsx
@@ -1,1350 +1,239 @@
-"use client"
+import Link from "next/link"
+import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
+import { PolicySnippet } from "@/components/marketing/facelift/PolicySnippet"
+import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
+import { AgentSurfaceStrip } from "@/components/marketing/facelift/AgentSurfaceStrip"
+import { ThreatModelRow } from "@/components/marketing/facelift/ThreatModelRow"
+import { CapabilityStatus } from "@/components/marketing/facelift/CapabilityStatus"
 
-import { useState } from "react"
-import { CtaLink } from "@/components/marketing/CtaLink"
-
-export default function GuardLandingPage() {
-  return (
-    <>
-      <HeroSection />
-      <ProofStripSection />
-      <MoatSection />
-      <FailClosedSection />
-      <ToolsSection />
-      <ProxyCompareSection />
-      <GitHubEnterpriseSection />
-      <Phase1Section />
-      <Phase2Section />
-      <EnforcementLayerSection />
-      <ProxySection />
-      <MCPSection />
-      <AgentIdentitySection />
-      <CedarImportSection />
-      <EnterpriseGradeSection />
-      <GatewayVsGuardSection />
-      <Phase3Section />
-      <FoundationLayerSection />
-      <FinalCTASection />
-    </>
-  )
+export const metadata = {
+  title: "Guard — Runtime policy for every AI agent | Conduct",
+  description:
+    "ConductGuard enforces runtime policy across AI agents, model gateways, and MCP tools — before consequential actions execute. Allow. Approve. Block. Prove.",
 }
 
-
-
-/* ─── Hero ─────────────────────────────────────────────────────────────── */
-
-function HeroSection() {
+export default function GuardPage() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
-      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        Runtime AI Governance that compounds
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        Your team is already using AI agents.<br />
-        <span className="bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">Guard is how you govern them.</span>
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-4">
-        Most governance stops at day one. Guard gets smarter every session. It learns your codebase, your team&apos;s patterns, and your risk profile over time.
-      </p>
-      <p className="text-base text-stone-600 max-w-2xl mx-auto leading-relaxed mb-3">
-        Other runtime AI governance tools want you to import an SDK and wrap every model call. Guard installs in 10 minutes. One policy enforces across every AI tool your team already uses — Claude Code, Claude.ai, Claude Desktop, Codex CLI, Codex Desktop, ChatGPT, Cursor, Copilot, and Windsurf.
-      </p>
-      <p className="text-base text-indigo-600 italic max-w-2xl mx-auto leading-relaxed mb-3">
-        GitHub gives the CISO a setting. ConductGuard gives them enforcement.
-      </p>
-      <p className="text-base text-stone-500 italic max-w-2xl mx-auto leading-relaxed mb-4">
-        The agent inherits the permission. It doesn&apos;t inherit the caution.
-      </p>
-      <p className="text-base text-stone-500 max-w-2xl mx-auto leading-relaxed mb-8">
-        Guard evaluates runtime admissibility before every agent action executes — applying refusal rails at the execution boundary, not in a policy document. Without runtime enforcement, agents experience permission drift, accumulating authority across tool calls that no single approval authorised.
-      </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <CtaLink className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors w-full sm:w-auto text-center" />
-        <a href="https://cal.com/sudhi-seshachala-pks7pd" target="_blank" rel="noopener" className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-base font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center">
-          Book a Demo
-        </a>
-      </div>
-      <p className="text-xs text-stone-400 mt-4">Free tier · No infrastructure changes · Works in minutes</p>
-    </section>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-/* ─── Proof Strip ──────────────────────────────────────────────────────── */
-
-function ProofStripSection() {
-  return (
-    <section className="bg-stone-950 border-y border-stone-800 py-6 px-6">
-      <div className="max-w-5xl mx-auto">
-        <p className="text-center text-[10px] font-semibold uppercase tracking-widest text-stone-500 mb-5">
-          From 18 days of production use, one developer
-        </p>
-        <div className="flex flex-wrap items-start justify-center gap-x-12 gap-y-5">
-
-          {/* Production deploys blocked */}
-          <div className="flex flex-col items-center gap-1">
-            <span className="text-2xl font-black text-red-400 tracking-tight">6</span>
-            <span className="text-xs text-stone-400">production deploys blocked</span>
-            <span className="text-[10px] text-stone-600">before execution</span>
-          </div>
-
-          {/* PII spike */}
-          <div className="flex flex-col items-center gap-1 border border-stone-700 rounded-xl px-5 py-3 bg-stone-900">
-            <span className="text-2xl font-black text-white tracking-tight">971</span>
-            <span className="text-xs text-stone-300 font-semibold">PII events screened in a single day</span>
-            <span className="text-[10px] text-stone-500 mt-1">30x the normal baseline</span>
-          </div>
-
-          {/* Credential leaks */}
-          <div className="flex flex-col items-center gap-1">
-            <span className="text-2xl font-black text-white tracking-tight">2</span>
-            <span className="text-xs text-stone-400">credential leaks caught</span>
-            <span className="text-[10px] text-stone-600">in commit messages, same session</span>
-          </div>
-
-          {/* Spend visibility */}
-          <div className="flex flex-col items-center gap-1">
-            <span className="text-2xl font-black text-white tracking-tight">$4,170</span>
-            <span className="text-xs text-stone-400">AI spend made visible</span>
-            <span className="text-[10px] text-stone-600">by tool and by day</span>
-          </div>
-
-        </div>
-        <p className="text-center text-[10px] text-stone-600 mt-5">
-          Small sample, real system. We&apos;ll publish team-scale numbers when we have them.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Tools — Works everywhere ────────────────────────────────────────── */
-
-const TOOLS = [
-  { name: "Claude Code",      icon: "⬡", install: "conduct guard sync" },
-  { name: "Claude.ai",        icon: "⬡", install: "MCP server" },
-  { name: "Claude Desktop",   icon: "⬡", install: "MCP server" },
-  { name: "Codex CLI",        icon: "⬡", install: "conduct guard sync" },
-  { name: "Codex Desktop",    icon: "⬡", install: "MCP server" },
-  { name: "ChatGPT",          icon: "⬡", install: "MCP server" },
-  { name: "Cursor",           icon: "⬡", install: "conduct guard sync --cursor" },
-  { name: "VS Code + Copilot",icon: "⬡", install: "code --add-mcp '{...}'" },
-  { name: "Windsurf",         icon: "⬡", install: "conduct guard sync --windsurf" },
-]
-
-
-
-/* ─── Fail-closed ──────────────────────────────────────────────────────── */
-
-function MoatSection() {
-  const pillars = [
-    {
-      title: "Signed configuration",
-      body: "Every workspace signs its active policy set. Every Guard check verifies the signature before enforcing. A tampered pack — pushed by anyone, at any layer — is rejected before it can decide anything.",
-    },
-    {
-      title: "Hash-chained audit",
-      body: "Every decision (block, warn, audit, inject) appends to a SHA-256 chain rooted at workspace genesis. Any missing or altered entry breaks the chain and is detected on one-click verification. Compliance evidence you can hand to an auditor.",
-    },
-    {
-      title: "Policy-first, not detection-first",
-      body: "Rules decide before the action executes — block, warn, audit, or inject — with a structured reason. Firewalls flag anomalies after the fact. Guard sets what is admissible up front.",
-    },
-  ]
-
-  return (
-    <section className="px-6 py-20 bg-white">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3">Where the moat lives</p>
-          <h2 className="text-3xl sm:text-4xl font-black tracking-tight text-stone-900 mb-4">
-            Governance, not observability.
-          </h2>
-          <p className="text-stone-500 max-w-2xl mx-auto leading-relaxed">
-            Runtime firewalls like <span className="font-semibold text-stone-700">Straiker</span> and <span className="font-semibold text-stone-700">Lakera</span> tell you what an agent did. Guard controls what an agent can do — with signed policy and cryptographic proof.
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Guard
           </p>
-          <p className="mt-3 text-xs text-stone-400 max-w-2xl mx-auto">
-            The only vendor whose default pack catches its own token shapes. Conduct-issued and Agent Booster secrets included.
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Runtime policy for every AI agent.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-4">
+            Conduct Guard enforces runtime policy across supported AI agents, model gateways, and MCP
+            tools — before consequential actions execute.
           </p>
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-5">
-          {pillars.map((p) => (
-            <div key={p.title} className="border border-stone-200 rounded-xl p-6 bg-stone-50">
-              <h3 className="text-base font-bold text-stone-900 mb-2">{p.title}</h3>
-              <p className="text-sm text-stone-600 leading-relaxed">{p.body}</p>
-            </div>
-          ))}
-        </div>
-
-        <div className="mt-10 border border-emerald-200 bg-emerald-50 rounded-xl p-6 flex flex-col sm:flex-row items-start sm:items-center gap-5">
-          <div className="flex-1">
-            <p className="text-xs font-semibold uppercase tracking-widest text-emerald-700 mb-1">Free wedge tier</p>
-            <h3 className="text-lg font-bold text-stone-900 mb-1">Start with Discovery.</h3>
-            <p className="text-sm text-stone-600 leading-relaxed">
-              Read-only visibility into every AI action across your team, for free. No policy to author, nothing to install upstream. When you&apos;re ready to enforce, promote a rule from what Discovery already saw.
-            </p>
-          </div>
-          <a href="/sign-up" className="inline-flex items-center gap-2 rounded-lg bg-stone-900 text-white px-5 py-3 text-sm font-semibold hover:bg-stone-800 transition-colors whitespace-nowrap">
-            Turn on Discovery
-          </a>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-
-function FailClosedSection() {
-  return (
-    <section className="bg-stone-950 border-y border-stone-800 px-6 py-16">
-      <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-start md:items-center gap-10">
-        <div className="flex-1">
-          <p className="text-xs font-semibold uppercase tracking-widest text-red-400 mb-3">Architectural commitment</p>
-          <h2 className="text-2xl sm:text-3xl font-black text-white tracking-tight leading-tight mb-4">
-            Fail-closed by default.
-          </h2>
-          <p className="text-stone-400 leading-relaxed mb-4">
-            If the Guard API is unreachable, tool calls block. Not silently allowed. Every new workspace starts fail-closed. Fail-open is available but you have to choose it explicitly.
+          <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-10">
+            Allow. Approve. Block. Prove.
           </p>
-          <p className="text-stone-500 text-sm leading-relaxed">
-            Most governance tools default to fail-open because it avoids support tickets. We default to fail-closed because that&apos;s the only default that means your policy actually enforces when infrastructure degrades. The inconvenience is intentional.
-          </p>
-        </div>
-        <div className="rounded-2xl border border-stone-700 bg-stone-900 px-8 py-6 min-w-[240px]">
-          <p className="text-xs font-bold uppercase tracking-widest text-stone-500 mb-4">What happens on outage</p>
-          <ul className="space-y-3">
-            {[
-              ["Guard API unreachable", "Tool calls block", "text-red-400"],
-              ["Guard API degraded", "Cached policy applies", "text-amber-400"],
-              ["Guard API restored", "Full enforcement resumes", "text-emerald-400"],
-            ].map(([state, outcome, color]) => (
-              <li key={state} className="flex flex-col gap-0.5">
-                <span className="text-xs text-stone-500">{state}</span>
-                <span className={`text-sm font-semibold ${color}`}>{outcome}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-
-function ToolsSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 py-16">
-      <div className="text-center mb-10">
-        <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3">One policy. Every AI tool.</p>
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight mb-4">
-          Works where your team already codes.
-        </h2>
-        <p className="text-stone-500 text-lg max-w-xl mx-auto">
-          Install once. ConductGuard enforces the same policy across every AI tool — no per-tool config, no gaps.
-        </p>
-      </div>
-
-      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-8">
-        {([
-          { name: "Claude Code",       badge: "hook + MCP" },
-          { name: "Claude.ai",         badge: "MCP" },
-          { name: "Claude Desktop",    badge: "MCP" },
-          { name: "Codex CLI",         badge: "hook" },
-          { name: "Codex Desktop",     badge: "MCP" },
-          { name: "ChatGPT",           badge: "MCP" },
-          { name: "Cursor",            badge: "MCP" },
-          { name: "VS Code + Copilot", badge: "MCP" },
-          { name: "Windsurf",          badge: "MCP" },
-        ] as {name:string,badge:string}[]).map((tool) => (
-          <div key={tool.name} className="border border-stone-200 rounded-xl p-4 text-center bg-white shadow-sm">
-            <p className="font-semibold text-stone-800 text-sm mb-1">{tool.name}</p>
-            <span className="text-[10px] font-semibold uppercase tracking-widest text-indigo-500 bg-indigo-50 px-2 py-0.5 rounded-full">
-              {tool.badge}
-            </span>
-          </div>
-        ))}
-      </div>
-
-      <div className="bg-stone-950 rounded-2xl p-6 text-sm font-mono text-stone-300 max-w-xl mx-auto">
-        <p className="text-stone-500 text-xs mb-3"># Install, sync, discover, validate</p>
-        <p><span className="text-indigo-400">$</span> pip install conduct-cli</p>
-        <p><span className="text-indigo-400">$</span> conduct guard sync</p>
-        <p className="text-stone-500 text-xs">↳ hook installed · MCP registered · policy active</p>
-        <p className="mt-2"><span className="text-indigo-400">$</span> conduct guard discover</p>
-        <p className="text-stone-500 text-xs">↳ Guard covers 9 of 11 agents · 2 uncovered (instructions shown)</p>
-        <p className="mt-2"><span className="text-indigo-400">$</span> conduct guard lint</p>
-        <p className="text-stone-500 text-xs">↳ 12 rules · no issues · policy is valid</p>
-      </div>
-
-      <p className="text-center text-xs text-stone-400 mt-6">
-        Also discoverable via the{" "}
-        <a href="https://registry.modelcontextprotocol.io" className="text-indigo-500 hover:underline" target="_blank" rel="noopener noreferrer">
-          MCP Registry
-        </a>
-        {" "}— install directly from VS Code or any MCP-compatible client.
-      </p>
-    </section>
-  )
-}
-
-/* ─── Enforcement Layer ────────────────────────────────────────────────── */
-
-function EnforcementLayerSection() {
-  return (
-    <section className="bg-stone-950 px-6 py-20">
-      <div className="max-w-4xl mx-auto">
-        <div className="grid md:grid-cols-2 gap-12 items-center">
-
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-4">The enforcement layer</p>
-            <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-5">
-              Whatever your team runs in Claude, Guard sits in front of it.
-            </h2>
-            <p className="text-stone-400 leading-relaxed mb-6">
-              Teams are building operating systems inside Claude — deal desks, security audits, engineering autopilots. The prompts are good. The reviewer is a suggestion.
-            </p>
-            <p className="text-stone-300 leading-relaxed mb-4">
-              ConductGuard is structural enforcement. Policies are evaluated against real rules, not prompt instructions. A block exits with code 2 — Claude stops. The audit trail is in your dashboard, not the chat history.
-            </p>
-            <p className="text-stone-400 leading-relaxed mb-8">
-              Segregation of duties only holds at the moment an agent acts. ConductGuard evaluates policy at the commit boundary, not in a quarterly review or a policy doc.
-            </p>
-
-          </div>
-
-          <div className="space-y-3">
-            {[
-              { label: "Prompt-based reviewer", desc: "Model can ignore it or hallucinate compliance", bad: true },
-              { label: "ConductGuard policy", desc: "Refusal rails evaluated against real rule set — block exits with code 2. Refusal conditions are structural, not advisory.", bad: false },
-              { label: "Chat history audit", desc: "No structured search, no team visibility", bad: true },
-              { label: "Conduct audit log", desc: "Every run, every block, every output — searchable", bad: false },
-              { label: "Spend as an afterthought", desc: "You see the bill at end of month", bad: true },
-              { label: "Guard spend limits", desc: "Hard stops per user, per project, enforced in real time", bad: false },
-            ].map((item) => (
-              <div key={item.label} className={`flex items-start gap-3 rounded-xl px-4 py-3 border ${item.bad ? "border-stone-700 bg-stone-900" : "border-indigo-800 bg-indigo-950"}`}>
-                <span className={`mt-0.5 text-sm ${item.bad ? "text-stone-600" : "text-indigo-400"}`}>{item.bad ? "✕" : "✓"}</span>
-                <div>
-                  <p className={`text-sm font-semibold ${item.bad ? "text-stone-500 line-through" : "text-white"}`}>{item.label}</p>
-                  <p className="text-xs text-stone-500 mt-0.5">{item.desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Proxy ─────────────────────────────────────────────────────────────── */
-
-function ProxySection() {
-  return (
-    <section className="bg-white px-6 py-20">
-      <div className="max-w-4xl mx-auto">
-        <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3 text-center">Guard Proxy</p>
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight leading-tight mb-4 text-center">
-          One env var. Enforcement on every LLM call.
-        </h2>
-        <p className="text-stone-500 text-lg leading-relaxed mb-12 text-center max-w-2xl mx-auto">
-          Point your AI tools at the Guard Proxy instead of Anthropic or OpenAI. Policies apply before the request forwards. Nothing changes in your code.
-        </p>
-
-        <div className="grid md:grid-cols-2 gap-10 items-start">
-
-          {/* Code block */}
-          <div className="rounded-xl bg-stone-950 p-6 font-mono text-sm leading-relaxed overflow-x-auto">
-            <p className="text-stone-500 text-xs mb-4 uppercase tracking-widest">Before</p>
-            <p className="text-stone-400 break-all">ANTHROPIC_BASE_URL=<span className="text-rose-400">https://api.anthropic.com</span></p>
-            <p className="text-stone-400 mt-1 break-all">OPENAI_BASE_URL=<span className="text-rose-400">https://api.openai.com/v1</span></p>
-
-            <div className="border-t border-stone-800 my-5" />
-
-            <p className="text-stone-500 text-xs mb-4 uppercase tracking-widest">After</p>
-            <p className="text-stone-300 break-all">ANTHROPIC_BASE_URL=<span className="text-indigo-400">https://api.conductai.ai/proxy/anthropic</span></p>
-            <p className="text-stone-300 mt-1 break-all">OPENAI_BASE_URL=<span className="text-indigo-400">https://api.conductai.ai/proxy/openai/v1</span></p>
-
-            <div className="border-t border-stone-800 my-5" />
-            <p className="text-stone-500 text-xs">Or run <span className="text-indigo-300">conduct guard sync</span> to apply automatically.</p>
-          </div>
-
-          {/* Capability list */}
-          <div className="space-y-6">
-            {[
-              {
-                icon: "🛡️",
-                title: "Policies enforced before forwarding",
-                desc: "Block secret leaks, restrict models, cap spend — evaluated against your workspace rules before the request ever reaches the provider.",
-              },
-              {
-                icon: "🔀",
-                title: "Route through your own gateway",
-                desc: "Set Portkey, Helicone, LiteLLM, or Azure OpenAI as upstream. Guard sits in front and applies policies regardless of where traffic ends up.",
-              },
-              {
-                icon: "📋",
-                title: "Every call in your audit trail",
-                desc: "Developer, tool, model, prompt summary, decision, cost — all in Guard Activity alongside your hook-layer events.",
-              },
-            ].map((item) => (
-              <div key={item.title} className="flex gap-4">
-                <span className="text-2xl mt-0.5">{item.icon}</span>
-                <div>
-                  <p className="font-semibold text-stone-900 mb-1">{item.title}</p>
-                  <p className="text-stone-500 text-sm leading-relaxed">{item.desc}</p>
-                </div>
-              </div>
-            ))}
-
-
-          </div>
-
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Proxy Comparison ─────────────────────────────────────────────────── */
-
-function ProxyCompareSection() {
-  const rows = [
-    { cap: "LLM calls reach the model",          direct: true,  byo: true,  guard: true,  guardByo: true  },
-    { cap: "Observability / logging",             direct: false, byo: true,  guard: true,  guardByo: true  },
-    { cap: "Cost tracking",                       direct: false, byo: "By API key", guard: "By agent", guardByo: "By agent" },
-    { cap: "Policy enforcement (block / warn)",   direct: false, byo: false, guard: true,  guardByo: true  },
-    { cap: "Blocks the call before it sends",     direct: false, byo: false, guard: true,  guardByo: true  },
-    { cap: "Agent identity on every call",        direct: false, byo: false, guard: true,  guardByo: true  },
-    { cap: "Audit trail tied to run + workflow",  direct: false, byo: false, guard: true,  guardByo: true  },
-    { cap: "Spend budget per agent / workflow",   direct: false, byo: false, guard: true,  guardByo: true  },
-    { cap: "Custom routing / caching",            direct: false, byo: true,  guard: true,  guardByo: true  },
-  ]
-
-  function Cell({ val }: { val: boolean | string }) {
-    if (val === true)  return <span className="text-emerald-500 font-bold text-base">✓</span>
-    if (val === false) return <span className="text-stone-300 text-base">—</span>
-    return <span className="text-stone-500 text-xs leading-tight">{val}</span>
-  }
-
-  const cols = ["", "Direct LLM", "Portkey / Helicone", "Guard Proxy", "Guard + BYO"]
-
-  return (
-    <section className="bg-stone-50 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3 text-center">Why Guard Proxy</p>
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight leading-tight mb-4 text-center">
-          Observe or enforce — pick one. Unless you use Guard.
-        </h2>
-        <p className="text-stone-500 text-base leading-relaxed mb-12 text-center max-w-2xl mx-auto">
-          Portkey and Helicone sit beside the call and observe. Guard sits in front and can stop it.
-          Set an LLM upstream in Proxy Settings to keep Portkey&apos;s routing with Guard&apos;s enforcement on top.
-        </p>
-
-        <div className="overflow-x-auto rounded-xl border border-stone-200 bg-white">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-stone-100">
-                {cols.map((c, i) => (
-                  <th key={c} className={`px-5 py-4 text-left font-semibold ${i === 0 ? "text-stone-400 w-64" : i === 3 ? "text-indigo-600 bg-indigo-50" : i === 4 ? "text-indigo-700 bg-indigo-50" : "text-stone-700"}`}>
-                    {c}
-                  </th>
-                ))}
-              </tr>
-            </thead>
-            <tbody>
-              {rows.map((row, ri) => (
-                <tr key={row.cap} className={`border-b border-stone-50 ${ri % 2 === 0 ? "bg-white" : "bg-stone-50/60"}`}>
-                  <td className="px-5 py-3.5 text-stone-600 font-medium">{row.cap}</td>
-                  <td className="px-5 py-3.5 text-center"><Cell val={row.direct} /></td>
-                  <td className="px-5 py-3.5 text-center"><Cell val={row.byo} /></td>
-                  <td className="px-5 py-3.5 text-center bg-indigo-50/40"><Cell val={row.guard} /></td>
-                  <td className="px-5 py-3.5 text-center bg-indigo-50/40"><Cell val={row.guardByo} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-
-        <p className="text-stone-400 text-xs text-center mt-5">
-          Custom routing in Guard Proxy: set any LLM upstream (Portkey, LiteLLM, Azure OpenAI) in Settings → Proxy.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-/* ─── GitHub Enterprise ────────────────────────────────────────────────── */
-
-function GitHubEnterpriseSection() {
-  return (
-    <section className="border-y border-stone-200 bg-white px-6 py-16">
-      <div className="max-w-4xl mx-auto">
-        <div className="grid md:grid-cols-2 gap-12 items-center">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-4">GitHub Copilot Enterprise</p>
-            <h2 className="text-3xl font-black text-stone-900 tracking-tight leading-tight mb-4">
-              One API key. Every developer covered.
-            </h2>
-            <p className="text-stone-500 leading-relaxed mb-6">
-              GitHub Copilot for Business supports hosted MCP servers. Add the ConductGuard URL to your org settings once — every developer in your org gets policy enforcement automatically. No CLI install. No per-developer setup.
-            </p>
-            <div className="space-y-2 text-sm text-stone-600">
-              <div className="flex items-center gap-2"><span className="text-emerald-500">✓</span> Admin generates one API key from Settings</div>
-              <div className="flex items-center gap-2"><span className="text-emerald-500">✓</span> Paste URL into GitHub org MCP settings</div>
-              <div className="flex items-center gap-2"><span className="text-emerald-500">✓</span> All developers get Guard enforcement on next Copilot session</div>
-              <div className="flex items-center gap-2"><span className="text-emerald-500">✓</span> Full audit trail in the Conduct dashboard</div>
-            </div>
-          </div>
-
-          <div className="space-y-4">
-            <div className="rounded-xl border border-stone-200 bg-stone-50 p-5">
-              <p className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-3">MCP server URL</p>
-              <code className="block text-xs font-mono text-stone-700 break-all leading-relaxed">
-                https://api.conductai.ai/guard/mcp
-              </code>
-            </div>
-            <div className="rounded-xl border border-stone-200 bg-stone-50 p-5">
-              <p className="text-xs font-semibold text-stone-400 uppercase tracking-wide mb-3">Authorization header</p>
-              <code className="block text-xs font-mono text-stone-700">
-                Authorization: Bearer cond_live_xxx
-              </code>
-              <p className="text-xs text-stone-400 mt-2">Generate from conductai.ai → Settings → API Keys</p>
-            </div>
-            <p className="text-xs text-stone-400 text-center">
-              Works with GitHub Copilot for Business, Cursor, Windsurf, and any MCP-compatible AI tool.
-            </p>
-          </div>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Phase 1 — Month 1: Visibility ───────────────────────────────────── */
-
-function Phase1Section() {
-  const cards = [
-    {
-      icon: "🔍",
-      title: "Shadow AI discovered in seconds",
-      body: "conduct guard discover scans your machine and shows coverage instantly — \"Guard covers 9 of 11 agents.\" Every uncovered tool gets step-by-step remediation instructions.",
-    },
-    {
-      icon: "💸",
-      title: "Spend by developer, by day, by tool",
-      body: "No more waiting for the invoice. See exactly where AI budget is going in real time.",
-    },
-    {
-      icon: "📋",
-      title: "Full audit trail from day one",
-      body: "Every tool call logged with decision, developer identity, and timestamp. One place, always current.",
-    },
-    {
-      icon: "✅",
-      title: "Validate policy before it hits prod",
-      body: "conduct guard lint checks every rule locally — unique IDs, valid regexes, correct actions. Ship with confidence, not a prayer.",
-    },
-  ]
-
-  return (
-    <section className="py-24 px-6 bg-white">
-      <div className="max-w-5xl mx-auto">
-        <div className="mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500 mb-3">Month 1</p>
-          <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight leading-tight mb-4 max-w-2xl">
-            You can&apos;t govern what you can&apos;t see. Now you can see everything.
-          </h2>
-          <p className="text-xl text-stone-500 max-w-2xl leading-relaxed">
-            Within 10 minutes of install, you see every AI agent your team is running, what tools it has access to, and who owns it. Guard is your organization&apos;s memory of its AI — not a spreadsheet, not a quarterly review.
-          </p>
-        </div>
-        <div className="grid sm:grid-cols-2 gap-5">
-          {cards.map(c => (
-            <div key={c.title} className="rounded-2xl border border-stone-200 p-6 hover:border-stone-300 hover:shadow-sm transition-all">
-              <span className="text-2xl mb-3 block">{c.icon}</span>
-              <h3 className="text-base font-bold text-stone-900 leading-snug mb-2">{c.title}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{c.body}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Phase 2 — Month 3: Governance ───────────────────────────────────── */
-
-interface Incident {
-  badge: string
-  badgeStyle: string
-  rule: string
-  headline: string
-  detail: string
-}
-
-function Phase2Section() {
-  const incidents: Incident[] = [
-    {
-      badge: "BLOCKED",
-      badgeStyle: "bg-red-100 text-red-700",
-      rule: "approve-prod-deploy",
-      headline: "Force-deploy to production, intercepted",
-      detail: "AI attempted vercel deploy --prod --force at 3:11pm on a Friday. Guard blocked it before it executed.",
-    },
-    {
-      badge: "BLOCKED",
-      badgeStyle: "bg-red-100 text-red-700",
-      rule: "no-secret-in-commit-msg",
-      headline: "Secret embedded in git commit, caught",
-      detail: "AI tried to commit code with a credential token in the commit message. Fired twice in the same session.",
-    },
-    {
-      badge: "WARNED",
-      badgeStyle: "bg-amber-100 text-amber-700",
-      rule: "pii-redact",
-      headline: "971 PII events in a single day",
-      detail: "Jun 19 spiked 30× the 32/day baseline. Without Guard, every one of those calls would have sent raw credentials to an LLM.",
-    },
-  ]
-
-  return (
-    <section className="py-24 px-6 bg-stone-50">
-      <div className="max-w-5xl mx-auto">
-        <div className="mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500 mb-3">Month 3</p>
-          <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight leading-tight mb-4 max-w-2xl">
-            It caught things your team would never have seen.
-          </h2>
-          <p className="text-xl text-stone-500 max-w-2xl leading-relaxed">
-            Policies enforced at the tool layer, not in a doc. At the moment the agent runs, not the morning after.
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-5 mb-8">
-          {incidents.map(inc => (
-            <div key={inc.rule} className="rounded-2xl border border-stone-200 bg-white p-6 flex flex-col gap-3 hover:border-stone-300 hover:shadow-sm transition-all">
-              <div className="flex items-center gap-2">
-                <span className={`inline-block px-2 py-0.5 rounded-full text-[10px] font-bold tracking-wider ${inc.badgeStyle}`}>
-                  {inc.badge}
-                </span>
-                <span className="text-[10px] font-mono text-stone-400">{inc.rule}</span>
-              </div>
-              <h3 className="text-sm font-bold text-stone-900 leading-snug">{inc.headline}</h3>
-              <p className="text-xs text-stone-500 leading-relaxed">{inc.detail}</p>
-            </div>
-          ))}
-        </div>
-
-        <div className="rounded-2xl bg-indigo-50 border border-indigo-100 px-8 py-6 flex flex-col sm:flex-row items-start sm:items-center gap-4">
-          <div className="flex-1">
-            <p className="text-sm font-semibold text-stone-900 mb-1">What would&apos;ve happened without Guard?</p>
-            <p className="text-sm text-stone-500 leading-relaxed">
-              The production deploy would have executed. Six times in 18 days, on one developer's machine.
-            </p>
-          </div>
-          <CtaLink className="flex-shrink-0 rounded-xl bg-indigo-600 text-white px-6 py-3 text-sm font-bold hover:bg-indigo-700 transition-colors whitespace-nowrap" />
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Phase 3 — Month 6–12: Intelligence ──────────────────────────────── */
-
-function Phase3Section() {
-  return (
-    <section className="py-24 px-6 bg-white">
-      <div className="max-w-5xl mx-auto">
-        <div className="mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-500 mb-3">Month 6–12</p>
-          <h2 className="text-3xl sm:text-4xl font-bold text-stone-900 tracking-tight leading-tight mb-4 max-w-3xl">
-            Guard learns as it runs. Every session makes the next one more accurate for your team.
-          </h2>
-          <p className="text-xl text-stone-500 max-w-2xl leading-relaxed">
-            Two memory systems work together. One knows your codebase. One knows your team.
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-5 mb-8">
-
-          {/* LEFT: Contextual Memory — light card */}
-          <div className="rounded-[20px] border border-[#f0eef8] bg-[#faf9ff] p-8 flex flex-col gap-5">
-            <div className="flex flex-col gap-1">
-              <span className="text-2xl">🧠</span>
-              <span className="text-[10px] font-bold uppercase tracking-widest text-violet-700 mt-2">Playbook Layer</span>
-              <span className="text-xl font-extrabold text-stone-900">Contextual Memory</span>
-            </div>
-            <p className="text-[15px] text-stone-600 leading-relaxed">
-              Per-workflow, per-repo. Every agent template reads what worked before it acts, then writes what it learned when it finishes.
-            </p>
-            <ul className="flex flex-col gap-3.5">
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-700 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-stone-900">Knows which files are fragile</span>
-                  <span className="text-stone-500">. Run 1 explores. Run 10 goes straight to the right file.</span>
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-700 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-stone-900">Avoids repeating past mistakes</span>
-                  <span className="text-stone-500">. If a fix caused a regression last time, the agent knows.</span>
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-700 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-stone-900">Compounds across every run</span>
-                  <span className="text-stone-500">. A workflow that has run 50 times on your repo is more valuable than a fresh install anywhere else.</span>
-                </span>
-              </li>
-            </ul>
-            <div className="rounded-xl bg-[#f4f0ff] border border-[#ede9fe] px-5 py-4">
-              <p className="text-[11px] font-bold uppercase tracking-wider text-violet-700 mb-1.5">How it works</p>
-              <p className="text-[13px] text-stone-600 leading-relaxed">Before every run → reads prior outcomes. After every run → writes what happened.</p>
-            </div>
-          </div>
-
-          {/* RIGHT: Team Session Memory — dark card */}
-          <div
-            className="rounded-[20px] p-8 flex flex-col gap-5"
-            style={{ background: "linear-gradient(135deg, #0a0815, #1f1048)" }}
-          >
-            <div className="flex flex-col gap-1">
-              <span className="text-2xl">👥</span>
-              <span className="text-[10px] font-bold uppercase tracking-widest text-violet-400 mt-2">CLI Layer</span>
-              <span className="text-xl font-extrabold text-white">Team Session Memory</span>
-            </div>
-            <p className="text-[15px] leading-relaxed" style={{ color: "rgba(255,255,255,0.55)" }}>
-              Per-developer, across every AI tool. The CLI hook captures sessions passively. Zero extra effort from your team.
-            </p>
-            <ul className="flex flex-col gap-3.5">
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-400 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-white">Knows how each developer works</span>
-                  <span style={{ color: "rgba(255,255,255,0.45)" }}>. Sarah always requires tests. The security lead flags credential exposure.</span>
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-400 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-white">Captured across all AI tools</span>
-                  <span style={{ color: "rgba(255,255,255,0.45)" }}>. One CLI hook. Every session adds to the team&apos;s shared context.</span>
-                </span>
-              </li>
-              <li className="flex items-start gap-2.5">
-                <span className="w-[7px] h-[7px] rounded-full bg-violet-400 flex-shrink-0 mt-[5px]" />
-                <span className="text-sm">
-                  <span className="font-semibold text-white">The agent behaves like a team member</span>
-                  <span style={{ color: "rgba(255,255,255,0.45)" }}>. Not a contractor who just showed up. An engineer who&apos;s been here for months.</span>
-                </span>
-              </li>
-            </ul>
-            <div
-              className="rounded-xl px-5 py-4"
-              style={{ background: "rgba(255,255,255,0.05)", border: "1px solid rgba(255,255,255,0.08)" }}
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
             >
-              <p className="text-[11px] font-bold uppercase tracking-wider text-violet-400 mb-1.5">How it works</p>
-              <p className="text-[13px] leading-relaxed" style={{ color: "rgba(255,255,255,0.5)" }}>
-                <code className="text-[13px] opacity-70">conduct login</code> installs a hook. Each session is captured silently. Patterns accumulate. Templates draw on this automatically.
-              </p>
-            </div>
-          </div>
-
-        </div>
-
-        {/* Together callout */}
-        <div
-          className="rounded-[20px] px-10 py-10 text-center"
-          style={{ background: "linear-gradient(135deg, #7c3aed, #4c1d95)" }}
-        >
-          <h3 className="text-[22px] font-extrabold text-white tracking-tight mb-3">
-            An agent that knows your codebase and your team.
-          </h3>
-          <p className="text-[15px] leading-relaxed mb-6 max-w-lg mx-auto" style={{ color: "rgba(255,255,255,0.7)" }}>
-            GitHub Actions has zero memory. Copilot has no team context. Conduct compounds both: silently, continuously, from day one.
-          </p>
-          <CtaLink className="inline-flex items-center rounded-xl bg-white text-violet-700 px-7 py-3.5 text-base font-bold hover:bg-violet-50 transition-colors" />
-        </div>
-
-      </div>
-    </section>
-  )
-}
-
-/* ─── MCP ──────────────────────────────────────────────────────────────── */
-
-function MCPSection() {
-  const clients = [
-    { name: "Claude Desktop", icon: "🖥️" },
-    { name: "Claude.ai", icon: "🌐" },
-    { name: "Cursor", icon: "⚡" },
-    { name: "Windsurf", icon: "🏄" },
-    { name: "VS Code Copilot", icon: "💠" },
-    { name: "Codex CLI", icon: "⌨️" },
-    { name: "Devin", icon: "🤖" },
-    { name: "Any MCP agent", icon: "🔌" },
-  ]
-  return (
-    <section className="bg-stone-950 px-6 py-24">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-3">MCP-native governance</p>
-          <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-5">
-            If your AI agent speaks MCP,<br />ConductGuard already governs it.
-          </h2>
-          <p className="text-stone-400 text-lg leading-relaxed max-w-2xl mx-auto">
-            No CLI install. No hook. No code changes. Any agent that connects to <code className="text-indigo-300 text-base">conductguard-mcp</code> inherits your team&apos;s policies the moment it starts.
-          </p>
-        </div>
-
-        {/* Client grid */}
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-12">
-          {clients.map(c => (
-            <div key={c.name} className="rounded-xl border border-stone-800 bg-stone-900 px-4 py-4 flex items-center gap-3">
-              <span className="text-xl">{c.icon}</span>
-              <span className="text-sm font-medium text-stone-300">{c.name}</span>
-            </div>
-          ))}
-        </div>
-
-        {/* Two columns: how it works + what gets enforced */}
-        <div className="grid md:grid-cols-2 gap-6 mb-10">
-          <div className="rounded-2xl border border-stone-800 bg-stone-900 p-8">
-            <p className="text-xs font-bold uppercase tracking-widest text-indigo-400 mb-4">How it works</p>
-            <ol className="space-y-4">
-              {[
-                ["Agent connects", "Any MCP-capable agent adds conductguard-mcp as a server — one URL, one API key."],
-                ["Policy syncs", "Your active ConductGuard policy propagates instantly. No redeploy required."],
-                ["Every tool call checked", "guard_check fires before the agent acts. Block, warn, or audit — your rules, enforced."],
-                ["Audit trail written", "Every decision logged to the same Flight Recorder your security team already uses."],
-              ].map(([step, desc], i) => (
-                <li key={step} className="flex gap-4">
-                  <span className="w-6 h-6 rounded-full bg-indigo-600 text-white text-xs font-bold flex items-center justify-center flex-shrink-0 mt-0.5">{i + 1}</span>
-                  <div>
-                    <p className="text-sm font-semibold text-white mb-0.5">{step}</p>
-                    <p className="text-sm text-stone-400 leading-relaxed">{desc}</p>
-                  </div>
-                </li>
-              ))}
-            </ol>
-          </div>
-
-          <div className="rounded-2xl border border-stone-800 bg-stone-900 p-8">
-            <p className="text-xs font-bold uppercase tracking-widest text-indigo-400 mb-4">What gets enforced</p>
-            <ul className="space-y-3">
-              {[
-                ["Prompt injection", "Malicious instructions in external content intercepted before the model sees them."],
-                ["Credential exposure", "API keys and secrets blocked from leaving your network in LLM calls."],
-                ["PII in prompts", "Patient data, PII flagged before it reaches the provider."],
-                ["Spend limits", "Per-developer token budgets enforced across every connected agent."],
-                ["Blast radius tracking", "Every action scored by scope — local / repo / network / destructive."],
-                ["Human sovereignty", "Approval gates are first-class workflow blocks, not optional add-ons. Conduct preserves human sovereignty at every step that matters."],
-                ["Custody proof", "Every decision cryptographically logged at the execution boundary — not reconstructed after the fact. SOC2 auditors get proof, not promises. Every allowed action produces a Governance Authorization Artifact: replay-verifiable evidence that authorisation was confirmed before execution."],
-              ].map(([label, desc]) => (
-                <li key={label} className="flex gap-3">
-                  <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 flex-shrink-0 mt-[7px]" />
-                  <div>
-                    <span className="text-sm font-semibold text-white">{label} — </span>
-                    <span className="text-sm text-stone-400">{desc}</span>
-                  </div>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-
-        {/* Connect snippet */}
-        <div className="rounded-2xl border border-stone-800 bg-stone-900 px-8 py-6">
-          <p className="text-xs font-bold uppercase tracking-widest text-stone-500 mb-3">Add to any MCP client</p>
-          <pre className="text-sm font-mono text-indigo-300 leading-relaxed overflow-x-auto">{`{
-  "mcpServers": {
-    "conductguard": {
-      "url": "https://api.conductai.ai/guard/mcp",
-      "headers": { "Authorization": "Bearer <your-api-key>" }
-    }
-  }
-}`}</pre>
-          <p className="text-xs text-stone-500 mt-3">Works with Claude Desktop, Cursor, Windsurf, VS Code, Codex CLI, and any MCP-compatible agent.</p>
-        </div>
-
-        {/* SDK code snippets */}
-        <CodeSnippetSection />
-      </div>
-    </section>
-  )
-}
-
-function CodeSnippetSection() {
-  const [tab, setTab] = useState<"ts" | "py" | "java" | "csharp" | "go">("ts")
-
-  const snippets: Record<typeof tab, { label: string; code: string }> = {
-    ts: {
-      label: "TypeScript",
-      code: `import Anthropic from "@anthropic-ai/sdk";
-
-const client = new Anthropic();
-
-const response = await client.beta.messages.create({
-  model: "claude-opus-4-5",
-  max_tokens: 1024,
-  tools: [{
-    type: "mcp",
-    server_url: "https://api.conductai.ai/guard/mcp",
-    server_name: "ConductGuard",
-    authorization_token: process.env.CONDUCT_API_KEY,
-  }],
-  messages: [{ role: "user", content: "..." }],
-});
-// Every tool call is now governed by your Guard policy`,
-    },
-    py: {
-      label: "Python",
-      code: `import anthropic, os
-
-client = anthropic.Anthropic()
-
-response = client.beta.messages.create(
-    model="claude-opus-4-5",
-    max_tokens=1024,
-    tools=[{
-        "type": "mcp",
-        "server_url": "https://api.conductai.ai/guard/mcp",
-        "server_name": "ConductGuard",
-        "authorization_token": os.environ["CONDUCT_API_KEY"],
-    }],
-    messages=[{"role": "user", "content": "..."}],
-)
-# Every tool call is now governed by your Guard policy`,
-    },
-    java: {
-      label: "Java",
-      code: `import java.net.http.*;
-import java.net.URI;
-
-// Connect via HTTP — any MCP-over-SSE client works
-var request = HttpRequest.newBuilder()
-    .uri(URI.create("https://api.conductai.ai/guard/mcp"))
-    .header("Authorization", "Bearer " + System.getenv("CONDUCT_API_KEY"))
-    .header("Content-Type", "application/json")
-    .POST(HttpRequest.BodyPublishers.ofString(payload))
-    .build();
-
-var client = HttpClient.newHttpClient();
-var response = client.send(request, HttpResponse.BodyHandlers.ofString());
-// guard_check, guard_status, guard_activity tools available`,
-    },
-    csharp: {
-      label: "C#",
-      code: `using System.Net.Http.Json;
-
-var client = new HttpClient();
-client.DefaultRequestHeaders.Add(
-    "Authorization", $"Bearer {Environment.GetEnvironmentVariable("CONDUCT_API_KEY")}");
-
-// Call any Guard MCP tool over HTTP
-var response = await client.PostAsJsonAsync(
-    "https://api.conductai.ai/guard/mcp",
-    new { method = "tools/call", params = new { name = "guard_check", arguments = new { action = "..." } } }
-);
-// Returns: { "result": "ALLOWED" | "BLOCKED" | "WARNED" }`,
-    },
-    go: {
-      label: "Go",
-      code: `package main
-
-import (
-  "bytes"
-  "encoding/json"
-  "net/http"
-  "os"
-)
-
-client := &http.Client{}
-body, _ := json.Marshal(map[string]any{
-  "method": "tools/call",
-  "params": map[string]any{
-    "name":      "guard_check",
-    "arguments": map[string]any{"action": "..."},
-  },
-})
-req, _ := http.NewRequest("POST", "https://api.conductai.ai/guard/mcp", bytes.NewReader(body))
-req.Header.Set("Authorization", "Bearer "+os.Getenv("CONDUCT_API_KEY"))
-req.Header.Set("Content-Type", "application/json")
-resp, _ := client.Do(req)
-// Returns: { "result": "ALLOWED" | "BLOCKED" | "WARNED" }`,
-    },
-  }
-
-  const tabs = [
-    { id: "ts" as const, label: "TypeScript" },
-    { id: "py" as const, label: "Python" },
-    { id: "java" as const, label: "Java" },
-    { id: "csharp" as const, label: "C#" },
-    { id: "go" as const, label: "Go" },
-  ]
-
-  return (
-    <div className="mt-6 rounded-2xl border border-stone-800 bg-stone-900 overflow-hidden">
-      <div className="flex items-center justify-between px-6 pt-5 pb-0">
-        <p className="text-xs font-bold uppercase tracking-widest text-stone-500">Connect from any language</p>
-        <div className="flex gap-1">
-          {tabs.map(t => (
-            <button
-              key={t.id}
-              onClick={() => setTab(t.id)}
-              className={`px-3 py-1.5 rounded-lg text-xs font-semibold transition-colors ${
-                tab === t.id
-                  ? "bg-indigo-600 text-white"
-                  : "text-stone-400 hover:text-stone-200 hover:bg-stone-800"
-              }`}
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
             >
-              {t.label}
-            </button>
-          ))}
-        </div>
-      </div>
-      <pre className="px-6 py-5 text-sm font-mono text-indigo-200 leading-relaxed overflow-x-auto whitespace-pre">
-        {snippets[tab].code}
-      </pre>
-      <div className="px-6 pb-4">
-        <p className="text-xs text-stone-500">
-          Same Guard policy enforced regardless of language. Java and C# use the MCP HTTP/SSE transport directly.
-        </p>
-      </div>
+              Book a Demo
+            </Link>
+          </div>
+        </section>
+
+        {/* One policy across surfaces */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            One policy across your AI agent stack.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Write the rule once. Guard applies it wherever your agents work — through the CLI hook,
+            the HTTP proxy, and the MCP layer. No separate configuration per tool.
+          </p>
+          <AgentSurfaceStrip />
+        </section>
+
+        {/* Allow / Approve / Block trio */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Three decisions. One engine.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard evaluates every action before it executes and returns one of three decisions.
+            The decision, the rule that fired, and the reason are all recorded.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            <DecisionCard
+              agent="claude-code / deploy-agent"
+              action="run_unit_tests"
+              resource="orders-db"
+              policy="production-change-v4"
+              decision="ALLOW"
+              reason="Action within policy limits"
+            />
+            <DecisionCard
+              agent="claude-code / deploy-agent"
+              action="deploy_production"
+              resource="payments-api"
+              policy="production-change-v4"
+              decision="APPROVE"
+              reason="Production deployment outside approved change window"
+              showButtons
+            />
+            <DecisionCard
+              agent="cursor-agent-17"
+              action="update_terraform"
+              resource="prod-vpc"
+              policy="no-production-network-change"
+              decision="BLOCK"
+              reason="Production network modifications require approved change record."
+            />
+          </div>
+        </section>
+
+        {/* Consequential actions */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Consequential actions</h2>
+          <p className="text-stone-500 text-sm leading-relaxed max-w-2xl mb-6">
+            Guard was built for actions that cannot be undone. Refunds, production deployments,
+            secret reads, network changes — these need a policy decision before they execute, not after.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+            {[
+              { action: "process_refund", context: "$840 · customer C-8911", outcome: "BLOCK", label: "over $500 limit" },
+              { action: "deploy_production", context: "payments-api · outside change window", outcome: "APPROVE", label: "routes to Slack" },
+              { action: "read_env", context: "SECRET_KEY · prod environment", outcome: "BLOCK", label: "secret access denied" },
+            ].map(({ action, context, outcome, label }) => (
+              <div key={action} className="border border-stone-200 rounded-xl bg-white p-4 font-mono">
+                <p className="text-[11px] text-stone-900 font-bold mb-1">{action}</p>
+                <p className="text-[10px] text-stone-400 mb-3">{context}</p>
+                <span className={`text-[10px] font-bold ${outcome === "BLOCK" ? "text-red-600" : "text-amber-600"}`}>
+                  {outcome}
+                </span>
+                <span className="text-[10px] text-stone-400 ml-1">— {label}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Policy snippet */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Policy that can be inspected.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Policies are YAML files checked into your repository. No black-box rule engine. Any engineer
+            can read, modify, and audit the rules that govern your agents.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-start">
+            <PolicySnippet language="yaml" />
+            <PolicySnippet
+              language="cedar"
+              title="production-change.cedar"
+            />
+          </div>
+          <div className="mt-6 border border-stone-200 rounded-xl bg-stone-50 px-5 py-4 inline-block">
+            <p className="text-xs font-mono text-stone-400 mb-1 uppercase tracking-widest">Lens</p>
+            <p className="text-sm font-mono text-stone-700">
+              &ldquo;Ask Lens: &lsquo;what did Guard block last week?&rsquo;&rdquo;
+            </p>
+          </div>
+        </section>
+
+        {/* Evidence */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Every decision leaves a receipt.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard records the agent, action, resource, decision, rule, reason, and user for every evaluation.
+            The receipt is hash-chained — altered entries break the chain.
+          </p>
+          <div className="flex justify-center">
+            <EvidenceReceipt />
+          </div>
+        </section>
+
+        {/* Deployment */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Deployment</h2>
+          <CapabilityStatus
+            showLegend
+            items={[
+              { name: "SaaS (conductai.ai)", status: "SHIPPED", note: "US-based" },
+              { name: "Docker Compose (self-hosted)", status: "SHIPPED" },
+              { name: "Kubernetes", status: "PREVIEW", note: "Reference templates" },
+              { name: "Air-gapped / on-prem", status: "PLANNED" },
+            ]}
+          />
+          <p className="text-xs text-stone-400 mt-4">
+            Same policy engine, same CLI, same audit trail — regardless of where Guard runs.
+          </p>
+        </section>
+
+        {/* What Guard does NOT protect */}
+        <section className="mb-20 border border-stone-200 rounded-2xl overflow-hidden">
+          <div className="px-6 py-5 bg-stone-50 border-b border-stone-200">
+            <h2 className="text-lg font-bold text-stone-900">What Guard does not protect</h2>
+            <p className="text-xs text-stone-400 mt-1">
+              We publish where Guard stops. Honest scope is a design requirement.
+            </p>
+          </div>
+          <div className="px-6 py-2">
+            <ThreatModelRow
+              threat="Actions that bypass the hook, proxy, or MCP layer"
+              coverage="Not protected"
+              detail="Guard only evaluates actions routed through its enforcement surfaces. An agent that does not use the hook, proxy, or MCP layer is invisible to Guard."
+            />
+            <ThreatModelRow
+              threat="Pre-call prompt injection (before Guard sees the prompt)"
+              coverage="Partial"
+              detail="Guard evaluates the tool call after the model has decided to call it. Injection attacks that alter the model intent before tool selection are upstream of Guard."
+            />
+            <ThreatModelRow
+              threat="Consequential actions guarded by policy"
+              coverage="Protected"
+              detail="Refunds, deployments, network changes, secret reads — any action routed through Guard is evaluated before execution."
+            />
+            <ThreatModelRow
+              threat="Cross-agent correlation (Operations context)"
+              coverage="Not protected"
+              detail="Guard evaluates each action in isolation. Context from prior actions by other agents is not yet available. This is the Operations gap — planned."
+            />
+            <ThreatModelRow
+              threat="Audit trail integrity"
+              coverage="Protected"
+              detail="SHA-256 hash chain on every decision. Altered entries break verification."
+            />
+            <ThreatModelRow
+              threat="Model-layer attacks (adversarial inputs to the LLM itself)"
+              coverage="Partial"
+              detail="Guard includes a prompt-injection detection pack and pattern-based detectors. ML-based detection is not implemented."
+            />
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">Put runtime policy in front of your agents.</h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <a
+              href="https://github.com/conductai/conduct"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              View the open-source runtime →
+            </a>
+          </div>
+        </section>
+
+      </main>
     </div>
   )
 }
-
-/* ─── Agent Identity ───────────────────────────────────────────────────── */
-
-function AgentIdentitySection() {
-  const tokenTypes = [
-    {
-      prefix: "cond_agt_*",
-      label: "Session token",
-      ttl: "8 hours",
-      source: "conduct login",
-      use: "Claude Code, Cursor, Windsurf, Codex CLI — any interactive tool.",
-      color: "border-indigo-200 bg-indigo-50",
-      badge: "bg-indigo-100 text-indigo-700",
-    },
-    {
-      prefix: "cond_api_*",
-      label: "API token",
-      ttl: "Long-lived",
-      source: "Agent Identity page",
-      use: "CI/CD pipelines, server agents, integrations — any non-interactive context.",
-      color: "border-violet-200 bg-violet-50",
-      badge: "bg-violet-100 text-violet-700",
-    },
-  ]
-  return (
-    <section className="px-6 py-24 bg-white">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3">Know Your Agent (KYA)</p>
-          <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight leading-tight mb-5">
-            Every agent gets an attested identity.<br />Every call is attributed.
-          </h2>
-          <p className="text-stone-500 text-lg leading-relaxed max-w-2xl mx-auto">
-            Guard issues scoped tokens to every agent. Short-lived for interactive tools, long-lived for CI and integrations. Both enforce the same proxy rules and write to the same audit trail.
-          </p>
-          <p className="text-stone-500 text-base leading-relaxed max-w-2xl mx-auto mt-3">
-            Guard validates authority at the execution boundary — short-lived run tokens mean permissions expire with the action, not the session. Conduct uses short-lived run tokens: every run mints fresh credentials. There are no stale approvals.
-          </p>
-        </div>
-
-        <div className="grid md:grid-cols-2 gap-6 mb-10">
-          {tokenTypes.map(t => (
-            <div key={t.prefix} className={`rounded-2xl border ${t.color} p-8`}>
-              <div className="flex items-center justify-between mb-4">
-                <code className="text-sm font-mono font-bold text-stone-900">{t.prefix}</code>
-                <span className={`text-xs font-semibold px-2.5 py-1 rounded-full ${t.badge}`}>{t.label}</span>
-              </div>
-              <div className="space-y-3 text-sm">
-                <div className="flex gap-3">
-                  <span className="text-stone-400 w-16 shrink-0">Expires</span>
-                  <span className="text-stone-700 font-medium">{t.ttl}</span>
-                </div>
-                <div className="flex gap-3">
-                  <span className="text-stone-400 w-16 shrink-0">Issued by</span>
-                  <code className="text-stone-700 text-xs bg-white/60 px-1.5 py-0.5 rounded">{t.source}</code>
-                </div>
-                <div className="flex gap-3">
-                  <span className="text-stone-400 w-16 shrink-0">Use for</span>
-                  <span className="text-stone-600 leading-relaxed">{t.use}</span>
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        <div className="grid md:grid-cols-3 gap-4">
-          {[
-            ["RFC 8693 compliant", "Token exchange follows the same standard as Okta and Entra. Your security team already knows the protocol."],
-            ["Auto-refresh", "Session tokens refresh 5 minutes before expiry. No manual re-login during long coding sessions."],
-            ["Workspace-scoped", "Tokens are enforced to a single workspace. Cross-workspace reuse is rejected at the proxy."],
-          ].map(([title, desc]) => (
-            <div key={title} className="rounded-xl border border-stone-200 bg-stone-50 px-5 py-5">
-              <p className="text-sm font-bold text-stone-900 mb-2">{title}</p>
-              <p className="text-xs text-stone-500 leading-relaxed">{desc}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-
-/* ─── Cedar Import ─────────────────────────────────────────────────────── */
-
-function CedarImportSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-200 px-6 py-20">
-      <div className="max-w-4xl mx-auto">
-        <div className="grid md:grid-cols-2 gap-12 items-center">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3">IAM policy import</p>
-            <h2 className="text-3xl font-black text-stone-900 tracking-tight leading-tight mb-4">
-              Already have IAM policies? Import them.
-            </h2>
-            <p className="text-stone-500 leading-relaxed mb-4">
-              If your org already runs Cedar policies with AWS Verified Permissions or Bedrock AgentCore, Guard imports them directly. Same policy language, same authoring workflow, evaluated at the tool call. Your IAM team owns the policy. Your engineering team enforces it.
-            </p>
-            <p className="text-stone-500 text-sm leading-relaxed mb-6">
-              Cedar policies get compiled into Guard&apos;s evaluation engine on install. Import once, enforce everywhere.
-            </p>
-            <div className="rounded-xl bg-stone-950 p-5 font-mono text-sm leading-relaxed mb-4">
-              <p className="text-stone-500 text-xs mb-2"># Import your Cedar policies (JSON) as a Guard pack</p>
-              <p className="text-indigo-300">$ conduct import-cedar ./cedar-policies.json \</p>
-              <p className="text-indigo-300 pl-4">--pack-slug my-iam --pack-name "My IAM" --install</p>
-              <p className="text-stone-500 text-xs mt-2">↳ Compiled to Guard rules · Pack installed · Policy active</p>
-            </div>
-            <p className="text-xs text-stone-400">
-              Cedar is the policy language used by AWS Verified Permissions and Amazon Bedrock AgentCore. If you author policies in Cedar today, they import without modification.
-            </p>
-          </div>
-          <div className="space-y-5">
-            {[
-              {
-                icon: "📋",
-                title: "Same authoring workflow",
-                desc: "Write policies in Cedar. Your IAM team keeps ownership. Guard evaluates them at runtime without a rewrite.",
-              },
-              {
-                icon: "⚡",
-                title: "Evaluated at the tool call",
-                desc: "Cedar conditions run at the execution boundary — before the agent acts, not in a post-hoc audit.",
-              },
-              {
-                icon: "🔄",
-                title: "One import, all agents covered",
-                desc: "A Cedar pack installs across every agent your team runs — Claude Code, Cursor, Copilot, CI pipelines — via the same policy sync that applies to native Guard rules.",
-              },
-            ].map((item) => (
-              <div key={item.title} className="flex gap-4">
-                <span className="text-2xl mt-0.5">{item.icon}</span>
-                <div>
-                  <p className="font-semibold text-stone-900 mb-1">{item.title}</p>
-                  <p className="text-stone-500 text-sm leading-relaxed">{item.desc}</p>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-
-/* ─── Enterprise grade ─────────────────────────────────────────────────── */
-
-function EnterpriseGradeSection() {
-  const decisions = [
-    {
-      label: "30-second policy propagation",
-      body: "When you revoke a rule, every developer's machine picks it up within 30 seconds — automatically, with no manual sync. The background drain daemon refreshes policy on every active session.",
-      tag: "Policy enforcement",
-    },
-    {
-      label: "SHA-256 hash chain, one-click verification",
-      body: "Every audit event is linked to the previous one via a SHA-256 chain. A CISO can open the Governance page, click Verify integrity, and confirm the log has not been altered — no CLI needed.",
-      tag: "Audit trail",
-    },
-    {
-      label: "Real-time incident feed",
-      body: "The activity feed streams new events within two seconds of each tool call. Click Go Live during an incident and watch blocks appear across your team in real time, without refreshing.",
-      tag: "Live monitoring",
-    },
-    {
-      label: "Daemon health visible in guard status",
-      body: "The background event daemon self-heals: stale processes are detected, killed, and replaced on the next tool call. `conduct guard status` shows running, stale, or not running — not a silent gap.",
-      tag: "Reliability",
-    },
-    {
-      label: "Proxy coverage check in every status call",
-      body: "`conduct guard status` shows which AI providers are actually routed through the Guard proxy in the current shell — and flags the ones that are not, with the exact command to fix it.",
-      tag: "Coverage visibility",
-    },
-  ]
-
-  return (
-    <section className="bg-stone-950 px-6 py-24 border-t border-stone-900">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-14">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-3">Built for enterprise security</p>
-          <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-5">
-            Five decisions that separate<br />governance from compliance theater.
-          </h2>
-          <p className="text-stone-400 text-lg leading-relaxed max-w-2xl mx-auto">
-            Every tool claims to govern AI. These are the choices that show we actually thought about what happens when things go wrong.
-          </p>
-        </div>
-
-        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
-          {decisions.map((d) => (
-            <div key={d.label} className="rounded-2xl border border-stone-800 bg-stone-900 p-6 flex flex-col gap-3">
-              <span className="text-xs font-bold uppercase tracking-widest text-indigo-400">{d.tag}</span>
-              <h3 className="text-base font-bold text-white leading-snug">{d.label}</h3>
-              <p className="text-sm text-stone-400 leading-relaxed">{d.body}</p>
-            </div>
-          ))}
-        </div>
-
-      </div>
-    </section>
-  )
-}
-
-/* ─── Final CTA ────────────────────────────────────────────────────────── */
-
-
-function GatewayVsGuardSection() {
-  return (
-    <section className="bg-white border-t border-stone-100 px-6 py-20">
-      <div className="max-w-3xl mx-auto">
-        <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-4">How ConductGuard is different</p>
-        <h2 className="text-3xl font-bold text-stone-900 mb-4 leading-tight">
-          A gateway governs what the model costs.<br />Guard governs what the agent does.
-        </h2>
-        <p className="text-stone-500 mb-10 text-lg">
-          Provider gateways sit between your team and the LLM. They cap spend, enforce SSO, and log model requests. That&apos;s the right layer for cost control.
-        </p>
-        <div className="grid md:grid-cols-2 gap-6 mb-10">
-          <div className="border border-stone-200 rounded-xl p-6">
-            <p className="text-sm font-semibold text-stone-400 uppercase tracking-widest mb-4">Provider gateway</p>
-            <ul className="space-y-3 text-sm text-stone-600">
-              {([
-                ["yes", "Caps LLM spend per user"],
-                ["yes", "SSO sign-in"],
-                ["yes", "Model selection controls"],
-                ["no",  "Sees tool calls (Bash, Write, Read)"],
-                ["no",  "Blocks destructive commands before they run"],
-                ["no",  "Detects credential leaks in tool input"],
-                ["no",  "One policy across Claude, Codex, ChatGPT, Cursor, Copilot"],
-                ["no",  "Custody proof audit log"],
-              ] as [string, string][]).map(([state, label]) => (
-                <li key={label} className="flex items-start gap-2">
-                  <span className={state === "yes" ? "text-green-500 font-bold mt-0.5" : "text-stone-300 font-bold mt-0.5"}>{state === "yes" ? "✓" : "✗"}</span>
-                  <span className={state === "no" ? "text-stone-400" : ""}>{label}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div className="border border-indigo-200 bg-indigo-50 rounded-xl p-6">
-            <p className="text-sm font-semibold text-indigo-500 uppercase tracking-widest mb-4">ConductGuard</p>
-            <ul className="space-y-3 text-sm text-stone-700">
-              {[
-                "Caps LLM spend per user",
-                "SSO sign-in",
-                "Model selection controls",
-                "Sees tool calls (Bash, Write, Read)",
-                "Blocks destructive commands before they run",
-                "Detects credential leaks in tool input",
-                "One policy across Claude, Codex, ChatGPT, Cursor, Copilot",
-                "Custody proof audit log",
-              ].map((label) => (
-                <li key={label} className="flex items-start gap-2">
-                  <span className="text-indigo-500 font-bold mt-0.5">✓</span>
-                  <span>{label}</span>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-        <p className="text-stone-400 text-sm">
-          Use a provider gateway for spend control. Use ConductGuard for everything the model touches after it decides what to do.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-function FoundationLayerSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-100 py-14 px-6">
-      <div className="max-w-5xl mx-auto">
-        <p className="text-center text-xs font-semibold uppercase tracking-widest text-stone-400 mb-8">Guard is Layer 2. Start at Layer 0.</p>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <a href="/team-os" className="group rounded-2xl border border-stone-200 bg-white p-6 hover:border-stone-400 hover:shadow-md transition-all flex gap-4">
-            <div className="text-2xl shrink-0">📄</div>
-            <div>
-              <div className="flex items-center gap-2 mb-1">
-                <p className="font-bold text-stone-900 text-sm">Team OS</p>
-                <span className="text-xs bg-emerald-100 text-emerald-700 px-2 py-0.5 rounded-full font-semibold">Free</span>
-              </div>
-              <p className="text-xs text-stone-500 leading-relaxed">
-                CLAUDE.md, REVIEW.md, and standards files — the quality bar Guard enforces, written down so every agent on your team starts from the same place.
-              </p>
-              <p className="text-xs font-semibold text-stone-600 group-hover:text-stone-900 mt-2 transition-colors">Get the templates →</p>
-            </div>
-          </a>
-          <a href="/sdd" className="group rounded-2xl border border-stone-200 bg-white p-6 hover:border-stone-400 hover:shadow-md transition-all flex gap-4">
-            <div className="text-2xl shrink-0">📐</div>
-            <div>
-              <p className="font-bold text-stone-900 text-sm mb-1">SDD Scanner</p>
-              <p className="text-xs text-stone-500 leading-relaxed">
-                Generate a SPEC.md before agents touch code. Guard enforces spec compliance at runtime — blocking actions that diverge from approved architecture.
-              </p>
-              <p className="text-xs font-semibold text-stone-600 group-hover:text-stone-900 mt-2 transition-colors">Generate your spec →</p>
-            </div>
-          </a>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function FinalCTASection() {
-  return (
-    <section className="py-24 px-6 bg-gradient-to-br from-indigo-600 to-violet-600">
-      <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-4">
-          Your team is already using AI agents.<br />Guard is how you govern them.
-        </h2>
-        <p className="text-indigo-200 text-lg leading-relaxed mb-10 max-w-xl mx-auto">
-          One platform. Two problems solved.
-        </p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <CtaLink className="rounded-xl bg-white text-indigo-600 px-7 py-3.5 text-base font-bold hover:bg-indigo-50 transition-colors w-full sm:w-auto text-center" />
-          <a href="https://cal.com/sudhi-seshachala-pks7pd" target="_blank" rel="noopener" className="rounded-xl border border-white/40 text-white px-7 py-3.5 text-base font-semibold hover:bg-white/10 transition-colors w-full sm:w-auto text-center">
-            Book a Demo
-          </a>
-        </div>
-        <p className="text-indigo-300 text-xs mt-5">Free tier · No infrastructure changes · Works in minutes</p>
-        <p className="text-indigo-300/70 text-xs mt-2">
-          Need on-premise or cloud deployment?{" "}
-          <a href="/deployment" className="underline hover:text-white transition-colors">See deployment options →</a>
-        </p>
-      </div>
-    </section>
-  )
-}
-

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -1,375 +1,191 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+import { RuntimeFlow } from "@/components/marketing/facelift/RuntimeFlow"
+import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 
 export const metadata = {
-  title: "MCP Gateway — One phone book for every AI agent's tools | Conduct",
+  title: "MCP — Runtime policy for MCP actions | Conduct",
   description:
-    "Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Pre-canned Registry + Bring Your Own MCP. Per-tool policy enforcement.",
+    "Guard intercepts every MCP tool call before it executes. Policy applies at the MCP call, not the client. Allow, approve, or block — with a signed receipt.",
 }
 
-export default function MCPGatewayPage() {
+export default function MCPPage() {
   return (
-    <>
-      <HeroSection />
-      <PositioningStrip />
-      <FeatureGrid />
-      <RegistrySection />
-      <UseCasesSection />
-      <ComparisonSection />
-      <ElevatorSection />
-      <CtaFooterSection />
-    </>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-function HeroSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-12 text-center">
-      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 border border-indigo-100 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-4">
-        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        Early access
-      </div>
-      <div className="inline-flex items-center gap-2 bg-stone-100 text-stone-600 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8 ml-2">
-        <span className="w-1.5 h-1.5 rounded-full bg-stone-400 inline-block" />
-        MCP Gateway
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-5">
-        One phone book for every AI agent&rsquo;s tools.
-      </h1>
-      <p className="text-xl text-stone-500 max-w-3xl mx-auto leading-relaxed mb-10">
-        Your agents ask Guard which MCP servers they can reach, get short-lived scoped tokens, and every tool call is policy-checked and hash-chained. Stop hardcoding endpoints. Stop pasting credentials into 20 configs. Rotate once, revoke instantly, audit everything.
-      </p>
-      <div className="flex flex-wrap justify-center gap-3">
-        <a
-          href="mailto:hello@conductai.ai?subject=MCP%20Gateway%20early%20access"
-          className="inline-flex items-center gap-2 rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-        >
-          Get early access
-        </a>
-        <a
-          href="https://github.com/sseshachala/conductai/issues/1246"
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all"
-        >
-          See the epic
-        </a>
-      </div>
-    </section>
-  )
-}
-
-function PositioningStrip() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-12">
-      <div className="bg-stone-900 text-white rounded-2xl px-8 py-8 text-center">
-        <p className="text-xl sm:text-2xl font-semibold leading-relaxed">
-          LiteLLM makes model calls fungible.
-          <br />
-          Guard makes tool access governable.
-        </p>
-        <p className="text-sm text-stone-400 mt-3 font-medium">
-          Different phone, different problem, different room.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-function FeatureGrid() {
-  const features: { icon: string; title: string; body: string }[] = [
-    {
-      icon: "\ud83d\udd0c",
-      title: "Boot-time discovery",
-      body: "guard.discover_mcps() returns the tools this agent may reach right now, with time-bounded scoped tokens.",
-    },
-    {
-      icon: "\ud83d\udd11",
-      title: "Per-agent credential brokering",
-      body: "Rotate a GitHub app token once. Every agent picks it up on next boot. Zero redeploys.",
-    },
-    {
-      icon: "\ud83c\udfaf",
-      title: "Policy per tool intent",
-      body: "\u201cThis agent may call GitHub MCP, but only for read operations.\u201d Two lines of YAML. Blocked calls log the rule id.",
-    },
-    {
-      icon: "\ud83d\udd17",
-      title: "Hash-chained audit",
-      body: "Every tool call is tamper-evident. Export to SIEM. Answer \u201cdid any agent touch customer-data last night\u201d in one query.",
-    },
-  ]
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-16">
-      <div className="grid sm:grid-cols-2 gap-6">
-        {features.map(f => (
-          <div key={f.title} className="border border-stone-200 rounded-xl bg-white p-6">
-            <div className="text-2xl mb-3">{f.icon}</div>
-            <h3 className="text-lg font-bold text-stone-900 mb-2">{f.title}</h3>
-            <p className="text-sm text-stone-600 leading-relaxed">{f.body}</p>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-function RegistrySection() {
-  const canned: { name: string; icon: string }[] = [
-    { name: "GitHub", icon: "\ud83d\udc19" },
-    { name: "Slack", icon: "\ud83d\udcac" },
-    { name: "Postgres", icon: "\ud83d\udc18" },
-    { name: "Filesystem", icon: "\ud83d\udcc1" },
-    { name: "Confluence", icon: "\ud83d\udcd8" },
-    { name: "Jira", icon: "\ud83d\udccb" },
-    { name: "GDrive", icon: "\ud83d\udcc2" },
-    { name: "Sentry", icon: "\ud83d\udea8" },
-    { name: "Linear", icon: "\ud83d\udcd0" },
-    { name: "Notion", icon: "\ud83d\udcdd" },
-  ]
-  const perToolRows: { icon: string; iconColor: string; tool: string; verdict: string }[] = [
-    { icon: "\u2713", iconColor: "text-emerald-600", tool: "GitHub.create_issue", verdict: "Allowed" },
-    { icon: "\u26a0", iconColor: "text-yellow-600", tool: "GitHub.merge_pr", verdict: "Requires human approval" },
-    { icon: "\u2715", iconColor: "text-red-600", tool: "Postgres.execute", verdict: "Blocked" },
-    { icon: "\u2713", iconColor: "text-emerald-600", tool: "Postgres.query", verdict: "Allowed (read-only)" },
-  ]
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-16">
-      <div className="text-center mb-10">
-        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
-          Registry + Bring Your Own
-        </h2>
-        <p className="text-stone-500 max-w-2xl mx-auto">
-          Two catalog sources, one enforcement layer. Every tool call is policy-checked whether the MCP shipped with Guard or you registered it yourself.
-        </p>
-      </div>
-      <div className="grid md:grid-cols-2 gap-6">
-        <div className="border border-stone-200 rounded-xl bg-white p-6">
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-[10px] font-bold uppercase tracking-widest text-indigo-700 bg-indigo-50 border border-indigo-100 px-2.5 py-1 rounded-full">
-              Pre-canned
-            </span>
-            <h3 className="text-lg font-bold text-stone-900">Conduct Registry</h3>
-          </div>
-          <p className="text-sm text-stone-600 leading-relaxed mb-4">
-            Curated MCPs with default policy packs already attached per tool. Click Enable, get sensible defaults (approval on writes, read-only for restricted roles, PII redaction on outputs). No week of policy writing before day one.
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            MCP
           </p>
-          <div className="grid grid-cols-5 gap-2">
-            {canned.map(m => (
-              <div key={m.name} className="flex flex-col items-center gap-1 p-2 rounded-lg bg-stone-50 border border-stone-100">
-                <span className="text-xl">{m.icon}</span>
-                <span className="text-[10px] font-semibold text-stone-500">{m.name}</span>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Runtime policy for MCP actions.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Guard sits between the MCP client and the MCP server. Every tool call is evaluated
+            against policy before it reaches the server. Policy applies at the MCP call — not at
+            the client, not at the model.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </section>
+
+        {/* MCP flow diagram */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            MCP client → Guard → MCP server.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard wraps the MCP transport layer. Clients connect to Guard as if it were the MCP server.
+            Guard evaluates each tool call and forwards allowed calls to the upstream server.
+            Blocked calls never reach the server.
+          </p>
+          <div className="border border-stone-200 rounded-2xl bg-stone-50 p-8 mb-8">
+            <RuntimeFlow variant="compact" />
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm font-mono">
+            {[
+              { step: "1", label: "MCP Client", desc: "Claude Desktop, Cursor, or any MCP-compatible client sends a tool call." },
+              { step: "2", label: "Guard evaluates", desc: "Guard checks the tool call against policy. Allow, approve, or block — before the server sees it." },
+              { step: "3", label: "MCP Server", desc: "Allowed calls reach the server. Blocked calls return a Guard decision with reason." },
+            ].map(({ step, label, desc }) => (
+              <div key={step} className="border border-stone-200 rounded-xl bg-white p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="w-5 h-5 rounded-full bg-stone-900 text-white text-[10px] font-bold flex items-center justify-center shrink-0">
+                    {step}
+                  </span>
+                  <span className="font-bold text-stone-900 text-[13px]">{label}</span>
+                </div>
+                <p className="text-stone-500 text-[12px] leading-relaxed">{desc}</p>
               </div>
             ))}
           </div>
-          <p className="text-xs text-stone-400 mt-3">10 MCPs at launch, more each month.</p>
-        </div>
-        <div className="border border-stone-200 rounded-xl bg-white p-6">
-          <div className="flex items-center gap-2 mb-3">
-            <span className="text-[10px] font-bold uppercase tracking-widest text-stone-700 bg-stone-100 border border-stone-200 px-2.5 py-1 rounded-full">
-              Bring your own
-            </span>
-            <h3 className="text-lg font-bold text-stone-900">Private MCPs</h3>
-          </div>
-          <p className="text-sm text-stone-600 leading-relaxed mb-4">
-            Register any MCP server. Guard introspects it via the standard tools/list call, pulls every tool schema, and lets admins attach policy packs per tool.
+        </section>
+
+        {/* Policy applies at the MCP call */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            Policy at the call, not the client.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            MCP clients do not enforce policy — they issue tool calls. Guard is the enforcement
+            point that sits at the transport layer. The same policy that governs Claude Code CLI
+            actions also governs MCP tool calls through the same engine.
           </p>
-          <pre className="bg-stone-900 text-stone-100 rounded-lg px-3 py-2 text-xs overflow-x-auto">
-            <code>{`$ conduct mcp add https://internal.mcp/finance
-  \u2192 17 tools introspected
-  \u2192 default pack applied (read-only)
-  \u2192 admin approval required to enable writes`}</code>
-          </pre>
-          <p className="text-xs text-stone-400 mt-3">Per-tool policies, not per-server.</p>
-        </div>
-      </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+            <DecisionCard
+              agent="claude-code / deploy-agent"
+              action="update_terraform"
+              resource="prod-vpc"
+              policy="no-production-network-change"
+              decision="BLOCK"
+              reason="Production network modifications require approved change record."
+            />
+            <DecisionCard
+              agent="cursor-agent-17"
+              action="deploy_production"
+              resource="payments-api"
+              policy="production-change-v4"
+              decision="APPROVE"
+              reason="Production deployment outside approved change window"
+              showButtons
+            />
+          </div>
+        </section>
 
-      <div className="mt-6 border border-stone-200 rounded-xl bg-stone-50 p-6">
-        <p className="text-xs font-bold uppercase tracking-widest text-stone-500 mb-3">
-          Per-tool policy examples
-        </p>
-        <div className="grid sm:grid-cols-2 gap-3 text-sm">
-          {perToolRows.map(r => (
-            <div key={r.tool} className="flex items-start gap-3 bg-white border border-stone-200 rounded-lg p-3">
-              <span className={`${r.iconColor} font-bold mt-0.5`}>{r.icon}</span>
-              <div>
-                <p className="font-semibold text-stone-800">{r.tool}</p>
-                <p className="text-xs text-stone-500">{r.verdict}</p>
-              </div>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-function UseCasesSection() {
-  const cases: { persona: string; title: string; before: string; after: string }[] = [
-    {
-      persona: "Platform Ops",
-      title: "End MCP tool sprawl",
-      before:
-        "Every agent has a copy of every MCP endpoint and every credential pasted into its config. Onboarding a new MCP means 20 config edits and 20 redeploys.",
-      after:
-        "One central catalog. Agents ask guard.discover_mcps() at boot. New MCPs propagate to every agent on next boot, no code changes.",
-    },
-    {
-      persona: "Security",
-      title: "Least privilege per agent",
-      before:
-        "Every agent shares one long-lived MCP token with full workspace scope. Blast radius of a compromised agent is every tool that token can touch.",
-      after:
-        "Per-agent scoped tokens minted on demand, TTL-bounded, revocable per agent. \u201cThis agent may call GitHub MCP only for read.\u201d Two lines of YAML.",
-    },
-    {
-      persona: "Compliance & Audit",
-      title: "Prove every tool call",
-      before:
-        "\u201cDid any agent hit customer-data MCP last night?\u201d = grep across 20 log formats, hope you have retention, hope nothing was rotated out.",
-      after:
-        "One query against the hash-chained audit log. Tamper-evident, resolving policy rule id attached to every call. SIEM-exportable.",
-    },
-    {
-      persona: "AI Coding Assistants",
-      title: "Govern Cursor, Copilot, Claude Desktop, Cline",
-      before:
-        "Developers install MCP servers ad hoc into their IDE configs. Central IT has zero visibility into which tools their AI assistants can reach.",
-      after:
-        "Discovery daemon detects MCPs registered in .mcp.json, Claude Desktop, Cursor, Windsurf. Central catalog with observe-then-enforce toggle. Devs use approved MCPs, everything else logged.",
-    },
-    {
-      persona: "AI Product Team",
-      title: "Ship agents in a week, not a quarter",
-      before:
-        "Enabling GitHub + Slack + Postgres MCPs for an agent means a week of reading MCP docs, writing per-tool rules, testing, and hoping nothing was missed.",
-      after:
-        "Enable pre-canned MCPs from the Conduct Registry. Sensible default policies attached per tool. Tune later. Ship this week.",
-    },
-  ]
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-16">
-      <div className="text-center mb-10">
-        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
-          Use cases
-        </h2>
-        <p className="text-stone-500">
-          Where MCP Gateway earns its place in the stack.
-        </p>
-      </div>
-      <div className="grid sm:grid-cols-2 gap-6">
-        {cases.map(c => (
-          <div
-            key={c.title}
-            className="border border-stone-200 rounded-xl bg-white p-6 flex flex-col"
-          >
-            <p className="text-[10px] font-bold uppercase tracking-widest text-indigo-700 mb-2">
-              {c.persona}
-            </p>
-            <h3 className="text-lg font-bold text-stone-900 mb-4">{c.title}</h3>
-            <div className="mb-4">
-              <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-1">
-                Before
+        {/* MCP capabilities */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <h2 className="text-lg font-bold text-stone-900 mb-4">What Guard brings to MCP</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm text-stone-600">
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">Tool discovery and registration</p>
+              <p className="leading-relaxed">
+                Conduct exposes a <span className="font-mono text-stone-700">.well-known/mcp.json</span> endpoint.
+                MCP clients can discover and register Guard-wrapped servers automatically.
               </p>
-              <p className="text-sm text-stone-600 leading-relaxed">{c.before}</p>
             </div>
             <div>
-              <p className="text-xs font-bold uppercase tracking-widest text-indigo-700 mb-1">
-                With MCP Gateway
+              <p className="font-semibold text-stone-900 mb-2">Tool interception and Guard checks</p>
+              <p className="leading-relaxed">
+                Every tool invocation is intercepted. Guard evaluates it against the workspace policy
+                before forwarding. No client-side configuration required.
               </p>
-              <p className="text-sm text-stone-700 leading-relaxed">{c.after}</p>
+            </div>
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">OAuth support</p>
+              <p className="leading-relaxed">
+                Guard supports OAuth for MCP tool authentication. Clients authenticate once;
+                Guard manages token scope and rotation.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">Hash-chained evidence</p>
+              <p className="leading-relaxed">
+                Every MCP tool call decision is recorded in the same audit trail as CLI and proxy
+                decisions. One receipt format across all enforcement surfaces.
+              </p>
             </div>
           </div>
-        ))}
-      </div>
-    </section>
-  )
-}
+        </section>
 
-function ComparisonSection() {
-  const rows: [string, string, string][] = [
-    ["Governs", "Model calls", "Tool calls"],
-    ["Audit granularity", "Completion", "Tool invocation"],
-    ["Credential type", "Inbound provider keys", "Outbound tool credentials"],
-    ["Policy vocabulary", "Model requests", "Tool intent"],
-    ["Answers \u201cwho called what\u201d", "Model, prompt", "Tool, arguments, side effect"],
-    ["Category age", "Mature", "Empty (nobody has planted the flag)"],
-  ]
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-16">
-      <div className="text-center mb-8">
-        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-2">
-          Not a competing proxy.
-        </h2>
-        <p className="text-stone-500">A different layer entirely.</p>
-      </div>
-      <div className="overflow-x-auto border border-stone-200 rounded-xl bg-white">
-        <table className="w-full text-sm">
-          <thead className="bg-stone-50 border-b border-stone-200">
-            <tr>
-              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-stone-500"></th>
-              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-stone-500">
-                LLM Proxy (LiteLLM, Portkey)
-              </th>
-              <th className="text-left px-6 py-3 text-xs font-bold uppercase tracking-widest text-indigo-700">
-                MCP Gateway (Guard)
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {rows.map(([label, a, b]) => (
-              <tr key={label} className="border-b border-stone-100 last:border-b-0">
-                <td className="px-6 py-4 font-semibold text-stone-700">{label}</td>
-                <td className="px-6 py-4 text-stone-600">{a}</td>
-                <td className="px-6 py-4 text-indigo-700 font-medium">{b}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </section>
-  )
-}
+        {/* Supported MCP clients */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Supported MCP clients</h2>
+          <div className="border border-stone-200 rounded-2xl overflow-hidden bg-white">
+            <div className="divide-y divide-stone-100">
+              {[
+                { client: "Claude Desktop", note: "Native MCP support", status: "Shipped" },
+                { client: "Cursor", note: "MCP tool calling", status: "Shipped" },
+                { client: "Custom agents", note: "Any MCP-compatible client via proxy or direct MCP", status: "Shipped" },
+              ].map(({ client, note, status }) => (
+                <div key={client} className="flex items-center justify-between px-6 py-4 text-sm">
+                  <div>
+                    <span className="font-medium text-stone-900">{client}</span>
+                    <span className="text-stone-400 ml-2 text-xs">{note}</span>
+                  </div>
+                  <span className="text-[10px] font-mono font-bold uppercase tracking-wider border border-emerald-200 bg-emerald-50 text-emerald-700 rounded px-2 py-0.5">
+                    {status}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
 
-function ElevatorSection() {
-  return (
-    <section className="max-w-3xl mx-auto px-6 pb-16">
-      <div className="border-l-4 border-indigo-500 bg-indigo-50/50 rounded-r-xl px-8 py-6">
-        <p className="text-lg text-stone-700 leading-relaxed">
-          Every enterprise with more than three AI agents has the same problem. Each agent hardcodes its own copy of every tool endpoint and every credential. Rotate a token, redeploy 20 things. Guard becomes the one place agents ask &ldquo;what tools am I allowed to reach right now, and with what credentials?&rdquo; Enable pre-canned MCPs from the Registry with sensible defaults, or register your own private MCPs and Guard introspects the tool schemas so you attach policy per tool. Every call is hash-chained. LiteLLM solved model sprawl. Nobody solved tool sprawl. That is Guard.
-        </p>
-      </div>
-    </section>
-  )
-}
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+            Policy at the MCP call. Not the client.
+          </h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/guard"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              See how Guard works →
+            </Link>
+          </div>
+        </section>
 
-function CtaFooterSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-24">
-      <div className="border border-stone-200 rounded-2xl bg-white p-10 text-center">
-        <h2 className="text-3xl font-black tracking-tight text-stone-900 mb-3">
-          Ready to stop pasting MCP tokens into 20 configs?
-        </h2>
-        <p className="text-stone-500 max-w-xl mx-auto mb-8">
-          MCP Gateway is in early access. Get on the list to try the boot-time discovery API and per-agent credential brokering the day it opens.
-        </p>
-        <div className="flex flex-wrap justify-center gap-3">
-          <a
-            href="mailto:hello@conductai.ai?subject=MCP%20Gateway%20early%20access"
-            className="inline-flex items-center gap-2 rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-          >
-            Get early access
-          </a>
-          <a
-            href="https://github.com/sseshachala/conductai/issues/1246"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all"
-          >
-            Read the build epic
-          </a>
-          <CtaLink className="inline-flex items-center gap-2 rounded-xl border border-stone-200 bg-white px-6 py-3 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all" />
-        </div>
-      </div>
-    </section>
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/(marketing)/open-source/page.tsx
+++ b/apps/web/src/app/(marketing)/open-source/page.tsx
@@ -1,226 +1,185 @@
-"use client"
+import Link from "next/link"
 
-import { useState } from "react"
-import { CtaLink } from "@/components/marketing/CtaLink"
+export const metadata = {
+  title: "Open Source — Conduct",
+  description:
+    "The components that matter most for trust are open. Four Apache-2.0 components: conduct-cli, Guard runtime core, Playbook DSL compiler, and Agent Booster MCP.",
+}
 
-/* ─── Page ──────────────────────────────────────────────────────────────── */
+const OSS_COMPONENTS = [
+  {
+    name: "conduct-cli",
+    license: "Apache-2.0",
+    repo: "github.com/conductai/conduct",
+    path: "packages/conduct-cli/",
+    pypi: "conduct-cli",
+    purpose: "Agent lifecycle management, Guard sync, policy testing. Runs on developer machines and in CI/CD.",
+  },
+  {
+    name: "Guard runtime core",
+    license: "Apache-2.0",
+    repo: "github.com/conductai/conduct",
+    path: "apps/api/app/guard/",
+    pypi: null,
+    purpose: "Core enforcement engine: rule evaluation, decision scoring, hash-chained audit trail. Runs inside the Conduct API server.",
+  },
+  {
+    name: "Playbook DSL compiler",
+    license: "Apache-2.0",
+    repo: "github.com/conductai/conduct",
+    path: "apps/api/app/compiler/",
+    pypi: null,
+    purpose: "Compiles YAML playbook definitions into executable DAG runs. Shared by all 39 shipped playbooks.",
+  },
+  {
+    name: "Agent Booster MCP",
+    license: "Apache-2.0",
+    repo: "github.com/conductai/conduct",
+    path: "tools/booster/",
+    pypi: null,
+    purpose: "Developer productivity tools (semantic search, smart read, test coverage) for Claude Code and Cursor. Runs locally or on Vercel.",
+  },
+]
 
 export default function OpenSourcePage() {
   return (
-    <>
-      <HeroSection />
-      <ProjectsSection />
-      <CtaSection />
-    </>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-/* ─── Hero ──────────────────────────────────────────────────────────────── */
-
-function HeroSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-12 text-center">
-      <div className="inline-flex items-center gap-2 bg-stone-100 text-stone-600 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-stone-400 inline-block" />
-        Open Source
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-5">
-        Open Source
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed">
-        Apache 2.0. Free for everyone — individuals, teams, and companies — for commercial and non-commercial use, with an explicit patent grant from contributors.
-      </p>
-    </section>
-  )
-}
-
-/* ─── Projects ──────────────────────────────────────────────────────────── */
-
-function ProjectsSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pb-20 flex flex-col gap-8">
-      <ProjectCard
-        name="Conduct Guard"
-        tagline="Runtime policy enforcement for AI agents"
-        description="Guard sits at the LLM call and shell tool boundary — block, warn, audit, or inject before an action executes. Ships with 15 compliance packs (OWASP, SOC 2, HIPAA, PCI, EU AI Act), a canvas UI, YAML playbook DSL, and hash-chained audit trail. Apache 2.0 — free for commercial and non-commercial use, with an explicit patent grant."
-        install={["git clone https://github.com/sseshachala/conductai", "docker compose up"]}
-        githubUrl="https://github.com/sseshachala/conductai"
-        guardRelation="This is Guard itself — the policy engine, packs, canvas, and hash chain. Self-host for full control, or use the hosted product."
-        badgeColor="bg-stone-900 text-white"
-        badgeLabel="Platform"
-      />
-      <ProjectCard
-        name="Conduct Router"
-        tagline="LLM proxy with per-agent tokens, retries, and audit"
-        description="Router is the Guard-aware LLM proxy — every model call runs through it. Per-agent tokens (cond_agt_*), provider fallback, retry-on-upstream-error, spend metering, and full request/response audit. Sits in the same repo as Guard; deploy together or use the proxy standalone in front of any AI SDK."
-        install={["git clone https://github.com/sseshachala/conductai", "docker compose up grouter"]}
-        githubUrl="https://github.com/sseshachala/conductai"
-        guardRelation="Router is the enforcement point Guard uses at runtime — every LLM call is checked against active packs before the upstream request goes out."
-        badgeColor="bg-indigo-100 text-indigo-700"
-        badgeLabel="Proxy"
-      />
-      <ProjectCard
-        name="Agent Booster"
-        tagline="Context-efficient reads for Claude Code"
-        description="Agent Booster intercepts Read and Grep calls and returns only the relevant symbol slices — cutting token usage 60-90% on large codebases."
-        install="pip install agent-booster"
-        githubUrl="https://github.com/sseshachala/agent-booster"
-        guardRelation="Agent Booster runs inside your AI coding session. Guard governs what that session can do. Together: token-efficient AND policy-enforced."
-        badgeColor="bg-violet-100 text-violet-700"
-        badgeLabel="Python"
-      />
-      <ProjectCard
-        name="RTK — Rust Token Killer"
-        tagline="60-90% token savings on dev operations"
-        description="A transparent CLI proxy that filters verbose command output (build errors, test results, git diffs) down to signal-only. Works with any AI coding tool."
-        install={["cargo install rtk", "brew install rtk"]}
-        githubUrl="https://github.com/sseshachala/rtk"
-        guardRelation="RTK reduces the token surface area of every shell command. Guard enforces policy on every shell command. Complementary layers."
-        badgeColor="bg-orange-100 text-orange-700"
-        badgeLabel="Rust"
-      />
-    </section>
-  )
-}
-
-function ProjectCard({
-  name,
-  tagline,
-  description,
-  install,
-  githubUrl,
-  guardRelation,
-  badgeColor,
-  badgeLabel,
-}: {
-  name: string
-  tagline: string
-  description: string
-  install: string | string[]
-  githubUrl: string
-  guardRelation: string
-  badgeColor: string
-  badgeLabel: string
-}) {
-  const anchorId = name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "")
-  const installLines = Array.isArray(install) ? install : [install]
-
-  return (
-    <div id={anchorId} className="border border-stone-200 rounded-xl bg-white overflow-hidden scroll-mt-24">
-      {/* Header */}
-      <div className="px-8 pt-8 pb-6 border-b border-stone-100">
-        <div className="flex items-start justify-between gap-4 flex-wrap">
-          <div>
-            <div className="flex items-center gap-3 mb-1">
-              <h2 className="text-2xl font-black text-stone-900 tracking-tight">{name}</h2>
-              <span className={`text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full ${badgeColor}`}>
-                {badgeLabel}
-              </span>
-            </div>
-            <p className="text-stone-500 text-sm font-medium">{tagline}</p>
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Open Source
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Open where trust matters.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            The components that determine whether Guard is trustworthy are open. The enforcement engine,
+            the audit trail, and the CLI are Apache-2.0 — readable, auditable, and forkable.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <a
+              href="https://github.com/conductai/conduct"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              View the open-source runtime →
+            </a>
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
           </div>
-          <a
-            href={githubUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center gap-2 border border-stone-200 rounded-lg px-4 py-2 text-sm font-semibold text-stone-700 hover:border-stone-300 hover:shadow-sm transition-all flex-shrink-0"
-          >
-            <GitHubIcon />
-            GitHub
-          </a>
-        </div>
-      </div>
+        </section>
 
-      {/* Body */}
-      <div className="px-8 py-6 grid md:grid-cols-2 gap-8">
-        <div className="flex flex-col gap-5">
-          <p className="text-stone-600 text-sm leading-relaxed">{description}</p>
+        {/* Component table */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">4 open-source components</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            These are the exact components open-sourced as of the last audit (2026-09-01). All four are Apache-2.0.
+            The hosted product (SaaS at conductai.ai) runs the same code.
+          </p>
 
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-2">Install</p>
-            <div className="bg-stone-950 rounded-xl p-4 space-y-1.5">
-              {installLines.map((line, i) => (
-                <CopyableLine key={i} value={line} />
-              ))}
+          {/* Desktop table */}
+          <div className="hidden sm:block border border-stone-200 rounded-2xl overflow-hidden">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="bg-stone-50 border-b border-stone-200">
+                  <th className="text-left px-5 py-3 text-xs font-mono font-bold uppercase tracking-widest text-stone-400 w-1/4">Component</th>
+                  <th className="text-left px-5 py-3 text-xs font-mono font-bold uppercase tracking-widest text-stone-400 w-24">Licence</th>
+                  <th className="text-left px-5 py-3 text-xs font-mono font-bold uppercase tracking-widest text-stone-400 w-1/4">Repository path</th>
+                  <th className="text-left px-5 py-3 text-xs font-mono font-bold uppercase tracking-widest text-stone-400">Purpose</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-stone-100">
+                {OSS_COMPONENTS.map((c) => (
+                  <tr key={c.name} className="hover:bg-stone-50 transition-colors">
+                    <td className="px-5 py-4 font-mono font-bold text-stone-900 text-xs align-top">
+                      {c.name}
+                      {c.pypi && (
+                        <p className="text-[10px] text-stone-400 font-normal mt-0.5">PyPI: {c.pypi}</p>
+                      )}
+                    </td>
+                    <td className="px-5 py-4 align-top">
+                      <span className="text-xs font-mono border border-emerald-200 bg-emerald-50 text-emerald-700 rounded px-2 py-0.5">
+                        {c.license}
+                      </span>
+                    </td>
+                    <td className="px-5 py-4 font-mono text-xs text-stone-500 align-top break-all">
+                      {c.path}
+                    </td>
+                    <td className="px-5 py-4 text-xs text-stone-600 leading-relaxed align-top">
+                      {c.purpose}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Mobile cards */}
+          <div className="sm:hidden space-y-4">
+            {OSS_COMPONENTS.map((c) => (
+              <div key={c.name} className="border border-stone-200 rounded-xl p-5 bg-white">
+                <div className="flex items-start justify-between gap-2 mb-3">
+                  <p className="font-mono font-bold text-stone-900 text-sm">{c.name}</p>
+                  <span className="text-[10px] font-mono border border-emerald-200 bg-emerald-50 text-emerald-700 rounded px-2 py-0.5 shrink-0">
+                    {c.license}
+                  </span>
+                </div>
+                <p className="text-[11px] font-mono text-stone-400 mb-2">{c.path}</p>
+                <p className="text-xs text-stone-600 leading-relaxed">{c.purpose}</p>
+                {c.pypi && (
+                  <p className="text-[10px] text-stone-400 mt-2">PyPI: {c.pypi}</p>
+                )}
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* What open means */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <h2 className="text-lg font-bold text-stone-900 mb-4">What open means here</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm text-stone-600 leading-relaxed">
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">Apache-2.0</p>
+              <p>
+                The entire repository — CLI, Guard runtime, compiler, web UI, and API — is Apache-2.0.
+                The SaaS product runs this source. There is no closed core.
+              </p>
+            </div>
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">Self-hosted</p>
+              <p>
+                Run Guard on your own infrastructure using Docker Compose. The same policy engine
+                and audit trail, on hardware you control. Kubernetes support is in preview.
+              </p>
             </div>
           </div>
-        </div>
+        </section>
 
-        <div className="border border-stone-200 rounded-xl bg-stone-50 p-5 flex flex-col gap-3">
-          <div className="flex items-center gap-2">
-            <span className="text-base">🛡️</span>
-            <p className="text-xs font-semibold uppercase tracking-widest text-stone-500">How it relates to Guard</p>
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">Start with the source.</h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <a
+              href="https://github.com/conductai/conduct"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              View on GitHub →
+            </a>
+            <Link
+              href="/deployment"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Deployment options →
+            </Link>
           </div>
-          <p className="text-sm text-stone-600 leading-relaxed">{guardRelation}</p>
-        </div>
-      </div>
+        </section>
+
+      </main>
     </div>
-  )
-}
-
-function CopyableLine({ value }: { value: string }) {
-  const [copied, setCopied] = useState(false)
-
-  function copy() {
-    navigator.clipboard.writeText(value).then(() => {
-      setCopied(true)
-      setTimeout(() => setCopied(false), 1800)
-    })
-  }
-
-  return (
-    <div className="flex items-center justify-between gap-3 group">
-      <code className="text-xs font-mono text-stone-300 flex-1">
-        <span className="text-indigo-400">$ </span>
-        {value}
-      </code>
-      <button
-        onClick={copy}
-        className="text-[10px] font-semibold text-stone-600 hover:text-stone-300 transition-colors opacity-0 group-hover:opacity-100 flex-shrink-0"
-        aria-label={`Copy: ${value}`}
-      >
-        {copied ? "copied" : "copy"}
-      </button>
-    </div>
-  )
-}
-
-function GitHubIcon() {
-  return (
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
-      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
-    </svg>
-  )
-}
-
-/* ─── CTA ───────────────────────────────────────────────────────────────── */
-
-function CtaSection() {
-  return (
-    <section className="border-t border-stone-200 bg-stone-50 px-6 py-14">
-      <div className="max-w-5xl mx-auto text-center">
-        <p className="text-stone-700 font-semibold text-lg mb-2">
-          Built something on top of Guard, Booster, or RTK?
-        </p>
-        <p className="text-stone-500 text-sm mb-8">We&apos;d love to hear about it.</p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <a
-            href="mailto:hello@conductai.ai"
-            className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-sm font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center"
-          >
-            hello@conductai.ai
-          </a>
-          <a
-            href="https://github.com/sseshachala"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-flex items-center justify-center gap-2 rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-sm font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto"
-          >
-            <GitHubIcon />
-            GitHub
-          </a>
-        </div>
-      </div>
-    </section>
   )
 }

--- a/apps/web/src/app/(marketing)/playbooks/page.tsx
+++ b/apps/web/src/app/(marketing)/playbooks/page.tsx
@@ -1,256 +1,251 @@
-"use client"
-
-import { useEffect, useState } from "react"
 import Link from "next/link"
-import { useAuth } from "@clerk/nextjs"
+import { PlaybookTile } from "@/components/marketing/facelift/PlaybookTile"
+import type { PlaybookCategory, BlockType } from "@/components/marketing/facelift/PlaybookTile"
 
-// ponytail: env-gate so preview builds without Clerk key don't crash at
-// prerender. Same pattern as CtaLink and WorkspaceProvider.
-const CLERK_ENABLED = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
-function useSignedIn(): boolean | undefined {
-  if (!CLERK_ENABLED) return false
-  // eslint-disable-next-line react-hooks/rules-of-hooks
-  return useAuth().isSignedIn
+export const metadata = {
+  title: "Playbooks — Conduct",
+  description:
+    "39 shipped playbooks for AI agent teams. Code review, security, incident response, CI/CD, and more — each one combining brain, guard, approval, and evidence blocks.",
 }
 
-interface Playbook {
-  slug: string
+interface PlaybookEntry {
   name: string
-  icon: string
+  category: PlaybookCategory
   description: string
-  tags: string[]
-  category: string
-  featured: boolean
+  blocks: BlockType[]
 }
 
-const CATEGORY_ORDER = [
-  "All",
-  "Issue to PR",
-  "Code Review",
-  "Issue Triage",
-  "CI/CD",
-  "Testing",
-  "Security",
-  "AI Governance",
-  "Incidents & Ops",
-  "Release Management",
-  "Docs",
-  "Platform & Infra",
+const PLAYBOOKS: PlaybookEntry[] = [
+  // Code Review
+  { name: "pr-reviewer", category: "code-review", description: "Reviews every pull request with an AI brain block; Guard checks before posting comments.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "copilot-reviewer", category: "code-review", description: "Runs a structured review pass on Copilot-suggested changes before merge.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "bulk-pr-reviewer", category: "code-review", description: "Batch-reviews open PRs in a repository overnight.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "terraform-reviewer", category: "code-review", description: "Static analysis plus Guard policy check on every Terraform plan before apply.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  // CI/CD
+  { name: "release-gating", category: "ci-cd", description: "Holds a release until Guard clears all policy checks and a human approves.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "release-readiness", category: "ci-cd", description: "Evaluates tests, coverage, and Guard signal before promoting to production.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "dependency-updater", category: "ci-cd", description: "Opens PRs for outdated dependencies; Guard blocks known-vulnerable versions.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "smoke-test", category: "ci-cd", description: "Runs a post-deploy smoke suite; Guard enforces test-pass policy before marking green.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "multi-env-smoke-test", category: "ci-cd", description: "Fans smoke tests across staging and production in parallel.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "security-patch-updater", category: "ci-cd", description: "Automatically applies security patches and routes high-severity changes to human approval.", blocks: ["trigger", "tool", "guard", "approval", "output"] },
+  // Security
+  { name: "security-scanner", category: "security", description: "Scans codebase for secrets, misconfigurations, and known CVEs. Guard blocks on critical findings.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "security-loop", category: "security", description: "Continuous security loop that re-scans on every commit and opens issues for new findings.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "security-autopilot-fix", category: "security", description: "Generates and opens fix PRs for security findings; Guard gates the push step.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "threat-modeler", category: "security", description: "Runs a threat-modelling pass against architecture docs; produces a findings report.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "ai-risk-assessment", category: "security", description: "Assesses AI-generated code for risk patterns mapped to the OWASP Agentic Top 10.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "dependency-audit", category: "security", description: "Audits transitive dependencies for licence conflicts and known vulnerabilities.", blocks: ["trigger", "tool", "guard", "output"] },
+  // Incident
+  { name: "incident-responder", category: "incident", description: "Triages on-call alerts, collects context, and pages the right owner. Guard checks before any action.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "postmortem-drafter", category: "incident", description: "Drafts a structured postmortem from incident timeline and Slack threads.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "ai-incident-drill", category: "incident", description: "Runs a synthetic incident scenario to test your response runbook.", blocks: ["trigger", "brain", "guard", "output"] },
+  // Monitoring
+  { name: "network-diagnosis-agent", category: "monitoring", description: "Diagnoses network degradation by correlating logs and metrics across infrastructure.", blocks: ["trigger", "tool", "brain", "guard", "output"] },
+  { name: "docs-drift-detector", category: "monitoring", description: "Detects when documentation drifts from code and opens issues for the delta.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "codebase-guard-monitor", category: "monitoring", description: "Monitors Guard activity across your codebase; surfaces policy-coverage gaps.", blocks: ["trigger", "tool", "guard", "output"] },
+  { name: "ai-drift-detector", category: "monitoring", description: "Detects when AI-generated code diverges from established team patterns.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "ai-output-auditor", category: "monitoring", description: "Audits a sample of AI completions for quality, accuracy, and policy compliance.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "multi-repo-scanner", category: "monitoring", description: "Scans across all repositories in an organisation for a given pattern or risk.", blocks: ["trigger", "tool", "guard", "output"] },
+  // Onboarding
+  { name: "acme-onboarding-e2e", category: "onboarding", description: "End-to-end onboarding flow for new workspace members, including Guard policy assignment.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "self-driving-network-approval-demo", category: "onboarding", description: "Demo playbook: network change requires human approval via Slack before Guard allows.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "base-autopilot", category: "onboarding", description: "Reference autopilot skeleton — extend with domain-specific brain and guard blocks.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "release-notes", category: "onboarding", description: "Generates release notes from merged PRs and posts to Slack.", blocks: ["trigger", "brain", "output"] },
+  { name: "ci-notify", category: "onboarding", description: "Posts CI pass/fail status to Slack with Guard-sourced context.", blocks: ["trigger", "tool", "output"] },
+  // Issue management
+  { name: "issue-triage", category: "code-review", description: "Triages incoming GitHub issues: labels, assignee, and priority suggestions.", blocks: ["trigger", "brain", "guard", "output"] },
+  { name: "oss-issue-sweep", category: "code-review", description: "Sweeps open issues on public repos and surfaces stale, duplicate, or blocked ones.", blocks: ["trigger", "brain", "output"] },
+  // Testing
+  { name: "flaky-test-detective", category: "ci-cd", description: "Identifies and quarantines flaky tests; Guard blocks merges until they are resolved.", blocks: ["trigger", "tool", "brain", "guard", "output"] },
+  { name: "bughunter-active-scan", category: "security", description: "Active scan of a deployed service for common vulnerability classes.", blocks: ["trigger", "tool", "guard", "output"] },
+  // Autopilot reference
+  { name: "autopilot", category: "onboarding", description: "Full autopilot reference — brain-guided loop with Guard on every action and approval gates.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "autopilot-approved", category: "onboarding", description: "Autopilot variant where every action requires explicit human approval.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
+  { name: "thirdparty-autopilot-fix", category: "security", description: "Autopilot that triages and fixes issues surfaced by third-party security scanners.", blocks: ["trigger", "brain", "guard", "approval", "output"] },
 ]
 
-const CATEGORY_COLORS: Record<string, string> = {
-  "Issue to PR":        "bg-violet-100",
-  "Code Review":        "bg-stone-200",
-  "Issue Triage":       "bg-amber-100",
-  "CI/CD":              "bg-emerald-100",
-  "Testing":            "bg-blue-100",
-  "Security":           "bg-red-100",
-  "AI Governance":      "bg-teal-100",
-  "Incidents & Ops":    "bg-orange-100",
-  "Release Management": "bg-indigo-100",
-  "Docs":               "bg-lime-100",
-  "Platform & Infra":   "bg-sky-100",
+const CATEGORY_LABELS: Record<PlaybookCategory, string> = {
+  "code-review": "Code Review & Issues",
+  "ci-cd": "CI / CD & Testing",
+  security: "Security",
+  incident: "Incident Response",
+  monitoring: "Monitoring & Observability",
+  onboarding: "Onboarding & Reference",
 }
 
-const MODULES = [
-  {
-    id: "conductguard",
-    icon: "🛡️",
-    name: "ConductGuard",
-    description: "Real-time AI activity monitoring. Tracks tool usage, enforces policies, and surfaces spend across your team's AI coding tools.",
-    href: "/packs?tab=modules",
-    badge: "Governance",
-    badgeColor: "bg-teal-100 text-teal-700",
-  },
-]
+const CATEGORIES: PlaybookCategory[] = ["code-review", "ci-cd", "security", "incident", "monitoring", "onboarding"]
 
-const COMPLIANCE_PACKS = [
-  {
-    id: "conduct-owasp",
-    icon: "🔐",
-    name: "OWASP Top 10",
-    description: "6 guard rules + 10 security rules covering injection, broken access control, weak session management, SSRF, and more.",
-    rules: "16 rules",
-    badgeColor: "bg-orange-100 text-orange-700",
-  },
-  {
-    id: "conduct-soc2",
-    icon: "📋",
-    name: "SOC 2",
-    description: "Blocks hardcoded secrets and PII logging. Keeps your audit trail clean for SOC 2 Type II compliance.",
-    rules: "5 rules",
-    badgeColor: "bg-blue-100 text-blue-700",
-  },
-  {
-    id: "conduct-hipaa",
-    icon: "🏥",
-    name: "HIPAA",
-    description: "Detects PHI patterns (SSN, DOB, medical record numbers) and blocks unencrypted health data in AI-generated code.",
-    rules: "5 rules",
-    badgeColor: "bg-emerald-100 text-emerald-700",
-  },
-  {
-    id: "conduct-pci-dss",
-    icon: "💳",
-    name: "PCI DSS",
-    description: "Guards against PAN, CVV, and card number exposure in AI-generated code. Blocks logging of cardholder data.",
-    rules: "4 rules",
-    badgeColor: "bg-violet-100 text-violet-700",
-  },
-]
-
-
-
-function PlaybookCard({ p }: { p: Playbook }) {
-  const tileBg = CATEGORY_COLORS[p.category] ?? "bg-stone-100"
+export default function PlaybooksPage() {
   return (
-    <Link
-      href={`/playbooks/${p.slug}`}
-      className="flex items-center gap-4 bg-white border border-stone-200 rounded-xl px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group"
-    >
-      <div className={`w-11 h-11 rounded-xl ${tileBg} flex items-center justify-center text-xl shrink-0`}>
-        {p.icon}
-      </div>
-      <div className="min-w-0 flex-1">
-        <p className="text-sm font-medium text-stone-900 truncate">{p.name}</p>
-        <p className="text-xs text-stone-500 mt-0.5 line-clamp-2 leading-relaxed">{p.description}</p>
-      </div>
-      <svg className="w-4 h-4 text-stone-300 group-hover:text-stone-500 shrink-0 transition-colors" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-        <path strokeLinecap="round" strokeLinejoin="round" d="M9 5l7 7-7 7" />
-      </svg>
-    </Link>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-function SectionHeader({ title, description }: { title: string; description: string }) {
-  return (
-    <div className="mb-5">
-      <h2 className="text-base font-semibold text-stone-900">{title}</h2>
-      <p className="text-xs text-stone-500 mt-0.5">{description}</p>
-    </div>
-  )
-}
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Playbooks
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Playbooks. 39 shipped.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Each playbook combines a brain block for reasoning, a guard block for policy enforcement,
+            approval gates for consequential actions, and hash-chained evidence for every decision.
+            The same primitives. Every workflow.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
+          </div>
+        </section>
 
-export default function AutomationsPage() {
-  const [playbooks, setPlaybooks] = useState<Playbook[]>([])
-  const [loading, setLoading] = useState(true)
-  const [activeCategory, setActiveCategory] = useState("All")
-  const isSignedIn = useSignedIn()
+        {/* Stats strip */}
+        <section className="mb-16 border border-stone-200 rounded-2xl bg-stone-50 grid grid-cols-2 sm:grid-cols-4 divide-y sm:divide-y-0 sm:divide-x divide-stone-200">
+          {[
+            { n: "39", label: "Shipped playbooks" },
+            { n: "15", label: "Compliance packs" },
+            { n: "6", label: "BYO gateway adapters" },
+            { n: "3", label: "Enforcement surfaces" },
+          ].map(({ n, label }) => (
+            <div key={label} className="px-6 py-5 text-center">
+              <p className="text-2xl font-black text-stone-900 font-mono">{n}</p>
+              <p className="text-xs text-stone-400 mt-1">{label}</p>
+            </div>
+          ))}
+        </section>
 
-  useEffect(() => {
-    const apiUrl = process.env.NEXT_PUBLIC_API_URL
-    if (!apiUrl) return
-    fetch(`${apiUrl}/workflows/playbooks`)
-      .then(r => r.ok ? r.json() : [])
-      .then(setPlaybooks)
-      .finally(() => setLoading(false))
-  }, [])
+        {/* Composability explanation */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">What every playbook is made of</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Playbooks are not scripts. They are structured compositions of typed blocks. The same block types
+            appear across all 39 playbooks — which means policy, approval, and evidence are never bolt-ons.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              {
+                type: "Brain",
+                colour: "border-violet-200 bg-violet-50",
+                badge: "bg-violet-600 text-white",
+                desc: "Reasoning step. Reads context, decides what to do next. One brain per decision boundary.",
+              },
+              {
+                type: "Guard",
+                colour: "border-emerald-200 bg-emerald-50",
+                badge: "bg-emerald-600 text-white",
+                desc: "Policy check. Every action that touches an external system passes through a guard block before it executes.",
+              },
+              {
+                type: "Approval",
+                colour: "border-amber-200 bg-amber-50",
+                badge: "bg-amber-500 text-white",
+                desc: "Human-in-the-loop gate. Pauses the run and routes to Slack or Lens until a human decides.",
+              },
+              {
+                type: "Evidence",
+                colour: "border-stone-200 bg-white",
+                badge: "bg-stone-700 text-white",
+                desc: "Hash-chained receipt for every decision in the run. Replay any action, answer any auditor.",
+              },
+            ].map(({ type, colour, badge, desc }) => (
+              <div key={type} className={`border rounded-xl p-5 ${colour}`}>
+                <span className={`inline-block text-[10px] font-mono font-bold uppercase tracking-wider rounded px-2 py-0.5 mb-3 ${badge}`}>
+                  {type}
+                </span>
+                <p className="text-sm text-stone-700 leading-relaxed">{desc}</p>
+              </div>
+            ))}
+          </div>
+        </section>
 
-  const categories = CATEGORY_ORDER.filter(
-    c => c === "All" || playbooks.some(p => p.category === c)
-  )
+        {/* Category list + tile grid */}
+        {CATEGORIES.map((cat) => {
+          const tiles = PLAYBOOKS.filter((p) => p.category === cat)
+          return (
+            <section key={cat} className="mb-16">
+              <div className="flex items-baseline gap-3 mb-6">
+                <h2 className="text-lg font-bold text-stone-900">{CATEGORY_LABELS[cat]}</h2>
+                <span className="text-xs font-mono text-stone-400">{tiles.length} playbooks</span>
+              </div>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {tiles.map((p) => (
+                  <PlaybookTile
+                    key={p.name}
+                    name={p.name}
+                    category={p.category}
+                    description={p.description}
+                    blocks={p.blocks}
+                  />
+                ))}
+              </div>
+            </section>
+          )
+        })}
 
-  const visible = activeCategory === "All"
-    ? playbooks
-    : playbooks.filter(p => p.category === activeCategory)
-
-  return (
-    <main className="max-w-5xl mx-auto px-6 py-12 space-y-16">
-
-        {/* Automations */}
-        <section>
-          <div className="mb-8">
-            <h1 className="text-2xl font-semibold text-stone-900">All Automations</h1>
-            <p className="text-sm text-stone-500 mt-1">
-              Pre-built YAML playbooks for AI-assisted engineering teams.{" "}
-              <Link href={isSignedIn ? "https://app.conductai.ai/guard" : "/sign-up"} className="text-stone-700 font-medium hover:underline">Install in your workspace →</Link>
+        {/* Cross-agent extension + Operations teaser */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-3">
+            Cross-agent extension
+          </p>
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            The same playbook runs across any agent surface.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed max-w-2xl mb-6">
+            Install a playbook once. It governs Claude Code, Cursor, Codex, and custom agents through the same
+            policy engine. No per-tool configuration. No parallel audit trails.
+          </p>
+          <div className="border border-stone-200 rounded-xl bg-white px-5 py-4 inline-block mb-6">
+            <p className="text-xs font-mono text-stone-400 mb-1 uppercase tracking-widest">Lens</p>
+            <p className="text-sm font-mono text-stone-700">
+              &ldquo;Ask Lens: &lsquo;which playbooks ran this week?&rsquo;&rdquo;
             </p>
           </div>
-
-          {/* Category tabs */}
-          <div className="flex gap-1.5 flex-wrap mb-6">
-            {categories.map(cat => (
-              <button
-                key={cat}
-                onClick={() => setActiveCategory(cat)}
-                className={`text-xs px-3 py-1.5 rounded-lg font-medium transition-colors ${
-                  activeCategory === cat
-                    ? "bg-stone-900 text-white"
-                    : "bg-stone-100 text-stone-600 hover:bg-stone-200"
-                }`}
-              >
-                {cat}
-              </button>
-            ))}
-          </div>
-
-          {loading ? (
-            <div className="flex items-center justify-center py-20">
-              <div className="w-5 h-5 border-2 border-stone-300 border-t-stone-600 rounded-full animate-spin" />
-            </div>
-          ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              {visible.map(p => <PlaybookCard key={p.slug} p={p} />)}
-            </div>
-          )}
-        </section>
-
-        {/* Modules */}
-        <section>
-          <SectionHeader
-            title="Modules"
-            description="Full-stack features that add new capabilities to your workspace."
-          />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {MODULES.map(m => (
-              <Link
-                key={m.id}
-                href={m.href}
-                className="flex items-start gap-4 bg-white border border-stone-200 rounded-xl px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group"
-              >
-                <div className="w-11 h-11 rounded-xl bg-stone-100 flex items-center justify-center text-xl shrink-0">
-                  {m.icon}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 mb-0.5">
-                    <p className="text-sm font-medium text-stone-900">{m.name}</p>
-                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${m.badgeColor}`}>{m.badge}</span>
-                  </div>
-                  <p className="text-xs text-stone-500 leading-relaxed">{m.description}</p>
-                </div>
-              </Link>
-            ))}
+          <div className="pt-4 border-t border-stone-200">
+            <p className="text-xs font-mono uppercase tracking-widest text-stone-400 mb-2">
+              Coming — Design Partner Preview
+            </p>
+            <p className="text-sm text-stone-500 leading-relaxed max-w-xl">
+              Operations will extend the playbook runtime to correlate events across external systems —
+              letting Guard decisions account for what happened before this action, not just the action itself.
+              Available to design partners first.
+            </p>
           </div>
         </section>
 
-        {/* Skill Packs */}
-        <section>
-          <SectionHeader
-            title="Skill Packs"
-            description="Pre-built guard + security rule sets mapped to industry standards. Install in one click."
-          />
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-            {COMPLIANCE_PACKS.map(pack => (
-              <Link
-                key={pack.id}
-                href="/packs?tab=compliance"
-                className="flex items-start gap-4 bg-white border border-stone-200 rounded-xl px-5 py-4 hover:border-stone-300 hover:shadow-sm transition-all group"
-              >
-                <div className="w-11 h-11 rounded-xl bg-stone-100 flex items-center justify-center text-xl shrink-0">
-                  {pack.icon}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2 mb-0.5">
-                    <p className="text-sm font-medium text-stone-900">{pack.name}</p>
-                    <span className={`text-[10px] font-semibold px-1.5 py-0.5 rounded ${pack.badgeColor}`}>{pack.rules}</span>
-                  </div>
-                  <p className="text-xs text-stone-500 leading-relaxed">{pack.description}</p>
-                </div>
-              </Link>
-            ))}
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">Start with Discovery. Add playbooks as you go.</h2>
+          <p className="text-stone-500 text-sm mb-8 max-w-lg mx-auto leading-relaxed">
+            Discovery maps what your agents are doing today. Playbooks extend that into governed, repeatable
+            automation — with policy at every step.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <a
+              href="https://github.com/conductai/conduct"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              View the open-source runtime →
+            </a>
           </div>
         </section>
 
-    </main>
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/(marketing)/solutions/action-governance/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/action-governance/page.tsx
@@ -1,240 +1,163 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 
 export const metadata = {
-  title: "Action Governance for business agents | Conduct",
+  title: "Action Governance — Control what AI agents do | Conduct",
   description:
-    "Your agents call the tool. Conduct decides if the tool runs. Guard sits between the agent and every refund, cancellation, account update, and commitment, checking each call against the current policy before the action commits.",
+    "Guard evaluates every consequential action before it executes. Refund caps, production deployments, secret reads — policy runs at the action, not the report.",
 }
 
 export default function ActionGovernancePage() {
   return (
-    <>
-      <HeroSection />
-      <ProblemSection />
-      <HowItWorksSection />
-      <PolicyExampleSection />
-      <MetricsSection />
-      <CtaSection />
-    </>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-function HeroSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
-      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        For CX, ops, and platform teams shipping business agents
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        What your agent does.{" "}
-        <span className="bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">Not just what it can.</span>
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-8">
-        An agent that answers questions is a search box with a hallucination risk. An agent that issues
-        refunds is a financial actor with the same risk. Guard sits between the agent and the action tool
-        so the answer to &ldquo;can I do this&rdquo; is decided by policy, not by prompt.
-      </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <a
-          href="/docs#action-tools"
-          className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors w-full sm:w-auto text-center"
-        >
-          See the policy pattern
-        </a>
-        <a
-          href="https://cal.com/sudhi-seshachala-pks7pd"
-          target="_blank"
-          rel="noopener"
-          className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-base font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center"
-        >
-          Book a walkthrough
-        </a>
-      </div>
-    </section>
-  )
-}
-
-const CASES = [
-  {
-    headline: "Air Canada.",
-    body: "A chatbot invented a bereavement fare policy. The tribunal ordered the airline to honor it. The agent had authority to commit the company. Nobody had put a policy in front of the commitment.",
-  },
-  {
-    headline: "Klarna.",
-    body: "A rules change misfired inside an automated CX flow. Thousands of decisions had to be reversed after the fact. The blast radius was measured in customer relationships, not tickets.",
-  },
-  {
-    headline: "Your next incident.",
-    body: "An agent will offer a refund larger than the disputed amount. An agent will cancel a subscription for the wrong reason code. An agent will commit a price it should not commit. The mistake will look reasonable in the transcript.",
-  },
-]
-
-function ProblemSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-200 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <h2 className="text-center text-2xl font-black text-stone-900 tracking-tight mb-10">
-          Agents that take real actions leave real receipts.
-        </h2>
-        <div className="grid md:grid-cols-3 gap-6">
-          {CASES.map((c) => (
-            <div key={c.headline} className="border border-stone-200 rounded-xl bg-white p-6">
-              <h3 className="text-sm font-bold text-stone-900 mb-2">{c.headline}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{c.body}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-const STEPS = [
-  {
-    n: "01",
-    title: "The agent calls an action tool.",
-    body: "issue_refund, cancel_subscription, update_account, send_email, apply_credit. Any tool that produces a real-world outcome.",
-  },
-  {
-    n: "02",
-    title: "Guard checks the call against the current policy.",
-    body: "Is this refund inside the allowed amount for the agent role. Is the cancellation reason on the allowed list. Does the commitment need a supervisor.",
-  },
-  {
-    n: "03",
-    title: "Allow, warn, or block.",
-    body: "Allow runs the tool. Warn hands off to a human. Block returns a clean refusal the agent can explain to the customer in language.",
-  },
-  {
-    n: "04",
-    title: "One audit line, hash-chained.",
-    body: "Customer, amount, reason, reviewer, and the specific rule that fired. Finance sees the audit line, not the mistake.",
-  },
-]
-
-function HowItWorksSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 py-20">
-      <div className="text-center mb-12">
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight mb-4">
-          Policy in front of every action.
-        </h2>
-        <p className="text-stone-500 max-w-2xl mx-auto">
-          Guard treats action calls the way a payment processor treats card auths. Every call goes through
-          policy before the outcome commits.
-        </p>
-      </div>
-      <div className="space-y-4">
-        {STEPS.map((s) => (
-          <div key={s.n} className="border border-stone-200 rounded-xl p-6 bg-white flex gap-5">
-            <span className="text-xs font-mono text-stone-400 flex-shrink-0 mt-1">{s.n}</span>
-            <div>
-              <h3 className="text-base font-bold text-stone-900 mb-1.5">{s.title}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{s.body}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-function PolicyExampleSection() {
-  return (
-    <section className="bg-stone-950 px-6 py-20">
-      <div className="max-w-4xl mx-auto">
-        <div className="mb-8">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-3 text-center">A real policy, in YAML</p>
-          <h2 className="text-center text-3xl font-black text-white tracking-tight mb-4">
-            The refund-cap rule.
-          </h2>
-          <p className="text-stone-400 text-center max-w-2xl mx-auto text-sm leading-relaxed">
-            Declarative. Ship without a deploy. This rule blocks refunds above a hard cap and requires
-            supervisor review for anything more than twice the disputed amount.
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Action Governance
           </p>
-        </div>
-        <div className="border border-stone-700 rounded-xl bg-stone-900 p-6 overflow-x-auto">
-          <pre className="text-sm text-stone-200 font-mono leading-relaxed">
-{`# ~/.conductguard/policies/refund-cap.yaml
-name: refund-cap
-applies_to:
-  - "tool:issue_refund"
-rules:
-  - id: block-over-1000
-    when:
-      arg.amount_usd: { gt: 1000 }
-    action: block
-    reason: "Refund exceeds hard cap. Route to finance."
-
-  - id: warn-over-2x-dispute
-    when:
-      arg.amount_usd: { gt: "\${arg.disputed_amount_usd} * 2" }
-    action: warn
-    handoff: supervisor
-    reason: "Refund is more than twice the disputed amount. Supervisor review required."`}
-          </pre>
-        </div>
-        <p className="text-stone-500 text-sm mt-6 text-center">
-          The same pattern applies to any action tool. Cancellations, pricing commitments, DB writes,
-          outbound sends. The rule grammar is the same.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-const METRICS = [
-  { k: "Actions above threshold", v: "How often the agent tried something big enough to matter." },
-  { k: "Human handoffs per week", v: "The volume routed to a person. Guides staffing and threshold tuning." },
-  { k: "Out-of-policy attempts", v: "Blocks that would have been mistakes. Your best signal that the policy is real." },
-  { k: "Median handoff time", v: "The customer wait cost. Tune your escalation SLA against this." },
-]
-
-function MetricsSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 py-20">
-      <h2 className="text-center text-3xl font-black text-stone-900 tracking-tight mb-10">
-        Metrics that move once policy is in front.
-      </h2>
-      <div className="grid sm:grid-cols-2 gap-5">
-        {METRICS.map((m) => (
-          <div key={m.k} className="border border-stone-200 rounded-xl p-6 bg-white">
-            <h3 className="text-sm font-bold text-stone-900 mb-2">{m.k}</h3>
-            <p className="text-sm text-stone-500 leading-relaxed">{m.v}</p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Control the action before it becomes an outcome.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Every AI agent action that touches money, infrastructure, or sensitive data is evaluated
+            by Guard before it executes. Allow, approve, or block — with a signed record of why.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
           </div>
-        ))}
-      </div>
-    </section>
-  )
-}
+        </section>
 
-function CtaSection() {
-  return (
-    <section className="px-6 py-24 bg-gradient-to-br from-indigo-600 to-violet-600">
-      <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-4">
-          Give your agents authority they can prove.
-        </h2>
-        <p className="text-indigo-100 text-lg mb-8">
-          Guard’s policy engine is the same one that runs on your model calls today. Gating an action
-          tool is one YAML rule, not a new integration.
-        </p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <a
-            href="/docs#action-tools"
-            className="rounded-xl bg-white text-indigo-600 px-8 py-3.5 text-base font-bold hover:bg-indigo-50 transition-colors w-full sm:w-auto text-center"
-          >
-            See the policy pattern
-          </a>
-          <a
-            href="/use-cases#action-governance"
-            className="rounded-xl border border-white/40 text-white px-8 py-3.5 text-base font-semibold hover:bg-white/10 transition-colors w-full sm:w-auto text-center"
-          >
-            Read the deep dive
-          </a>
-        </div>
-      </div>
-    </section>
+        {/* 3 stories — the core */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Three stories. One engine.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-10 max-w-2xl">
+            The same Guard policy engine handles the full range of consequential business actions.
+            The decision, the rule, and the reason are the same data structure across all three.
+          </p>
+
+          {/* Story 1 — Refund cap */}
+          <div className="mb-12">
+            <div className="mb-4">
+              <span className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400">Story 1</span>
+              <h3 className="text-lg font-bold text-stone-900 mt-1">Refund over the cap</h3>
+              <p className="text-sm text-stone-500 mt-1 max-w-xl leading-relaxed">
+                A support agent attempts to process a $840 refund for customer C-8911. The refund-cap
+                policy blocks it. A smaller refund ($120) on the same account proceeds immediately.
+              </p>
+            </div>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+              <DecisionCard
+                agent="codex / release-agent"
+                action="process_refund"
+                resource="customer C-8911"
+                policy="refund-cap"
+                decision="BLOCK"
+                reason="Refunds over $500 require human approval per FIN-07."
+              />
+              <DecisionCard
+                agent="codex / release-agent"
+                action="process_refund"
+                resource="customer C-8911"
+                policy="refund-cap"
+                decision="ALLOW"
+                reason="Refund of $120 is within the $500 automatic approval limit."
+              />
+            </div>
+          </div>
+
+          {/* Story 2 — Production deploy approval */}
+          <div className="mb-12">
+            <div className="mb-4">
+              <span className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400">Story 2</span>
+              <h3 className="text-lg font-bold text-stone-900 mt-1">Production deployment outside change window</h3>
+              <p className="text-sm text-stone-500 mt-1 max-w-xl leading-relaxed">
+                A deploy agent attempts to push to production at 14:32 UTC — outside the approved change
+                window. Guard routes to Slack for human approval rather than blocking outright.
+              </p>
+            </div>
+            <div className="max-w-sm">
+              <DecisionCard
+                agent="claude-code / deploy-agent"
+                action="deploy_production"
+                resource="payments-api"
+                policy="production-change-v4"
+                decision="APPROVE"
+                reason="Production deployment outside approved change window"
+                showButtons
+              />
+            </div>
+          </div>
+
+          {/* Story 3 — Secret read block */}
+          <div className="mb-4">
+            <div className="mb-4">
+              <span className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400">Story 3</span>
+              <h3 className="text-lg font-bold text-stone-900 mt-1">Secret read in production environment</h3>
+              <p className="text-sm text-stone-500 mt-1 max-w-xl leading-relaxed">
+                An agent attempts to read a production secret during a scheduled task. Guard blocks
+                the action — secret access from automated agents requires an explicit exemption.
+              </p>
+            </div>
+            <div className="max-w-sm">
+              <DecisionCard
+                agent="cursor-agent-17"
+                action="read_env"
+                resource="orders-db"
+                policy="no-production-network-change"
+                decision="BLOCK"
+                reason="Production secret reads by automated agents are not permitted without an approved exemption."
+              />
+            </div>
+          </div>
+        </section>
+
+        {/* What this is not */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <h2 className="text-lg font-bold text-stone-900 mb-3">
+            Policy at the action, not at the report.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed max-w-2xl">
+            Action governance is not an audit log you review after the fact. Guard runs at the moment
+            the agent calls the action — before money moves, before the deployment lands, before the
+            secret is read. The decision is made then, with a receipt that proves it.
+          </p>
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+            Govern the action, not the aftermath.
+          </h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/guard"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              See how Guard works →
+            </Link>
+          </div>
+        </section>
+
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/(marketing)/solutions/engineering-leaders/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/engineering-leaders/page.tsx
@@ -1,171 +1,180 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+import { AgentSurfaceStrip } from "@/components/marketing/facelift/AgentSurfaceStrip"
+import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 
-/* ─── Page ──────────────────────────────────────────────────────────────── */
-
-export default function EngineeringLeadersPage() {
-  return (
-    <>
-      <HeroSection />
-      <ProblemSection />
-      <PitchSection />
-      <ProofArcSection />
-      <CtaSection />
-    </>
-  )
+export const metadata = {
+  title: "Engineering Agents — Consistent policy across every AI tool | Conduct",
+  description:
+    "Let developers choose their AI tools. Guard enforces consistent policy across Claude Code, Cursor, Copilot, and Codex — without slowing anyone down.",
 }
 
-/* ─── Hero ──────────────────────────────────────────────────────────────── */
-
-function HeroSection() {
+export default function EngineeringAgentsPage() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
-      <div className="inline-flex items-center gap-2 bg-stone-100 text-stone-600 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-stone-400 inline-block" />
-        For engineering leaders
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        Ship AI-assisted code without becoming<br className="hidden sm:block" />
-        <span className="bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent"> the incident report.</span>
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-8">
-        ConductAI gives platform teams a control plane for AI coding agents — policy personas per team, spend hard-stops, and a CI gate that blocks non-compliant commits.
-      </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <CtaLink className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors w-full sm:w-auto text-center" />
-        <a
-          href="https://cal.com/sudhi-seshachala-pks7pd"
-          target="_blank"
-          rel="noopener"
-          className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-base font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center"
-        >
-          Book a demo
-        </a>
-      </div>
-    </section>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-/* ─── Problem ───────────────────────────────────────────────────────────── */
-
-const PROBLEMS = [
-  {
-    headline: "AI agents are multiplying.",
-    body: "Every developer has Claude Code, Copilot, or Cursor. There's no inventory of what they're doing.",
-  },
-  {
-    headline: "Spend is invisible.",
-    body: "AI token costs accumulate per-developer with no budget controls. Finance asks. Engineering shrugs.",
-  },
-  {
-    headline: "The blast radius is unknown.",
-    body: "When an agent deletes the wrong file or exfiltrates a secret, you find out from the security team, not from a dashboard.",
-  },
-]
-
-function ProblemSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-200 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <div className="grid md:grid-cols-3 gap-6">
-          {PROBLEMS.map((p) => (
-            <div key={p.headline} className="border border-stone-200 rounded-xl bg-white p-6">
-              <h3 className="text-sm font-bold text-stone-900 mb-2">{p.headline}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{p.body}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Pitch ─────────────────────────────────────────────────────────────── */
-
-const FEATURES = [
-  {
-    icon: "👥",
-    title: "Policy personas per team",
-    desc: "Conservative / Standard / Developer. Assign per team. Change without redeploying.",
-  },
-  {
-    icon: "💸",
-    title: "Spend hard-stops",
-    desc: "Per-developer and per-workspace token budgets. Agents stop when the limit is hit.",
-  },
-  {
-    icon: "🚦",
-    title: "CI release gate",
-    desc: "conduct ci --exit-nonzero-on-block. Blocks PRs from merging if a Guard policy was violated in the session that produced them.",
-  },
-]
-
-function PitchSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 py-20">
-      <div className="text-center mb-12">
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight mb-4">
-          One control plane for every AI coding session.
-        </h2>
-      </div>
-      <div className="grid md:grid-cols-3 gap-5">
-        {FEATURES.map((f) => (
-          <div key={f.title} className="border border-stone-200 rounded-xl p-6 bg-white hover:border-stone-300 hover:shadow-sm transition-all">
-            <span className="text-2xl block mb-3">{f.icon}</span>
-            <h3 className="text-sm font-bold text-stone-900 mb-2">{f.title}</h3>
-            <p className="text-sm text-stone-500 leading-relaxed">{f.desc}</p>
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Engineering Agents
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Let developers choose. Enforce policy everywhere.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Your engineers use Claude Code, Cursor, Copilot, and Codex. Guard applies the same
+            runtime policy across all of them — without a separate configuration per tool.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
           </div>
-        ))}
-      </div>
-    </section>
-  )
-}
+        </section>
 
-/* ─── Proof arc ─────────────────────────────────────────────────────────── */
+        {/* Let developers choose */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Developers keep their tools.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard integrates through the CLI hook, the HTTP proxy, and the MCP layer. Developers
+            install once and keep using whichever AI tool they prefer. Policy travels with the agent,
+            not with the tool.
+          </p>
+          <AgentSurfaceStrip />
+        </section>
 
-function ProofArcSection() {
-  return (
-    <section className="bg-stone-950 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <div className="text-center mb-12">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-3">What changes on day one</p>
-          <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight">
-            Every AI coding session is visible.
+        {/* Consistent policy */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            Consistent policy across every agent tool.
           </h2>
-        </div>
-        <div className="max-w-2xl mx-auto">
-          <div className="border border-stone-700 rounded-xl bg-stone-900 p-8">
-            <h3 className="text-base font-bold text-white mb-3 leading-snug">Full session visibility from install</h3>
-            <p className="text-sm text-stone-400 leading-relaxed">
-              Within ten minutes you know which AI tools your team is running, who is using them, and what they are doing. Spend is visible by developer and by day. Policy violations surface in the activity feed as they happen.
-            </p>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            The same policy file governs all four agent tools. A rule written for Claude Code applies
+            to Cursor and Codex without modification. One policy, no per-tool exceptions.
+          </p>
+          <div className="border border-stone-200 rounded-2xl overflow-hidden bg-white">
+            <div className="px-6 py-4 bg-stone-50 border-b border-stone-200">
+              <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400">
+                Same rule — all surfaces
+              </p>
+            </div>
+            <div className="divide-y divide-stone-100">
+              {[
+                { agent: "claude-code / deploy-agent", tool: "Claude Code", surface: "CLI hook" },
+                { agent: "cursor-agent-17", tool: "Cursor", surface: "CLI hook · proxy" },
+                { agent: "copilot-reviewer", tool: "Copilot", surface: "CLI hook" },
+                { agent: "codex / release-agent", tool: "Codex", surface: "CLI hook · proxy" },
+              ].map(({ agent, tool, surface }) => (
+                <div key={agent} className="flex items-center justify-between px-6 py-3 font-mono text-xs">
+                  <div className="flex items-center gap-3">
+                    <span className="text-stone-900 font-medium">{agent}</span>
+                    <span className="text-stone-400 hidden sm:inline">·</span>
+                    <span className="text-stone-400 hidden sm:inline">{tool}</span>
+                  </div>
+                  <span className="text-stone-400 text-[10px]">{surface}</span>
+                </div>
+              ))}
+            </div>
           </div>
-        </div>
-      </div>
-    </section>
-  )
-}
+        </section>
 
-/* ─── CTA ───────────────────────────────────────────────────────────────── */
+        {/* Action table */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">
+            Allow, approve, or block — per action.
+          </h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard applies the same decision framework across all agent tools. Routine actions
+            proceed without friction. Consequential ones pause for approval. Prohibited ones stop.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-6">
+            <DecisionCard
+              agent="claude-code / deploy-agent"
+              action="run_tests"
+              resource="orders-db"
+              policy="production-change-v4"
+              decision="ALLOW"
+              reason="Action within policy limits"
+              compact
+            />
+            <DecisionCard
+              agent="codex / release-agent"
+              action="deploy_production"
+              resource="payments-api"
+              policy="production-change-v4"
+              decision="APPROVE"
+              reason="Production deployment outside approved change window"
+              showButtons
+              compact
+            />
+            <DecisionCard
+              agent="cursor-agent-17"
+              action="update_terraform"
+              resource="prod-vpc"
+              policy="no-production-network-change"
+              decision="BLOCK"
+              reason="Production network modifications require approved change record."
+              compact
+            />
+          </div>
+        </section>
 
-function CtaSection() {
-  return (
-    <section className="px-6 py-24 bg-gradient-to-br from-indigo-600 to-violet-600">
-      <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-4">
-          Ready to put a control plane on your AI agents?
-        </h2>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mt-8">
-          <CtaLink className="rounded-xl bg-white text-indigo-600 px-8 py-3.5 text-base font-bold hover:bg-indigo-50 transition-colors w-full sm:w-auto text-center" />
-          <a
-            href="https://cal.com/sudhi-seshachala-pks7pd"
-            target="_blank"
-            rel="noopener"
-            className="rounded-xl border border-white/40 text-white px-8 py-3.5 text-base font-semibold hover:bg-white/10 transition-colors w-full sm:w-auto text-center"
-          >
-            Book a demo
-          </a>
-        </div>
-      </div>
-    </section>
+        {/* Why this matters for eng leads */}
+        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
+          <h2 className="text-lg font-bold text-stone-900 mb-4">What this changes for engineering leads</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 text-sm text-stone-600">
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">Before Guard</p>
+              <ul className="space-y-2 leading-relaxed">
+                <li>Each AI tool enforces policy differently — or not at all</li>
+                <li>Audit trails scattered across tools</li>
+                <li>Policy drift as teams adopt new agents</li>
+                <li>Compliance questions answered by guessing</li>
+              </ul>
+            </div>
+            <div>
+              <p className="font-semibold text-stone-900 mb-2">With Guard</p>
+              <ul className="space-y-2 leading-relaxed">
+                <li>One policy file governs all agent tools</li>
+                <li>Every decision logged in one audit trail</li>
+                <li>New agents inherit policy automatically</li>
+                <li>Compliance questions answered with signed receipts</li>
+              </ul>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+            Consistent policy. Every agent. Every action.
+          </h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/guard"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              See how Guard works →
+            </Link>
+          </div>
+        </section>
+
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/(marketing)/solutions/security-compliance/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/security-compliance/page.tsx
@@ -1,210 +1,210 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
+import { CapabilityStatus } from "@/components/marketing/facelift/CapabilityStatus"
+import { ThreatModelRow } from "@/components/marketing/facelift/ThreatModelRow"
 
-/* ─── Page ──────────────────────────────────────────────────────────────── */
-
-export default function SecurityCompliancePage() {
-  return (
-    <>
-      <HeroSection />
-      <ProblemSection />
-      <PitchSection />
-      <CompliancePacksCallout />
-      <VendorLayerCallout />
-      <CtaSection />
-    </>
-  )
+export const metadata = {
+  title: "Security Teams — Enforcement and evidence for AI agents | Conduct",
+  description:
+    "Guard enforces runtime policy across every AI agent. Every decision is hash-chained. Every compliance question has a signed answer.",
 }
 
-/* ─── Hero ──────────────────────────────────────────────────────────────── */
-
-function HeroSection() {
+export default function SecurityTeamsPage() {
   return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
-      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        For security &amp; compliance
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        AI agents are an unaudited actor class.{" "}
-        <span className="bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">Until now.</span>
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-8">
-        ConductAI maps every agent decision to OWASP identifiers your auditor already recognises — with an immutable audit log and one-click compliance pack installation.
-      </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <CtaLink className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors w-full sm:w-auto text-center" />
-        <a
-          href="https://cal.com/sudhi-seshachala-pks7pd"
-          target="_blank"
-          rel="noopener"
-          className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-base font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center"
-        >
-          Book a demo
-        </a>
-      </div>
-    </section>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6">
 
-/* ─── Problem ───────────────────────────────────────────────────────────── */
-
-const PROBLEMS = [
-  {
-    headline: "No audit trail.",
-    body: "Your SIEM sees network traffic. Your EDR sees file writes. Neither knows an AI agent caused them or what policy was in effect.",
-  },
-  {
-    headline: "Compliance frameworks don't cover agents.",
-    body: "SOC 2, HIPAA, and PCI DSS were written before autonomous AI tools existed. Your auditor is improvising.",
-  },
-  {
-    headline: "Shadow agents are invisible.",
-    body: "Developers install AI tools without IT approval. You have no inventory of what's running or what it has access to.",
-  },
-]
-
-function ProblemSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-200 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <div className="grid md:grid-cols-3 gap-6">
-          {PROBLEMS.map((p) => (
-            <div key={p.headline} className="border border-stone-200 rounded-xl bg-white p-6">
-              <h3 className="text-sm font-bold text-stone-900 mb-2">{p.headline}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{p.body}</p>
-            </div>
-          ))}
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Pitch ─────────────────────────────────────────────────────────────── */
-
-const CAPABILITIES = [
-  {
-    icon: "🗂️",
-    title: "OWASP-mapped events",
-    desc: "Every Guard decision is tagged with the OWASP LLM Top 10 category it enforced. Your auditor speaks this language.",
-  },
-  {
-    icon: "🔗",
-    title: "Immutable audit log",
-    desc: "Hash-chained. Every event links to the policy version that produced it. Tamper-evident by construction.",
-  },
-  {
-    icon: "📑",
-    title: "SOC 2 evidence generation",
-    desc: "Export a filtered audit log by date range and control category. One click, not a week of log mining.",
-  },
-  {
-    icon: "🔍",
-    title: "Shadow agent discovery",
-    desc: "Guard's hook detects AI tools running on developer machines without IT registration. Surfaces them in the dashboard.",
-  },
-]
-
-function PitchSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 py-20">
-      <div className="text-center mb-12">
-        <h2 className="text-3xl sm:text-4xl font-black text-stone-900 tracking-tight mb-4">
-          Enforcement, not just observation.
-        </h2>
-      </div>
-      <div className="grid sm:grid-cols-2 gap-5">
-        {CAPABILITIES.map((c) => (
-          <div key={c.title} className="border border-stone-200 rounded-xl p-6 bg-white hover:border-stone-300 hover:shadow-sm transition-all flex gap-4">
-            <span className="text-2xl flex-shrink-0 mt-0.5">{c.icon}</span>
-            <div>
-              <h3 className="text-sm font-bold text-stone-900 mb-2">{c.title}</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">{c.desc}</p>
-            </div>
+        {/* Hero */}
+        <section className="pt-20 pb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Security Teams
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Enforcement at runtime. Evidence for every decision.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+            Guard runs before the action executes — not after. Every allow, approve, and block
+            produces a signed receipt. Your compliance team has answers, not logs to correlate.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Book a Demo
+            </Link>
           </div>
-        ))}
-      </div>
-    </section>
-  )
-}
+        </section>
 
-/* ─── Compliance packs callout ──────────────────────────────────────────── */
-
-const PACKS = ["OWASP LLM Top 10", "SOC 2", "HIPAA", "PCI DSS"]
-
-function CompliancePacksCallout() {
-  return (
-    <section className="bg-stone-950 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <div className="border border-stone-700 rounded-xl bg-stone-900 p-8 text-center">
-          <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-4">One-click compliance packs</p>
-          <div className="flex flex-wrap items-center justify-center gap-3 mb-6">
-            {PACKS.map((pack) => (
-              <span
-                key={pack}
-                className="border border-stone-700 rounded-lg px-4 py-2 text-sm font-semibold text-stone-300 bg-stone-800"
-              >
-                {pack}
-              </span>
+        {/* Enforcement */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Enforcement, not detection.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard intercepts every action before it executes and evaluates it against policy. This
+            is not a SIEM or a log analyser. Policy runs at the action layer — before money moves,
+            before the deployment lands, before the secret is read.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm font-mono">
+            {[
+              { surface: "CLI hook", agents: "Claude Code · Cursor · Copilot · Codex", status: "SHIPPED" },
+              { surface: "HTTP proxy", agents: "Any SDK with configurable base URL", status: "SHIPPED" },
+              { surface: "MCP layer", agents: "Claude Desktop · Cursor · Custom MCP clients", status: "SHIPPED" },
+            ].map(({ surface, agents, status }) => (
+              <div key={surface} className="border border-stone-200 rounded-xl bg-white p-5">
+                <div className="flex items-center gap-2 mb-2">
+                  <span className="text-[10px] font-bold uppercase tracking-wider border border-emerald-200 bg-emerald-50 text-emerald-700 rounded px-1.5 py-0.5">
+                    {status}
+                  </span>
+                </div>
+                <p className="text-stone-900 font-bold text-[13px] mb-1">{surface}</p>
+                <p className="text-stone-400 text-[11px] leading-relaxed">{agents}</p>
+              </div>
             ))}
           </div>
-          <p className="text-stone-400 text-sm leading-relaxed max-w-lg mx-auto mb-8">
-            Each pack installs a pre-built rule set signed by Conduct. Policies propagate to every governed agent instantly.
+        </section>
+
+        {/* Evidence */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Signed evidence for every decision.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Every Guard evaluation produces a receipt. The receipt records the agent, action,
+            resource, decision, rule that fired, user, and timestamp. Receipts are SHA-256 hash-chained —
+            altered entries break verification. No pixel editing required to make your audit trail look right.
           </p>
-          <a
-            href="/registry"
-            className="inline-flex items-center gap-1 rounded-xl bg-indigo-600 hover:bg-indigo-700 text-white px-6 py-3 text-sm font-semibold transition-colors"
-          >
-            Browse the Registry →
-          </a>
-        </div>
-      </div>
-    </section>
-  )
-}
+          <div className="flex justify-center">
+            <EvidenceReceipt />
+          </div>
+        </section>
 
-/* ─── CTA ───────────────────────────────────────────────────────────────── */
+        {/* Compliance packs */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">15 compliance packs. Shipped.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-6 max-w-2xl">
+            Each pack is a JSON ruleset mapped to a compliance standard. Install once and Guard
+            evaluates every agent action against the pack&apos;s rules automatically.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 text-xs font-mono">
+            {[
+              "Conduct base",
+              "OWASP Agentic Top 10",
+              "SOC 2 CC7.3",
+              "HIPAA §164.312",
+              "PCI DSS 4.0",
+              "EU AI Act",
+              "NIST AI RMF",
+              "ISO 42001",
+              "IRS 1075",
+              "Prompt injection",
+              "Network operations",
+              "Endpoint attacks",
+              "Financial services",
+              "Life sciences",
+              "Support operations",
+            ].map((pack) => (
+              <div
+                key={pack}
+                className="border border-stone-200 rounded-lg bg-white px-4 py-2.5 text-stone-700 flex items-center gap-2"
+              >
+                <span className="w-1.5 h-1.5 rounded-full bg-emerald-500 shrink-0" />
+                {pack}
+              </div>
+            ))}
+          </div>
+        </section>
 
-function VendorLayerCallout() {
-  return (
-    <section className="max-w-4xl mx-auto px-6 py-16">
-      <div className="border border-stone-200 rounded-2xl bg-stone-50 p-8 text-center">
-        <p className="text-xs font-bold uppercase tracking-widest text-indigo-600 mb-3">The honest read</p>
-        <p className="text-lg text-stone-800 font-semibold leading-relaxed mb-3">
-          No single vendor has a comprehensive answer.
-        </p>
-        <p className="text-sm text-stone-600 leading-relaxed max-w-2xl mx-auto">
-          Bain said it directly to CEOs in July 2026. Your stack will layer across identity, registry, gateway, evaluation, and observability. Guard is the runtime governance layer. It integrates cleanly with your identity provider, your evaluation platform, your model providers, and your agent frameworks. Not trying to be all of them.
-        </p>
-      </div>
-    </section>
-  )
-}
+        {/* Deployment */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Deploy where your controls need to live.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-6 max-w-2xl">
+            Guard runs in your cloud, on your infrastructure, or as SaaS. Same policy engine,
+            same audit trail, regardless of deployment model.
+          </p>
+          <CapabilityStatus
+            showLegend
+            items={[
+              { name: "SaaS (conductai.ai)", status: "SHIPPED", note: "US-based" },
+              { name: "Docker Compose (self-hosted)", status: "SHIPPED" },
+              { name: "Kubernetes", status: "PREVIEW", note: "Reference templates" },
+              { name: "Air-gapped / on-prem", status: "PLANNED" },
+            ]}
+          />
+        </section>
 
-function CtaSection() {
-  return (
-    <section className="px-6 py-24 bg-gradient-to-br from-indigo-600 to-violet-600">
-      <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-4">
-          Give your auditor something they can work with.
-        </h2>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3 mt-8">
-          <a
-            href="https://cal.com/sudhi-seshachala-pks7pd"
-            target="_blank"
-            rel="noopener"
-            className="rounded-xl bg-white text-indigo-600 px-8 py-3.5 text-base font-bold hover:bg-indigo-50 transition-colors w-full sm:w-auto text-center"
-          >
-            Book a demo
-          </a>
-          <a
-            href="/registry"
-            className="rounded-xl border border-white/40 text-white px-8 py-3.5 text-base font-semibold hover:bg-white/10 transition-colors w-full sm:w-auto text-center"
-          >
-            Browse compliance packs →
-          </a>
-        </div>
-      </div>
-    </section>
+        {/* Threat model */}
+        <section className="mb-20 border border-stone-200 rounded-2xl overflow-hidden">
+          <div className="px-6 py-5 bg-stone-50 border-b border-stone-200">
+            <h2 className="text-lg font-bold text-stone-900">Guard threat coverage</h2>
+            <p className="text-xs text-stone-400 mt-1">
+              Honest scope. We publish where Guard stops.
+            </p>
+          </div>
+          <div className="px-6 py-2">
+            <ThreatModelRow
+              threat="Consequential actions guarded by policy"
+              coverage="Protected"
+              detail="Refunds, deployments, network changes, secret reads — any action routed through Guard is evaluated before execution."
+            />
+            <ThreatModelRow
+              threat="Audit trail integrity"
+              coverage="Protected"
+              detail="SHA-256 hash chain on every decision. Altered entries break verification."
+            />
+            <ThreatModelRow
+              threat="Compliance pack coverage (SOC2, HIPAA, PCI DSS, EU AI Act, and 11 more)"
+              coverage="Protected"
+              detail="15 JSON rulesets evaluated against every agent action automatically."
+            />
+            <ThreatModelRow
+              threat="Pre-call prompt injection"
+              coverage="Partial"
+              detail="Guard includes a prompt-injection detection pack. Attacks that alter model intent before tool selection are upstream of Guard."
+            />
+            <ThreatModelRow
+              threat="Model-layer attacks (adversarial inputs to the LLM)"
+              coverage="Partial"
+              detail="Pattern-based detectors. ML-based detection is not implemented."
+            />
+            <ThreatModelRow
+              threat="Actions that bypass Guard enforcement surfaces"
+              coverage="Not protected"
+              detail="An agent that does not use the hook, proxy, or MCP layer is invisible to Guard."
+            />
+            <ThreatModelRow
+              threat="Cross-agent context correlation"
+              coverage="Not protected"
+              detail="Guard evaluates each action in isolation. Operations context is planned."
+            />
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+            Runtime enforcement. Signed evidence. Honest scope.
+          </h2>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start Discovery — 14 days free
+            </Link>
+            <Link
+              href="/security"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              View full threat model →
+            </Link>
+          </div>
+        </section>
+
+      </main>
+    </div>
   )
 }


### PR DESCRIPTION
Replaces #1593. Rebuilt on latest main after #1586 landed. Same content, clean history.

## 8 pages
- /playbooks — full pillar (39 shipped hero, category list, composability, cross-agent extension)
- /guard — shorter rebuild (One policy, Allow/Approve/Block trio, policy definition, evidence, threat model)
- /evidence — expanded stub to full pillar (decision, approval, execution, integrity, retention, compliance mapping)
- /mcp-gateway — Gateway framing removed; MCP client to Guard to MCP server flow
- /open-source — exact 4 components from product-truth section 12 in a table
- /solutions/action-governance — central transaction UI + 3 canonical stories
- /solutions/engineering-leaders — relabeled Engineering Agents in-page
- /solutions/security-compliance — relabeled Security Teams in-page

## Queued for follow-up
Two remaining pages from plan section 6 to be shipped in a small follow-up PR.

## 1 squashed commit
- e91f96c6 feat(web): W3 per-page rebuilds — 8 pages per facelift plan section 6

Net diff: +1458 / -2708.

Closes #1593.