### PR TITLE
feat(web): un-gate /evidence + Agent -> Guard -> Model/Tool pill diagram on /mcp-gateway

### DIFF
--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link"
-import { RuntimeFlow } from "@/components/marketing/facelift/RuntimeFlow"
 import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 
 export const metadata = {
@@ -45,15 +44,27 @@ export default function MCPPage() {
         {/* MCP flow diagram */}
         <section className="mb-20">
           <h2 className="text-2xl font-bold text-stone-900 mb-3">
-            MCP client → Guard → MCP server.
+            Agent → Guard → Model / Tool.
           </h2>
           <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
             Guard wraps the MCP transport layer. Clients connect to Guard as if it were the MCP server.
             Guard evaluates each tool call and forwards allowed calls to the upstream server.
             Blocked calls never reach the server.
           </p>
-          <div className="border border-stone-200 rounded-2xl bg-stone-50 p-8 mb-8">
-            <RuntimeFlow variant="compact" />
+          <div className="border border-stone-200 rounded-2xl bg-white p-8 sm:p-12 mb-8">
+            <div className="flex items-center justify-center gap-3 sm:gap-6">
+              <div className="flex-1 max-w-[220px] border border-stone-200 rounded-2xl bg-white px-4 sm:px-6 py-6 sm:py-8 text-center shadow-sm">
+                <p className="text-lg sm:text-2xl font-black tracking-tight text-stone-900">Agent</p>
+              </div>
+              <FlowArrow />
+              <div className="flex-1 max-w-[220px] rounded-2xl bg-stone-900 px-4 sm:px-6 py-6 sm:py-8 text-center shadow-md">
+                <p className="text-lg sm:text-2xl font-black tracking-tight text-white">Guard</p>
+              </div>
+              <FlowArrow />
+              <div className="flex-1 max-w-[220px] border border-stone-200 rounded-2xl bg-white px-4 sm:px-6 py-6 sm:py-8 text-center shadow-sm">
+                <p className="text-base sm:text-2xl font-black tracking-tight text-stone-900 whitespace-nowrap">Model / Tool</p>
+              </div>
+            </div>
           </div>
           <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm font-mono">
             {[
@@ -187,5 +198,24 @@ export default function MCPPage() {
 
       </main>
     </div>
+  )
+}
+
+function FlowArrow() {
+  return (
+    <svg
+      className="w-5 h-3 sm:w-8 sm:h-4 text-stone-400 shrink-0"
+      viewBox="0 0 32 16"
+      fill="none"
+      aria-hidden="true"
+    >
+      <path
+        d="M0 8h26M20 2l6 6-6 6"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
   )
 }

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 import { type NextRequest, NextResponse } from "next/server"
 
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/evidence", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
 
 const isAppSubdomain = (req: NextRequest) =>
   req.headers.get("host")?.startsWith("app.")


### PR DESCRIPTION
Two small marketing polish fixes on top of the P1 facelift.

## Ships

### 1. Un-gate \`/evidence\`
Add \`/evidence\` to \`isPublicRoute\` in \`apps/web/src/middleware.ts\`. It was previously gated by Clerk auth so unauth prospects hitting the page were bounced to \`/sign-in\`. \`/evidence\` is a marketing page — should be crawlable and shareable.

### 2. New hero diagram on \`/mcp-gateway\`
Replace the shared \`RuntimeFlow\` (arrows + text lanes) with the three-pill diagram Sudhi shared:

> **Agent** (white pill) → **Guard** (black pill) → **Model / Tool** (white pill)

Cleaner mental model at the top of the page. H2 aligned to match. The three-step explainer cards below (MCP Client / Guard evaluates / MCP Server) are unchanged.

Inline SVG for the arrow; no new component file, no new dep. \`RuntimeFlow\` import removed from this page (still used elsewhere).

## Also flagged (not in this PR)
Same middleware pattern is gating other marketing pages that shipped in the facelift and probably shouldn't be gated:
- \`/book-demo\`, \`/deployment\`, \`/discovery\`, \`/frameworks\`, \`/mcp-gateway\`, \`/open-source\`, \`/router\`, \`/security\`, \`/team-os\`

Ask if you want the same one-line fix applied to those.

## Verification
- \`npx tsc --noEmit -p apps/web/tsconfig.json\` clean.
- Diff: +35 / -5 across 2 files.