### PR TITLE
feat(seo): disambiguate ConductAI brand from namesake (entity graph + FAQ page + tagline audit)

### DIFF
--- a/apps/web/src/app/(marketing)/what-is-conduct-ai/page.tsx
+++ b/apps/web/src/app/(marketing)/what-is-conduct-ai/page.tsx
@@ -1,0 +1,138 @@
+export const metadata = {
+  title: "What is Conduct AI? Runtime Governance for AI Agents | Conduct",
+  description:
+    "Conduct AI (conductai.ai) is the runtime governance layer for AI agents. Allow, warn, or block every model and tool call before it commits. Hash-chained audit for every decision.",
+  alternates: {
+    canonical: "https://conductai.ai/what-is-conduct-ai",
+  },
+}
+
+const faqs: { q: string; a: string }[] = [
+  {
+    q: "What is Conduct AI?",
+    a: "Conduct AI (conductai.ai) is the runtime governance layer for AI agents. It sits between your agents and the models or tools they call, and enforces workspace policy on every action: allow, warn, block, or pause for human approval. Every decision lands in a hash-chained tamper-evident audit trail. Conduct ships pre-built compliance packs for SOC 2, HIPAA, PCI DSS 4.0, EU AI Act, NIST AI RMF, ISO 42001, IRS 1075, and OWASP LLM Top 10.",
+  },
+  {
+    q: "How is Conduct different from other AI governance tools?",
+    a: "Most AI safety tools are per-app or per-framework — NeMo Guardrails governs one NeMo app, LangChain callbacks govern one LangChain app. Conduct is a workspace-wide substrate that governs every agent across every framework: LLMs (Anthropic, OpenAI, Azure, Google, Bedrock — 400+ models via proxy), MCP servers, CLI tools (Claude Code, Cursor, Windsurf), and playbook workflows. One rule catalog, one audit chain, one console for the whole fleet.",
+  },
+  {
+    q: "What does Conduct actually do at runtime?",
+    a: "Conduct intercepts agent actions before they commit. When an agent asks to call an LLM, invoke an MCP tool, run a shell command, or execute a playbook step, Conduct checks it against the workspace policy. Actions that match a rule get allowed, warned, blocked, or paused for human approval (with Slack integration). Every decision is written to a hash-chained ledger so auditors can prove exactly what happened, in what order, and who approved it.",
+  },
+  {
+    q: "Is Conduct AI the same as Conduct AI London (the SAP/ERP company)?",
+    a: "No. Conduct (conductai.ai) is a US-based platform for AI agent runtime governance — identity, policy enforcement, audit, and compliance for AI systems. The similarly-named Conduct AI in London is a different, unrelated company that focuses on SAP and legacy ERP analysis. Different market, different product, different team.",
+  },
+  {
+    q: "Is Conduct AI open source?",
+    a: "Yes. The Conduct platform is Apache 2.0 licensed, source on GitHub at github.com/sseshachala/conductai. Plugin packages (conduct-cli, conduct-litellm-guard, conduct-nemo-guard) are published to PyPI and installable with pip.",
+  },
+  {
+    q: "Who uses Conduct AI?",
+    a: "Platform teams shipping AI agents to production, CISOs adding runtime governance to an existing agent stack, NOC and SRE teams evaluating autonomous ops, and vertical teams in healthcare, financial services, and government adding compliance evidence to their AI workflows. Conduct is currently hiring two design partners for Q4 2026.",
+  },
+  {
+    q: "What frameworks does Conduct integrate with?",
+    a: "NVIDIA NeMo Guardrails (via conduct-nemo-guard plugin), LiteLLM (via conduct-litellm-guard plugin and native LiteLLM upstream integration), Claude Code, Cursor, Windsurf, and any tool or agent that can call an HTTP endpoint, MCP server, or Guard SDK. Conduct is framework-agnostic — it sits underneath your agents, not inside them.",
+  },
+  {
+    q: "How do I get started with Conduct AI?",
+    a: "Book a 30-minute scoping call at cal.com/sudhi-seshachala-pks7pd, install the CLI with `pip install conduct-cli`, or explore the platform docs at conductai.ai/docs. Design-partner seats are open for Q4 2026 — two teams get direct founder access, priority Guard packs, and named engineering support.",
+  },
+]
+
+const faqJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": faqs.map(f => ({
+    "@type": "Question",
+    "name": f.q,
+    "acceptedAnswer": {
+      "@type": "Answer",
+      "text": f.a,
+    },
+  })),
+}
+
+export default function WhatIsConductAIPage() {
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+      />
+      <HeroSection />
+      <FaqSection />
+      <CtaSection />
+    </>
+  )
+}
+
+function HeroSection() {
+  return (
+    <section className="max-w-4xl mx-auto px-6 pt-20 pb-12 text-center">
+      <p className="text-xs font-semibold uppercase tracking-widest text-stone-400 mb-4">About Conduct</p>
+      <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-tight mb-6">
+        What is Conduct AI?
+      </h1>
+      <p className="text-lg text-stone-600 max-w-2xl mx-auto leading-relaxed">
+        Conduct AI (<a href="https://conductai.ai" className="text-indigo-600 hover:text-indigo-800 font-semibold">conductai.ai</a>) is the runtime
+        governance layer for AI agents. Allow, warn, or block every model and tool call before it commits.
+        Hash-chained audit for every decision. Compliance packs for SOC 2, HIPAA, PCI DSS 4.0, EU AI Act,
+        NIST AI RMF, ISO 42001, and more.
+      </p>
+    </section>
+  )
+}
+
+function FaqSection() {
+  return (
+    <section className="py-16 px-6 bg-white border-t border-stone-100">
+      <div className="max-w-3xl mx-auto">
+        <h2 className="text-2xl sm:text-3xl font-bold text-stone-900 tracking-tight mb-10 text-center">
+          Frequently asked questions
+        </h2>
+        <div className="space-y-8">
+          {faqs.map(f => (
+            <div key={f.q}>
+              <h3 className="text-base font-bold text-stone-900 mb-3 leading-snug">{f.q}</h3>
+              <p className="text-sm text-stone-600 leading-relaxed">{f.a}</p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}
+
+function CtaSection() {
+  return (
+    <section className="py-20 px-6 bg-gradient-to-br from-indigo-50 via-white to-violet-50 border-t border-indigo-100">
+      <div className="max-w-2xl mx-auto text-center">
+        <h2 className="text-2xl sm:text-3xl font-bold text-stone-900 tracking-tight mb-4">
+          Ready to see it live?
+        </h2>
+        <p className="text-base text-stone-600 mb-6">
+          Book a 30-min walkthrough, or install the CLI and try the demo yourself.
+        </p>
+        <div className="flex flex-col sm:flex-row items-center justify-center gap-3">
+          <a
+            href="https://cal.com/sudhi-seshachala-pks7pd"
+            target="_blank"
+            rel="noopener"
+            className="rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-bold hover:bg-stone-700 transition-colors"
+          >
+            Book a walkthrough
+          </a>
+          <a
+            href="/partners#design-partners"
+            className="rounded-xl border border-stone-300 bg-white text-stone-900 px-6 py-3 text-sm font-bold hover:border-stone-500 transition-colors"
+          >
+            Design partners (2 open) →
+          </a>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -79,10 +79,17 @@ const softwareAppJsonLd = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
   "name": "Conduct",
+  "alternateName": ["Conduct AI", "ConductAI", "Conduct.ai"],
+  "sameAs": [
+    "https://github.com/sseshachala/conductai",
+    "https://pypi.org/project/conduct-cli/",
+    "https://pypi.org/project/conduct-litellm-guard/",
+    "https://pypi.org/project/conduct-nemo-guard/"
+  ],
   "applicationCategory": "DeveloperApplication",
   "operatingSystem": "Web",
   "url": "https://conductai.ai",
-  "description": "Governed AI automations for engineering teams. Turn tickets, PRs, alerts, and incidents into auditable workflows with human approval before anything merges.",
+  "description": "Runtime governance for AI agents. Allow, warn, or block every model and tool call before it commits. Hash-chained audit for every decision. Compliance packs for SOC 2, HIPAA, PCI DSS, EU AI Act, SR 11-7, and FDA CSA.",
   "offers": {
     "@type": "Offer",
     "price": "0",

--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "conduct-cli"
 version = "0.10.0"
-description = "CLI for Conduct AI — secure, govern, install agents, manage projects, run tests"
+description = "Runtime governance for AI agents. CLI for Conduct AI — secure, govern, install agents, manage projects, run tests"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.9"

--- a/packages/conduct-daemon/pyproject.toml
+++ b/packages/conduct-daemon/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.backends.legacy:build"
 [project]
 name = "conduct-daemon"
 version = "0.1.0"
-description = "ConductGuard local policy enforcement daemon"
+description = "Runtime governance for AI agents. ConductGuard local policy enforcement daemon"
 requires-python = ">=3.11"
 dependencies = [
     "aiohttp>=3.9",

--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "conduct-litellm-guard"
 version = "0.1.1"
-description = "Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
+description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }

--- a/packages/conduct-nemo-guard/pyproject.toml
+++ b/packages/conduct-nemo-guard/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "conduct-nemo-guard"
 version = "0.1.0"
-description = "Conduct Guard as a NeMo Guardrails plugin — enforce runtime policy on every Colang flow and LLM call."
+description = "Runtime governance for AI agents. Conduct Guard as a NeMo Guardrails plugin — enforce runtime policy on every Colang flow and LLM call."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
## Problem
Google AI Overview for `what is conductai` currently answers with the London-based SAP/ERP company also named Conduct AI. We own the exact-match domain, but they own the exact-match search intent because they have more inbound signal on that query.

## Three-track fix

### 1. Root layout entity graph enrichment
Enriches the SoftwareApplication JSON-LD in `apps/web/src/app/layout.tsx`:
- `alternateName`: ["Conduct AI", "ConductAI", "Conduct.ai"] — tells Google our brand has these variants
- `sameAs`: GitHub + PyPI package URLs — cross-links our entity across authoritative sources so Google merges them into one knowledge graph node
- Updates stale SoftwareApplication description (was from the old 'engineering agents' framing) to match the runtime-governance hero copy

### 2. New page: `/what-is-conduct-ai`
Direct target for the exact-match query.

- 8 FAQs in `FAQPage` schema markup — this is the format Google prefers when promoting answers in AI Overview
- Includes explicit disambiguation question: 'How is this different from Conduct AI London?'
- Covers: what it is, how it differs from other AI governance tools, what it does at runtime, disambiguation from the SAP company, open source status, who uses it, framework integrations, getting started
- Follows the existing solutions/ page style (hero + FAQ + CTA sections)

### 3. Distinguisher tagline audit
Every place the brand appears in our-owned surfaces now leads with the same distinguisher — 'Runtime governance for AI agents.':

- `packages/conduct-cli/pyproject.toml`
- `packages/conduct-daemon/pyproject.toml`
- `packages/conduct-litellm-guard/pyproject.toml`
- `packages/conduct-nemo-guard/pyproject.toml`
- GitHub repo description (updated live via `gh repo edit` — not part of this PR diff but included in the story)

Carries through pip search, PyPI listing pages, IDE hover tooltips, and Google's rendering of the repo card.

## Manual follow-ups
Not code, but should happen this week for full effect:
- [ ] LinkedIn company page tagline: 'Runtime governance for AI agents.'
- [ ] X / Twitter bio: same
- [ ] Cross-post `/what-is-conduct-ai` to Hacker News (Show HN) when it feels natural
- [ ] Optional: trademark check on 'Conduct AI' at uspto.gov and IPO (UK) to know who has priority

## Why this works (not overnight)
- Entity graph + `sameAs` takes 2–4 weeks for Google to reindex and merge
- FAQ schema surfaces in AI Overview within days of first crawl
- Distinguisher tagline compounds over months — every new inbound link carries our distinguisher
- Expected: 3–6 months to shift the AI Overview answer for `what is conductai` to us

## Test plan
- [x] TypeScript compile passes (fixed `<Script>` → plain `<script>` for the FAQ JSON-LD)
- [ ] After deploy, view-source on /what-is-conduct-ai and confirm `application/ld+json` block renders
- [ ] Google Search Console: submit /what-is-conduct-ai + the updated homepage for reindex
- [ ] Rich Results Test (search.google.com/test/rich-results) on /what-is-conduct-ai — should recognize FAQPage schema