### PR TITLE
feat(web): un-gate 9 remaining marketing pages behind Clerk auth

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 import { type NextRequest, NextResponse } from "next/server"
 
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/evidence", "/mcp-gateway", "/security", "/deployment", "/open-source", "/router", "/team-os", "/frameworks(.*)", "/discovery", "/book-demo", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
 
 const isAppSubdomain = (req: NextRequest) =>
   req.headers.get("host")?.startsWith("app.")


### PR DESCRIPTION
Companion to #1605. Adds the remaining marketing pages to \`isPublicRoute\` in \`apps/web/src/middleware.ts\`.

## Opened
- \`/book-demo\`
- \`/deployment\`
- \`/discovery\`
- \`/frameworks(.*)\` — has sub-routes
- \`/mcp-gateway\`
- \`/open-source\`
- \`/router\`
- \`/security\`
- \`/team-os\`

All live under \`apps/web/src/app/(marketing)/\` and are meant for unauth prospects. Middleware was still bouncing visitors to \`/sign-in\`.

## Verification
- \`npx tsc --noEmit -p apps/web/tsconfig.json\` clean.
- Diff: +1 / -1 on one line of \`middleware.ts\`.

## Depends on / related
- #1605 opened \`/evidence\` and refreshed the \`/mcp-gateway\` hero diagram. Merge either order — same file, no conflicts expected since they touch different route strings on the same line (small rebase possible if second merger).