### PR TITLE
feat(web): surface /security in top nav + footer

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -112,6 +112,7 @@ function MarketingNav() {
           <ProductDropdown />
           <SolutionsDropdown />
           <DevelopersDropdown />
+          <a href="/security" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Security</a>
           <a href="/pricing" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Pricing</a>
           <a href="/blog" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Blog</a>
         </nav>
@@ -143,6 +144,7 @@ function MarketingFooter() {
         ["Playbooks", "/playbooks"],
         ["Evidence", "/evidence"],
         ["MCP", "/mcp-gateway"],
+        ["Security", "/security"],
         ["Pricing", "/pricing"],
       ] as [string, string][],
     },

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -46,6 +46,7 @@ function Nav() {
           <ProductDropdown />
           <SolutionsDropdown />
           <DevelopersDropdown />
+          <a href="/security" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Security</a>
           <a href="/pricing" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Pricing</a>
           <a href="/blog" className="text-sm font-medium text-stone-500 hover:text-stone-900 transition-colors">Blog</a>
         </nav>
@@ -92,6 +93,7 @@ function Nav() {
               <MobileNavItem href="/playbooks" label="Playbooks" />
               <MobileNavItem href="/evidence" label="Evidence" />
               <MobileNavItem href="/mcp-gateway" label="MCP" />
+              <MobileNavItem href="/security" label="Security" />
               <MobileNavItem href="/pricing" label="Pricing" />
             </MobileNavGroup>
             <MobileNavGroup label="Solutions">


### PR DESCRIPTION
## Summary
Adds \`/security\` to the top nav on both the homepage (\`apps/web/src/app/page.tsx\`) and the marketing route group (\`apps/web/src/app/(marketing)/layout.tsx\`), plus the footer Product column.

Placement: before \`/pricing\` in the top-level order — Developers → **Security** → Pricing → Blog. Security-conscious buyers see it before the pricing surface; matches Vercel and Snyk convention.

## Test plan
- [ ] Post-merge: view conductai.ai on desktop, confirm Security link visible in top nav
- [ ] Mobile: open drawer, expand Product, confirm Security appears
- [ ] Footer: Security link visible in Product column