### PR TITLE
fix(vercel): drop ignoreCommand from apps/web/vercel.json too

### DIFF
--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,4 +1,3 @@
 {
-  "installCommand": "npm install --prefix=../.. --prefer-offline --no-audit --no-fund",
-  "ignoreCommand": "git diff HEAD^ HEAD --name-only | grep -qE '^apps/web/'"
+  "installCommand": "npm install --prefix=../.. --prefer-offline --no-audit --no-fund"
 }


### PR DESCRIPTION
## Summary
PR #1609 dropped `ignoreCommand` from the root `vercel.json` but missed the app-level one at `apps/web/vercel.json`, which has inverted logic:

```
"git diff HEAD^ HEAD --name-only | grep -qE '^apps/web/'"
```

`grep -q` exits 0 on match → Vercel skips. So every merge that touches `apps/web/` silently cancels — exactly the failure #1609 fixed at the root. Confirmed on #1611's auto-deploy against the `conductai` project, canceled at 2s.

Same reasoning as #1609: every push builds; builds are cheap; silent skips on the marketing site are a lot worse.

## Test plan
- [ ] Once merged, watch the auto-deploy on the `conductai` project — should build, not cancel
- [ ] Verify conductai.ai reflects #1611 (MCP-client universal support copy) post-deploy