### PR TITLE
fix(web): add /pricing to Clerk publicRoutes matcher

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,7 +1,7 @@
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server"
 import { type NextRequest, NextResponse } from "next/server"
 
-const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/evidence", "/mcp-gateway", "/security", "/deployment", "/open-source", "/router", "/team-os", "/frameworks(.*)", "/discovery", "/book-demo", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
+const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/evidence", "/mcp-gateway", "/security", "/deployment", "/pricing", "/open-source", "/router", "/team-os", "/frameworks(.*)", "/discovery", "/book-demo", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
 
 const isAppSubdomain = (req: NextRequest) =>
   req.headers.get("host")?.startsWith("app.")


### PR DESCRIPTION
## Summary
#1613 shipped \`/pricing\` but the Clerk middleware allow-list wasn't updated — the route was 307-redirecting to \`/sign-in\`, unreachable to logged-out prospects. One-word insertion into \`createRouteMatcher\` fixes it.

## Test plan
- [ ] Post-merge: \`curl -sI https://conductai.ai/pricing\` returns 200, not 307
- [ ] Open \`/pricing\` in an incognito window — page renders