### PR TITLE
fix(vercel): drop ignoreCommand — it kept cancelling every apps/web deploy

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,5 @@
 {
   "buildCommand": "npx turbo run build --filter=marshal-web",
   "outputDirectory": ".next",
-  "framework": "nextjs",
-  "ignoreCommand": "! git show HEAD --name-only --pretty='' | grep -qE '^apps/web/|^vercel\\.json$|^turbo\\.json$|^package\\.json$'"
+  "framework": "nextjs"
 }


### PR DESCRIPTION
## Why

PR #1607 tried to fix the ignoreCommand from \`git diff HEAD~1\` to \`git show HEAD\` on the theory that shallow-clone made HEAD~1 unresolvable. **That did not fix it** — the #1607 merge commit itself (which only touched vercel.json) was also cancelled by the ignore step.

At this point we've spent enough tuning a shell one-liner that runs in Vercel's opaque hook environment. Drop it. Every push builds. Builds are cheap. Silently skipping every deploy is the failure mode we've been living with for the last hour and it is much worse.

## What ships

On merge, Vercel will build \`main\`'s current tip, which already includes:

| PR | What |
|---|---|
| #1602 | Facelift copy — homepage strap + Agent Discovery rename |
| #1604 | \`/lens\` route-collision hotfix |
| #1605 | \`/evidence\` public + \`/mcp-gateway\` hero diagram |
| #1606 | 9 more marketing routes public |
| #1608 | \`github.com/sseshachala/conductai\` URL fix (merge before or after) |

## Later

We can re-add a working \`ignoreCommand\` once we understand what git commands actually work in Vercel's hook environment. Not urgent.