### PR TITLE
fix(web): add /pricing link to homepage nav (desktop + mobile)

### DIFF
--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -46,6 +46,7 @@ function Nav() {
           <ProductDropdown />
           <SolutionsDropdown />
           <DevelopersDropdown />
+          <a href="/pricing" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Pricing</a>
           <a href="/blog" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Blog</a>
         </nav>
 
@@ -91,6 +92,7 @@ function Nav() {
               <MobileNavItem href="/playbooks" label="Playbooks" />
               <MobileNavItem href="/evidence" label="Evidence" />
               <MobileNavItem href="/mcp-gateway" label="MCP" />
+              <MobileNavItem href="/pricing" label="Pricing" />
             </MobileNavGroup>
             <MobileNavGroup label="Solutions">
               <MobileNavItem href="/solutions/engineering-leaders" label="Engineering Agents" />


### PR DESCRIPTION
## Summary
The homepage \`/\` uses its own inline \`Nav\` component in \`apps/web/src/app/page.tsx\` rather than the \`(marketing)\` route group's shared layout. #1613 added Pricing to the \`(marketing)\` layout only, so the homepage nav (which is what most prospects see first) was missing the link.

Adds Pricing to both:
- Desktop nav (between Developers and Blog)
- Mobile drawer's Product group (after MCP)

Matches the footer placement in #1613.

## Test plan
- [ ] Post-merge: view conductai.ai on desktop, confirm Pricing link visible in top nav
- [ ] Mobile: open drawer, expand Product, confirm Pricing appears