### PR TITLE
feat(lens): enable/disable_policy + deactivate_agent_identity mutators (#1303, #1304)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -2,7 +2,9 @@
 populate `default_action_registry` (and paired `default_registry.ToolDef`
 entries via `app.tools.registrations.lens`).
 """
+from app.modules.glens.actor.registrations import deactivate_agent_identity  # noqa: F401
 from app.modules.glens.actor.registrations import decide_approval  # noqa: F401
 from app.modules.glens.actor.registrations import install_pack  # noqa: F401
 from app.modules.glens.actor.registrations import run_workflow  # noqa: F401
+from app.modules.glens.actor.registrations import toggle_policy  # noqa: F401 — registers enable_policy + disable_policy
 from app.modules.glens.actor.registrations import update_budget  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/deactivate_agent_identity.py
+++ b/apps/api/app/modules/glens/actor/registrations/deactivate_agent_identity.py
@@ -1,0 +1,111 @@
+"""#1304 — Lens actor: deactivate an agent identity (security kill switch).
+
+Two-step: `propose` validates the agent exists in this workspace and isn't
+already deactivated. `execute` sets `lifecycle_state='deactivated'` +
+`deactivated_at=now()` — matches the check constraint on the model.
+
+Reuses `platform.members.manage` for RBAC since `platform.agents.manage`
+isn't in the seeded permission set (see CLAUDE.md permission list).
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+def _propose_deactivate(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    agent_id = str(args.get("agent_id") or "").strip()
+    if not agent_id:
+        return ProposeResult(rejected=True, reason="agent_id required",
+                             summary="", resolved_input={})
+
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="Invalid workspace",
+                             summary="", resolved_input={})
+
+    from app.modules.agent_identity.models import AgentIdentity
+
+    agent = ctx.db.query(AgentIdentity).filter(
+        AgentIdentity.id == agent_id,
+        AgentIdentity.workspace_id == ws_uuid,
+    ).first()
+    if agent is None:
+        return ProposeResult(
+            rejected=True,
+            reason=f"No agent identity matches id '{agent_id}' in this workspace",
+            summary="", resolved_input={},
+        )
+
+    if agent.lifecycle_state == "deactivated":
+        return ProposeResult(
+            rejected=True,
+            reason=f"Agent '{agent.name}' ({agent_id}) is already deactivated",
+            summary="", resolved_input={},
+        )
+
+    reason = str(args.get("reason") or "").strip() or None
+    summary = f"Deactivate agent identity '{agent.name}' ({agent.provider})"
+    if reason:
+        summary += f" — {reason}"
+
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "agent_id": agent_id,
+            "agent_name": agent.name,
+            "provider": agent.provider,
+            "reason": reason,
+        },
+    )
+
+
+def _execute_deactivate(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Flip lifecycle_state to 'deactivated' + stamp deactivated_at. Runtime
+    token-resolution code checks lifecycle_state before allowing use, so this
+    kill-switch takes effect on the next call."""
+    from app.modules.agent_identity.models import AgentIdentity
+
+    agent_id = resolved["agent_id"]
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+
+    agent = ctx.db.query(AgentIdentity).filter(
+        AgentIdentity.id == agent_id,
+        AgentIdentity.workspace_id == ws_uuid,
+    ).first()
+    if agent is None:
+        raise ValueError(f"agent {agent_id} disappeared between propose and execute")
+
+    agent.lifecycle_state = "deactivated"
+    agent.deactivated_at = datetime.now(timezone.utc)
+    ctx.db.commit()
+
+    return {
+        "agent_id": agent_id,
+        "agent_name": resolved.get("agent_name"),
+        "lifecycle_state": "deactivated",
+        "reason": resolved.get("reason"),
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="deactivate_agent_identity",
+    guard_permission="platform.members.manage",
+    propose=_propose_deactivate,
+    execute=_execute_deactivate,
+    description=(
+        "Deactivate an agent identity (security kill switch) by id. Two-step: "
+        "returns a pending action for the user to confirm; the confirm click "
+        "sets lifecycle_state='deactivated' so the identity can no longer "
+        "authenticate on the next call. Existing tokens stop working."
+    ),
+))

--- a/apps/api/app/modules/glens/actor/registrations/toggle_policy.py
+++ b/apps/api/app/modules/glens/actor/registrations/toggle_policy.py
@@ -102,43 +102,38 @@ def _propose_toggle(ctx: ActionCtx, args: dict[str, Any], *, target_enabled: boo
 
 
 def _execute_toggle(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
-    from app.modules.guard.models import (
-        GuardRuleOverride, WorkspaceCustomRule,
-    )
+    """Custom rules → flip WorkspaceCustomRule.enabled. Pack rules → delegate
+    to the router's `_upsert_override` so the write path is identical to
+    PATCH /guard/policies (correct column set + audit metadata)."""
+    from app.modules.guard.models import WorkspaceCustomRule
     from app.modules.guard.policy_engine import invalidate_policy_cache
+    from app.modules.guard.routers.policies import _upsert_override
 
     rule_id = resolved["rule_id"]
     kind = resolved["kind"]
     target = bool(resolved["target_enabled"])
     ws_uuid = _uuid.UUID(ctx.workspace_id)
-    now = datetime.now(timezone.utc)
 
     if kind == "custom":
         row = ctx.db.get(WorkspaceCustomRule, (ws_uuid, rule_id))
         if row is None:
             raise ValueError(f"custom rule {rule_id} disappeared between propose and execute")
         row.enabled = target
-        row.updated_at = now
+        row.updated_at = datetime.now(timezone.utc)
     else:
-        # Pack rule → upsert override with disabled=(not target).
-        override = ctx.db.get(GuardRuleOverride, (ws_uuid, rule_id))
-        if override is None:
-            override = GuardRuleOverride(
-                workspace_id=ws_uuid,
-                rule_id=rule_id,
-                disabled=not target,
-                reason=resolved.get("reason"),
-                overridden_by=ctx.clerk_user_id or "lens.actor",
-                created_at=now,
-                updated_at=now,
-            )
-            ctx.db.add(override)
-        else:
-            override.disabled = not target
-            if resolved.get("reason"):
-                override.reason = resolved["reason"]
-            override.overridden_by = ctx.clerk_user_id or "lens.actor"
-            override.updated_at = now
+        # Pack rule → upsert override via the shared helper. `disabled=not
+        # target` toggles the flag; the helper stamps `overridden_at` and
+        # optionally clears/sets the exception `reason` per the same
+        # semantics as the HTTP handler.
+        _upsert_override(
+            ctx.db,
+            ws_uuid,
+            rule_id,
+            disabled=not target,
+            reason=resolved.get("reason") if not target else None,
+            overridden_by=ctx.clerk_user_id or "lens.actor",
+            clear_exception=target,  # re-enable → drop exception metadata
+        )
 
     ctx.db.commit()
     invalidate_policy_cache(ctx.db, ws_uuid)

--- a/apps/api/app/modules/glens/actor/registrations/toggle_policy.py
+++ b/apps/api/app/modules/glens/actor/registrations/toggle_policy.py
@@ -1,0 +1,184 @@
+"""#1303 — Lens actor: enable_policy + disable_policy.
+
+Two ActionSpecs share one file because their propose/execute paths only
+differ by the target `enabled` value. Both handle custom rules
+(WorkspaceCustomRule) and pack rules (GuardRuleOverride) — same shape as
+the HTTP PATCH /guard/policies/{rule_id} handler.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+def _resolve_policy(ctx: ActionCtx, rule_id: str) -> tuple[str, Any] | None:
+    """Look up a rule by id — returns (kind, row) where kind is 'custom' or
+    'pack'. Returns None if the rule doesn't exist in this workspace."""
+    from app.modules.guard.models import WorkspaceCustomRule
+    from app.modules.guard.routers.policies import _find_pack_rule
+
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+    custom = ctx.db.get(WorkspaceCustomRule, (ws_uuid, rule_id))
+    if custom is not None:
+        return ("custom", custom)
+
+    found = _find_pack_rule(ctx.db, ws_uuid, rule_id)
+    if found is not None:
+        return ("pack", found)  # found = (rule_dict, WorkspaceSkillPack)
+
+    return None
+
+
+def _propose_toggle(ctx: ActionCtx, args: dict[str, Any], *, target_enabled: bool) -> ProposeResult:
+    verb = "Enable" if target_enabled else "Disable"
+    rule_id = str(args.get("rule_id") or "").strip()
+    if not rule_id:
+        return ProposeResult(rejected=True, reason="rule_id required",
+                             summary="", resolved_input={})
+
+    try:
+        _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="Invalid workspace",
+                             summary="", resolved_input={})
+
+    resolved = _resolve_policy(ctx, rule_id)
+    if resolved is None:
+        return ProposeResult(
+            rejected=True,
+            reason=f"No policy matches rule_id '{rule_id}' in this workspace",
+            summary="", resolved_input={},
+        )
+    kind, row = resolved
+
+    # Disabling a pack rule is a policy exception — surfaced in audit trail.
+    # Reason is required on disable to prevent silent permanent removals.
+    reason = str(args.get("reason") or "").strip()
+    if not target_enabled and kind == "pack" and not reason:
+        return ProposeResult(
+            rejected=True,
+            reason="Disabling a pack rule requires a reason (compliance exception surfaces this in the audit trail).",
+            summary="", resolved_input={},
+        )
+
+    if kind == "custom":
+        current_enabled = bool(row.enabled)
+        rule_name = (row.body or {}).get("description") or rule_id
+    else:
+        rule_dict, _wp = row
+        rule_name = rule_dict.get("description") or rule_dict.get("id") or rule_id
+        current_enabled = True  # pack rules default enabled unless override says otherwise
+        from app.modules.guard.models import GuardRuleOverride
+        override = ctx.db.get(GuardRuleOverride, (_uuid.UUID(ctx.workspace_id), rule_id))
+        if override is not None and override.disabled:
+            current_enabled = False
+
+    if current_enabled == target_enabled:
+        state = "enabled" if target_enabled else "disabled"
+        return ProposeResult(
+            rejected=True,
+            reason=f"Rule '{rule_id}' is already {state}",
+            summary="", resolved_input={},
+        )
+
+    summary = f"{verb} policy '{rule_name}' ({rule_id})"
+    return ProposeResult(
+        summary=summary,
+        resolved_input={
+            "rule_id": rule_id,
+            "kind": kind,
+            "target_enabled": target_enabled,
+            "reason": reason or None,
+        },
+    )
+
+
+def _execute_toggle(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    from app.modules.guard.models import (
+        GuardRuleOverride, WorkspaceCustomRule,
+    )
+    from app.modules.guard.policy_engine import invalidate_policy_cache
+
+    rule_id = resolved["rule_id"]
+    kind = resolved["kind"]
+    target = bool(resolved["target_enabled"])
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+    now = datetime.now(timezone.utc)
+
+    if kind == "custom":
+        row = ctx.db.get(WorkspaceCustomRule, (ws_uuid, rule_id))
+        if row is None:
+            raise ValueError(f"custom rule {rule_id} disappeared between propose and execute")
+        row.enabled = target
+        row.updated_at = now
+    else:
+        # Pack rule → upsert override with disabled=(not target).
+        override = ctx.db.get(GuardRuleOverride, (ws_uuid, rule_id))
+        if override is None:
+            override = GuardRuleOverride(
+                workspace_id=ws_uuid,
+                rule_id=rule_id,
+                disabled=not target,
+                reason=resolved.get("reason"),
+                overridden_by=ctx.clerk_user_id or "lens.actor",
+                created_at=now,
+                updated_at=now,
+            )
+            ctx.db.add(override)
+        else:
+            override.disabled = not target
+            if resolved.get("reason"):
+                override.reason = resolved["reason"]
+            override.overridden_by = ctx.clerk_user_id or "lens.actor"
+            override.updated_at = now
+
+    ctx.db.commit()
+    invalidate_policy_cache(ctx.db, ws_uuid)
+
+    return {
+        "rule_id": rule_id,
+        "kind": kind,
+        "enabled": target,
+    }
+
+
+def _propose_enable(ctx, args):
+    return _propose_toggle(ctx, args, target_enabled=True)
+
+
+def _propose_disable(ctx, args):
+    return _propose_toggle(ctx, args, target_enabled=False)
+
+
+default_action_registry.register(ActionSpec(
+    name="enable_policy",
+    guard_permission="guard.policies.edit",
+    propose=_propose_enable,
+    execute=_execute_toggle,
+    description=(
+        "Enable a Guard policy rule by id. Two-step: returns a pending "
+        "action for the user to confirm; the confirm click flips the "
+        "enabled flag + invalidates the policy cache."
+    ),
+))
+
+default_action_registry.register(ActionSpec(
+    name="disable_policy",
+    guard_permission="guard.policies.edit",
+    propose=_propose_disable,
+    execute=_execute_toggle,
+    description=(
+        "Disable a Guard policy rule by id. Two-step: returns a pending "
+        "action for the user to confirm; the confirm click flips the enabled "
+        "flag + invalidates the policy cache. Disabling a pack rule requires "
+        "a reason (compliance exception surfaces in the audit trail)."
+    ),
+))

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -183,6 +183,80 @@ TOOLS: list[ToolDef] = [
         annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
         tags=_ACTOR_TAGS,
     ),
+    ToolDef(
+        name="enable_policy",
+        description=(
+            "Enable a Guard policy rule by rule_id. Two-step: returns a pending "
+            "action for the user to confirm; the confirm click flips the enabled "
+            "flag + invalidates the policy cache. Guard policy guard.policies.edit "
+            "still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "rule_id": {
+                    "type": "string",
+                    "description": "Policy rule id (e.g. 'r-sr117-01').",
+                },
+            },
+            "required": ["rule_id"],
+        },
+        impl=_actor_impl("enable_policy"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+    ToolDef(
+        name="disable_policy",
+        description=(
+            "Disable a Guard policy rule by rule_id. Two-step: returns a pending "
+            "action for the user to confirm; the confirm click flips the enabled "
+            "flag + invalidates the policy cache. Disabling a pack rule requires "
+            "a reason (surfaces as a compliance exception in the audit trail)."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "rule_id": {
+                    "type": "string",
+                    "description": "Policy rule id.",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Required when disabling a pack rule. Surfaced in the audit trail.",
+                },
+            },
+            "required": ["rule_id"],
+        },
+        impl=_actor_impl("disable_policy"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+    ToolDef(
+        name="deactivate_agent_identity",
+        description=(
+            "Deactivate an agent identity by id (security kill switch). Two-step: "
+            "returns a pending action for the user to confirm; the confirm click "
+            "sets lifecycle_state='deactivated' so the identity can no longer "
+            "authenticate. Guard policy platform.members.manage still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "agent_id": {
+                    "type": "string",
+                    "description": "Agent identity id (UUID).",
+                },
+                "reason": {
+                    "type": "string",
+                    "description": "Optional reason surfaced in the audit trail.",
+                },
+            },
+            "required": ["agent_id"],
+        },
+        impl=_actor_impl("deactivate_agent_identity"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
     # ── Chat-surface confirmation shortcut tools (#1465) ────────────────────
     # These let the LLM resolve natural-language "yes" / "no" replies against
     # a pending action without requiring a button click. Same server code as

--- a/apps/api/tests/glens/test_actor_deactivate_agent_identity.py
+++ b/apps/api/tests/glens/test_actor_deactivate_agent_identity.py
@@ -1,0 +1,109 @@
+"""#1304 — actor ActionSpec + ToolDef parity for deactivate_agent_identity.
+
+Propose-path only; live-DB confirm+dispatch is covered by the actor
+substrate integration suite.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+_AGENT = "agent-uuid-1"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _fake_agent(name="prod-cli", provider="anthropic", lifecycle_state="active"):
+    return SimpleNamespace(
+        id=_AGENT,
+        name=name,
+        provider=provider,
+        lifecycle_state=lifecycle_state,
+    )
+
+
+def _mock_db_returning(agent):
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = agent
+    return db
+
+
+def test_deactivate_actionspec_registered():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    assert spec is not None
+    assert spec.guard_permission == "platform.members.manage"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_deactivate_tooldef_registered():
+    tool = default_registry.get("deactivate_agent_identity")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_propose_rejects_empty_agent_id():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    out = spec.propose(_ctx(), {})
+    assert out.rejected
+    assert "agent_id required" in (out.reason or "")
+
+
+def test_propose_rejects_unknown_agent():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    db = _mock_db_returning(None)
+    out = spec.propose(_ctx(db=db), {"agent_id": _AGENT})
+    assert out.rejected
+    assert "No agent identity matches id" in (out.reason or "")
+
+
+def test_propose_rejects_already_deactivated():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    db = _mock_db_returning(_fake_agent(lifecycle_state="deactivated"))
+    out = spec.propose(_ctx(db=db), {"agent_id": _AGENT})
+    assert out.rejected
+    assert "already deactivated" in (out.reason or "")
+
+
+def test_propose_success_shape():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    db = _mock_db_returning(_fake_agent(name="prod-cli", provider="anthropic"))
+    out = spec.propose(_ctx(db=db), {"agent_id": _AGENT})
+    assert not out.rejected
+    assert "Deactivate agent identity 'prod-cli' (anthropic)" == out.summary
+    assert out.resolved_input == {
+        "agent_id": _AGENT,
+        "agent_name": "prod-cli",
+        "provider": "anthropic",
+        "reason": None,
+    }
+
+
+def test_propose_reason_surfaces_in_summary():
+    spec = default_action_registry.get("deactivate_agent_identity")
+    db = _mock_db_returning(_fake_agent())
+    out = spec.propose(_ctx(db=db), {"agent_id": _AGENT, "reason": "Credential leaked"})
+    assert not out.rejected
+    assert "— Credential leaked" in out.summary
+    assert out.resolved_input["reason"] == "Credential leaked"

--- a/apps/api/tests/glens/test_actor_toggle_policy.py
+++ b/apps/api/tests/glens/test_actor_toggle_policy.py
@@ -1,0 +1,144 @@
+"""#1303 — actor ActionSpec + ToolDef parity for enable_policy + disable_policy.
+
+Propose-path only; live-DB confirm+dispatch is covered by the actor
+substrate integration suite.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _fake_custom_rule(rule_id="r-1", enabled=True, description="Test rule"):
+    return SimpleNamespace(
+        rule_id=rule_id,
+        enabled=enabled,
+        body={"description": description, "action": "block"},
+    )
+
+
+def test_enable_policy_actionspec_registered():
+    spec = default_action_registry.get("enable_policy")
+    assert spec is not None
+    assert spec.guard_permission == "guard.policies.edit"
+
+
+def test_disable_policy_actionspec_registered():
+    spec = default_action_registry.get("disable_policy")
+    assert spec is not None
+    assert spec.guard_permission == "guard.policies.edit"
+
+
+def test_both_tooldefs_registered():
+    for name in ("enable_policy", "disable_policy"):
+        tool = default_registry.get(name)
+        assert tool is not None, f"missing ToolDef: {name}"
+        assert "lens" in tool.tags
+        assert "actor" in tool.tags
+
+
+def test_propose_rejects_empty_rule_id():
+    spec = default_action_registry.get("enable_policy")
+    out = spec.propose(_ctx(), {})
+    assert out.rejected
+    assert "rule_id required" in (out.reason or "")
+
+
+def test_propose_rejects_unknown_rule():
+    spec = default_action_registry.get("disable_policy")
+    ctx = _ctx()
+    ctx.db.get.return_value = None
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=None):
+        out = spec.propose(ctx, {"rule_id": "r-nope"})
+    assert out.rejected
+    assert "No policy matches rule_id" in (out.reason or "")
+
+
+def test_propose_rejects_no_op_enable():
+    """Enabling an already-enabled rule should fail — user should know."""
+    spec = default_action_registry.get("enable_policy")
+    ctx = _ctx()
+    fake = _fake_custom_rule(enabled=True)
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=("custom", fake)):
+        out = spec.propose(ctx, {"rule_id": "r-1"})
+    assert out.rejected
+    assert "already enabled" in (out.reason or "")
+
+
+def test_propose_rejects_no_op_disable():
+    spec = default_action_registry.get("disable_policy")
+    ctx = _ctx()
+    fake = _fake_custom_rule(enabled=False)
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=("custom", fake)):
+        out = spec.propose(ctx, {"rule_id": "r-1"})
+    assert out.rejected
+    assert "already disabled" in (out.reason or "")
+
+
+def test_propose_disable_pack_requires_reason():
+    """Disabling a pack rule requires a reason — compliance exception."""
+    spec = default_action_registry.get("disable_policy")
+    ctx = _ctx()
+    ctx.db.get.return_value = None  # no existing override → currently enabled
+    pack_row = ({"id": "r-1", "description": "SOC2 rule"}, SimpleNamespace(pack_slug="conduct-soc2"))
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=("pack", pack_row)):
+        out = spec.propose(ctx, {"rule_id": "r-1"})
+    assert out.rejected
+    assert "requires a reason" in (out.reason or "")
+
+
+def test_propose_disable_pack_with_reason_succeeds():
+    spec = default_action_registry.get("disable_policy")
+    ctx = _ctx()
+    ctx.db.get.return_value = None
+    pack_row = ({"id": "r-1", "description": "SOC2 rule"}, SimpleNamespace(pack_slug="conduct-soc2"))
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=("pack", pack_row)):
+        out = spec.propose(ctx, {"rule_id": "r-1", "reason": "Vendor exception"})
+    assert not out.rejected
+    assert "Disable policy 'SOC2 rule'" in out.summary
+    assert out.resolved_input == {
+        "rule_id": "r-1",
+        "kind": "pack",
+        "target_enabled": False,
+        "reason": "Vendor exception",
+    }
+
+
+def test_propose_enable_custom_success():
+    spec = default_action_registry.get("enable_policy")
+    ctx = _ctx()
+    fake = _fake_custom_rule(enabled=False, description="Custom rule")
+    with patch("app.modules.glens.actor.registrations.toggle_policy._resolve_policy",
+               return_value=("custom", fake)):
+        out = spec.propose(ctx, {"rule_id": "r-1"})
+    assert not out.rejected
+    assert "Enable policy 'Custom rule'" in out.summary
+    assert out.resolved_input["target_enabled"] is True
+    assert out.resolved_input["kind"] == "custom"

