### PR TITLE
feat(web): /registry hides demo playbooks (branch-42, prompt-injection, self-driving, Acme)

### DIFF
--- a/apps/api/playbooks/registry.yaml
+++ b/apps/api/playbooks/registry.yaml
@@ -281,7 +281,7 @@ playbooks:
     file: acme-onboarding-e2e.yaml
     icon: "🧪"
     category: Testing
-    tags: [e2e, peekaboo, macos, onboarding, roles]
+    tags: [e2e, peekaboo, macos, onboarding, roles, demo]
     featured: true
     description: "Full role-coverage E2E test via Peekaboo GUI automation. Signs up an admin, invites developers + security, walks each persona through their journey, asserts correct permissions and UI state at every step."
 

--- a/apps/web/src/app/(marketing)/registry/page.tsx
+++ b/apps/web/src/app/(marketing)/registry/page.tsx
@@ -49,6 +49,7 @@ interface AutomationPack {
   description: string
   category: string
   icon?: string
+  tags?: string[]
 }
 
 const CATEGORY_ALL = "All"
@@ -71,7 +72,11 @@ export default function RegistryPage() {
           : Array.isArray(data?.playbooks)
           ? data.playbooks
           : []
-        setAutomationPacks(items)
+        // Marketing registry shows real playbooks only. Demo playbooks (branch-42,
+        // prompt-injection scenarios, Acme fixtures) are tagged `demo` in
+        // apps/api/playbooks/registry.yaml — filter them out here.
+        const real = items.filter((p) => !(p.tags ?? []).includes("demo"))
+        setAutomationPacks(real)
       })
       .catch(() => setAutomationPacks([]))
       .finally(() => setLoading(false))


### PR DESCRIPTION
## Fix
Marketing \`/registry\` currently shows every playbook from \`/workflows/playbooks\` — including four demos that shouldn't be customer-facing:

- Network Diagnosis Agent (branch-42 synthetic)
- Compromised Support Agent (prompt-injection scenario)
- Self Driving Network Approval Demo
- Acme Onboarding E2E (fictional company fixture)

## What ships
- **\`apps/api/playbooks/registry.yaml\`** — add \`demo\` tag to \`acme_onboarding_e2e\`. The other three already have it.
- **\`apps/web/src/app/(marketing)/registry/page.tsx\`** —
  - Add \`tags?: string[]\` to \`AutomationPack\` interface (API already returns it).
  - After fetch: \`items.filter(p => !(p.tags ?? []).includes("demo"))\`.

## Why client-side filter
API returns \`tags\` today (playbooks.py:72). No backend change needed. Authenticated workspaces still see demos via \`/workflows/playbooks\` — they're internal dev tools, just not marketing content.

## Verification
- \`npx tsc --noEmit -p apps/web/tsconfig.json\` clean.
- Diff: +7 / -2 across 2 files.

## Deploys after #1609
Same as everything else — waiting on the ignoreCommand removal PR.