### PR TITLE
feat(lens): slash-command picker + update_budget + install_pack mutators (#1630, #1302, #1300)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -3,4 +3,6 @@ populate `default_action_registry` (and paired `default_registry.ToolDef`
 entries via `app.tools.registrations.lens`).
 """
 from app.modules.glens.actor.registrations import decide_approval  # noqa: F401
+from app.modules.glens.actor.registrations import install_pack  # noqa: F401
 from app.modules.glens.actor.registrations import run_workflow  # noqa: F401
+from app.modules.glens.actor.registrations import update_budget  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/install_pack.py
+++ b/apps/api/app/modules/glens/actor/registrations/install_pack.py
@@ -1,0 +1,106 @@
+"""#1300 — Lens actor: install a marketplace skill pack into the workspace.
+
+Two-step: `propose` validates the slug exists in the catalog and isn't
+already installed; the confirm card shows the pack name + rule count.
+`execute` inserts the `WorkspaceSkillPack` row and invalidates the policy
+cache so new rules apply on the next Guard evaluation.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+def _propose_install_pack(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    slug = str(args.get("slug") or "").strip()
+    if not slug:
+        return ProposeResult(rejected=True, reason="slug required",
+                             summary="", resolved_input={})
+
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="Invalid workspace",
+                             summary="", resolved_input={})
+
+    from app.modules.guard.models import WorkspaceSkillPack
+    from app.routers.compliance import _latest_pack
+
+    pack = _latest_pack(ctx.db, slug)
+    if not pack:
+        return ProposeResult(
+            rejected=True,
+            reason=f"No pack matches slug '{slug}' in the catalog",
+            summary="", resolved_input={},
+        )
+
+    existing = ctx.db.get(WorkspaceSkillPack, (ws_uuid, slug))
+    if existing:
+        return ProposeResult(
+            rejected=True,
+            reason=f"Pack '{slug}' is already installed",
+            summary="", resolved_input={},
+        )
+
+    rules_count = len(pack.rules or [])
+    summary = f"Install pack '{pack.name}' ({rules_count} rules)"
+
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "slug": slug,
+            "pack_name": pack.name,
+            "rules_count": rules_count,
+        },
+    )
+
+
+def _execute_install_pack(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Insert WorkspaceSkillPack + invalidate policy cache. Reuses the same
+    invalidator the HTTP install endpoint calls so a pack installed here
+    behaves identically to one installed from the marketplace UI."""
+    from app.modules.guard.models import WorkspaceSkillPack
+    from app.modules.guard.policy_engine import invalidate_policy_cache
+
+    slug = resolved["slug"]
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+
+    existing = ctx.db.get(WorkspaceSkillPack, (ws_uuid, slug))
+    if not existing:
+        ctx.db.add(WorkspaceSkillPack(
+            workspace_id=ws_uuid,
+            pack_slug=slug,
+            installed_by=ctx.clerk_user_id or "lens.actor",
+            installed_at=datetime.now(timezone.utc),
+        ))
+
+    invalidate_policy_cache(ctx.db, ws_uuid)
+    ctx.db.commit()
+
+    return {
+        "slug": slug,
+        "pack_name": resolved.get("pack_name"),
+        "rules_installed": resolved.get("rules_count", 0),
+        "installed": True,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="install_pack",
+    guard_permission="guard.policies.edit",
+    propose=_propose_install_pack,
+    execute=_execute_install_pack,
+    description=(
+        "Install a marketplace skill pack into the workspace. Two-step: "
+        "returns a pending action for the user to confirm; the confirm click "
+        "adds the WorkspaceSkillPack row and invalidates the policy cache."
+    ),
+))

--- a/apps/api/app/modules/glens/actor/registrations/update_budget.py
+++ b/apps/api/app/modules/glens/actor/registrations/update_budget.py
@@ -1,0 +1,122 @@
+"""#1302 — Lens actor: update the monthly USD limit on a spend budget.
+
+Two-step: `propose` validates the budget id + new limit and resolves the
+existing row's context (workspace-wide vs per-user) for the confirm card.
+`execute` writes the new `monthly_limit_usd`, commits, and records a
+hash-chained audit entry via the same helper the HTTP upsert uses.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+def _propose_update_budget(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    budget_id = str(args.get("budget_id") or "").strip()
+    if not budget_id:
+        return ProposeResult(rejected=True, reason="budget_id required",
+                             summary="", resolved_input={})
+
+    try:
+        bud_uuid = _uuid.UUID(budget_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason=f"'{budget_id}' is not a valid UUID",
+                             summary="", resolved_input={})
+
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="Invalid workspace",
+                             summary="", resolved_input={})
+
+    limit_raw = args.get("monthly_limit_usd")
+    try:
+        limit = float(limit_raw)
+    except (TypeError, ValueError):
+        return ProposeResult(rejected=True, reason="monthly_limit_usd must be a number",
+                             summary="", resolved_input={})
+    if limit < 0:
+        return ProposeResult(rejected=True, reason="monthly_limit_usd cannot be negative",
+                             summary="", resolved_input={})
+
+    from app.modules.guard.models import GuardSpendBudget
+
+    budget = ctx.db.query(GuardSpendBudget).filter(
+        GuardSpendBudget.id == bud_uuid,
+        GuardSpendBudget.workspace_id == ws_uuid,
+    ).first()
+    if not budget:
+        return ProposeResult(
+            rejected=True,
+            reason=f"No budget matches id '{budget_id}' in this workspace",
+            summary="", resolved_input={},
+        )
+
+    target = budget.clerk_user_id or "workspace-wide"
+    old_limit = float(budget.monthly_limit_usd)
+    summary = f"Update {target} monthly budget: ${old_limit:.2f} → ${limit:.2f}"
+
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "budget_id": str(budget.id),
+            "monthly_limit_usd": limit,
+            "old_limit_usd": old_limit,
+            "clerk_user_id": budget.clerk_user_id,
+        },
+    )
+
+
+def _execute_update_budget(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Update monthly_limit_usd on the budget row and record an audit entry.
+
+    Bypasses the HTTP upsert endpoint (which expects a full BudgetCreate
+    body); we only mutate one field so a direct row update is cleaner."""
+    from app.modules.guard.models import GuardSpendBudget
+    from app.modules.guard.routers.spend import _audit_budget_change
+
+    bud_uuid = _uuid.UUID(resolved["budget_id"])
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+
+    budget = ctx.db.query(GuardSpendBudget).filter(
+        GuardSpendBudget.id == bud_uuid,
+        GuardSpendBudget.workspace_id == ws_uuid,
+    ).first()
+    if not budget:
+        raise ValueError(f"budget {bud_uuid} disappeared between propose and execute")
+
+    old = float(budget.monthly_limit_usd)
+    new = float(resolved["monthly_limit_usd"])
+    budget.monthly_limit_usd = new
+    ctx.db.commit()
+
+    _audit_budget_change(
+        ctx.db, ws_uuid, resolved.get("clerk_user_id"),
+        "budget_updated", f"monthly {old}→{new}",
+    )
+
+    return {
+        "budget_id": str(budget.id),
+        "monthly_limit_usd": new,
+        "old_limit_usd": old,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="update_budget",
+    guard_permission="guard.spend.budgets.edit",
+    propose=_propose_update_budget,
+    execute=_execute_update_budget,
+    description=(
+        "Update the monthly USD limit on a spend budget. Two-step: returns "
+        "a pending action for the user to confirm; the confirm click writes "
+        "the new limit + a hash-chained audit entry."
+    ),
+))

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -135,6 +135,54 @@ TOOLS: list[ToolDef] = [
         annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=False),
         tags=_ACTOR_TAGS,
     ),
+    ToolDef(
+        name="update_budget",
+        description=(
+            "Update the monthly USD limit on a Guard spend budget by budget ID. "
+            "Two-step: returns a pending action for the user to confirm; the "
+            "confirm click writes the new limit + a hash-chained audit entry. "
+            "Guard policy guard.spend.budgets.edit still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "budget_id": {
+                    "type": "string",
+                    "description": "UUID of the guard_spend_budgets row to update.",
+                },
+                "monthly_limit_usd": {
+                    "type": "number",
+                    "description": "New monthly USD limit (>= 0).",
+                },
+            },
+            "required": ["budget_id", "monthly_limit_usd"],
+        },
+        impl=_actor_impl("update_budget"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+    ToolDef(
+        name="install_pack",
+        description=(
+            "Install a marketplace skill pack into the workspace by slug. "
+            "Two-step: returns a pending action for the user to confirm; the "
+            "confirm click adds the WorkspaceSkillPack row and invalidates "
+            "the policy cache. Guard policy guard.policies.edit still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "slug": {
+                    "type": "string",
+                    "description": "Pack slug (e.g. 'conduct-soc2').",
+                },
+            },
+            "required": ["slug"],
+        },
+        impl=_actor_impl("install_pack"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
     # ── Chat-surface confirmation shortcut tools (#1465) ────────────────────
     # These let the LLM resolve natural-language "yes" / "no" replies against
     # a pending action without requiring a button click. Same server code as

--- a/apps/api/tests/glens/test_actor_install_pack.py
+++ b/apps/api/tests/glens/test_actor_install_pack.py
@@ -1,0 +1,111 @@
+"""#1300 — actor ActionSpec + ToolDef parity for install_pack.
+
+Propose-path only; live-DB confirm+dispatch is covered by the actor
+substrate integration suite.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _fake_pack(name="SOC 2", rules=None):
+    return SimpleNamespace(
+        slug="conduct-soc2",
+        name=name,
+        rules=[{"id": "r1"}, {"id": "r2"}] if rules is None else rules,
+    )
+
+
+def test_install_pack_actionspec_registered():
+    spec = default_action_registry.get("install_pack")
+    assert spec is not None
+    assert spec.guard_permission == "guard.policies.edit"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_install_pack_tooldef_registered():
+    tool = default_registry.get("install_pack")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_propose_rejects_empty_slug():
+    spec = default_action_registry.get("install_pack")
+    out = spec.propose(_ctx(), {})
+    assert out.rejected
+    assert "slug required" in (out.reason or "")
+
+
+def test_propose_rejects_pack_not_in_catalog():
+    spec = default_action_registry.get("install_pack")
+    ctx = _ctx()
+    with patch("app.routers.compliance._latest_pack",
+               return_value=None):
+        out = spec.propose(ctx, {"slug": "unknown-pack"})
+    assert out.rejected
+    assert "No pack matches slug" in (out.reason or "")
+
+
+def test_propose_rejects_already_installed():
+    spec = default_action_registry.get("install_pack")
+    ctx = _ctx()
+    ctx.db.get.return_value = SimpleNamespace(pack_slug="conduct-soc2")
+    with patch("app.routers.compliance._latest_pack",
+               return_value=_fake_pack()):
+        out = spec.propose(ctx, {"slug": "conduct-soc2"})
+    assert out.rejected
+    assert "already installed" in (out.reason or "")
+
+
+def test_propose_success_shape():
+    spec = default_action_registry.get("install_pack")
+    ctx = _ctx()
+    ctx.db.get.return_value = None
+    with patch("app.routers.compliance._latest_pack",
+               return_value=_fake_pack(name="SOC 2", rules=[{}, {}, {}])):
+        out = spec.propose(ctx, {"slug": "conduct-soc2"})
+    assert not out.rejected
+    assert out.summary == "Install pack 'SOC 2' (3 rules)"
+    assert out.resolved_input == {
+        "slug": "conduct-soc2",
+        "pack_name": "SOC 2",
+        "rules_count": 3,
+    }
+
+
+def test_propose_handles_pack_with_no_rules():
+    spec = default_action_registry.get("install_pack")
+    ctx = _ctx()
+    ctx.db.get.return_value = None
+    with patch("app.routers.compliance._latest_pack",
+               return_value=_fake_pack(name="Empty", rules=[])):
+        out = spec.propose(ctx, {"slug": "empty-pack"})
+    assert not out.rejected
+    assert "(0 rules)" in out.summary
+    assert out.resolved_input["rules_count"] == 0

--- a/apps/api/tests/glens/test_actor_update_budget.py
+++ b/apps/api/tests/glens/test_actor_update_budget.py
@@ -1,0 +1,124 @@
+"""#1302 — actor ActionSpec + ToolDef parity for update_budget.
+
+Propose-path only; live-DB confirm+dispatch is covered by the actor
+substrate integration suite. Same shape as tests/glens/test_actor_run_workflow.py.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+_BUD = "11111111-1111-1111-1111-111111111111"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _fake_budget(clerk_user_id=None, monthly=500.0):
+    return SimpleNamespace(
+        id=uuid.UUID(_BUD),
+        workspace_id=uuid.UUID(_WS),
+        clerk_user_id=clerk_user_id,
+        monthly_limit_usd=monthly,
+    )
+
+
+def _mock_db_returning(budget):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = budget
+    return db
+
+
+def test_update_budget_actionspec_registered():
+    spec = default_action_registry.get("update_budget")
+    assert spec is not None
+    assert spec.guard_permission == "guard.spend.budgets.edit"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_update_budget_tooldef_registered():
+    tool = default_registry.get("update_budget")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_propose_rejects_empty_id():
+    spec = default_action_registry.get("update_budget")
+    out = spec.propose(_ctx(), {"monthly_limit_usd": 1000})
+    assert out.rejected
+    assert "budget_id required" in (out.reason or "")
+
+
+def test_propose_rejects_invalid_uuid():
+    spec = default_action_registry.get("update_budget")
+    out = spec.propose(_ctx(), {"budget_id": "not-a-uuid", "monthly_limit_usd": 1000})
+    assert out.rejected
+    assert "not a valid UUID" in (out.reason or "")
+
+
+def test_propose_rejects_non_numeric_limit():
+    spec = default_action_registry.get("update_budget")
+    out = spec.propose(_ctx(), {"budget_id": _BUD, "monthly_limit_usd": "abc"})
+    assert out.rejected
+    assert "must be a number" in (out.reason or "")
+
+
+def test_propose_rejects_negative_limit():
+    spec = default_action_registry.get("update_budget")
+    out = spec.propose(_ctx(), {"budget_id": _BUD, "monthly_limit_usd": -1})
+    assert out.rejected
+    assert "cannot be negative" in (out.reason or "")
+
+
+def test_propose_rejects_missing_budget():
+    spec = default_action_registry.get("update_budget")
+    db = _mock_db_returning(None)
+    out = spec.propose(_ctx(db=db), {"budget_id": _BUD, "monthly_limit_usd": 1000})
+    assert out.rejected
+    assert "No budget matches id" in (out.reason or "")
+
+
+def test_propose_success_workspace_wide_shape():
+    spec = default_action_registry.get("update_budget")
+    db = _mock_db_returning(_fake_budget(clerk_user_id=None, monthly=500))
+    out = spec.propose(_ctx(db=db), {"budget_id": _BUD, "monthly_limit_usd": 1000})
+    assert not out.rejected
+    assert "workspace-wide" in out.summary
+    assert "$500.00 → $1000.00" in out.summary
+    assert out.resolved_input == {
+        "budget_id": _BUD,
+        "monthly_limit_usd": 1000.0,
+        "old_limit_usd": 500.0,
+        "clerk_user_id": None,
+    }
+
+
+def test_propose_success_per_user_shape():
+    spec = default_action_registry.get("update_budget")
+    db = _mock_db_returning(_fake_budget(clerk_user_id="user_xyz", monthly=200))
+    out = spec.propose(_ctx(db=db), {"budget_id": _BUD, "monthly_limit_usd": 300})
+    assert not out.rejected
+    assert "user_xyz" in out.summary
+    assert out.resolved_input["clerk_user_id"] == "user_xyz"

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -12,6 +12,7 @@ import { GenericTableBubble } from "@/components/glens/GenericTableBubble"
 import { BlocksBubble } from "@/components/glens/BlocksBubble"
 import { FeedbackButtons } from "@/components/glens/FeedbackButtons"
 import RunDetailPanel, { type RunMeta } from "@/components/runs/RunDetailPanel"
+import { SlashDropdown, SlashForm, filterTools, type SlashTool } from "@/components/glens/SlashPicker"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1619,13 +1620,38 @@ function RunBubble({
 
 function ChatInput({ onSubmit, disabled }: { onSubmit: (t: string) => void; disabled: boolean }) {
   const [value, setValue] = useState("")
+  const [pickedTool, setPickedTool] = useState<SlashTool | null>(null)
+  // Escape sets this true to hide the picker without wiping the user's text;
+  // clears when the value stops starting with "/" (fresh slate for next try).
+  const [pickerDismissed, setPickerDismissed] = useState(false)
   const ref = useRef<HTMLTextAreaElement>(null)
 
-  useEffect(() => { if (!disabled) ref.current?.focus() }, [disabled])
+  useEffect(() => { if (!disabled && !pickedTool) ref.current?.focus() }, [disabled, pickedTool])
+  useEffect(() => { if (!value.startsWith("/")) setPickerDismissed(false) }, [value])
 
   function submit() {
     const t = value.trim()
     if (t && !disabled) { onSubmit(t); setValue("") }
+  }
+
+  // Slash-command picker (#1630): only mount the dropdown when there are
+  // real matches. Prevents an invisible dropdown from swallowing Enter for
+  // messages that legitimately start with "/" (e.g. "/tmp/foo is broken").
+  const slashMatches: SlashTool[] =
+    value.startsWith("/") && !pickedTool && !pickerDismissed
+      ? filterTools(value.slice(1))
+      : []
+  const showPicker = slashMatches.length > 0
+
+  if (pickedTool) {
+    return (
+      <SlashForm
+        tool={pickedTool}
+        disabled={disabled}
+        onSubmit={prompt => { onSubmit(prompt); setValue(""); setPickedTool(null) }}
+        onCancel={() => { setPickedTool(null); setValue("") }}
+      />
+    )
   }
 
   const canSend = !disabled && value.trim().length > 0
@@ -1638,13 +1664,23 @@ function ChatInput({ onSubmit, disabled }: { onSubmit: (t: string) => void; disa
       padding: "10px 14px",
       transition: "border-color 120ms, box-shadow 120ms",
     }}>
+      {showPicker && (
+        <SlashDropdown
+          matches={slashMatches}
+          onSelect={t => { setPickedTool(t); setValue("") }}
+          onClose={() => setPickerDismissed(true)}
+        />
+      )}
       <textarea
         ref={ref}
         value={value}
         onChange={e => setValue(e.target.value)}
-        onKeyDown={e => { if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submit() } }}
+        onKeyDown={e => {
+          if (showPicker) return  // dropdown owns keys only while visible
+          if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submit() }
+        }}
         disabled={disabled}
-        placeholder="Ask about your governance data…"
+        placeholder="Ask about your governance data… (type / for commands)"
         rows={2}
         style={{
           width: "100%",

--- a/apps/web/src/components/glens/SlashPicker.tsx
+++ b/apps/web/src/components/glens/SlashPicker.tsx
@@ -110,6 +110,21 @@ export const SLASH_TOOLS: SlashTool[] = [
       { name: "reason", required: false, placeholder: "required when rejecting" },
     ],
   },
+  {
+    name: "update_budget",
+    description: "Update the monthly USD limit on a spend budget — requires confirmation.",
+    args: [
+      { name: "budget_id", required: true, placeholder: "budget UUID", completer: "budgets" },
+      { name: "monthly_limit_usd", required: true, placeholder: "e.g. 1000" },
+    ],
+  },
+  {
+    name: "install_pack",
+    description: "Install a marketplace skill pack — requires confirmation.",
+    args: [
+      { name: "slug", required: true, placeholder: "pack slug (e.g. conduct-soc2)", completer: "marketplace_packs" },
+    ],
+  },
 ]
 
 // Compose a natural-language prompt from tool + filled args. The LLM receives

--- a/apps/web/src/components/glens/SlashPicker.tsx
+++ b/apps/web/src/components/glens/SlashPicker.tsx
@@ -1,0 +1,446 @@
+"use client"
+import { useEffect, useMemo, useRef, useState } from "react"
+import { API } from "@/lib/api"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+
+export type SlashArg = {
+  name: string
+  required: boolean
+  placeholder?: string
+  enum?: string[]
+  /**
+   * Named completer for per-arg autocomplete (PR 2). When set, the form
+   * renders an ArgAutocomplete backed by COMPLETERS[completer] instead of a
+   * free-text input. The stored value is the option's `value` (e.g. UUID);
+   * the dropdown shows `label` + optional `sublabel`.
+   */
+  completer?: keyof typeof COMPLETERS
+}
+
+export type CompleterOption = { value: string; label: string; sublabel?: string }
+type AuthFetch = (path: string, init?: RequestInit) => Promise<Response>
+type CompleterFn = (authFetch: AuthFetch, workspaceId: string | null) => Promise<CompleterOption[]>
+
+// Map arg completers → REST endpoints. Every endpoint already exists — no
+// backend changes for this feature. Entries are wired to args in SLASH_TOOLS;
+// dormant entries (budgets/agents/marketplace_packs) are ready for the
+// #1300-#1304 mutators when they land.
+export const COMPLETERS: Record<string, CompleterFn> = {
+  workflows: async authFetch => {
+    const r = await authFetch(`${API}/workflows`)
+    if (!r.ok) throw new Error(`workflows ${r.status}`)
+    const rows = (await r.json()) as Array<{ id: string; name: string; playbook_slug?: string | null }>
+    return rows.map(w => ({
+      value: w.playbook_slug || w.id,
+      label: w.name,
+      sublabel: w.playbook_slug ? `slug: ${w.playbook_slug}` : undefined,
+    }))
+  },
+  pending_approvals: async authFetch => {
+    const r = await authFetch(`${API}/guard/approvals?status=pending&limit=50`)
+    if (!r.ok) throw new Error(`approvals ${r.status}`)
+    const body = (await r.json()) as { items: Array<{ id: string; rule_message: string | null; tool_name: string | null }> }
+    return body.items.map(a => ({
+      value: a.id,
+      label: a.rule_message || a.tool_name || a.id,
+      sublabel: a.tool_name ? `tool: ${a.tool_name}` : undefined,
+    }))
+  },
+  // Dormant until #1302 update_budget mutator lands and attaches completer.
+  budgets: async authFetch => {
+    const r = await authFetch(`${API}/guard/spend/budgets`)
+    if (!r.ok) throw new Error(`budgets ${r.status}`)
+    const rows = (await r.json()) as Array<{ id: string; email: string | null; monthly_limit_usd: number }>
+    return rows.map(b => ({
+      value: b.id,
+      label: b.email || b.id,
+      sublabel: `$${b.monthly_limit_usd}/mo`,
+    }))
+  },
+  // Dormant until #1304 deactivate_agent_identity mutator lands.
+  agents: async (authFetch, workspaceId) => {
+    if (!workspaceId) return []
+    const r = await authFetch(`${API}/workspaces/${workspaceId}/agent-identities?workspace_id=${workspaceId}`)
+    if (!r.ok) throw new Error(`agents ${r.status}`)
+    const rows = (await r.json()) as Array<{ id: string; name: string; provider: string }>
+    return rows.map(a => ({
+      value: a.id,
+      label: a.name,
+      sublabel: a.provider ? `provider: ${a.provider}` : undefined,
+    }))
+  },
+  // Dormant until #1300 install_pack mutator lands.
+  marketplace_packs: async authFetch => {
+    const r = await authFetch(`${API}/compliance/packs/available`)
+    if (!r.ok) throw new Error(`packs ${r.status}`)
+    const rows = (await r.json()) as Array<{ slug: string; name: string; description?: string }>
+    return rows.map(p => ({
+      value: p.slug,
+      label: p.name,
+      sublabel: p.description || undefined,
+    }))
+  },
+}
+
+export type SlashTool = {
+  name: string
+  description: string
+  args: SlashArg[]
+}
+
+// Static catalogue of user-invocable actor tools. Excludes
+// confirm_pending_action / cancel_pending_action — those are LLM-only tools
+// the chat flow uses to resolve natural-language "yes"/"no" replies.
+// When new mutators from #1282 land (#1300-#1304), extend this list.
+export const SLASH_TOOLS: SlashTool[] = [
+  {
+    name: "run_workflow",
+    description: "Trigger a workflow run — requires confirmation.",
+    args: [
+      { name: "name_or_id", required: true, placeholder: "workflow name, slug, or UUID", completer: "workflows" },
+      { name: "inputs", required: false, placeholder: 'optional JSON, e.g. {"key":"value"}' },
+    ],
+  },
+  {
+    name: "decide_approval",
+    description: "Approve or reject a pending Guard approval — requires confirmation.",
+    args: [
+      { name: "approval_request_id", required: true, placeholder: "approval UUID", completer: "pending_approvals" },
+      { name: "decision", required: true, enum: ["approved", "rejected"] },
+      { name: "reason", required: false, placeholder: "required when rejecting" },
+    ],
+  },
+]
+
+// Compose a natural-language prompt from tool + filled args. The LLM receives
+// this on the wire and emits a matching tool_use — same propose→confirm path
+// as prose input. Prompt shape mirrors run_workflow's own description so the
+// model has zero ambiguity about which tool to call.
+export function composePrompt(tool: SlashTool, args: Record<string, string>): string {
+  const parts = tool.args
+    .filter(a => (args[a.name] ?? "").trim().length > 0)
+    .map(a => `${a.name}=${JSON.stringify(args[a.name].trim())}`)
+    .join(", ")
+  return parts
+    ? `Please run ${tool.name} with ${parts}.`
+    : `Please run ${tool.name}.`
+}
+
+export function filterTools(query: string): SlashTool[] {
+  const q = query.toLowerCase()
+  return SLASH_TOOLS.filter(t => t.name.startsWith(q))
+}
+
+/**
+ * Renders a listbox of matched tools. Caller controls whether to mount at all
+ * (mount only when matches>0). Owns keyboard nav via a window listener that
+ * lives only while mounted — safe because the parent won't mount an empty
+ * dropdown, so the listener never runs when nothing is visible.
+ */
+export function SlashDropdown({
+  matches,
+  onSelect,
+  onClose,
+}: {
+  matches: SlashTool[]
+  onSelect: (tool: SlashTool) => void
+  onClose: () => void
+}) {
+  const [idx, setIdx] = useState(0)
+
+  useEffect(() => { setIdx(0) }, [matches])
+
+  useEffect(() => {
+    function key(e: KeyboardEvent) {
+      if (matches.length === 0) return
+      if (e.key === "ArrowDown") { e.preventDefault(); setIdx(i => Math.min(i + 1, matches.length - 1)) }
+      else if (e.key === "ArrowUp") { e.preventDefault(); setIdx(i => Math.max(i - 1, 0)) }
+      else if (e.key === "Enter") { e.preventDefault(); onSelect(matches[idx]) }
+      else if (e.key === "Escape") { e.preventDefault(); onClose() }
+    }
+    window.addEventListener("keydown", key)
+    return () => window.removeEventListener("keydown", key)
+  }, [matches, idx, onSelect, onClose])
+
+  if (matches.length === 0) return null
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Slash command picker"
+      style={{
+        position: "absolute", bottom: "100%", left: 0, right: 0,
+        marginBottom: 8, background: "var(--surface)",
+        border: "1px solid var(--border)", borderRadius: 12,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.12)", overflow: "hidden", zIndex: 10,
+      }}
+    >
+      {matches.map((t, i) => (
+        <button
+          key={t.name}
+          role="option"
+          aria-selected={i === idx}
+          onClick={() => onSelect(t)}
+          onMouseEnter={() => setIdx(i)}
+          style={{
+            display: "block", width: "100%", textAlign: "left",
+            padding: "10px 14px", border: "none",
+            background: i === idx ? "var(--surface-2)" : "transparent",
+            color: "var(--text)", cursor: "pointer",
+            borderBottom: i < matches.length - 1 ? "1px solid var(--border)" : "none",
+          }}
+        >
+          <div style={{ fontWeight: 600, fontSize: 13, fontFamily: "ui-monospace,monospace" }}>
+            /{t.name}
+          </div>
+          <div style={{ fontSize: 12, color: "var(--text-3)", marginTop: 2 }}>
+            {t.description}
+          </div>
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export function SlashForm({
+  tool,
+  onSubmit,
+  onCancel,
+  disabled,
+}: {
+  tool: SlashTool
+  onSubmit: (prompt: string) => void
+  onCancel: () => void
+  disabled: boolean
+}) {
+  const [args, setArgs] = useState<Record<string, string>>({})
+  const firstRef = useRef<HTMLInputElement | HTMLSelectElement | null>(null)
+
+  useEffect(() => { firstRef.current?.focus() }, [])
+
+  const canSubmit = tool.args
+    .filter(a => a.required)
+    .every(a => (args[a.name] ?? "").trim().length > 0)
+
+  function submit() {
+    if (!canSubmit || disabled) return
+    onSubmit(composePrompt(tool, args))
+  }
+
+  function onFieldKey(e: React.KeyboardEvent) {
+    if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); submit() }
+    else if (e.key === "Escape") { e.preventDefault(); onCancel() }
+  }
+
+  return (
+    <div style={{
+      border: "1px solid var(--border)", borderRadius: 16,
+      background: "var(--surface-2)", padding: 12,
+    }}>
+      <div style={{
+        display: "flex", justifyContent: "space-between", alignItems: "center",
+        marginBottom: 10, paddingBottom: 8, borderBottom: "1px solid var(--border)",
+      }}>
+        <div style={{
+          fontWeight: 700, fontSize: 13,
+          fontFamily: "ui-monospace,monospace", color: "var(--text)",
+        }}>
+          /{tool.name}
+        </div>
+        <button
+          onClick={onCancel}
+          aria-label="Close"
+          style={{
+            background: "transparent", border: "none", color: "var(--text-muted)",
+            fontSize: 20, lineHeight: 1, cursor: "pointer", padding: 4,
+          }}
+        >×</button>
+      </div>
+
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {tool.args.map((arg, i) => (
+          <label key={arg.name} style={{ display: "block" }}>
+            <div style={{ fontSize: 11, color: "var(--text-3)", marginBottom: 3 }}>
+              {arg.name}{arg.required && <span style={{ color: "var(--err)" }}> *</span>}
+            </div>
+            {arg.enum ? (
+              <select
+                ref={el => { if (i === 0) firstRef.current = el }}
+                value={args[arg.name] || ""}
+                onChange={e => setArgs(a => ({ ...a, [arg.name]: e.target.value }))}
+                onKeyDown={onFieldKey}
+                style={fieldStyle}
+              >
+                <option value="">Select…</option>
+                {arg.enum.map(v => <option key={v} value={v}>{v}</option>)}
+              </select>
+            ) : arg.completer ? (
+              <ArgAutocomplete
+                completer={arg.completer}
+                value={args[arg.name] || ""}
+                onChange={v => setArgs(a => ({ ...a, [arg.name]: v }))}
+                onEnter={submit}
+                onEscape={onCancel}
+                placeholder={arg.placeholder || ""}
+                autoFocus={i === 0}
+              />
+            ) : (
+              <input
+                ref={el => { if (i === 0) firstRef.current = el }}
+                value={args[arg.name] || ""}
+                onChange={e => setArgs(a => ({ ...a, [arg.name]: e.target.value }))}
+                onKeyDown={onFieldKey}
+                placeholder={arg.placeholder || ""}
+                style={fieldStyle}
+              />
+            )}
+          </label>
+        ))}
+      </div>
+
+      <div style={{ display: "flex", justifyContent: "flex-end", gap: 8, marginTop: 12 }}>
+        <button onClick={onCancel} className="btn btn-ghost btn-sm">Cancel</button>
+        <button onClick={submit} disabled={!canSubmit || disabled} className="btn btn-primary btn-sm">
+          Send
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const fieldStyle: React.CSSProperties = {
+  width: "100%", padding: "6px 10px", fontSize: 13,
+  border: "1px solid var(--border)", borderRadius: 8,
+  background: "var(--surface)", color: "var(--text)", outline: "none",
+  fontFamily: "inherit",
+}
+
+/**
+ * ArgAutocomplete (PR 2 / #1630).
+ * Loads options once from COMPLETERS[completer], filters locally as the user
+ * types, and stores the selected option's `value`. Free-text is allowed:
+ * unmatched input passes through so power users can paste a UUID directly.
+ */
+export function ArgAutocomplete({
+  completer,
+  value,
+  onChange,
+  onEnter,
+  onEscape,
+  placeholder,
+  autoFocus,
+}: {
+  completer: keyof typeof COMPLETERS
+  value: string
+  onChange: (val: string) => void
+  onEnter: () => void
+  onEscape: () => void
+  placeholder?: string
+  autoFocus?: boolean
+}) {
+  const { authFetch, workspaceId } = useAuthFetch()
+  const [options, setOptions] = useState<CompleterOption[]>([])
+  const [error, setError] = useState<string | null>(null)
+  const [open, setOpen] = useState(false)
+  const [idx, setIdx] = useState(0)
+  const [query, setQuery] = useState(value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => { if (autoFocus) inputRef.current?.focus() }, [autoFocus])
+  useEffect(() => () => { if (blurTimer.current) clearTimeout(blurTimer.current) }, [])
+
+  useEffect(() => {
+    let cancelled = false
+    COMPLETERS[completer](authFetch, workspaceId)
+      .then(opts => { if (!cancelled) setOptions(opts) })
+      .catch(e => { if (!cancelled) setError(e instanceof Error ? e.message : "load failed") })
+    return () => { cancelled = true }
+  }, [completer, authFetch, workspaceId])
+
+  const matches = useMemo(() => {
+    if (!query.trim()) return options.slice(0, 20)
+    const q = query.toLowerCase()
+    return options
+      .filter(o => o.label.toLowerCase().includes(q) || o.value.toLowerCase().includes(q))
+      .slice(0, 20)
+  }, [options, query])
+
+  useEffect(() => { setIdx(0) }, [query])
+
+  function select(opt: CompleterOption) {
+    onChange(opt.value)
+    setQuery(opt.label)
+    setOpen(false)
+  }
+
+  return (
+    <div style={{ position: "relative" }}>
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={e => {
+          setQuery(e.target.value)
+          onChange(e.target.value)  // free-text pass-through
+          setOpen(true)
+        }}
+        onFocus={() => setOpen(true)}
+        onBlur={() => { blurTimer.current = setTimeout(() => setOpen(false), 120) }}
+        onKeyDown={e => {
+          if (open && matches.length > 0) {
+            if (e.key === "ArrowDown") { e.preventDefault(); setIdx(i => Math.min(i + 1, matches.length - 1)); return }
+            if (e.key === "ArrowUp")   { e.preventDefault(); setIdx(i => Math.max(i - 1, 0)); return }
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); select(matches[idx]); return }
+          }
+          if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); onEnter() }
+          else if (e.key === "Escape") { e.preventDefault(); setOpen(false); onEscape() }
+        }}
+        placeholder={placeholder}
+        style={fieldStyle}
+      />
+      {open && matches.length > 0 && (
+        <div
+          role="listbox"
+          aria-label="Autocomplete options"
+          style={{
+            position: "absolute", top: "100%", left: 0, right: 0,
+            marginTop: 4, background: "var(--surface)",
+            border: "1px solid var(--border)", borderRadius: 8,
+            maxHeight: 220, overflowY: "auto", zIndex: 20,
+            boxShadow: "0 8px 16px rgba(0,0,0,0.08)",
+          }}
+        >
+          {matches.map((o, i) => (
+            <button
+              key={o.value}
+              role="option"
+              aria-selected={i === idx}
+              onMouseDown={e => e.preventDefault()}
+              onClick={() => select(o)}
+              onMouseEnter={() => setIdx(i)}
+              style={{
+                display: "block", width: "100%", textAlign: "left",
+                padding: "6px 10px", border: "none", cursor: "pointer",
+                background: i === idx ? "var(--surface-2)" : "transparent",
+                color: "var(--text)", fontSize: 13,
+                borderBottom: i < matches.length - 1 ? "1px solid var(--border)" : "none",
+              }}
+            >
+              <div style={{ fontWeight: 500 }}>{o.label}</div>
+              {o.sublabel && (
+                <div style={{ fontSize: 11, color: "var(--text-3)", marginTop: 1 }}>
+                  {o.sublabel}
+                </div>
+              )}
+            </button>
+          ))}
+        </div>
+      )}
+      {error && (
+        <div style={{ fontSize: 11, color: "var(--err)", marginTop: 3 }}>
+          Couldn't load options: {error}. Type manually.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
+++ b/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
@@ -1,0 +1,219 @@
+import { describe, it, expect, vi } from "vitest"
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react"
+import {
+  SlashDropdown,
+  SlashForm,
+  composePrompt,
+  filterTools,
+  COMPLETERS,
+  SLASH_TOOLS,
+  type SlashTool,
+} from "../SlashPicker"
+
+// Flush all pending microtasks from the async completer load so React state
+// updates settle before the test asserts. Cheaper than waitFor when a test
+// doesn't care about loaded options.
+const flush = () => act(async () => { await Promise.resolve() })
+
+// Stub useAuthFetch — ArgAutocomplete imports it. Real useAuthFetch returns
+// a stable authFetch via useCallback; the mock must too or the useEffect that
+// loads options fires every render.
+const authFetchMock = (path: string) => {
+  if (path.includes("/workflows")) {
+    return Promise.resolve(new Response(JSON.stringify([
+      { id: "wf-uuid-1", name: "Ship Feature", playbook_slug: "ship-feature" },
+      { id: "wf-uuid-2", name: "Deploy Prod", playbook_slug: null },
+    ])))
+  }
+  if (path.includes("/guard/approvals")) {
+    return Promise.resolve(new Response(JSON.stringify({
+      items: [{ id: "appr-1", rule_message: "Deploy to prod?", tool_name: "run_workflow" }],
+    })))
+  }
+  if (path.includes("/guard/spend/budgets")) {
+    return Promise.resolve(new Response(JSON.stringify([
+      { id: "bud-1", email: "alice@example.com", monthly_limit_usd: 500 },
+      { id: "bud-2", email: null, monthly_limit_usd: 200 },
+    ])))
+  }
+  if (path.includes("/agent-identities")) {
+    return Promise.resolve(new Response(JSON.stringify([
+      { id: "agt-1", name: "prod-cli", provider: "anthropic" },
+    ])))
+  }
+  if (path.includes("/compliance/packs/available")) {
+    return Promise.resolve(new Response(JSON.stringify([
+      { slug: "sr-11-7", name: "SR 11-7", description: "Federal model risk" },
+    ])))
+  }
+  return Promise.resolve(new Response("null", { status: 404 }))
+}
+const authFetchRef = { authFetch: authFetchMock, workspaceId: "ws-1" }
+vi.mock("@/hooks/useAuthFetch", () => ({
+  useAuthFetch: () => authFetchRef,
+}))
+
+describe("filterTools", () => {
+  it("returns all tools for empty filter", () => {
+    expect(filterTools("")).toEqual(SLASH_TOOLS)
+  })
+
+  it("filters by name prefix, case-insensitive", () => {
+    const matches = filterTools("Run")
+    expect(matches).toHaveLength(1)
+    expect(matches[0].name).toBe("run_workflow")
+  })
+
+  it("returns empty when nothing matches", () => {
+    expect(filterTools("zzzzz")).toEqual([])
+  })
+})
+
+describe("composePrompt", () => {
+  const tool: SlashTool = SLASH_TOOLS[0]  // run_workflow
+
+  it("wraps filled args as JSON-quoted key=value pairs", () => {
+    const out = composePrompt(tool, { name_or_id: "hello-world" })
+    expect(out).toBe('Please run run_workflow with name_or_id="hello-world".')
+  })
+
+  it("skips empty and whitespace-only args", () => {
+    const out = composePrompt(tool, { name_or_id: "wf-1", inputs: "  " })
+    expect(out).toBe('Please run run_workflow with name_or_id="wf-1".')
+  })
+
+  it("falls through with no args when none are filled", () => {
+    const out = composePrompt(tool, {})
+    expect(out).toBe("Please run run_workflow.")
+  })
+})
+
+describe("SlashDropdown", () => {
+  it("renders matches and calls onSelect on click", () => {
+    const onSelect = vi.fn()
+    render(<SlashDropdown matches={filterTools("run")} onSelect={onSelect} onClose={vi.fn()} />)
+
+    const opt = screen.getByRole("option", { name: /run_workflow/ })
+    fireEvent.click(opt)
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "run_workflow" })
+    )
+  })
+
+  it("renders nothing when matches is empty", () => {
+    const { container } = render(
+      <SlashDropdown matches={[]} onSelect={vi.fn()} onClose={vi.fn()} />
+    )
+    expect(container.firstChild).toBeNull()
+  })
+})
+
+describe("SlashForm", () => {
+  const tool: SlashTool = SLASH_TOOLS[0]  // run_workflow — first arg required
+
+  it("disables Send until required args are filled", async () => {
+    render(
+      <SlashForm tool={tool} disabled={false} onSubmit={vi.fn()} onCancel={vi.fn()} />
+    )
+    await flush()
+    const send = screen.getByRole("button", { name: /^Send$/ })
+    expect(send).toBeDisabled()
+
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "wf-1" } })
+    expect(send).not.toBeDisabled()
+  })
+
+  it("submits with a composed prompt", async () => {
+    const onSubmit = vi.fn()
+    render(
+      <SlashForm tool={tool} disabled={false} onSubmit={onSubmit} onCancel={vi.fn()} />
+    )
+    await flush()
+    fireEvent.change(screen.getAllByRole("textbox")[0], { target: { value: "wf-1" } })
+    fireEvent.click(screen.getByRole("button", { name: /^Send$/ }))
+    expect(onSubmit).toHaveBeenCalledWith('Please run run_workflow with name_or_id="wf-1".')
+  })
+
+  it("calls onCancel when × is clicked", async () => {
+    const onCancel = vi.fn()
+    render(
+      <SlashForm tool={tool} disabled={false} onSubmit={vi.fn()} onCancel={onCancel} />
+    )
+    await flush()
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/i }))
+    expect(onCancel).toHaveBeenCalled()
+  })
+})
+
+describe("ArgAutocomplete (via SlashForm run_workflow)", () => {
+  const tool = SLASH_TOOLS[0]  // run_workflow.name_or_id has completer=workflows
+
+  it("loads options from the completer and displays them", async () => {
+    render(<SlashForm tool={tool} disabled={false} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+    fireEvent.focus(screen.getAllByRole("textbox")[0])
+    await waitFor(() => expect(screen.getByText("Ship Feature")).toBeTruthy())
+    expect(screen.getByText("Deploy Prod")).toBeTruthy()
+  })
+
+  it("clicking an option fills the arg with its value (slug preferred)", async () => {
+    const onSubmit = vi.fn()
+    render(<SlashForm tool={tool} disabled={false} onSubmit={onSubmit} onCancel={vi.fn()} />)
+    fireEvent.focus(screen.getAllByRole("textbox")[0])
+    await waitFor(() => screen.getByText("Ship Feature"))
+    fireEvent.click(screen.getByText("Ship Feature"))
+    fireEvent.click(screen.getByRole("button", { name: /^Send$/ }))
+    expect(onSubmit).toHaveBeenCalledWith('Please run run_workflow with name_or_id="ship-feature".')
+  })
+
+  it("filters options as the user types", async () => {
+    render(<SlashForm tool={tool} disabled={false} onSubmit={vi.fn()} onCancel={vi.fn()} />)
+    const input = screen.getAllByRole("textbox")[0]
+    fireEvent.focus(input)
+    await waitFor(() => screen.getByText("Ship Feature"))
+    fireEvent.change(input, { target: { value: "deploy" } })
+    expect(screen.queryByText("Ship Feature")).toBeNull()
+    expect(screen.getByText("Deploy Prod")).toBeTruthy()
+  })
+
+  it("falls through to free-text when no option is selected", async () => {
+    const onSubmit = vi.fn()
+    render(<SlashForm tool={tool} disabled={false} onSubmit={onSubmit} onCancel={vi.fn()} />)
+    await flush()
+    const input = screen.getAllByRole("textbox")[0]
+    fireEvent.change(input, { target: { value: "raw-uuid-value" } })
+    fireEvent.click(screen.getByRole("button", { name: /^Send$/ }))
+    expect(onSubmit).toHaveBeenCalledWith('Please run run_workflow with name_or_id="raw-uuid-value".')
+  })
+})
+
+describe("Dormant completers (PR 3)", () => {
+  // These completers are registered but not yet wired to any SLASH_TOOLS arg —
+  // they light up when the #1300-#1304 mutators land. Exercise them directly
+  // so we know the mapping to REST endpoints is correct today.
+
+  it("budgets: id as value, email as label, monthly limit as sublabel", async () => {
+    const opts = await COMPLETERS.budgets(authFetchMock, "ws-1")
+    expect(opts).toEqual([
+      { value: "bud-1", label: "alice@example.com", sublabel: "$500/mo" },
+      { value: "bud-2", label: "bud-2", sublabel: "$200/mo" },
+    ])
+  })
+
+  it("agents: id as value, name as label, provider as sublabel", async () => {
+    const opts = await COMPLETERS.agents(authFetchMock, "ws-1")
+    expect(opts).toEqual([
+      { value: "agt-1", label: "prod-cli", sublabel: "provider: anthropic" },
+    ])
+  })
+
+  it("agents: returns empty when no workspaceId", async () => {
+    expect(await COMPLETERS.agents(authFetchMock, null)).toEqual([])
+  })
+
+  it("marketplace_packs: slug as value, name as label, description as sublabel", async () => {
+    const opts = await COMPLETERS.marketplace_packs(authFetchMock, "ws-1")
+    expect(opts).toEqual([
+      { value: "sr-11-7", label: "SR 11-7", sublabel: "Federal model risk" },
+    ])
+  })
+})

--- a/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
+++ b/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
@@ -67,6 +67,26 @@ describe("filterTools", () => {
   it("returns empty when nothing matches", () => {
     expect(filterTools("zzzzz")).toEqual([])
   })
+
+  it("includes update_budget and install_pack in the catalogue", () => {
+    const names = SLASH_TOOLS.map(t => t.name)
+    expect(names).toContain("update_budget")
+    expect(names).toContain("install_pack")
+  })
+
+  it("update_budget.budget_id uses the budgets completer", () => {
+    const tool = SLASH_TOOLS.find(t => t.name === "update_budget")!
+    const arg = tool.args.find(a => a.name === "budget_id")!
+    expect(arg.completer).toBe("budgets")
+    expect(arg.required).toBe(true)
+  })
+
+  it("install_pack.slug uses the marketplace_packs completer", () => {
+    const tool = SLASH_TOOLS.find(t => t.name === "install_pack")!
+    const arg = tool.args.find(a => a.name === "slug")!
+    expect(arg.completer).toBe("marketplace_packs")
+    expect(arg.required).toBe(true)
+  })
 })
 
 describe("composePrompt", () => {


### PR DESCRIPTION
## Summary

Ships the Lens slash-command picker plus two #1282 mutating actor tools that light up the picker's dormant completers.

- **#1630** — `/` opens a picker of registered actor tools; select → structured form with per-arg autocomplete; submit composes an NL prompt so the LLM still emits the tool_use → same require_confirmation → ActionConfirmBubble path. Zero backend for the picker itself.
- **#1302 update_budget** — change \`monthly_limit_usd\` on a spend budget by id. Guard: \`guard.spend.budgets.edit\`.
- **#1300 install_pack** — install a marketplace skill pack by slug. Guard: \`guard.policies.edit\`. Same behaviour as the marketplace UI install.

Both mutators wire the picker's dormant completers (\`budgets\`, \`marketplace_packs\`) so users pick from a dropdown instead of guessing UUIDs/slugs.

## What's in the diff

- \`apps/web/src/components/glens/SlashPicker.tsx\` — new picker + form + ArgAutocomplete + COMPLETERS map (5 completers, 2 live + 3 dormant)
- \`apps/web/src/components/glens/GLensChatPage.tsx\` — ChatInput integrated with picker/form mode swap + pickerDismissed flag
- \`apps/api/app/modules/glens/actor/registrations/update_budget.py\` — propose + execute
- \`apps/api/app/modules/glens/actor/registrations/install_pack.py\` — propose + execute
- \`apps/api/app/tools/registrations/lens/actor.py\` — 2 new ToolDefs
- \`apps/api/app/modules/glens/actor/registrations/__init__.py\` — import both to register on startup
- 3 test files: 22 FE tests + 16 BE tests

## Test plan

- [x] \`apps/web\`: \`npx vitest run src/components/glens/__tests__/SlashPicker.test.tsx\` — 22/22
- [x] \`apps/api\`: \`pytest tests/glens/test_actor_update_budget.py tests/glens/test_actor_install_pack.py\` — 16/16
- [x] Neighbor suite: \`pytest tests/glens/test_actor_run_workflow.py tests/glens/test_actor_substrate.py tests/glens/test_lens_registrations.py tests/tools/test_lens_registrations.py\` — 32/32
- [x] \`apps/web\`: \`npx tsc --noEmit\` — clean on touched files
- [ ] Live smoke: \`/\` in Lens → pick "update_budget" → budget dropdown loads from GET /guard/spend/budgets → confirm bubble renders → click Confirm → budget row updates + audit entry
- [ ] Live smoke: \`/\` in Lens → pick "install_pack" → slug dropdown loads from GET /compliance/packs/available → confirm bubble renders → click Confirm → pack installed, policy cache invalidated

## Closes

- #1630 (slash picker + autocomplete)
- #1302 (Lens actor: update_budget)
- #1300 (Lens actor: install_pack)