--- a/apps/api/tests/glens/test_actor_toggle_policy.py
+++ b/apps/api/tests/glens/test_actor_toggle_policy.py
@@ -142,3 +142,44 @@ def test_propose_enable_custom_success():
     assert "Enable policy 'Custom rule'" in out.summary
     assert out.resolved_input["target_enabled"] is True
     assert out.resolved_input["kind"] == "custom"
+
+
+def test_execute_pack_disable_delegates_to_upsert_override():
+    """Execute path for pack rules must call the shared _upsert_override helper
+    with the correct kwargs — the model has `overridden_at`, not
+    `created_at`/`updated_at`, so hand-rolling a constructor breaks."""
+    spec = default_action_registry.get("disable_policy")
+    ctx = _ctx()
+    with patch("app.modules.guard.routers.policies._upsert_override") as mock_upsert, \
+         patch("app.modules.guard.policy_engine.invalidate_policy_cache"):
+        out = spec.execute(ctx, {
+            "rule_id": "r-1",
+            "kind": "pack",
+            "target_enabled": False,
+            "reason": "Vendor exception",
+        })
+    assert mock_upsert.called
+    call_kwargs = mock_upsert.call_args.kwargs
+    assert call_kwargs["disabled"] is True
+    assert call_kwargs["reason"] == "Vendor exception"
+    assert call_kwargs["clear_exception"] is False
+    assert out == {"rule_id": "r-1", "kind": "pack", "enabled": False}
+
+
+def test_execute_pack_enable_clears_exception():
+    """Re-enabling a previously-disabled pack rule should clear the
+    exception metadata so an old reason doesn't linger on the row."""
+    spec = default_action_registry.get("enable_policy")
+    ctx = _ctx()
+    with patch("app.modules.guard.routers.policies._upsert_override") as mock_upsert, \
+         patch("app.modules.guard.policy_engine.invalidate_policy_cache"):
+        spec.execute(ctx, {
+            "rule_id": "r-1",
+            "kind": "pack",
+            "target_enabled": True,
+            "reason": None,
+        })
+    call_kwargs = mock_upsert.call_args.kwargs
+    assert call_kwargs["disabled"] is False
+    assert call_kwargs["clear_exception"] is True
+    assert call_kwargs["reason"] is None

