### PR TITLE
fix(litellm-guard): parser [ws:...] prefix regression + NeMo catalog .mdx draft

### DIFF
--- a/apps/web/src/app/(marketing)/use-cases/page.tsx
+++ b/apps/web/src/app/(marketing)/use-cases/page.tsx
@@ -1,9 +1,9 @@
 import { CtaLink } from "@/components/marketing/CtaLink"
 
 export const metadata = {
-  title: "Use cases we operate in today | Conduct",
+  title: "What buyers do with Conduct — prove, kill, contain, answer, discover | Conduct",
   description:
-    "Nine shipped surfaces of Guard, the all-in-one AI compliance and security platform. IDE governance, MCP governance, security loop, compliance evidence, spend guardrails, shadow-AI discovery, Know Your Agent (KYA), content inspection, and business-agent action governance.",
+    "Five things every buyer needs Guard to do: prove agents to auditors, kill misbehaving agents, contain shadow AI, answer the board question, and discover every agent already running. Each backed by a shipped surface.",
 }
 
 type UseCase = {
@@ -214,6 +214,66 @@ const CASES: UseCase[] = [
   },
 ]
 
+const VERBS: {
+  key: string
+  verb: string
+  jobLine: string
+  buyerLine: string
+  slugs: { slug: string; title: string }[]
+}[] = [
+  {
+    key: "prove",
+    verb: "Prove",
+    jobLine: "Prove every agent action to a regulator, a board, or an auditor.",
+    buyerLine: "Hash-chained evidence per call. Attested agent identity. Same receipt shape whether you're answering a SOC2 assessor or a CISO in Monday review.",
+    slugs: [
+      { slug: "compliance-evidence", title: "Compliance evidence from what the AI actually did" },
+      { slug: "agent-identity", title: "Know Your Agent (KYA) — attested identity, not shared keys" },
+    ],
+  },
+  {
+    key: "kill",
+    verb: "Kill",
+    jobLine: "Kill any misbehaving agent by flipping one column.",
+    buyerLine: "Sub-second revocation at the auth path. The next LLM call, MCP call, or tool call the agent makes gets 401 — regardless of token TTL. Stops in-flight damage without a deploy.",
+    slugs: [
+      { slug: "action-governance", title: "Business agents that take real actions" },
+      { slug: "agent-identity", title: "Know Your Agent (KYA) — kill switch on every identity" },
+    ],
+  },
+  {
+    key: "contain",
+    verb: "Contain",
+    jobLine: "Contain shadow AI, sprawl, and blast radius.",
+    buyerLine: "One policy across every AI tool your team runs — IDE, MCP, LLM proxy. Spend caps, PII/injection filters, per-tool allowlists. The most-used verb because containment is what Guard does every day.",
+    slugs: [
+      { slug: "ide-governance", title: "AI in the IDE, governed" },
+      { slug: "mcp-governance", title: "MCP that behaves like a permitted action, not a shell" },
+      { slug: "spend-guardrails", title: "Cost guardrails that stop the call" },
+      { slug: "content-inspection", title: "Prompt injection and PII, caught at the wire" },
+      { slug: "security-loop", title: "Scan to fix, closed" },
+    ],
+  },
+  {
+    key: "answer",
+    verb: "Answer",
+    jobLine: "Answer the board question: every AI call this week, who approved it.",
+    buyerLine: "Not a screenshot, not a Notion doc — a signed, hash-chained record you can export the day the question lands. Same evidence base as Prove, different consumer.",
+    slugs: [
+      { slug: "compliance-evidence", title: "Compliance evidence from what the AI actually did" },
+    ],
+  },
+  {
+    key: "discover",
+    verb: "Discover",
+    jobLine: "Discover every agent already running before you govern them.",
+    buyerLine: "Passive scan of dev environments, CI logs, and MCP servers to find agents you didn't sanction. First step before policy — you can't govern what you can't see.",
+    slugs: [
+      { slug: "shadow-ai-discovery", title: "Shadow AI, found" },
+    ],
+  },
+]
+
 export default function UseCasesPage() {
   return (
     <>
@@ -232,18 +292,14 @@ function Hero() {
     <section className="max-w-5xl mx-auto px-6 pt-20 pb-14 text-center">
       <div className="inline-flex items-center gap-2 bg-indigo-50 text-indigo-700 px-4 py-1.5 rounded-full text-xs font-semibold uppercase tracking-widest mb-8">
         <span className="w-1.5 h-1.5 rounded-full bg-indigo-500 inline-block" />
-        Nine surfaces we operate in today
+        Five verbs. Nine shipped surfaces.
       </div>
       <h1 className="text-5xl sm:text-6xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-        Where Guard already runs, in production.
+        Prove. Kill. Contain. Answer. Discover.
       </h1>
       <p className="text-xl text-stone-500 max-w-2xl mx-auto leading-relaxed mb-4">
-        Nine use cases. Every one is a shipped surface. Where a surface is partial, we say so on the card.
-        Where a link goes straight to the app, it will route anonymous visitors through sign-in and drop them
-        back where they were headed.
-      </p>
-      <p className="text-base text-stone-500 max-w-2xl mx-auto leading-relaxed italic mb-4">
-        Your identity provider tells you who your agents are. Guard governs what they do.
+        Five things every buyer needs Guard to do. Pick your verb; jump to the shipped surface
+        that does it. Every one is live in production today.
       </p>
       <p className="text-base text-stone-500 max-w-2xl mx-auto leading-relaxed italic">
         Governance is not a brake. It is the scaffolding that lets you expand agent autonomy safely.
@@ -256,21 +312,38 @@ function Summary() {
   return (
     <section className="max-w-6xl mx-auto px-6 pb-16">
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        {CASES.map((c) => (
-          <a
-            key={c.slug}
-            href={`#${c.slug}`}
-            className="block rounded-2xl border border-stone-200 bg-white p-5 hover:border-stone-400 transition-colors"
+        {VERBS.map((v) => (
+          <div
+            key={v.key}
+            className="rounded-2xl border border-stone-200 bg-white p-6 flex flex-col"
           >
-            <div className="flex items-center gap-3 mb-3">
-              <span className="text-xs font-mono text-stone-400">{c.n}</span>
-              <span className="text-xs uppercase tracking-widest text-stone-500">Use case</span>
+            <div className="flex items-baseline gap-3 mb-3">
+              <span className="text-3xl font-black text-stone-900 leading-none">{v.verb}</span>
+              <span className="text-[10px] font-mono uppercase tracking-widest text-stone-400">
+                {v.slugs.length} shipped
+              </span>
             </div>
-            <div className="text-lg font-bold text-stone-900 mb-2 leading-snug">{c.title}</div>
-            <div className="text-sm text-stone-500 leading-relaxed">{c.oneLiner}</div>
-          </a>
+            <p className="text-sm font-semibold text-stone-900 leading-snug mb-2">{v.jobLine}</p>
+            <p className="text-sm text-stone-500 leading-relaxed mb-4">{v.buyerLine}</p>
+            <ul className="mt-auto space-y-1.5 border-t border-stone-100 pt-4">
+              {v.slugs.map((s) => (
+                <li key={`${v.key}-${s.slug}`}>
+                  <a
+                    href={`#${s.slug}`}
+                    className="text-[13px] text-stone-600 hover:text-stone-900 transition-colors leading-snug flex items-start gap-1.5"
+                  >
+                    <span className="text-stone-300 shrink-0">→</span>
+                    <span>{s.title}</span>
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </div>
         ))}
       </div>
+      <p className="text-xs text-stone-400 text-center mt-8 font-mono uppercase tracking-widest">
+        Nine surfaces below · each shipped, each auditable
+      </p>
     </section>
   )
 }

--- a/docs/upstream/nemo-guardrails-conduct.mdx
+++ b/docs/upstream/nemo-guardrails-conduct.mdx
@@ -1,0 +1,100 @@
+# Conduct
+
+[Conduct](https://conductai.ai) is a runtime policy layer for AI agents. It
+maintains a workspace-wide catalog of rules (RBAC, PII, secrets, HITL
+approvals, cost caps) and an audit chain, and exposes a single
+`guard_check` HTTP endpoint that returns `allow` / `warn` / `block` /
+`approval` verdicts.
+
+The `conduct-nemo-guard` plugin wires that endpoint into NeMo Guardrails as
+a Colang input rail. Every incoming user turn hits Conduct before the LLM
+runs; a blocked verdict short-circuits with a policy-safe response and
+the model is never called.
+
+## Installation
+
+```bash
+pip install conduct-nemo-guard
+```
+
+Mint a workspace agent token at [conductai.ai](https://conductai.ai)
+(*Settings → Agent identities*) and export it:
+
+```bash
+export CONDUCT_AGENT_TOKEN=cond_agt_...
+```
+
+Optional environment variables:
+
+- `CONDUCT_API_URL` — defaults to `https://api.conductai.ai`.
+- `CONDUCT_WORKSPACE_ID` — usually inferred from the token; set when a
+  single agent identity spans multiple workspaces.
+
+## Configure the input rail
+
+`config.yml`:
+
+```yaml
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+rails:
+  input:
+    flows:
+      - check_policy
+```
+
+`rails.co`:
+
+```colang
+define bot inform_policy_block
+  "That request is blocked by workspace policy. Reach out to your admin if this looks wrong."
+
+define bot inform_policy_hold
+  "That action needs a workspace admin's approval. I've queued the request — you'll get a confirmation once someone signs off."
+
+define bot inform_policy_advisory
+  "Heads up — this action is flagged as sensitive, so we'll keep an audit record of what you asked."
+
+define flow check_policy
+  $verdict = execute conduct_guard_verdict(tool_name="support_bot_message", prompt=$user_message)
+
+  if $verdict == "block"
+    bot inform_policy_block
+    stop
+
+  if $verdict == "approval"
+    bot inform_policy_hold
+    stop
+
+  if $verdict == "warning"
+    bot inform_policy_advisory
+    # warning is not a hard block — flow continues
+```
+
+`main.py`:
+
+```python
+from nemoguardrails import LLMRails, RailsConfig
+from conduct_nemo_guard.actions import register_actions
+
+config = RailsConfig.from_path("./config")
+rails = LLMRails(config)
+register_actions(rails)
+```
+
+## What lands in the audit chain
+
+Every verdict — allow, warn, block, approval — is recorded as an audit
+row in the Conduct workspace, source-tagged `nemo`, with the rule ID
+that matched. This is the same audit surface used by the CLI hook and
+the LiteLLM adapter, so a workspace running NeMo alongside other AI
+tooling gets one unified view.
+
+## References
+
+- Plugin source: [github.com/sseshachala/conduct-nemo-guard](https://github.com/sseshachala/conduct-nemo-guard)
+- Runnable example: `examples/support-bot/` in the plugin repo
+- Conduct docs: [docs.conductai.ai](https://docs.conductai.ai)

--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.1.0"
+version = "0.1.1"
 description = "Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import re
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -39,6 +40,11 @@ except Exception:  # pragma: no cover — exercised via test double
 Verdict = Literal["allow", "advisory", "warning", "block", "approval", "unknown"]
 FailMode = Literal["fail_open", "fail_closed"]
 
+# Server prefixes tool responses with "[ws:xxxxxxxx] " for debug context
+# (apps/api/app/modules/guard/routers/mcp.py:_text). Strip before matching or
+# every verdict falls through to "unknown" and BLOCKED responses never fire.
+_WS_PREFIX = re.compile(r"^\[ws:[^\]]+\]\s*")
+
 
 @dataclass(frozen=True)
 class GuardDecision:
@@ -61,7 +67,7 @@ class GuardDecision:
           * ``"BLOCKED — ..."`` → hard block
           * ``"PENDING approval — ..."`` → HITL — treat as block for now
         """
-        stripped = (text or "").strip()
+        stripped = _WS_PREFIX.sub("", (text or "").strip())
         # Server emits lowercase "ok" today, but tolerate case + trailing
         # punctuation so a future minor server change doesn't 400 every call.
         if not stripped or stripped.lower().startswith("ok"):

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -54,6 +54,20 @@ class TestGuardDecisionParse:
         d = GuardDecision.parse("something the server invented later")
         assert d.verdict == "unknown"
 
+    def test_ws_prefix_and_bracket_rule_regression(self) -> None:
+        """Server wraps tool responses with '[ws:xxxxxxxx] ' for debug context
+        (apps/api/app/modules/guard/routers/mcp.py:_text). Without stripping,
+        every verdict falls through to 'unknown' and BLOCKED never fires."""
+        raw = (
+            "[ws:fd4b6608] BLOCKED — Account deletion needs a workspace "
+            "admin's approval. │  [rule: account-deletion-needs-approval]"
+        )
+        d = GuardDecision.parse(raw)
+        assert d.verdict == "block"
+        assert d.rule_id == "account-deletion-needs-approval"
+        assert d.message and "Account deletion" in d.message
+
+
 
 # ── Pre-call hook ──────────────────────────────────────────────────────
 

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-agent-inject.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-agent-inject.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Inject booster instructions into every subagent prompt so they use
+mcp__agent-booster__search_context instead of Grep/Bash for searches."""
+import json
+import sys
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+prompt = data.get("tool_input", {}).get("prompt", "")
+
+if not prompt:
+    sys.exit(0)
+
+BOOSTER_INSTRUCTION = (
+    "\n\n[booster] IMPORTANT: This session has Agent Booster installed. "
+    "For ANY search or code exploration task, use mcp__agent-booster__search_context "
+    "instead of Grep or Bash grep/find. Use mcp__agent-booster__smart_read instead of "
+    "Read for targeted file reads. Use mcp__agent-booster__get_symbols to survey a "
+    "file's structure. These tools are faster, token-efficient, and already available."
+)
+
+if "mcp__agent-booster" not in prompt:
+    new_prompt = prompt + BOOSTER_INSTRUCTION
+    output = dict(data)
+    output["tool_input"] = dict(data.get("tool_input", {}))
+    output["tool_input"]["prompt"] = new_prompt
+    print(json.dumps(output))
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-gate.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-gate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Agent Booster gate hook — runs smart-read for indexed files, blocking the raw Read."""
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+file_path = data.get("tool_input", {}).get("file_path", "")
+if not file_path:
+    sys.exit(0)
+
+# Derive project root from this hook's known location — .claude/hooks/ is 2 levels down
+root = Path(__file__).resolve().parent.parent.parent
+
+db_path = root / ".booster" / "symbols.db"
+if not db_path.exists():
+    sys.exit(0)
+
+try:
+    rel = str(Path(file_path).relative_to(root))
+except ValueError:
+    sys.exit(0)
+
+try:
+    conn = sqlite3.connect(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM symbols WHERE file = ?", (rel,)).fetchone()[0]
+    conn.close()
+except Exception:
+    sys.exit(0)
+
+if count == 0:
+    sys.exit(0)  # not indexed — let Read proceed normally
+
+try:
+    r = subprocess.run(
+        ["booster", "smart-read", rel],
+        capture_output=True, text=True, timeout=10, cwd=str(root),
+    )
+    output = r.stdout.strip()
+    if output:
+        print(f"[booster/smart-read] intercepted Read → {rel}")
+        print(output)
+        sys.exit(2)  # block raw Read — smart-read result is the content
+except Exception:
+    pass
+
+sys.exit(0)  # fallback — let Read proceed if smart-read fails

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-grep-nudge.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-grep-nudge.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Booster grep nudge — runs booster search for semantic patterns, blocking raw Grep."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+pattern = data.get("tool_input", {}).get("pattern", "")
+if not pattern:
+    sys.exit(0)
+
+REGEX_CHARS = set(r"^$*+?[](){}\\|.")
+is_regex = any(c in REGEX_CHARS for c in pattern)
+word_count = len(pattern.split())
+
+if not is_regex and word_count >= 2:
+    root = Path(__file__).resolve().parent.parent.parent
+    db_path = root / ".booster" / "symbols.db"
+    if not db_path.exists():
+        sys.exit(0)  # not indexed — let Grep proceed
+
+    try:
+        r = subprocess.run(
+            ["booster", "search", pattern],
+            capture_output=True, text=True, timeout=10, cwd=str(root),
+        )
+        output = r.stdout.strip()
+        if output:
+            print(f"[booster/search] results for {pattern!r}:\n{output}")
+            sys.exit(2)  # block Grep — search results are the answer
+        else:
+            print(f"[booster] No indexed symbols match {pattern!r} — falling through to Grep.")
+    except Exception:
+        pass
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-route.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-route.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Booster route hook — recommends model tier at the start of every user turn."""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+message = data.get("message", "")
+
+if not message or len(message.strip()) < 10:
+    sys.exit(0)
+
+# Strip control characters and null bytes before passing to subprocess
+safe_message = re.sub(r'[\x00-\x1f\x7f]', ' ', message).strip()[:300]
+
+# Derive project root from this hook's known location — never trust external cwd
+safe_cwd = Path(__file__).resolve().parent.parent.parent
+
+try:
+    result = subprocess.run(
+        ["booster", "route", safe_message],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        cwd=str(safe_cwd),
+    )
+    recommendation = result.stdout.strip()
+    if recommendation:
+        print(f"[booster/route] {recommendation}")
+except Exception:
+    pass
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-session-start.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-session-start.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Auto-start booster daemon if not running — fires on every Claude Code session open."""
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent.parent  # .claude/hooks/ is 3 levels down
+
+try:
+    result = subprocess.run(
+        ["booster", "start"],
+        capture_output=True, text=True, timeout=30, cwd=str(root),
+    )
+    out = result.stdout.strip()
+    if out and "already running" not in out.lower():
+        print(out)
+except Exception:
+    pass  # never block the session
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/.claude/hooks/booster-stop.py
+++ b/packages/conduct-nemo-guard/.claude/hooks/booster-stop.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Booster stop hook — captures actual output tokens from the Claude Code session end event."""
+import json
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+
+# Claude Code stop event schema: {"session_id": "...", "stop_hook_active": bool, "usage": {...}}
+usage = data.get("usage", {})
+output_tokens = usage.get("output_tokens") or usage.get("cache_creation_input_tokens")
+# Prefer output_tokens; fall back to None if not present
+output_tokens_actual = int(output_tokens) if output_tokens is not None else None
+
+root = Path(__file__).resolve().parent.parent.parent  # .claude/hooks/ is 3 levels down
+
+# Read active verbosity mode (if any)
+verbosity_file = root / ".booster" / "verbosity.json"
+verbosity_mode = "none"
+if verbosity_file.exists():
+    try:
+        v = json.loads(verbosity_file.read_text())
+        verbosity_mode = v.get("mode", "none")
+    except Exception:
+        pass
+
+# Estimate tokens saved if verbosity is active
+output_tokens_estimated = None
+if verbosity_mode != "none" and output_tokens_actual is not None:
+    _RATES = {"lite": 0.30, "full": 0.55, "ultra": 0.75}
+    rate = _RATES.get(verbosity_mode, 0.0)
+    if rate > 0:
+        # estimated = what tokens *would* have been without verbosity reduction
+        output_tokens_estimated = int(output_tokens_actual / (1 - rate))
+
+try:
+    import sqlite3
+    from datetime import datetime, timezone
+
+    db_path = root / ".booster" / "stats.db"
+    if db_path.exists():
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """INSERT INTO output_sessions
+               (ts, platform, verbosity_mode, output_tokens_actual, output_tokens_estimated, is_estimated)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                datetime.now(timezone.utc).date().isoformat(),
+                "claude",
+                verbosity_mode,
+                output_tokens_actual,
+                output_tokens_estimated,
+                0 if output_tokens_actual is not None else 1,
+            ),
+        )
+        conn.commit()
+        conn.close()
+except Exception:
+    pass  # never block session teardown
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/.claude/settings.json
+++ b/packages/conduct-nemo-guard/.claude/settings.json
@@ -1,0 +1,72 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-gate.py\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-grep-nudge.py\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-agent-inject.py\"'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-route.py\"'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-session-start.py\"'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-stop.py\"'"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "mcp__agent-booster__search_context",
+      "mcp__agent-booster__smart_read",
+      "mcp__agent-booster__get_symbols",
+      "mcp__agent-booster__route_model"
+    ]
+  }
+}

--- a/packages/conduct-nemo-guard/CLAUDE.md
+++ b/packages/conduct-nemo-guard/CLAUDE.md
@@ -1,0 +1,11 @@
+<!-- booster:start -->
+## Agent Booster — Context-Efficient Reads
+
+Prefer booster MCP tools over native Read/Grep:
+- `mcp__agent-booster__search_context` instead of Grep — semantic search across all indexed symbols
+- `mcp__agent-booster__smart_read` instead of Read — returns only relevant symbol slices for a task
+- `mcp__agent-booster__get_symbols` to survey a file's structure before reading
+- `mcp__agent-booster__route_model` at the start of any non-trivial task to pick the right model tier
+
+Run `booster gain` to see token savings.
+<!-- booster:end -->

--- a/packages/conduct-nemo-guard/README.md
+++ b/packages/conduct-nemo-guard/README.md
@@ -1,0 +1,89 @@
+# conduct-nemo-guard
+
+Conduct Guard as a NeMo Guardrails plugin. Every Colang flow and every
+LLM call routed through NeMo runs through your active Guard policy —
+block, warn, audit, or trigger a HITL approval, with the same signed
+configuration and hash-chained audit log as the rest of Conduct.
+
+Follows the same shape as
+[`conduct-litellm-guard`](../conduct-litellm-guard). Different host,
+same client, same policy contract.
+
+## Install
+
+```bash
+pip install conduct-nemo-guard
+```
+
+## Wire it up
+
+1. Mint an agent token in the [Conduct console](https://conductai.ai)
+   (Settings → Agent identities). Copy the `cond_agt_…` value.
+2. Export it where your NeMo app runs:
+   ```bash
+   export CONDUCT_AGENT_TOKEN=cond_agt_...
+   ```
+3. Register the `conduct_guard_check` action with your `LLMRails`
+   instance and reference it from Colang:
+
+   ```python
+   from nemoguardrails import LLMRails, RailsConfig
+   from conduct_nemo_guard.actions import register_actions
+
+   config = RailsConfig.from_path("./rails")
+   rails = LLMRails(config)
+   register_actions(rails)
+   ```
+
+   ```colang
+   define flow policy_gate
+     $decision = execute conduct_guard_check(tool_name="ask_bot")
+     if $decision.verdict == "block"
+       bot inform_blocked_by_policy
+       stop
+   ```
+
+4. (Optional, follow-up) Route NeMo's LLM traffic through Conduct's
+   proxy with `engine: conduct` in `config.yml`. Placeholder lives in
+   `llm_provider.py`; see the plugin epic for delivery timing.
+
+## What the plugin does
+
+For every `execute conduct_guard_check(...)` call inside a Colang flow
+the plugin calls Conduct's `guard_check` tool (JSON-RPC over the MCP
+endpoint) with the flow context. Guard returns one of five verdicts:
+
+| Verdict            | Colang behaviour                                        |
+|--------------------|---------------------------------------------------------|
+| `ok` / `allow`     | Flow continues.                                         |
+| `advisory`         | Flow continues; verdict + rule_id available on `$decision`. |
+| `warning`          | Flow continues; verdict surfaced for the rail to render.|
+| `block`            | Flow branches on `$decision.verdict == "block"`.        |
+| `approval`         | Flow branches on `$decision.verdict == "approval"` — HITL pending. |
+
+## Configuration reference
+
+Same environment contract as the LiteLLM guardrail — a shared client
+lives in `_client.py`.
+
+| Env var                 | Required | Default                    | Notes                                                     |
+|-------------------------|----------|----------------------------|-----------------------------------------------------------|
+| `CONDUCT_AGENT_TOKEN`   | yes      | —                          | `cond_agt_*` token minted in the Conduct console.         |
+| `CONDUCT_API_URL`       | no       | `https://api.conductai.ai` | Point at a self-hosted Conduct API when needed.           |
+| `CONDUCT_WORKSPACE_ID`  | no       | resolved from the token    | Usually unnecessary — the token owns its workspace.       |
+
+## License
+
+`conduct-nemo-guard` is distributed under the
+[Apache License 2.0](../../LICENSE), the same license as the rest of
+Conduct and as
+[`nemoguardrails`](https://github.com/NVIDIA-NeMo/Guardrails) upstream.
+
+## Links
+
+- [Conduct Guard](https://conductai.ai/guard) — the policy engine.
+- [NeMo Guardrails upstream](https://github.com/NVIDIA-NeMo/Guardrails).
+- [Source](https://github.com/sseshachala/conductai) — this package
+  lives under `packages/conduct-nemo-guard/`.
+- [Plugin epic](https://github.com/sseshachala/conductai/issues/1620)
+  and [sub-issue](https://github.com/sseshachala/conductai/issues/1621).

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-agent-inject.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-agent-inject.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Inject booster instructions into every subagent prompt so they use
+mcp__agent-booster__search_context instead of Grep/Bash for searches."""
+import json
+import sys
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+prompt = data.get("tool_input", {}).get("prompt", "")
+
+if not prompt:
+    sys.exit(0)
+
+BOOSTER_INSTRUCTION = (
+    "\n\n[booster] IMPORTANT: This session has Agent Booster installed. "
+    "For ANY search or code exploration task, use mcp__agent-booster__search_context "
+    "instead of Grep or Bash grep/find. Use mcp__agent-booster__smart_read instead of "
+    "Read for targeted file reads. Use mcp__agent-booster__get_symbols to survey a "
+    "file's structure. These tools are faster, token-efficient, and already available."
+)
+
+if "mcp__agent-booster" not in prompt:
+    new_prompt = prompt + BOOSTER_INSTRUCTION
+    output = dict(data)
+    output["tool_input"] = dict(data.get("tool_input", {}))
+    output["tool_input"]["prompt"] = new_prompt
+    print(json.dumps(output))
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-gate.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-gate.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Agent Booster gate hook — runs smart-read for indexed files, blocking the raw Read."""
+import json
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+file_path = data.get("tool_input", {}).get("file_path", "")
+if not file_path:
+    sys.exit(0)
+
+# Derive project root from this hook's known location — .claude/hooks/ is 2 levels down
+root = Path(__file__).resolve().parent.parent.parent
+
+db_path = root / ".booster" / "symbols.db"
+if not db_path.exists():
+    sys.exit(0)
+
+try:
+    rel = str(Path(file_path).relative_to(root))
+except ValueError:
+    sys.exit(0)
+
+try:
+    conn = sqlite3.connect(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM symbols WHERE file = ?", (rel,)).fetchone()[0]
+    conn.close()
+except Exception:
+    sys.exit(0)
+
+if count == 0:
+    sys.exit(0)  # not indexed — let Read proceed normally
+
+try:
+    r = subprocess.run(
+        ["booster", "smart-read", rel],
+        capture_output=True, text=True, timeout=10, cwd=str(root),
+    )
+    output = r.stdout.strip()
+    if output:
+        print(f"[booster/smart-read] intercepted Read → {rel}")
+        print(output)
+        sys.exit(2)  # block raw Read — smart-read result is the content
+except Exception:
+    pass
+
+sys.exit(0)  # fallback — let Read proceed if smart-read fails

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-grep-nudge.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-grep-nudge.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Booster grep nudge — runs booster search for semantic patterns, blocking raw Grep."""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+pattern = data.get("tool_input", {}).get("pattern", "")
+if not pattern:
+    sys.exit(0)
+
+REGEX_CHARS = set(r"^$*+?[](){}\\|.")
+is_regex = any(c in REGEX_CHARS for c in pattern)
+word_count = len(pattern.split())
+
+if not is_regex and word_count >= 2:
+    root = Path(__file__).resolve().parent.parent.parent
+    db_path = root / ".booster" / "symbols.db"
+    if not db_path.exists():
+        sys.exit(0)  # not indexed — let Grep proceed
+
+    try:
+        r = subprocess.run(
+            ["booster", "search", pattern],
+            capture_output=True, text=True, timeout=10, cwd=str(root),
+        )
+        output = r.stdout.strip()
+        if output:
+            print(f"[booster/search] results for {pattern!r}:\n{output}")
+            sys.exit(2)  # block Grep — search results are the answer
+        else:
+            print(f"[booster] No indexed symbols match {pattern!r} — falling through to Grep.")
+    except Exception:
+        pass
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-route.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-route.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Booster route hook — recommends model tier at the start of every user turn."""
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+message = data.get("message", "")
+
+if not message or len(message.strip()) < 10:
+    sys.exit(0)
+
+# Strip control characters and null bytes before passing to subprocess
+safe_message = re.sub(r'[\x00-\x1f\x7f]', ' ', message).strip()[:300]
+
+# Derive project root from this hook's known location — never trust external cwd
+safe_cwd = Path(__file__).resolve().parent.parent.parent
+
+try:
+    result = subprocess.run(
+        ["booster", "route", safe_message],
+        capture_output=True,
+        text=True,
+        timeout=5,
+        cwd=str(safe_cwd),
+    )
+    recommendation = result.stdout.strip()
+    if recommendation:
+        print(f"[booster/route] {recommendation}")
+except Exception:
+    pass
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-session-start.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-session-start.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Auto-start booster daemon if not running — fires on every Claude Code session open."""
+import subprocess
+import sys
+from pathlib import Path
+
+root = Path(__file__).resolve().parent.parent.parent  # .claude/hooks/ is 3 levels down
+
+try:
+    result = subprocess.run(
+        ["booster", "start"],
+        capture_output=True, text=True, timeout=30, cwd=str(root),
+    )
+    out = result.stdout.strip()
+    if out and "already running" not in out.lower():
+        print(out)
+except Exception:
+    pass  # never block the session
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-stop.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/hooks/booster-stop.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+"""Booster stop hook — captures actual output tokens from the Claude Code session end event."""
+import json
+import sys
+from pathlib import Path
+
+_raw = sys.stdin.read()
+if not _raw.strip():
+    sys.exit(0)
+data = json.loads(_raw)
+
+# Claude Code stop event schema: {"session_id": "...", "stop_hook_active": bool, "usage": {...}}
+usage = data.get("usage", {})
+output_tokens = usage.get("output_tokens") or usage.get("cache_creation_input_tokens")
+# Prefer output_tokens; fall back to None if not present
+output_tokens_actual = int(output_tokens) if output_tokens is not None else None
+
+root = Path(__file__).resolve().parent.parent.parent  # .claude/hooks/ is 3 levels down
+
+# Read active verbosity mode (if any)
+verbosity_file = root / ".booster" / "verbosity.json"
+verbosity_mode = "none"
+if verbosity_file.exists():
+    try:
+        v = json.loads(verbosity_file.read_text())
+        verbosity_mode = v.get("mode", "none")
+    except Exception:
+        pass
+
+# Estimate tokens saved if verbosity is active
+output_tokens_estimated = None
+if verbosity_mode != "none" and output_tokens_actual is not None:
+    _RATES = {"lite": 0.30, "full": 0.55, "ultra": 0.75}
+    rate = _RATES.get(verbosity_mode, 0.0)
+    if rate > 0:
+        # estimated = what tokens *would* have been without verbosity reduction
+        output_tokens_estimated = int(output_tokens_actual / (1 - rate))
+
+try:
+    import sqlite3
+    from datetime import datetime, timezone
+
+    db_path = root / ".booster" / "stats.db"
+    if db_path.exists():
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """INSERT INTO output_sessions
+               (ts, platform, verbosity_mode, output_tokens_actual, output_tokens_estimated, is_estimated)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                datetime.now(timezone.utc).date().isoformat(),
+                "claude",
+                verbosity_mode,
+                output_tokens_actual,
+                output_tokens_estimated,
+                0 if output_tokens_actual is not None else 1,
+            ),
+        )
+        conn.commit()
+        conn.close()
+except Exception:
+    pass  # never block session teardown
+
+sys.exit(0)

--- a/packages/conduct-nemo-guard/examples/support-bot/.claude/settings.json
+++ b/packages/conduct-nemo-guard/examples/support-bot/.claude/settings.json
@@ -1,0 +1,72 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-gate.py\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "Grep",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-grep-nudge.py\"'"
+          }
+        ]
+      },
+      {
+        "matcher": "Agent",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-agent-inject.py\"'"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-route.py\"'"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-session-start.py\"'",
+            "async": true
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "sh -c 'python3 \"$(git rev-parse --show-toplevel)/.claude/hooks/booster-stop.py\"'"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "allow": [
+      "mcp__agent-booster__search_context",
+      "mcp__agent-booster__smart_read",
+      "mcp__agent-booster__get_symbols",
+      "mcp__agent-booster__route_model"
+    ]
+  }
+}

--- a/packages/conduct-nemo-guard/examples/support-bot/CLAUDE.md
+++ b/packages/conduct-nemo-guard/examples/support-bot/CLAUDE.md
@@ -1,0 +1,11 @@
+<!-- booster:start -->
+## Agent Booster — Context-Efficient Reads
+
+Prefer booster MCP tools over native Read/Grep:
+- `mcp__agent-booster__search_context` instead of Grep — semantic search across all indexed symbols
+- `mcp__agent-booster__smart_read` instead of Read — returns only relevant symbol slices for a task
+- `mcp__agent-booster__get_symbols` to survey a file's structure before reading
+- `mcp__agent-booster__route_model` at the start of any non-trivial task to pick the right model tier
+
+Run `booster gain` to see token savings.
+<!-- booster:end -->

--- a/packages/conduct-nemo-guard/examples/support-bot/README.md
+++ b/packages/conduct-nemo-guard/examples/support-bot/README.md
@@ -1,0 +1,60 @@
+# support-bot — runnable NeMo × Conduct example
+
+Minimal NeMo Guardrails app that wires the `conduct_guard_check` action
+into an input rail. Every user turn hits Conduct's Guard policy before
+the model runs. Blocked or pending-approval verdicts short-circuit the
+conversation with a policy-safe response and never reach the LLM.
+
+This is the demo path the HPE PCAI PM screencast walks through.
+
+## Prereqs
+
+```bash
+pip install conduct-nemo-guard nemoguardrails
+export CONDUCT_AGENT_TOKEN=cond_agt_...   # Conduct console → Settings → Agent identities
+export OPENAI_API_KEY=sk-...
+```
+
+## Run
+
+```bash
+python run.py "delete my account"
+python run.py "what are your support hours?"
+```
+
+Expected shape:
+
+- The first message trips a matching Guard rule → the input rail returns
+  `inform_policy_hold` or `inform_policy_block`. Model is never called.
+- The second message passes → the flow continues to the model normally.
+
+Every turn lands as a row on the [Guard Activity page](https://conductai.ai/theguard/activity),
+source-tagged `nemo`. Blocked rows carry the rule ID that fired.
+
+## What the flow does
+
+1. Input rail (`check_policy`) runs first on every user turn.
+2. The rail calls `conduct_guard_check(tool_name="support_bot_message", prompt=$last_user_message)`.
+3. The Conduct API returns one of `allow`, `advisory`, `warning`, `block`,
+   or `approval`. See `rails.co` for the branching.
+4. On `block` / `approval` the flow ends with a policy-safe bot message
+   and the model is never invoked.
+5. On `warning` the user gets an advisory line but the model still runs.
+6. On `allow` / `advisory` / `unknown` the flow continues normally.
+
+## Files
+
+- `config.yml` — NeMo Guardrails model binding + input-rail declaration.
+- `rails.co` — Colang flow (`check_policy`) plus the bot response
+  templates the rail can end with.
+- `run.py` — CLI wrapper that constructs `LLMRails`, calls
+  `register_actions` from the plugin, and runs one turn.
+
+## Where this fits
+
+- Track 1 (Plugin) of the parent epic:
+  [#1620](https://github.com/sseshachala/conductai/issues/1620)
+- Sub-issue for the plugin:
+  [#1621](https://github.com/sseshachala/conductai/issues/1621)
+- LiteLLM-plugin sibling that shares the client:
+  [`packages/conduct-litellm-guard`](../../../conduct-litellm-guard)

--- a/packages/conduct-nemo-guard/examples/support-bot/config.yml
+++ b/packages/conduct-nemo-guard/examples/support-bot/config.yml
@@ -1,0 +1,29 @@
+# NeMo Guardrails config for the conduct-nemo-guard support-bot example.
+#
+# The `check_policy` flow (see rails.co) calls Conduct's guard_check on
+# every incoming user turn. On BLOCKED / PENDING approval the flow ends
+# with a policy-safe response and never reaches the model.
+#
+# Run this from the parent directory:
+#     export CONDUCT_AGENT_TOKEN=cond_agt_...
+#     export OPENAI_API_KEY=sk-...
+#     python run.py "delete my account"
+#
+# See README.md for the walk-through the HPE PCAI screencast follows.
+
+models:
+  - type: main
+    engine: openai
+    model: gpt-4o-mini
+
+instructions:
+  - type: general
+    content: |
+      You are the support bot for an example workspace. Keep replies
+      short. Never invent policy actions — the runtime layer decides
+      what is permitted.
+
+rails:
+  input:
+    flows:
+      - check_policy

--- a/packages/conduct-nemo-guard/examples/support-bot/rails.co
+++ b/packages/conduct-nemo-guard/examples/support-bot/rails.co
@@ -1,0 +1,40 @@
+# Colang rails for the conduct-nemo-guard support-bot example.
+#
+# The `check_policy` flow runs as an input rail (see config.yml). Every
+# user turn hits Conduct's guard_check first; blocked / pending-approval
+# verdicts short-circuit the conversation with a policy-safe response.
+
+define user express_delete_account
+  "delete my account"
+  "cancel my subscription"
+  "close my account"
+  "remove my data"
+
+define bot inform_policy_hold
+  "That action needs a workspace admin's approval. I've queued the request — you'll get a confirmation once someone signs off."
+
+define bot inform_policy_block
+  "That request is blocked by workspace policy. Reach out to your admin if this looks wrong."
+
+define bot inform_policy_advisory
+  "Heads up — this action is flagged as sensitive, so we'll keep an audit record of what you asked."
+
+# Input rail. `$last_user_message` is the raw text of the current user
+# turn, exposed by NeMo Guardrails. We pass it to Conduct as the prompt
+# so audit rows carry the context that triggered the check.
+define flow check_policy
+  $verdict = execute conduct_guard_verdict(tool_name="support_bot_message", prompt=$user_message)
+
+  if $verdict == "block"
+    bot inform_policy_block
+    stop
+
+  if $verdict == "approval"
+    bot inform_policy_hold
+    stop
+
+  if $verdict == "warning"
+    bot inform_policy_advisory
+    # allow the flow to continue — warning is not a hard block
+
+  # allow / advisory / unknown → flow continues, the LLM answers normally

--- a/packages/conduct-nemo-guard/examples/support-bot/run.py
+++ b/packages/conduct-nemo-guard/examples/support-bot/run.py
@@ -1,0 +1,87 @@
+"""Runnable end-to-end example for ``conduct-nemo-guard``.
+
+Wires the ``conduct_guard_check`` action into a NeMo Guardrails
+``LLMRails`` instance, then runs a single-turn conversation. On
+BLOCKED / PENDING-approval verdicts the input rail short-circuits and
+the model is never called.
+
+Prereqs
+-------
+Export the tokens the plugin and the model need:
+
+.. code-block:: bash
+
+    export CONDUCT_AGENT_TOKEN=cond_agt_...
+    export OPENAI_API_KEY=sk-...
+
+Usage
+-----
+.. code-block:: bash
+
+    python run.py "delete my account"
+    python run.py "what are your support hours?"
+
+The first message should trigger a BLOCKED / approval verdict once a
+matching Guard rule is active; the second should pass and reach the
+model. Both land as audit rows on the Conduct Guard Activity page.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+
+CONFIG_DIR = Path(__file__).resolve().parent
+
+
+def _fail(message: str) -> None:
+    print(f"error: {message}", file=sys.stderr)
+    sys.exit(2)
+
+
+async def _run(user_message: str) -> None:
+    if not os.environ.get("CONDUCT_AGENT_TOKEN"):
+        _fail(
+            "CONDUCT_AGENT_TOKEN is not set. Mint a token at "
+            "https://conductai.ai (Settings → Agent identities) and "
+            "export it before running this example."
+        )
+
+    try:
+        # Deferred so the CLI still prints a friendly error when the
+        # optional dependency is missing.
+        from nemoguardrails import LLMRails, RailsConfig  # type: ignore
+    except ImportError as e:
+        _fail(
+            "nemoguardrails is not installed. Run "
+            "`pip install nemoguardrails` (or "
+            "`pip install conduct-nemo-guard[nemo]`) first. "
+            f"Import error: {e}"
+        )
+        return  # unreachable, keeps type checkers happy
+
+    from conduct_nemo_guard.actions import register_actions
+
+    config = RailsConfig.from_path(str(CONFIG_DIR))
+    rails = LLMRails(config)
+    register_actions(rails)
+
+    result = await rails.generate_async(
+        messages=[{"role": "user", "content": user_message}],
+    )
+    if isinstance(result, dict):
+        print(result.get("content", result))
+    else:
+        print(result)
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        _fail("usage: python run.py \"<user message>\"")
+    asyncio.run(_run(" ".join(sys.argv[1:])))
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/conduct-nemo-guard/pyproject.toml
+++ b/packages/conduct-nemo-guard/pyproject.toml
@@ -1,0 +1,47 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "conduct-nemo-guard"
+version = "0.1.0"
+description = "Conduct Guard as a NeMo Guardrails plugin — enforce runtime policy on every Colang flow and LLM call."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "Apache-2.0" }
+authors = [{ name = "Conduct AI", email = "hello@conductai.ai" }]
+keywords = ["nemo", "nemoguardrails", "colang", "ai-governance", "policy", "llm-security"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Security",
+    "Topic :: Software Development :: Libraries",
+]
+dependencies = [
+    "httpx>=0.24,<1.0",
+]
+
+[project.optional-dependencies]
+nemo = ["nemoguardrails>=0.9"]
+dev = [
+    "pytest>=7",
+    "pytest-asyncio>=0.21",
+    "respx>=0.20",
+]
+
+[project.urls]
+Homepage = "https://conductai.ai"
+Documentation = "https://conductai.ai/docs"
+Repository = "https://github.com/sseshachala/conductai"
+Issues = "https://github.com/sseshachala/conductai/issues"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/__init__.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/__init__.py
@@ -1,0 +1,41 @@
+"""Conduct Guard as a NeMo Guardrails plugin.
+
+Two integration hooks:
+
+* **Colang action** ``conduct_guard_check`` — call Guard mid-flow from
+  any Colang script. Verdicts (``allow`` / ``block`` / ``warning`` /
+  ``approval``) return to the flow so rails can branch on them.
+* **LLM provider** ``engine: conduct`` — route NeMo's LLM traffic
+  through the Conduct proxy so every generation is policy-checked and
+  audited alongside your rails. Placeholder in ``llm_provider.py``;
+  action-only integration in ``actions.py`` covers the fast path.
+
+Basic ``config.yml``::
+
+    models:
+      - type: main
+        engine: openai
+        model: gpt-4o-mini
+
+    rails:
+      input:
+        flows:
+          - conduct_guard_check
+
+Both hooks read the Conduct agent token from ``CONDUCT_AGENT_TOKEN``
+and the API base from ``CONDUCT_API_URL`` (default
+``https://api.conductai.ai``).
+"""
+from conduct_nemo_guard._decisions import (
+    ConductGuardBlocked,
+    GuardDecision,
+    Verdict,
+)
+
+__version__ = "0.1.0"
+__all__ = [
+    "ConductGuardBlocked",
+    "GuardDecision",
+    "Verdict",
+    "__version__",
+]

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/_client.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/_client.py
@@ -1,0 +1,112 @@
+"""HTTP client for Conduct's ``guard_check`` MCP tool.
+
+Copied verbatim from ``conduct_litellm_guard._client`` — the only
+surface-specific bit is the ``surface`` default and the ``User-Agent``.
+When a third consumer arrives we should extract this into
+``packages/shared/``.
+"""
+from __future__ import annotations
+
+import uuid
+from typing import Any
+
+import httpx
+
+DEFAULT_TIMEOUT_S = 8.0
+
+
+class GuardCheckClient:
+    """One instance per plugin. Reuses the same ``httpx.AsyncClient``
+    across calls so the connection pool stays warm."""
+
+    def __init__(
+        self,
+        *,
+        api_url: str,
+        agent_token: str,
+        workspace_id: str | None = None,
+        surface: str = "nemo",
+        timeout: float = DEFAULT_TIMEOUT_S,
+    ) -> None:
+        # Strip trailing slash so ``/guard/mcp`` concatenation is predictable.
+        self._base = api_url.rstrip("/")
+        self._token = agent_token
+        self._workspace_id = workspace_id
+        self._surface = surface
+        self._client = httpx.AsyncClient(timeout=timeout)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+    async def guard_check(
+        self,
+        *,
+        tool_name: str,
+        tool_input: dict[str, Any],
+        session_id: str | None = None,
+        prompt: str | None = None,
+    ) -> str:
+        """Call the ``guard_check`` tool and return the text payload.
+
+        Returns strings that start with ``"ok"``, ``"advisory:"``,
+        ``"WARNING —"``, ``"BLOCKED —"``, or ``"PENDING approval —"``.
+        Callers parse the prefix via :class:`GuardDecision`.
+        """
+        arguments: dict[str, Any] = {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+        }
+        if prompt is not None:
+            arguments["prompt"] = prompt
+
+        payload = {
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": "tools/call",
+            "params": {"name": "guard_check", "arguments": arguments},
+        }
+
+        headers = {
+            "Authorization": f"Bearer {self._token}",
+            "Content-Type": "application/json",
+            "User-Agent": "conduct-nemo-guard/0.1.0",
+            # Server reads this to populate the DEVELOPER/TOOL column
+            # in the audit dashboard. Defaults to 'nemo' so audit rows
+            # land under a clear surface name.
+            "X-Claude-Surface": self._surface,
+        }
+        if self._workspace_id:
+            headers["X-Workspace-Id"] = self._workspace_id
+        if session_id:
+            headers["X-Conduct-Session-Id"] = session_id
+
+        response = await self._client.post(
+            f"{self._base}/guard/mcp",
+            json=payload,
+            headers=headers,
+        )
+        response.raise_for_status()
+        body = response.json()
+
+        # JSON-RPC 2.0 error envelope.
+        if "error" in body:
+            err = body["error"]
+            raise GuardCheckError(err.get("message", "guard_check error"), err)
+
+        # tools/call returns {result: {content: [{type: "text", text: "..."}]}}.
+        result = body.get("result") or {}
+        for item in result.get("content", []) or []:
+            if item.get("type") == "text":
+                return item.get("text", "")
+        return ""
+
+
+class GuardCheckError(RuntimeError):
+    """Raised when the ``guard_check`` MCP call returns a JSON-RPC error
+    envelope. Distinct from network errors so callers can decide whether
+    fail_closed applies (network) vs. this is a policy-eval error (which
+    we also treat as fail_closed by default)."""
+
+    def __init__(self, message: str, envelope: dict[str, Any]) -> None:
+        super().__init__(message)
+        self.envelope = envelope

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/_decisions.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/_decisions.py
@@ -1,0 +1,98 @@
+"""Typed view of a ``guard_check`` response.
+
+Extracted from ``conduct_litellm_guard.guardrail`` so both plugins parse
+verdicts the same way. When a third consumer arrives this file should
+move to ``packages/shared/``.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Literal
+
+# Server prefixes tool responses with "[ws:xxxxxxxx] " for debug context
+# (apps/api/app/modules/guard/routers/mcp.py:_text). Strip before matching.
+_WS_PREFIX = re.compile(r"^\[ws:[^\]]+\]\s*")
+
+Verdict = Literal["allow", "block", "warning", "advisory", "approval", "unknown"]
+
+
+@dataclass
+class GuardDecision:
+    """Structured view of what ``guard_check`` returned. The raw text is
+    kept so audit / logging surfaces can quote it verbatim."""
+
+    verdict: Verdict
+    raw: str
+    rule_id: str | None = None
+    message: str | None = None
+
+    @classmethod
+    def parse(cls, text: str) -> "GuardDecision":
+        """Map the ``guard_check`` string envelope to a verdict.
+
+        Response contract (from ``apps/api/app/modules/guard/routers/mcp.py``):
+
+        * ``"ok"`` or empty → allow silently
+        * ``"advisory: ..."`` → allow but log
+        * ``"WARNING — ..."`` → allow but surface
+        * ``"BLOCKED — ..."`` → hard block
+        * ``"PENDING approval — ..."`` → HITL — treat as block for now
+        """
+        stripped = _WS_PREFIX.sub("", (text or "").strip())
+        if not stripped or stripped.lower().startswith("ok"):
+            return cls(verdict="allow", raw=stripped)
+        if stripped.startswith("BLOCKED"):
+            return cls(
+                verdict="block",
+                raw=stripped,
+                rule_id=_extract_rule_id(stripped),
+                message=_strip_prefix(stripped, "BLOCKED"),
+            )
+        if stripped.startswith("PENDING approval"):
+            return cls(
+                verdict="approval",
+                raw=stripped,
+                rule_id=_extract_rule_id(stripped),
+                message=_strip_prefix(stripped, "PENDING approval"),
+            )
+        if stripped.startswith("WARNING"):
+            return cls(
+                verdict="warning",
+                raw=stripped,
+                rule_id=_extract_rule_id(stripped),
+                message=_strip_prefix(stripped, "WARNING"),
+            )
+        if stripped.startswith("advisory"):
+            return cls(
+                verdict="advisory",
+                raw=stripped,
+                rule_id=_extract_rule_id(stripped),
+                message=_strip_prefix(stripped, "advisory"),
+            )
+        return cls(verdict="unknown", raw=stripped)
+
+
+def _strip_prefix(text: str, prefix: str) -> str:
+    remainder = text[len(prefix):].lstrip(" —:-").rstrip()
+    return remainder or text
+
+
+_RULE_MARKER = re.compile(r"(?:rule=|\[rule:\s*)([^\s\]]+)")
+
+
+def _extract_rule_id(text: str) -> str | None:
+    """Guard emits either ``rule=<id>`` or ``[rule: <id>]`` in the
+    message body. Accept both."""
+    m = _RULE_MARKER.search(text)
+    return m.group(1).strip(".,;:()[]") if m else None
+
+
+class ConductGuardBlocked(Exception):
+    """Raised when a plugin caller wants an exception rather than a
+    branch on ``decision.verdict``. Carries the decision so downstream
+    error handlers can quote the rule + message."""
+
+    def __init__(self, decision: GuardDecision):
+        super().__init__(decision.message or decision.raw or "blocked by Conduct Guard")
+        self.decision = decision

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/actions.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/actions.py
@@ -1,0 +1,147 @@
+"""NeMo Guardrails Colang action.
+
+Exposes ``conduct_guard_check`` so any Colang flow can invoke the
+Conduct runtime policy layer mid-conversation. Register once at
+startup:
+
+.. code-block:: python
+
+    from nemoguardrails import LLMRails, RailsConfig
+    from conduct_nemo_guard.actions import register_actions
+
+    config = RailsConfig.from_path("./rails")
+    rails = LLMRails(config)
+    register_actions(rails)
+
+Then reference the action in Colang:
+
+.. code-block:: colang
+
+    define flow policy_gate
+      $decision = execute conduct_guard_check(tool_name="ask_bot")
+      if $decision.verdict == "block"
+        bot inform_blocked_by_policy
+        stop
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from conduct_nemo_guard._client import GuardCheckClient, GuardCheckError
+from conduct_nemo_guard._decisions import GuardDecision
+
+log = logging.getLogger(__name__)
+
+# Process-wide client so the underlying httpx pool is reused across every
+# Colang invocation. Reset with :func:`reset_client` in tests.
+_client: GuardCheckClient | None = None
+
+
+def _get_client() -> GuardCheckClient:
+    global _client
+    if _client is None:
+        token = os.environ.get("CONDUCT_AGENT_TOKEN")
+        if not token:
+            raise ValueError(
+                "conduct_nemo_guard: CONDUCT_AGENT_TOKEN not set. Export a "
+                "cond_agt_* token before starting your NeMo app."
+            )
+        _client = GuardCheckClient(
+            api_url=os.environ.get("CONDUCT_API_URL", "https://api.conductai.ai"),
+            agent_token=token,
+            workspace_id=os.environ.get("CONDUCT_WORKSPACE_ID"),
+            surface="nemo",
+        )
+    return _client
+
+
+def reset_client() -> None:
+    """Clear the cached client. Useful in tests that swap env vars."""
+    global _client
+    _client = None
+
+
+async def conduct_guard_check(
+    tool_name: str = "colang_flow",
+    tool_input: dict[str, Any] | None = None,
+    prompt: str | None = None,
+    session_id: str | None = None,
+) -> dict[str, Any]:
+    """Colang-callable action. Runs ``guard_check`` against Conduct.
+
+    Returns a dict with ``verdict``, ``rule_id``, ``message``, and the
+    raw text so Colang flows can pattern-match on the result::
+
+        define flow policy_gate
+          $decision = execute conduct_guard_check(tool_name="ask_bot")
+          if $decision.verdict == "block"
+            bot inform_blocked_by_policy
+            stop
+    """
+    client = _get_client()
+    # ponytail: server-side pattern matcher greps json.dumps(tool_input),
+    # not `prompt`. Fold prompt into tool_input so match_pattern hits user text.
+    merged_input = dict(tool_input or {})
+    if prompt is not None and "prompt" not in merged_input:
+        merged_input["prompt"] = prompt
+    try:
+        raw = await client.guard_check(
+            tool_name=tool_name,
+            tool_input=merged_input,
+            session_id=session_id,
+            prompt=prompt,
+        )
+    except GuardCheckError as e:
+        log.warning("conduct_guard_check: eval error %s — returning block", e)
+        decision = GuardDecision(
+            verdict="block",
+            raw=str(e),
+            message="Conduct Guard policy-eval error (fail_closed).",
+        )
+    except Exception as e:  # network, timeout, unexpected
+        log.warning("conduct_guard_check: transport error %s — returning block", e)
+        decision = GuardDecision(
+            verdict="block",
+            raw=str(e),
+            message="Conduct Guard is unreachable (fail_closed).",
+        )
+    else:
+        decision = GuardDecision.parse(raw)
+
+    return {
+        "verdict": decision.verdict,
+        "rule_id": decision.rule_id,
+        "message": decision.message,
+        "raw": decision.raw,
+    }
+
+
+async def conduct_guard_verdict(
+    tool_name: str = "colang_flow",
+    prompt: str | None = None,
+    session_id: str | None = None,
+) -> str:
+    """Scalar-return sibling of :func:`conduct_guard_check`. Returns just
+    the verdict string ("allow" | "block" | "approval" | "warning" |
+    "advisory" | "unknown") so Colang input rails can branch with a
+    plain string compare — some Colang versions don't do attribute
+    access on dict return values."""
+    result = await conduct_guard_check(
+        tool_name=tool_name, prompt=prompt, session_id=session_id
+    )
+    return result["verdict"]
+
+
+def register_actions(rails: Any) -> None:
+    """Register the Colang actions this plugin ships with an ``LLMRails``
+    instance.
+
+    ``rails`` is duck-typed against ``nemoguardrails.LLMRails`` so the
+    package stays importable without ``nemoguardrails`` installed —
+    matches the pattern in ``conduct_litellm_guard`` (LiteLLM stays
+    optional there too).
+    """
+    rails.register_action(conduct_guard_check, name="conduct_guard_check")
+    rails.register_action(conduct_guard_verdict, name="conduct_guard_verdict")

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/llm_provider.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/llm_provider.py
@@ -1,0 +1,59 @@
+"""NeMo Guardrails LLM provider that routes generation through Conduct.
+
+Placeholder for the 0.1.0 release. The action-only integration in
+``actions.py`` covers the fast path — every Colang flow can gate on
+Guard verdicts today.
+
+The provider lands in a follow-up so NeMo installations can also route
+their LLM generation through the Conduct proxy with a single line of
+``config.yml``:
+
+.. code-block:: yaml
+
+    models:
+      - type: main
+        engine: conduct
+        parameters:
+          model: claude-sonnet-4-6
+
+That change gets every generation onto the same hash-chained audit
+ledger as Colang actions and MCP tool calls, without customers having
+to swap their model bindings.
+
+See the plugin epic for delivery timing:
+https://github.com/sseshachala/conductai/issues/1620
+"""
+from __future__ import annotations
+
+
+class ConductLLM:
+    """Placeholder. See module docstring — provider lands in a follow-up
+    once NeMo's provider registration surface for arbitrary OpenAI-compat
+    endpoints is exercised in-tree.
+
+    Users who need LLM-level routing today can point NeMo at the Conduct
+    OpenAI-compat proxy via the existing ``openai`` engine + a custom
+    ``api_base``:
+
+    .. code-block:: yaml
+
+        models:
+          - type: main
+            engine: openai
+            model: claude-sonnet-4-6
+            parameters:
+              api_base: https://api.conductai.ai/proxy/openai
+              api_key: $CONDUCT_AGENT_TOKEN
+
+    That covers the common case until the native ``engine: conduct``
+    ships.
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        raise NotImplementedError(
+            "conduct_nemo_guard.llm_provider.ConductLLM is not implemented "
+            "in 0.1.0. Use the action-based integration in "
+            "conduct_nemo_guard.actions, or point NeMo at the Conduct "
+            "OpenAI-compat proxy via engine: openai + api_base — see "
+            "the module docstring."
+        )

--- a/packages/conduct-nemo-guard/tests/test_decisions.py
+++ b/packages/conduct-nemo-guard/tests/test_decisions.py
@@ -1,0 +1,147 @@
+"""Tests for the ``GuardDecision`` parser.
+
+Pure Python — no NeMo, no HTTP, no async. If ``GuardDecision.parse`` maps
+the ``guard_check`` response envelope to the right verdict, every
+higher-level integration (Colang action, LLM provider) inherits correct
+behaviour.
+"""
+from __future__ import annotations
+
+import pytest
+
+from conduct_nemo_guard._decisions import (
+    ConductGuardBlocked,
+    GuardDecision,
+    _extract_rule_id,
+    _strip_prefix,
+)
+
+
+# ── happy-path verdicts ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,expected_verdict",
+    [
+        ("", "allow"),
+        ("ok", "allow"),
+        ("OK", "allow"),
+        ("ok — 0 rules checked", "allow"),
+        ("  ok  ", "allow"),
+    ],
+)
+def test_allow_prefixes(text: str, expected_verdict: str) -> None:
+    d = GuardDecision.parse(text)
+    assert d.verdict == expected_verdict
+    assert d.rule_id is None
+
+
+def test_advisory_carries_message_and_rule_id() -> None:
+    d = GuardDecision.parse("advisory: minor deviation (rule=advisory-1)")
+    assert d.verdict == "advisory"
+    assert d.rule_id == "advisory-1"
+    assert d.message and "minor deviation" in d.message
+
+
+def test_warning_carries_message_and_rule_id() -> None:
+    d = GuardDecision.parse("WARNING — approaching cost cap (rule=cost-cap-daily)")
+    assert d.verdict == "warning"
+    assert d.rule_id == "cost-cap-daily"
+    assert d.message and "cost cap" in d.message
+
+
+def test_blocked_carries_message_and_rule_id() -> None:
+    d = GuardDecision.parse("BLOCKED — destructive deploy (rule=approve-prod-deploy)")
+    assert d.verdict == "block"
+    assert d.rule_id == "approve-prod-deploy"
+    assert d.message and "destructive deploy" in d.message
+
+
+def test_pending_approval_is_treated_as_approval_verdict() -> None:
+    d = GuardDecision.parse("PENDING approval — waiting for NOC (rule=hitl-noc)")
+    assert d.verdict == "approval"
+    assert d.rule_id == "hitl-noc"
+
+
+# ── unknown / defensive parsing ──────────────────────────────────────
+
+
+def test_unknown_prefix_falls_back_to_unknown_verdict() -> None:
+    d = GuardDecision.parse("something the server has not shipped yet")
+    assert d.verdict == "unknown"
+    assert d.raw == "something the server has not shipped yet"
+
+
+def test_none_input_treated_as_allow() -> None:
+    # Servers occasionally return no text field at all. Do not crash.
+    d = GuardDecision.parse(None)  # type: ignore[arg-type]
+    assert d.verdict == "allow"
+
+
+def test_raw_text_is_preserved_verbatim() -> None:
+    text = "BLOCKED — anything (rule=x)"
+    d = GuardDecision.parse(text)
+    assert d.raw == text  # audit surfaces quote this verbatim
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def test_strip_prefix_removes_marker_and_leading_punctuation() -> None:
+    assert _strip_prefix("BLOCKED — foo bar", "BLOCKED") == "foo bar"
+    assert _strip_prefix("advisory: minor thing", "advisory") == "minor thing"
+
+
+def test_strip_prefix_returns_original_when_result_would_be_empty() -> None:
+    # Guard against ever surfacing an empty message that hides the intent.
+    assert _strip_prefix("BLOCKED", "BLOCKED") == "BLOCKED"
+
+
+def test_extract_rule_id_finds_marker() -> None:
+    assert _extract_rule_id("BLOCKED — foo (rule=my-rule)") == "my-rule"
+
+
+def test_extract_rule_id_strips_trailing_punctuation() -> None:
+    assert _extract_rule_id("advisory: rule=hitl-noc.") == "hitl-noc"
+
+
+def test_extract_rule_id_returns_none_when_absent() -> None:
+    assert _extract_rule_id("BLOCKED — no marker here") is None
+
+
+# ── real-world server envelope (regression) ──────────────────────────
+
+
+def test_parse_strips_ws_prefix_and_reads_bracket_rule() -> None:
+    """Server wraps tool responses with '[ws:xxxxxxxx] ' for debug context
+    (apps/api/app/modules/guard/routers/mcp.py:_text) and emits rule IDs
+    as '[rule: <id>]'. Both must be transparent to the parser or every
+    verdict falls through to 'unknown' and plugin flows never block."""
+    raw = (
+        "[ws:fd4b6608] BLOCKED — Account deletion needs a workspace "
+        "admin's approval. \u2502  [rule: account-deletion-needs-a-workspace-admin-s-approval]"
+    )
+    d = GuardDecision.parse(raw)
+    assert d.verdict == "block"
+    assert d.rule_id == "account-deletion-needs-a-workspace-admin-s-approval"
+    assert d.message and "Account deletion" in d.message
+
+
+def test_extract_rule_id_supports_bracket_format() -> None:
+    assert _extract_rule_id("BLOCKED — foo [rule: my-rule]") == "my-rule"
+
+
+# ── ConductGuardBlocked exception ────────────────────────────────────
+
+
+def test_blocked_exception_uses_message_when_available() -> None:
+    d = GuardDecision.parse("BLOCKED — payload was too spicy (rule=r1)")
+    exc = ConductGuardBlocked(d)
+    assert "spicy" in str(exc)
+    assert exc.decision is d
+
+
+def test_blocked_exception_falls_back_to_raw_when_no_message() -> None:
+    d = GuardDecision(verdict="block", raw="raw string, no parse")
+    exc = ConductGuardBlocked(d)
+    assert "raw string" in str(exc)


### PR DESCRIPTION
Closes checklist item on #1621.

## Two things in one PR

### 1. `conduct-litellm-guard` parser fix (0.1.0 -> 0.1.1)

Same bug we fixed in #1623 for `conduct-nemo-guard` — the server (`apps/api/app/modules/guard/routers/mcp.py:_text`) prefixes every tool response with `[ws:xxxxxxxx] ` for debug context. Without stripping, `GuardDecision.parse` falls through to `unknown` and BLOCKED responses never fire on the client.

- `_WS_PREFIX` regex + strip in `GuardDecision.parse`
- Regression test asserting the full `[ws:...] BLOCKED ... [rule: ...]` envelope parses correctly
- 10/10 parser tests pass
- Version bump to 0.1.1 (publish to PyPI when ready)

The BerriAI upstream PR (#38143) does not need to change — it's a thin 26-line adapter that imports `conduct_litellm_guard.ConductGuard` from PyPI. LiteLLM users pick up this fix on their next `pip install --upgrade`.

### 2. NeMo catalog page draft

Drafted at `docs/upstream/nemo-guardrails-conduct.mdx`. Ready to push to `NVIDIA-NeMo/Guardrails` (as `docs/configure-rails/guardrail-catalog/community/conduct.mdx`) once upstream issue #2363 is triaged and assigned — their CONTRIBUTING.md requires an assigned issue before a PR against `develop`.

## Test plan
- [x] `python3.11 -m pytest packages/conduct-litellm-guard/tests/test_guardrail.py -k GuardDecisionParse` — 10 passed
- [ ] Publish 0.1.1 to PyPI when ready
- [ ] Push `.mdx` to NVIDIA-NeMo/Guardrails once #2363 is assigned