### PR TITLE
feat(web): ship /pricing page — 4 tiers, per-agent-identity model

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -112,6 +112,7 @@ function MarketingNav() {
           <ProductDropdown />
           <SolutionsDropdown />
           <DevelopersDropdown />
+          <a href="/pricing" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Pricing</a>
           <a href="/blog" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Blog</a>
         </nav>
         <div className="flex items-center gap-3">
@@ -142,6 +143,7 @@ function MarketingFooter() {
         ["Playbooks", "/playbooks"],
         ["Evidence", "/evidence"],
         ["MCP", "/mcp-gateway"],
+        ["Pricing", "/pricing"],
       ] as [string, string][],
     },
     {

--- a/apps/web/src/app/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,212 @@
+import Link from "next/link"
+
+export const metadata = {
+  title: "Pricing — Conduct",
+  description:
+    "One list price per governed agent identity. Same price whether you run Conduct on our cloud or your own. Free tier for up to 3 agents.",
+}
+
+type Tier = {
+  name: string
+  price: string
+  cadence?: string
+  cap: string
+  tagline: string
+  cta: { label: string; href: string }
+  highlight?: boolean
+  includes: string[]
+}
+
+const TIERS: Tier[] = [
+  {
+    name: "Free",
+    price: "$0",
+    cap: "Up to 3 agents",
+    tagline: "For individual devs, POCs, and internal tinkering.",
+    cta: { label: "Start free", href: "/sign-up" },
+    includes: [
+      "Full policy engine — allow, block, approve, prove",
+      "Hash-chained audit trail",
+      "MCP + proxy + CLI hook enforcement",
+      "Community support (GitHub Discussions)",
+    ],
+  },
+  {
+    name: "Team",
+    price: "$99",
+    cadence: "per agent / month",
+    cap: "Up to 25 agents",
+    tagline: "For engineering teams governing their first fleet of agents.",
+    cta: { label: "Start 14-day trial", href: "/sign-up" },
+    highlight: true,
+    includes: [
+      "Everything in Free",
+      "Slack + email approval fanout",
+      "Signed evidence exports",
+      "Slack + email support (business hours)",
+      "SSO (Google, Microsoft, Okta)",
+    ],
+  },
+  {
+    name: "Business",
+    price: "$79",
+    cadence: "per agent / month",
+    cap: "25–100 agents",
+    tagline: "Volume pricing for orgs standardising governance across many agents.",
+    cta: { label: "Talk to sales", href: "/book-demo" },
+    includes: [
+      "Everything in Team",
+      "Priority support (24h response)",
+      "Custom policy pack authoring",
+      "Role-based access control (RBAC)",
+      "Compliance evidence templates (SOC2, ISO, HIPAA)",
+    ],
+  },
+  {
+    name: "Enterprise",
+    price: "Contact us",
+    cap: "100+ agents · Self-hosted · Air-gapped",
+    tagline: "For regulated industries, self-host, and design-partner engagements.",
+    cta: { label: "Contact us", href: "/book-demo" },
+    includes: [
+      "Everything in Business",
+      "Self-hosted deployment (Docker, Kubernetes, air-gapped)",
+      "Signed SLA + dedicated success engineer",
+      "Custom policy development",
+      "Procurement, security review, and MSA support",
+    ],
+  },
+]
+
+export default function PricingPage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <main className="max-w-6xl mx-auto px-6">
+        {/* Hero */}
+        <section className="pt-20 pb-14 text-center">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            Pricing
+          </p>
+          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            One list. Priced per governed agent.
+          </h1>
+          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed">
+            Every tier includes the full policy engine, hash-chained audit trail, and every
+            enforcement surface — MCP, proxy, and CLI hook. You pay for how many agent
+            identities you govern, not which features you unlock.
+          </p>
+        </section>
+
+        {/* Tier grid */}
+        <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-14">
+          {TIERS.map((t) => (
+            <div
+              key={t.name}
+              className={`flex flex-col rounded-2xl p-6 border ${
+                t.highlight
+                  ? "border-stone-900 bg-stone-50 shadow-sm"
+                  : "border-stone-200 bg-white"
+              }`}
+            >
+              <div className="mb-5">
+                <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-2">
+                  {t.name}
+                </p>
+                <div className="flex items-baseline gap-1.5 mb-1">
+                  <span className="text-3xl font-black text-stone-900">{t.price}</span>
+                  {t.cadence && (
+                    <span className="text-xs text-stone-500">{t.cadence}</span>
+                  )}
+                </div>
+                <p className="text-xs font-mono text-stone-500">{t.cap}</p>
+              </div>
+
+              <p className="text-sm text-stone-600 leading-relaxed mb-5">{t.tagline}</p>
+
+              <ul className="text-sm text-stone-600 space-y-2 mb-6">
+                {t.includes.map((line) => (
+                  <li key={line} className="flex items-start gap-2 leading-relaxed">
+                    <span className="text-stone-300 shrink-0 mt-0.5">·</span>
+                    <span>{line}</span>
+                  </li>
+                ))}
+              </ul>
+
+              <Link
+                href={t.cta.href}
+                className={`mt-auto inline-block text-center rounded-xl px-4 py-2.5 text-sm font-semibold transition-colors ${
+                  t.highlight
+                    ? "bg-stone-900 text-white hover:bg-stone-700"
+                    : "border border-stone-200 bg-white text-stone-700 hover:bg-stone-50"
+                }`}
+              >
+                {t.cta.label}
+              </Link>
+            </div>
+          ))}
+        </section>
+
+        {/* Self-host clarity */}
+        <section className="mb-14 rounded-2xl border border-stone-200 bg-stone-50 p-8">
+          <h2 className="text-lg font-bold text-stone-900 mb-2">
+            Self-hosted? Same list price. Same features.
+          </h2>
+          <p className="text-sm text-stone-600 leading-relaxed max-w-3xl">
+            Self-hosted deployments (Docker, Kubernetes, air-gapped) are available on Enterprise.
+            The list price is the same — you're paying for policy enforcement, audit, and support,
+            not for where the pods run. Deploy where your compliance boundary needs it, keep the
+            same commercial terms.
+          </p>
+        </section>
+
+        {/* Feature parity note */}
+        <section className="mb-14 grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
+          {[
+            {
+              title: "One engine — every surface",
+              body: "MCP tool interception, LLM proxy, and CLI hooks all run through the same policy engine and write to the same audit chain.",
+            },
+            {
+              title: "One agent identity",
+              body: "Every governed agent gets a cond_agt_* identity with RBAC, TTL, rate + spend caps. That identity is the unit you pay for.",
+            },
+            {
+              title: "Bring your own LLM",
+              body: "100+ providers — Anthropic, OpenAI, Bedrock, Azure, Ollama, self-host — through one gateway. No provider markup.",
+            },
+          ].map((f) => (
+            <div key={f.title} className="rounded-xl border border-stone-200 bg-white p-5">
+              <p className="font-semibold text-stone-900 mb-2 text-sm">{f.title}</p>
+              <p className="text-stone-500 leading-relaxed text-[13px]">{f.body}</p>
+            </div>
+          ))}
+        </section>
+
+        {/* CTA */}
+        <section className="mb-20 text-center border-t border-stone-100 pt-14">
+          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+            Not sure which tier fits?
+          </h2>
+          <p className="text-stone-500 max-w-xl mx-auto mb-6 leading-relaxed">
+            Start on Free — govern up to 3 agents in an afternoon. Upgrade when your fleet grows,
+            or talk to us about design-partner terms if you're deploying at scale early.
+          </p>
+          <div className="flex flex-wrap justify-center gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            >
+              Start free
+            </Link>
+            <Link
+              href="/book-demo"
+              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+            >
+              Talk to sales →
+            </Link>
+          </div>
+        </section>
+      </main>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
New \`/pricing\` route with four public tiers, priced per governed agent identity (\`cond_agt_*\`):

| Tier | Price | Cap |
|---|---|---|
| Free | \$0 | Up to 3 agents |
| **Team** (highlighted) | **\$99/agent/mo** | Up to 25 agents |
| Business | \$79/agent/mo | 25–100 agents |
| Enterprise | Contact us | 100+ · self-hosted · air-gapped |

Design decisions worth calling out:
- **Per agent identity, not per user/seat/call.** Aligns cost with the product's atomic unit.
- **Every tier includes the full policy engine and every enforcement surface** (MCP, proxy, CLI hook). Tiers gate scale + support, never features.
- **Self-host = same list price**, called out explicitly in its own section. Prevents buyers from arbitraging hosting vs. license. Same posture as Snyk and Chainguard.
- **No feature-comparison matrix.** Kept clean per Sudhi's ask.

Motivated by the 2026-09-03 Toboggan Labs call — every serious evaluator now hits a pricing surface on the first click instead of a bespoke reply being the bottleneck. Design-partner terms stay 1:1, off this page.

## Test plan
- [ ] \`pnpm --filter web dev\` — smoke render, verify hover states and responsive grid at sm/md/lg
- [ ] Confirm CTAs route to \`/sign-up\` and \`/book-demo\`
- [ ] Vercel preview link once auto-deploy fires