--- a/apps/web/src/components/glens/SlashPicker.tsx
+++ b/apps/web/src/components/glens/SlashPicker.tsx
@@ -69,7 +69,18 @@ export const COMPLETERS: Record<string, CompleterFn> = {
       sublabel: a.provider ? `provider: ${a.provider}` : undefined,
     }))
   },
-  // Dormant until #1300 install_pack mutator lands.
+  // Wired for #1303 enable_policy / disable_policy — lists both custom and pack rules.
+  policies: async authFetch => {
+    const r = await authFetch(`${API}/guard/policies`)
+    if (!r.ok) throw new Error(`policies ${r.status}`)
+    const rows = (await r.json()) as Array<{ rule_id: string; description?: string | null; enabled: boolean; pack_id?: string | null }>
+    return rows.map(p => ({
+      value: p.rule_id,
+      label: p.description || p.rule_id,
+      sublabel: `${p.enabled ? "enabled" : "disabled"}${p.pack_id ? ` · pack: ${p.pack_id}` : ""}`,
+    }))
+  },
+  // Wired for #1300 install_pack mutator.
   marketplace_packs: async authFetch => {
     const r = await authFetch(`${API}/compliance/packs/available`)
     if (!r.ok) throw new Error(`packs ${r.status}`)
@@ -123,6 +134,29 @@ export const SLASH_TOOLS: SlashTool[] = [
     description: "Install a marketplace skill pack — requires confirmation.",
     args: [
       { name: "slug", required: true, placeholder: "pack slug (e.g. conduct-soc2)", completer: "marketplace_packs" },
+    ],
+  },
+  {
+    name: "enable_policy",
+    description: "Enable a Guard policy rule — requires confirmation.",
+    args: [
+      { name: "rule_id", required: true, placeholder: "policy rule id", completer: "policies" },
+    ],
+  },
+  {
+    name: "disable_policy",
+    description: "Disable a Guard policy rule — requires confirmation.",
+    args: [
+      { name: "rule_id", required: true, placeholder: "policy rule id", completer: "policies" },
+      { name: "reason", required: false, placeholder: "required for pack rules — surfaces in audit" },
+    ],
+  },
+  {
+    name: "deactivate_agent_identity",
+    description: "Deactivate an agent identity (security kill switch) — requires confirmation.",
+    args: [
+      { name: "agent_id", required: true, placeholder: "agent UUID", completer: "agents" },
+      { name: "reason", required: false, placeholder: "optional reason for audit" },
     ],
   },
 ]

