### PR TITLE
feat(web): W4 final — rollout + security rebuilds, hetero reframe, docs stub

### DIFF
--- a/apps/web/src/app/(marketing)/deployment/page.tsx
+++ b/apps/web/src/app/(marketing)/deployment/page.tsx
@@ -1,316 +1,136 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+
+export const metadata = {
+  title: "Deployment — Conduct",
+  description:
+    "Deploy Guard where your controls need to live. SaaS, Docker, Kubernetes preview, or air-gapped.",
+}
+
+type Status = "SHIPPED" | "PREVIEW" | "PLANNED"
+
+const OPTIONS: {
+  name: string
+  status: Status
+  tagline: string
+  description: string
+  bullets: string[]
+}[] = [
+  {
+    name: "SaaS",
+    status: "SHIPPED",
+    tagline: "conductai.ai",
+    description:
+      "Hosted at conductai.ai. Same CLI, same audit trail. Zero infrastructure to run — fastest path from install to first blocked action.",
+    bullets: [
+      "US and EU regions",
+      "Free tier + 14-day Discovery trial",
+      "Rolling updates managed by Conduct",
+    ],
+  },
+  {
+    name: "Docker",
+    status: "SHIPPED",
+    tagline: "Self-hosted",
+    description:
+      "Single-container image. Runs on your servers, in your VPC, wherever Docker runs. No outbound calls to Conduct infrastructure required.",
+    bullets: [
+      "docker-compose.yml provided",
+      "Postgres + Redis dependencies",
+      "Full policy engine parity with SaaS",
+    ],
+  },
+  {
+    name: "Kubernetes",
+    status: "PREVIEW",
+    tagline: "Helm chart",
+    description:
+      "Helm chart for production Kubernetes clusters. HPA, PDB, and network policies included. Preview — reach out for pilot access.",
+    bullets: [
+      "values.yaml customization",
+      "Prometheus scrape targets",
+      "Service mesh compatible",
+    ],
+  },
+  {
+    name: "Air-gapped",
+    status: "PLANNED",
+    tagline: "No outbound",
+    description:
+      "Fully isolated rollout for regulated or classified environments. Manual audit chain export, offline update bundles. Design partners engaged.",
+    bullets: [
+      "No outbound calls",
+      "Offline update bundles",
+      "Manifest hash verification",
+    ],
+  },
+]
+
+const STATUS_STYLE: Record<Status, string> = {
+  SHIPPED: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  PREVIEW: "bg-amber-50 text-amber-700 border-amber-200",
+  PLANNED: "bg-stone-50 text-stone-500 border-stone-200",
+}
 
 export default function DeploymentPage() {
   return (
-    <>
-      <HeroSection />
-      <TiersSection />
-      <CompareSection />
-      <HowItWorksSection />
-      <CtaSection />
-    </>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-5xl mx-auto px-6 py-20">
+        <section className="mb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Rollout
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            Deploy Guard where your controls need to live.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed">
+            Same policy engine, same CLI, same audit trail — wherever your data must stay.
+          </p>
+        </section>
 
-/* ─── Hero ──────────────────────────────────────────────────────────────── */
-
-function HeroSection() {
-  return (
-    <section className="max-w-5xl mx-auto px-6 pt-20 pb-16 text-center">
-      <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        Flexible deployment
-      </div>
-      <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        Deploy where your<br />
-        <span className="bg-gradient-to-r from-indigo-600 to-violet-600 bg-clip-text text-transparent">security policy requires.</span>
-      </h1>
-      <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-4">
-        ConductGuard runs as SaaS, inside your cloud account, or fully on-premise. Same policy engine, same CLI, same audit trail — wherever your data must stay.
-      </p>
-      <p className="text-base text-stone-500 italic max-w-2xl mx-auto leading-relaxed mb-8">
-        The agent inherits the permission. It doesn&apos;t inherit the caution.
-      </p>
-      <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-        <CtaLink className="rounded-xl bg-stone-900 text-white px-7 py-3.5 text-base font-semibold hover:bg-stone-700 transition-colors w-full sm:w-auto text-center" />
-        <a
-          href="https://cal.com/sudhi-seshachala-pks7pd"
-          target="_blank"
-          rel="noopener"
-          className="rounded-xl border border-stone-300 bg-white text-stone-700 px-7 py-3.5 text-base font-semibold hover:border-stone-400 hover:shadow-sm transition-all w-full sm:w-auto text-center"
-        >
-          Talk to us
-        </a>
-      </div>
-    </section>
-  )
-}
-
-/* ─── Three tiers ───────────────────────────────────────────────────────── */
-
-const TIERS = [
-  {
-    tag: "Fastest to start",
-    name: "SaaS",
-    tagline: "Up in 10 minutes. Nothing to manage.",
-    description:
-      "Managed by Conduct. Policy engine, audit trail, dashboard, and proxy all hosted on conductai.ai. No infrastructure decisions.",
-    bullets: [
-      "pip install conduct-cli, then conduct guard sync",
-      "Policy active across your team in minutes",
-      "Automatic upgrades, zero ops overhead",
-      "Free tier available",
-    ],
-    who: "Startups and engineering teams who want governance now, not in Q3.",
-    cta: "Start free",
-    ctaHref: "https://conductai.ai",
-    accent: "indigo",
-    dark: false,
-  },
-  {
-    tag: "Enterprise preferred",
-    name: "Cloud (BYOC)",
-    tagline: "Your cloud account. Our software.",
-    description:
-      "Deploy ConductGuard into your own AWS, GCP, or Azure account. Audit trail, policy engine, and proxy run in your VPC. Data never leaves your environment.",
-    bullets: [
-      "Terraform module — up in one apply",
-      "Works with your existing RDS, ElastiCache, and VPC",
-      "CLI points at your instance: conduct guard join --url https://guard.yourco.com",
-      "You control upgrades and data retention",
-    ],
-    who: "Financial services, healthcare, and any org with data residency requirements.",
-    cta: "Book a call",
-    ctaHref: "https://cal.com/sudhi-seshachala-pks7pd",
-    accent: "violet",
-    dark: true,
-  },
-  {
-    tag: "Air-gapped",
-    name: "On-Premise",
-    tagline: "Fully inside your perimeter.",
-    description:
-      "Docker Compose or Helm chart. Runs on your servers, your Kubernetes cluster, or an air-gapped environment. No outbound calls to Conduct infrastructure.",
-    bullets: [
-      "Docker images delivered to your registry",
-      "Helm chart for Kubernetes deployments",
-      "Works fully air-gapped — no external dependencies",
-      "Alembic migrations included — you own the schema",
-    ],
-    who: "Government, defence, and regulated enterprises with strict perimeter requirements.",
-    cta: "Contact us",
-    ctaHref: "https://cal.com/sudhi-seshachala-pks7pd",
-    accent: "stone",
-    dark: false,
-  },
-]
-
-function TiersSection() {
-  return (
-    <section className="max-w-6xl mx-auto px-6 py-20">
-      <div className="grid md:grid-cols-3 gap-6">
-        {TIERS.map((tier) => (
-          <div
-            key={tier.name}
-            className={`rounded-2xl border p-8 flex flex-col gap-5 ${
-              tier.dark
-                ? "bg-stone-950 border-stone-800 text-white"
-                : "bg-white border-stone-200 text-stone-900"
-            }`}
-          >
-            <div>
-              <span
-                className={`text-[10px] font-bold uppercase tracking-widest ${
-                  tier.dark ? "text-indigo-400" : "text-indigo-600"
-                }`}
-              >
-                {tier.tag}
-              </span>
-              <h2
-                className={`text-2xl font-black mt-1 mb-1 ${
-                  tier.dark ? "text-white" : "text-stone-900"
-                }`}
-              >
-                {tier.name}
-              </h2>
-              <p
-                className={`text-sm font-semibold ${
-                  tier.dark ? "text-stone-300" : "text-stone-600"
-                }`}
-              >
-                {tier.tagline}
-              </p>
-            </div>
-
-            <p className={`text-sm leading-relaxed ${tier.dark ? "text-stone-400" : "text-stone-500"}`}>
-              {tier.description}
-            </p>
-
-            <ul className="flex flex-col gap-2.5">
-              {tier.bullets.map((b) => (
-                <li key={b} className="flex items-start gap-2.5">
-                  <span className={`mt-[3px] text-xs ${tier.dark ? "text-indigo-400" : "text-indigo-500"}`}>✓</span>
-                  <span className={`text-sm ${tier.dark ? "text-stone-300" : "text-stone-600"}`}>{b}</span>
-                </li>
-              ))}
-            </ul>
-
+        <section className="mb-20 grid grid-cols-1 md:grid-cols-2 gap-6">
+          {OPTIONS.map((opt) => (
             <div
-              className={`rounded-xl px-4 py-3 text-xs leading-relaxed mt-auto ${
-                tier.dark
-                  ? "bg-stone-900 border border-stone-800 text-stone-400"
-                  : "bg-stone-50 border border-stone-100 text-stone-500"
-              }`}
+              key={opt.name}
+              className="border border-stone-200 rounded-2xl p-6 bg-white flex flex-col"
             >
-              <span className="font-semibold">Best for: </span>{tier.who}
-            </div>
-
-            <a
-              href={tier.ctaHref}
-              target={tier.ctaHref.startsWith("http") ? "_blank" : undefined}
-              rel="noopener"
-              className={`w-full text-center rounded-xl px-6 py-3 text-sm font-bold transition-colors ${
-                tier.dark
-                  ? "bg-indigo-600 text-white hover:bg-indigo-700"
-                  : "bg-stone-900 text-white hover:bg-stone-700"
-              }`}
-            >
-              {tier.cta}
-            </a>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-/* ─── Comparison table ──────────────────────────────────────────────────── */
-
-const ROWS = [
-  { cap: "Time to first policy",         saas: "10 minutes",    byoc: "~1 day",           onprem: "~2 days"          },
-  { cap: "Infrastructure managed by",    saas: "Conduct",       byoc: "You (your cloud)",  onprem: "You (on-site)"    },
-  { cap: "Data residency",               saas: "conductai.ai",  byoc: "Your VPC",          onprem: "Your servers"     },
-  { cap: "Audit trail location",         saas: "Conduct cloud", byoc: "Your RDS",          onprem: "Your DB"          },
-  { cap: "Air-gap support",              saas: false,           byoc: false,               onprem: true               },
-  { cap: "Automatic upgrades",           saas: true,            byoc: "Optional",          onprem: "Manual"           },
-  { cap: "Custom domain",                saas: false,           byoc: true,                onprem: true               },
-  { cap: "Terraform module",             saas: false,           byoc: true,                onprem: true               },
-  { cap: "Helm / Docker Compose",        saas: false,           byoc: true,                onprem: true               },
-  { cap: "Free tier",                    saas: true,            byoc: false,               onprem: false              },
-  { cap: "CLI works identically",        saas: true,            byoc: true,                onprem: true               },
-  { cap: "Same policy engine",           saas: true,            byoc: true,                onprem: true               },
-]
-
-function Cell({ val }: { val: boolean | string }) {
-  if (val === true)  return <span className="text-emerald-500 font-bold">✓</span>
-  if (val === false) return <span className="text-stone-300">—</span>
-  return <span className="text-stone-500 text-xs">{val}</span>
-}
-
-function CompareSection() {
-  return (
-    <section className="bg-stone-50 border-y border-stone-200 px-6 py-20">
-      <div className="max-w-5xl mx-auto">
-        <p className="text-xs font-semibold uppercase tracking-widest text-indigo-600 mb-3 text-center">Compare tiers</p>
-        <h2 className="text-3xl font-black text-stone-900 tracking-tight text-center mb-10">
-          Same governance. Your choice of where it runs.
-        </h2>
-        <div className="overflow-x-auto rounded-xl border border-stone-200 bg-white">
-          <table className="w-full text-sm">
-            <thead>
-              <tr className="border-b border-stone-100">
-                <th className="px-5 py-4 text-left text-stone-400 font-semibold w-64">Capability</th>
-                <th className="px-5 py-4 text-center text-stone-700 font-semibold">SaaS</th>
-                <th className="px-5 py-4 text-center text-indigo-600 font-semibold bg-indigo-50">Cloud (BYOC)</th>
-                <th className="px-5 py-4 text-center text-stone-700 font-semibold">On-Premise</th>
-              </tr>
-            </thead>
-            <tbody>
-              {ROWS.map((row, i) => (
-                <tr key={row.cap} className={`border-b border-stone-50 ${i % 2 === 0 ? "bg-white" : "bg-stone-50/60"}`}>
-                  <td className="px-5 py-3.5 text-stone-600 font-medium">{row.cap}</td>
-                  <td className="px-5 py-3.5 text-center"><Cell val={row.saas} /></td>
-                  <td className="px-5 py-3.5 text-center bg-indigo-50/40"><Cell val={row.byoc} /></td>
-                  <td className="px-5 py-3.5 text-center"><Cell val={row.onprem} /></td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </section>
-  )
-}
-
-/* ─── How it works ──────────────────────────────────────────────────────── */
-
-function HowItWorksSection() {
-  return (
-    <section className="bg-stone-950 px-6 py-20">
-      <div className="max-w-4xl mx-auto">
-        <p className="text-xs font-semibold uppercase tracking-widest text-indigo-400 mb-3 text-center">One CLI. Any deployment.</p>
-        <h2 className="text-3xl font-black text-white tracking-tight text-center mb-4">
-          Switching deployment model is one flag.
-        </h2>
-        <p className="text-stone-400 text-center mb-12 max-w-xl mx-auto">
-          The CLI reads <code className="text-indigo-300">api_url</code> from your Guard config. Point it at your instance and everything — hooks, proxy, MCP, audit trail — follows automatically.
-        </p>
-
-        <div className="grid md:grid-cols-3 gap-4">
-          {[
-            {
-              label: "SaaS",
-              code: `# Default — no config needed\npip install conduct-cli\nconduct guard sync`,
-            },
-            {
-              label: "Cloud (BYOC)",
-              code: `# Join your cloud instance\nconduct guard join \\\n  --url https://guard.yourco.com \\\n  --token cond_live_xxx`,
-            },
-            {
-              label: "On-Premise",
-              code: `# Deploy then join\ndocker compose up -d\nconduct guard join \\\n  --url https://guard.internal \\\n  --token cond_live_xxx`,
-            },
-          ].map((item) => (
-            <div key={item.label} className="rounded-xl border border-stone-800 bg-stone-900 p-5">
-              <p className="text-xs font-bold uppercase tracking-widest text-indigo-400 mb-3">{item.label}</p>
-              <pre className="text-xs font-mono text-stone-300 leading-relaxed whitespace-pre">{item.code}</pre>
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="text-xl font-bold text-stone-900">{opt.name}</h2>
+                <span
+                  className={`text-[10px] font-mono font-bold uppercase tracking-wider border rounded px-2 py-0.5 ${STATUS_STYLE[opt.status]}`}
+                >
+                  {opt.status}
+                </span>
+              </div>
+              <p className="text-xs font-mono text-stone-400 uppercase tracking-wider mb-4">
+                {opt.tagline}
+              </p>
+              <p className="text-sm text-stone-600 leading-relaxed mb-5">
+                {opt.description}
+              </p>
+              <ul className="text-sm text-stone-500 space-y-1.5 mt-auto">
+                {opt.bullets.map((b) => (
+                  <li key={b} className="flex items-start gap-2">
+                    <span className="text-stone-300 shrink-0">·</span>
+                    <span>{b}</span>
+                  </li>
+                ))}
+              </ul>
             </div>
           ))}
-        </div>
+        </section>
 
-        <p className="text-stone-600 text-xs text-center mt-8">
-          Policy engine, proxy, MCP server, and audit trail work identically across all three tiers.
-        </p>
-      </div>
-    </section>
-  )
-}
-
-/* ─── CTA ───────────────────────────────────────────────────────────────── */
-
-function CtaSection() {
-  return (
-    <section className="py-24 px-6 bg-gradient-to-br from-indigo-600 to-violet-600">
-      <div className="max-w-3xl mx-auto text-center">
-        <h2 className="text-3xl sm:text-4xl font-black text-white tracking-tight leading-tight mb-4">
-          Not sure which tier fits?
-        </h2>
-        <p className="text-indigo-200 text-lg leading-relaxed mb-10 max-w-xl mx-auto">
-          Start with SaaS. Migrate to BYOC or on-premise when your compliance team asks. The CLI command is the same either way.
-        </p>
-        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
-          <CtaLink className="rounded-xl bg-white text-indigo-600 px-7 py-3.5 text-base font-bold hover:bg-indigo-50 transition-colors w-full sm:w-auto text-center" />
-          <a
-            href="https://cal.com/sudhi-seshachala-pks7pd"
-            target="_blank"
-            rel="noopener"
-            className="rounded-xl border border-white/40 text-white px-7 py-3.5 text-base font-semibold hover:bg-white/10 transition-colors w-full sm:w-auto text-center"
+        <section className="text-center border-t border-stone-100 pt-16">
+          <p className="text-lg text-stone-600 max-w-xl mx-auto leading-relaxed mb-6">
+            Not sure which fits? Start on SaaS, migrate to Docker or Kubernetes when compliance asks.
+          </p>
+          <Link
+            href="/sign-up"
+            className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
           >
-            Talk to us
-          </a>
-        </div>
-        <p className="text-indigo-300 text-xs mt-5">Free tier · No infrastructure changes · Works in minutes</p>
-      </div>
-    </section>
+            Start Discovery — 14 days free
+          </Link>
+        </section>
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/(marketing)/docs/discovery/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/discovery/page.tsx
@@ -1,0 +1,58 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Discovery — Conduct Docs",
+  description:
+    "How Conduct's Discovery flow works and what it surfaces during the 14-day trial.",
+}
+
+export default function DocsDiscoveryPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-3xl mx-auto px-6 py-20">
+        <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+          Docs → Discovery
+        </p>
+        <h1 className="text-3xl sm:text-4xl font-black tracking-tight text-stone-900 leading-[1.1] mb-4">
+          Discovery
+        </h1>
+        <p className="text-lg text-stone-500 leading-relaxed mb-10">
+          Discovery scans the AI tools your team is already using and shows you what runs where — Claude Code, Cursor, Codex, Copilot, MCP clients — so you know what Guard needs to enforce before you turn it on.
+        </p>
+
+        <section className="mb-10">
+          <h2 className="text-lg font-bold text-stone-900 mb-3">What it surfaces</h2>
+          <ul className="text-sm text-stone-600 space-y-2 list-disc pl-5">
+            <li>Every agent tool active on developer machines and CI</li>
+            <li>Which resources each tool has reached (files, endpoints, credentials)</li>
+            <li>Frequency and cost of tool invocations</li>
+            <li>Gaps where policy is missing</li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-lg font-bold text-stone-900 mb-3">Trial timeline</h2>
+          <ul className="text-sm text-stone-600 space-y-2 list-disc pl-5">
+            <li>Day 0 — sign up, install CLI on one machine</li>
+            <li>Day 1–2 — scan surfaces which tools your team runs</li>
+            <li>Day 3–7 — first draft policies suggested from the scan</li>
+            <li>Day 8–14 — trial enforcement with block-warn mode</li>
+          </ul>
+        </section>
+
+        <section className="mb-10">
+          <h2 className="text-lg font-bold text-stone-900 mb-3">See also</h2>
+          <ul className="text-sm text-stone-600 space-y-2">
+            <li>· <Link href="/guard" className="text-stone-900 font-semibold hover:underline">How Guard enforces</Link></li>
+            <li>· <Link href="/evidence" className="text-stone-900 font-semibold hover:underline">What each decision leaves behind</Link></li>
+            <li>· <Link href="/deployment" className="text-stone-900 font-semibold hover:underline">Where to run Guard</Link></li>
+          </ul>
+        </section>
+
+        <div className="mt-16 pt-8 border-t border-stone-100 text-sm text-stone-400">
+          Full docs shipping soon. Meanwhile: <Link href="/sign-up" className="text-stone-900 font-semibold hover:underline">start Discovery</Link>.
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/apps/web/src/app/(marketing)/guard/page.tsx
+++ b/apps/web/src/app/(marketing)/guard/page.tsx
@@ -175,9 +175,9 @@ export default function GuardPage() {
         {/* What Guard does NOT protect */}
         <section className="mb-20 border border-stone-200 rounded-2xl overflow-hidden">
           <div className="px-6 py-5 bg-stone-50 border-b border-stone-200">
-            <h2 className="text-lg font-bold text-stone-900">What Guard does not protect</h2>
+            <h2 className="text-lg font-bold text-stone-900">One policy where your stack isn&apos;t one vendor&apos;s.</h2>
             <p className="text-xs text-stone-400 mt-1">
-              We publish where Guard stops. Honest scope is a design requirement.
+              Cortex enforces inside Cortex. Copilot inside Copilot. Guard enforces <em>across</em> whatever mix your team actually runs. Here&apos;s the scope Guard owns — and what we intentionally leave to the tools and data layers you already have.
             </p>
           </div>
           <div className="px-6 py-2">

--- a/apps/web/src/app/(marketing)/security/page.tsx
+++ b/apps/web/src/app/(marketing)/security/page.tsx
@@ -1,131 +1,137 @@
-import { CtaLink } from "@/components/marketing/CtaLink"
+import Link from "next/link"
+import { ThreatModelRow } from "@/components/marketing/facelift/ThreatModelRow"
+
+export const metadata = {
+  title: "Security — Conduct",
+  description:
+    "How Guard enforces, evidences, and where its threat model draws the line. Runtime policy across every agent tool your team runs.",
+}
 
 export default function SecurityPage() {
   return (
-    <>
-      <HeroSection />
-      <LimitationsSection />
-      <DisclosureSection />
-    </>
-  )
-}
+    <div className="min-h-screen bg-white">
+      <main className="max-w-4xl mx-auto px-6 py-20">
+        <section className="mb-16 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Security
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            One policy where your stack isn&apos;t one vendor&apos;s.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed">
+            Cortex enforces inside Cortex. Copilot Studio inside Copilot. Bedrock inside Bedrock. Conduct enforces across whatever mix your team runs — with a scope you can inspect.
+          </p>
+        </section>
 
-/* ─── Hero ──────────────────────────────────────────────────────────────── */
+        <section className="mb-16">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Enforcement</h2>
+          <p className="text-stone-600 leading-relaxed mb-5">
+            Guard evaluates every action against your policy before it executes. Three enforcement surfaces catch every path an agent can take:
+          </p>
+          <ul className="text-sm text-stone-600 space-y-2.5">
+            <li className="flex items-start gap-3">
+              <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">CLI</span>
+              <span>Post-tool-use hook on Claude Code, Cursor, Codex, Copilot. Local decisions, no round-trip.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">HTTP</span>
+              <span>Drop-in base URL replacement in front of your model gateway. Every LLM request is policy-checked.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">MCP</span>
+              <span>Wraps MCP tool invocations before they reach the server. Same policy engine, different transport.</span>
+            </li>
+          </ul>
+        </section>
 
-function HeroSection() {
-  return (
-    <section className="max-w-3xl mx-auto px-6 pt-20 pb-10">
-      <div className="inline-flex items-center gap-2 bg-amber-50 text-amber-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
-        <span className="w-1.5 h-1.5 rounded-full bg-amber-500 inline-block" />
-        Threat model
-      </div>
-      <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        What we do not protect (yet).
-      </h1>
-      <p className="text-lg text-stone-500 leading-relaxed mb-4">
-        Guard enforces policies at the tool layer, across every AI agent your team runs. That scope is real and it compounds. There are also things it does not do today. This page names them directly, with our plan for each.
-      </p>
-      <p className="text-sm text-stone-400">Last reviewed: 2026-08-09</p>
-    </section>
-  )
-}
+        <section className="mb-16 border-t border-stone-100 pt-12">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Evidence</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Every decision is a receipt. Hash-chained (SHA-256) so tampering is detectable, exportable by policy, and answerable to auditors.
+          </p>
+          <Link
+            href="/evidence"
+            className="text-sm font-semibold text-stone-900 hover:text-stone-600"
+          >
+            See what a receipt contains →
+          </Link>
+        </section>
 
-/* ─── Limitations ────────────────────────────────────────────────────────── */
+        <section className="mb-16 border-t border-stone-100 pt-12">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Rollout</h2>
+          <p className="text-stone-600 leading-relaxed mb-4">
+            Run Guard as SaaS, in a container, on Kubernetes, or fully isolated. Same policy engine, same audit trail, wherever your data must stay.
+          </p>
+          <Link
+            href="/deployment"
+            className="text-sm font-semibold text-stone-900 hover:text-stone-600"
+          >
+            See rollout options →
+          </Link>
+        </section>
 
-function LimitationsSection() {
-  const items = [
-    {
-      title: "Credentials are decrypted in the executor process.",
-      status: "Known gap",
-      statusStyle: "bg-amber-100 text-amber-700",
-      body: "When a workflow block runs, credentials stored in your workspace are decrypted in memory inside the executor process. A compromised executor with sufficient access could read them in plaintext. This is standard practice for secret injection into running processes — it is not unique to Conduct — but it is a real attack surface.",
-      plan: "We are evaluating hardware-backed secret stores (AWS KMS envelope encryption, HashiCorp Vault dynamic secrets) that keep the plaintext window as short as possible and audit every decryption. The executor would receive a short-lived token, not the raw credential. Timeline: Q4 2026.",
-    },
-    {
-      title: "No per-environment egress allowlist.",
-      status: "Known gap",
-      statusStyle: "bg-amber-100 text-amber-700",
-      body: "Guard controls which tools an agent can call and enforces spend limits, but it does not currently restrict which network destinations a tool can reach. An agent with a Bash tool could make outbound requests to arbitrary endpoints — Guard will log the call but not block it based on destination.",
-      plan: "Per-environment egress rules are on the Guard policy roadmap. The plan is to add a destination_allowlist field to the policy schema, evaluated at the proxy layer before any outbound call forwards. This requires the Guard Proxy to be in the path — a requirement we will document explicitly. Target: Q1 2027.",
-    },
-    {
-      title: "No static analysis of third-party playbooks before install.",
-      status: "Known gap",
-      statusStyle: "bg-amber-100 text-amber-700",
-      body: "Playbooks from the marketplace or imported via YAML are not statically analysed for dangerous patterns before install. A malicious playbook could contain a Bash block that exfiltrates data on first run. Guard policies apply at runtime, so the first execution is when enforcement kicks in — not before.",
-      plan: "We are building a pre-install scanner that inspects block types, tool permissions, and shell commands against a deny-list before a playbook is activated. It will surface warnings in the install flow, not silently block. Community-contributed playbooks will require a manual review step before appearing in the public registry. Target: Q3 2026.",
-    },
-  ]
-
-  return (
-    <section className="max-w-3xl mx-auto px-6 py-10">
-      <div className="space-y-10">
-        {items.map((item) => (
-          <div key={item.title} className="border border-stone-200 rounded-2xl p-8 bg-white">
-            <div className="flex items-start justify-between gap-4 mb-5">
-              <h2 className="text-lg font-bold text-stone-900 leading-snug">{item.title}</h2>
-              <span className={`flex-shrink-0 text-xs font-semibold px-2.5 py-1 rounded-full ${item.statusStyle}`}>
-                {item.status}
-              </span>
+        <section className="mb-16 border-t border-stone-100 pt-12">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Threat model</h2>
+          <p className="text-stone-600 leading-relaxed mb-6">
+            We publish where Guard stops. Honest scope is a design requirement — and a differentiator, because heterogeneous coverage means we can&apos;t pretend to own every layer.
+          </p>
+          <div className="border border-stone-200 rounded-2xl overflow-hidden">
+            <div className="px-5 py-3 bg-stone-50 border-b border-stone-200">
+              <p className="text-xs font-mono font-bold text-stone-600 uppercase tracking-wider">
+                Coverage map
+              </p>
             </div>
-            <p className="text-stone-500 leading-relaxed mb-5">{item.body}</p>
-            <div className="rounded-xl bg-stone-50 border border-stone-100 px-5 py-4">
-              <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-2">Our plan</p>
-              <p className="text-sm text-stone-600 leading-relaxed">{item.plan}</p>
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  )
-}
-
-/* ─── Disclosure ─────────────────────────────────────────────────────────── */
-
-function DisclosureSection() {
-  return (
-    <section className="bg-stone-50 border-t border-stone-200 px-6 py-16">
-      <div className="max-w-3xl mx-auto">
-        <div className="grid md:grid-cols-2 gap-10 items-start">
-          <div>
-            <h2 className="text-xl font-bold text-stone-900 mb-3">Report a vulnerability.</h2>
-            <p className="text-stone-500 text-sm leading-relaxed mb-4">
-              If you find a security issue in Guard, the API, or the CLI, disclose it to us before making it public. We will respond within 48 hours, confirm scope, and keep you informed through resolution.
-            </p>
-            <a
-              href="mailto:security@conductai.ai"
-              className="inline-flex items-center gap-2 text-sm font-semibold text-indigo-600 hover:text-indigo-700 transition-colors"
-            >
-              security@conductai.ai
-            </a>
-            <p className="text-xs text-stone-400 mt-3">
-              We do not have a formal bug bounty programme yet. We will credit researchers by name if they wish.
-            </p>
-          </div>
-          <div>
-            <h2 className="text-xl font-bold text-stone-900 mb-3">What Guard does protect.</h2>
-            <ul className="space-y-2 text-sm text-stone-600">
-              {[
-                "Tool-layer enforcement — block or warn before the agent acts",
-                "Credential leak detection in prompts and tool inputs",
-                "PII screening before calls reach LLM providers",
-                "Spend limits enforced in real time per developer and workspace",
-                "SHA-256 hash-chained audit log, tamper-evident and CISO-verifiable",
-                "RFC 8693 token exchange for agent identity",
-                "Fail-closed by default on API outage",
-              ].map((item) => (
-                <li key={item} className="flex items-start gap-2">
-                  <span className="text-emerald-500 font-bold mt-0.5">✓</span>
-                  <span>{item}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="mt-6">
-              <CtaLink className="rounded-lg bg-stone-900 text-white px-5 py-2.5 text-sm font-semibold hover:bg-stone-700 transition-colors" />
+            <div className="px-5 py-2">
+              <ThreatModelRow
+                threat="Actions routed through Guard (CLI hook, HTTP proxy, MCP layer)"
+                coverage="Protected"
+                detail="All three surfaces run the same policy engine. Refunds, network changes, secret reads — every action routed through Guard is inspected."
+              />
+              <ThreatModelRow
+                threat="Audit trail integrity"
+                coverage="Protected"
+                detail="SHA-256 hash chain on every decision. Altered entries break verification."
+              />
+              <ThreatModelRow
+                threat="Pre-call prompt injection (before Guard sees the tool call)"
+                coverage="Partial"
+                detail="Injection detection pack + pattern-based checks. ML-based detection is not implemented."
+              />
+              <ThreatModelRow
+                threat="Model-layer attacks (adversarial inputs to the LLM itself)"
+                coverage="Partial"
+                detail="Prompt-injection pack included. Semantic ML detection not implemented."
+              />
+              <ThreatModelRow
+                threat="Cross-agent correlation (Operations context)"
+                coverage="Not protected"
+                detail="Guard evaluates each action in isolation today. Cross-agent context is the Operations gap — Design Partner Preview."
+              />
+              <ThreatModelRow
+                threat="Actions that bypass all three enforcement surfaces"
+                coverage="Not protected"
+                detail="An agent that does not use the hook, proxy, or MCP layer is invisible to Guard."
+              />
             </div>
           </div>
-        </div>
-      </div>
-    </section>
+        </section>
+
+        <section className="mb-16 border-t border-stone-100 pt-12">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">Responsible disclosure</h2>
+          <p className="text-stone-600 leading-relaxed">
+            Found a security issue? Email <a href="mailto:security@conductai.ai" className="text-stone-900 font-semibold hover:underline">security@conductai.ai</a>. We aim to acknowledge within 24 hours and coordinate on disclosure timing.
+          </p>
+        </section>
+
+        <section className="text-center border-t border-stone-100 pt-16">
+          <Link
+            href="/sign-up"
+            className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+          >
+            Start Discovery — 14 days free
+          </Link>
+        </section>
+      </main>
+    </div>
   )
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -521,32 +521,30 @@ function NativeControlsSection() {
   return (
     <section className="py-12 sm:py-20 px-4 sm:px-6 border-t border-stone-100 bg-stone-50">
       <div className="max-w-5xl mx-auto">
-        <div className="grid lg:grid-cols-2 gap-10 lg:gap-12 items-center">
-          <div className="order-2 lg:order-1">
-            <RuntimeFlow variant="compact" />
-          </div>
-          <div className="order-1 lg:order-2">
-            <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
-              Keep the controls you already have.
-            </h2>
-            <p className="text-stone-500 leading-relaxed mb-6 text-sm sm:text-base">
-              Guard sits in front of your existing model gateways. Point to your Azure endpoint, your OpenRouter key, your LiteLLM proxy — Guard intercepts and enforces without replacing the stack underneath.
-            </p>
-            <div className="space-y-3 text-sm text-stone-600">
-              <p className="flex items-start gap-2">
-                <span className="text-stone-400 font-mono shrink-0">SDK</span>
-                <span>Drop-in base URL replacement. No SDK changes.</span>
-              </p>
-              <p className="flex items-start gap-2">
-                <span className="text-stone-400 font-mono shrink-0">CLI</span>
-                <span>Post-tool-use hook on Claude Code, Cursor, Codex, Copilot.</span>
-              </p>
-              <p className="flex items-start gap-2">
-                <span className="text-stone-400 font-mono shrink-0">MCP</span>
-                <span>Guard wraps MCP tool invocations before they reach the server.</span>
-              </p>
-            </div>
-          </div>
+        <div className="text-center mb-10 sm:mb-14">
+          <h2 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-stone-900 tracking-tight mb-4">
+            One policy across your agent stack.
+          </h2>
+          <p className="text-stone-500 leading-relaxed max-w-2xl mx-auto text-sm sm:text-base">
+            Cortex enforces inside Cortex. Copilot Studio inside Copilot. Bedrock inside Bedrock. Conduct enforces <em>across</em> whatever mix your team actually runs — the native controls stay, Guard sits above them.
+          </p>
+        </div>
+        <div className="flex justify-center mb-12 overflow-x-auto">
+          <RuntimeFlow />
+        </div>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-6 max-w-3xl mx-auto text-sm text-stone-600">
+          <p className="flex items-start gap-2">
+            <span className="text-stone-400 font-mono shrink-0">SDK</span>
+            <span>Drop-in base URL replacement. No SDK changes.</span>
+          </p>
+          <p className="flex items-start gap-2">
+            <span className="text-stone-400 font-mono shrink-0">CLI</span>
+            <span>Post-tool-use hook on Claude Code, Cursor, Codex, Copilot.</span>
+          </p>
+          <p className="flex items-start gap-2">
+            <span className="text-stone-400 font-mono shrink-0">MCP</span>
+            <span>Guard wraps MCP tool invocations before they reach the server.</span>
+          </p>
         </div>
       </div>
     </section>


### PR DESCRIPTION
Closes remaining scope from facelift plan section 6 + folds in the heterogeneous-enforcement reframe.

## Ships
- /deployment — full rebuild per plan section 6 (4 cards: SaaS, Docker, K8s Preview, Air-gapped Planned). No BYOC card. Status color chips per card.
- /security — full rebuild (Enforcement, Evidence, Rollout, Threat map, Responsible disclosure). ThreatModelRow coverage table.
- /guard threat section — H2 reframe from defensive to offense framing. Same ThreatModelRow data underneath, different framing.
- Homepage section 6 — RuntimeFlow upgraded from compact to default fan (agents → Guard → decisions → downstream). Copy reframed to heterogeneous story. SDK/CLI/MCP bullets kept as evidence.
- /docs/discovery — new stub matching /docs/lens pattern. Closes last nav 404.

## Verification
Direct tsc clean on touched files. Pre-commit npx-tsc reports pre-existing next/link worktree symlink noise (same as prior facelift PRs). Pushed with --no-verify per approved worktree pattern.

Net diff: +313 / -431 (net -118).

Closes remaining plan section 6 scope.