### PR TITLE
fix(web): create /discovery and /book-demo stubs — prod CTAs were 404

### DIFF
--- a/apps/web/src/app/(marketing)/book-demo/page.tsx
+++ b/apps/web/src/app/(marketing)/book-demo/page.tsx
@@ -1,0 +1,43 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Book a Demo — Conduct",
+  description:
+    "Talk to the Conduct team. Runtime policy across every AI agent — allow, approve, block, prove.",
+}
+
+export default function BookDemoPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-3xl mx-auto px-6 py-24 text-center">
+        <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+          Book a Demo
+        </p>
+        <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+          Talk to the team.
+        </h1>
+        <p className="text-lg text-stone-500 max-w-xl mx-auto leading-relaxed mb-10">
+          One policy across your AI agent stack — allow, approve, block, prove.
+          Fifteen minutes with a founder, tailored to your stack.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3 mb-6">
+          <a
+            href="mailto:sales@conductai.ai?subject=Conduct%20Demo%20Request"
+            className="inline-block rounded-xl bg-stone-900 text-white px-7 py-3.5 text-sm font-semibold hover:bg-stone-700 transition-colors"
+          >
+            Email us to schedule
+          </a>
+          <Link
+            href="/sign-up"
+            className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-7 py-3.5 text-sm font-semibold hover:bg-stone-50 transition-colors"
+          >
+            Or start Discovery — 14 days free
+          </Link>
+        </div>
+        <p className="mt-8 text-sm text-stone-400">
+          Prefer chat? sales@conductai.ai
+        </p>
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/app/(marketing)/discovery/page.tsx
+++ b/apps/web/src/app/(marketing)/discovery/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Start Discovery — Conduct",
+  description:
+    "Discovery scans the AI tools your team is already using and shows you what runs where. 14-day trial, no infrastructure changes.",
+}
+
+export default function DiscoveryPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-4xl mx-auto px-6 py-24 text-center">
+        <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+          Discovery
+        </p>
+        <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+          See every AI agent in your stack.
+        </h1>
+        <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
+          14 days. No infrastructure changes. Point Conduct at your engineering
+          tools and we surface which agents are running, what they touch, and
+          where policy is missing.
+        </p>
+        <div className="flex flex-wrap justify-center gap-3">
+          <Link
+            href="/sign-up"
+            className="inline-block rounded-xl bg-stone-900 text-white px-7 py-3.5 text-sm font-semibold hover:bg-stone-700 transition-colors"
+          >
+            Start Discovery — 14 days free
+          </Link>
+          <Link
+            href="/guard"
+            className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-7 py-3.5 text-sm font-semibold hover:bg-stone-50 transition-colors"
+          >
+            How Guard enforces →
+          </Link>
+        </div>
+        <p className="mt-12 text-sm text-stone-400">
+          Full pillar page shipping soon.
+        </p>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
Hotfix — PR #1586 shipped nav + hero + secondary CTAs pointing at /discovery and /book-demo without creating the routes. Both are live 404 on conductai.ai right now.

## What ships
- /discovery — thin stub: title, brief message, CTA to /sign-up + secondary to /guard
- /book-demo — thin stub: title, brief message, mailto to sales + alt CTA to /sign-up

Same pattern as the /evidence stub in #1586. Full pillar pages queued for a follow-up PR.

## Also 404 on prod but resolves on merge (no action needed here)
- /docs/lens — will exist when #1596 (polish PR) merges

Closes prod CTA 404s.