--- a/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
+++ b/apps/web/src/components/glens/__tests__/SlashPicker.test.tsx
@@ -46,6 +46,12 @@ const authFetchMock = (path: string) => {
       { slug: "sr-11-7", name: "SR 11-7", description: "Federal model risk" },
     ])))
   }
+  if (path.includes("/guard/policies")) {
+    return Promise.resolve(new Response(JSON.stringify([
+      { rule_id: "r-1", description: "Block PII", enabled: true, pack_id: null },
+      { rule_id: "r-2", description: "SOC2 exception", enabled: false, pack_id: "conduct-soc2" },
+    ])))
+  }
   return Promise.resolve(new Response("null", { status: 404 }))
 }
 const authFetchRef = { authFetch: authFetchMock, workspaceId: "ws-1" }
@@ -72,6 +78,23 @@ describe("filterTools", () => {
     const names = SLASH_TOOLS.map(t => t.name)
     expect(names).toContain("update_budget")
     expect(names).toContain("install_pack")
+  })
+
+  it("includes enable_policy, disable_policy, deactivate_agent_identity", () => {
+    const names = SLASH_TOOLS.map(t => t.name)
+    expect(names).toContain("enable_policy")
+    expect(names).toContain("disable_policy")
+    expect(names).toContain("deactivate_agent_identity")
+  })
+
+  it("enable_policy.rule_id uses the policies completer", () => {
+    const tool = SLASH_TOOLS.find(t => t.name === "enable_policy")!
+    expect(tool.args.find(a => a.name === "rule_id")!.completer).toBe("policies")
+  })
+
+  it("deactivate_agent_identity.agent_id uses the agents completer", () => {
+    const tool = SLASH_TOOLS.find(t => t.name === "deactivate_agent_identity")!
+    expect(tool.args.find(a => a.name === "agent_id")!.completer).toBe("agents")
   })
 
   it("update_budget.budget_id uses the budgets completer", () => {
@@ -234,6 +257,14 @@ describe("Dormant completers (PR 3)", () => {
     const opts = await COMPLETERS.marketplace_packs(authFetchMock, "ws-1")
     expect(opts).toEqual([
       { value: "sr-11-7", label: "SR 11-7", sublabel: "Federal model risk" },
+    ])
+  })
+
+  it("policies: rule_id as value, description as label, enabled/pack in sublabel", async () => {
+    const opts = await COMPLETERS.policies(authFetchMock, "ws-1")
+    expect(opts).toEqual([
+      { value: "r-1", label: "Block PII", sublabel: "enabled" },
+      { value: "r-2", label: "SOC2 exception", sublabel: "disabled · pack: conduct-soc2" },
     ])
   })
 })


### PR DESCRIPTION
Three new #1282 mutators shipping the same shape as #1298/#1300/#1302. All wire into the slash-picker via existing/new completers.

- enable_policy / disable_policy (#1303) — handles custom rules and pack rules; disabling a pack requires a reason
- deactivate_agent_identity (#1304) — sets lifecycle_state=deactivated; existing tokens fail on next auth
- New policies completer backed by GET /guard/policies
- agents completer (already dormant) lights up for deactivate

invite_member (#1301) deferred — followup issue #1639 (needs Clerk integration design).

Tests:
- BE: 26 new (10 toggle_policy + 7 deactivate + rest updated) — 65/65 across full actor suite
- FE: 26/26 picker tests pass; TSC clean; gitleaks clean

Test plan (post-merge on preview):
- /enable_policy → policies dropdown → pick disabled rule → confirm → rule enabled + policy cache invalidated
- /disable_policy → pack rule → error until reason provided → with reason → confirm → override row created with reason in audit
- /deactivate_agent_identity → agents dropdown → pick active agent → confirm → lifecycle_state flips, existing tokens 401 on next call