### PR TITLE
fix(vercel): ignoreCommand uses git show HEAD — HEAD~1 fails on shallow clone

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,5 @@
   "buildCommand": "npx turbo run build --filter=marshal-web",
   "outputDirectory": ".next",
   "framework": "nextjs",
-  "ignoreCommand": "! git diff HEAD~1 --name-only | grep -qE '^apps/web/|^vercel\\.json$|^turbo\\.json$|^package\\.json$'"
+  "ignoreCommand": "! git show HEAD --name-only --pretty='' | grep -qE '^apps/web/|^vercel\\.json$|^turbo\\.json$|^package\\.json$'"
 }


### PR DESCRIPTION
## The bug

Vercel does a **shallow clone (depth 1)** for deployments. Current \`ignoreCommand\` in \`vercel.json\` uses \`git diff HEAD~1 --name-only\` — HEAD~1 doesn't exist in that clone. The pipe to grep sees empty input, grep exits 1, the outer \`!\` inverts to 0, and Vercel reads exit 0 as **"cancel build"**.

## Impact — prod is running stale code

Every merge to \`main\` in the last hour was silently cancelled without deploying:

| PR | Merge SHA | Shipped | Deployed? |
|---|---|---|---|
| #1602 | 98c9295 | Facelift copy — homepage strap + Agent Discovery rename | ❌ |
| #1604 | baff9a2 | \`/lens\` route-collision hotfix | ❌ |
| #1605 | 7bf97e0 | \`/evidence\` public + \`/mcp-gateway\` hero diagram | ❌ |
| #1606 | eba9e94 | 9 more marketing routes public | ❌ |

All four show "Canceled by Ignored Build Step" on GitHub commit status. That's why \`/evidence\` and \`/mcp-gateway\` still bounce to \`/sign-in\` on prod.

## Fix

Swap \`git diff HEAD~1 --name-only\` for \`git show HEAD --name-only --pretty=''\`. Same output (files touched in the current commit), no dependency on HEAD~1, works on shallow clone. \`!\` semantics unchanged.

## One-shot recovery

Merging this triggers a build (vercel.json is in the grep pattern). That build deploys current main tip, which already includes all four backlogged PRs. One merge = everything ships.