### PR TITLE
feat(guard): Rule Schema v1 + Cedar bidirectional interchange story

### DIFF
--- a/apps/web/src/app/(app)/packs/[slug]/page.tsx
+++ b/apps/web/src/app/(app)/packs/[slug]/page.tsx
@@ -232,7 +232,7 @@ export default function PackDetailPage() {
             <button
               onClick={toggleCedar}
               disabled={cedarLoading}
-              title="Render this pack as Cedar text syntax"
+              title="Render + copy this pack as Cedar text — the AWS Verified Permissions language. Bidirectional interchange, no lock-in."
               style={{
                 padding: "10px 14px",
                 borderRadius: 8,
@@ -245,7 +245,7 @@ export default function PackDetailPage() {
                 cursor: cedarLoading ? "wait" : "pointer",
               }}
             >
-              {cedarLoading ? "Loading…" : cedarText !== null ? "Hide Cedar" : "View as Cedar"}
+              {cedarLoading ? "Loading…" : cedarText !== null ? "Hide Cedar" : "Export Cedar"}
             </button>
             <button
               onClick={togglePack}
@@ -278,12 +278,21 @@ export default function PackDetailPage() {
               </div>
               <div style={{ display: "flex", gap: 8 }}>
                 {cedarText && (
-                  <button
-                    onClick={copyCedar}
-                    style={{ padding: "4px 10px", borderRadius: 6, border: "1px solid var(--border)", background: "transparent", color: "var(--text-2)", fontSize: 11, cursor: "pointer" }}
-                  >
-                    {cedarCopied ? "✓ Copied" : "Copy"}
-                  </button>
+                  <>
+                    <button
+                      onClick={copyCedar}
+                      style={{ padding: "4px 10px", borderRadius: 6, border: "1px solid var(--border)", background: "transparent", color: "var(--text-2)", fontSize: 11, cursor: "pointer" }}
+                    >
+                      {cedarCopied ? "✓ Copied" : "Copy"}
+                    </button>
+                    <a
+                      href={`data:text/plain;charset=utf-8,${encodeURIComponent(cedarText)}`}
+                      download={`${slug}.cedar`}
+                      style={{ padding: "4px 10px", borderRadius: 6, border: "1px solid var(--border)", background: "transparent", color: "var(--text-2)", fontSize: 11, textDecoration: "none" }}
+                    >
+                      ⤓ Download .cedar
+                    </a>
+                  </>
                 )}
                 <button
                   onClick={toggleCedar}

--- a/apps/web/src/app/(app)/packs/page.tsx
+++ b/apps/web/src/app/(app)/packs/page.tsx
@@ -739,6 +739,7 @@ function RegistryContent({ getToken }: { getToken: (() => Promise<string | null>
         {marketTab === "compliance" && (
           <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
             <CedarImportBanner getToken={getToken} />
+            <CedarExportBanner />
             {packCatalog.map(pack => {
               const installed = installedPacks.has(pack.id)
               const busy = packInstalling === pack.id
@@ -760,6 +761,7 @@ function RegistryContent({ getToken }: { getToken: (() => Promise<string | null>
                     </div>
                     <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
                       {installed && <span className="sbadge ok">✓ Installed</span>}
+                      <CedarPackDownload slug={pack.id} getToken={getToken} />
                       {installed ? (
                         <>
                           <button onClick={() => installPack(pack.id)} disabled={!!packInstalling} className="btn btn-primary btn-sm" style={{ opacity: packInstalling && !busy ? 0.5 : 1 }}>
@@ -1679,5 +1681,73 @@ function CedarImportBanner({ getToken }: { getToken: (() => Promise<string | nul
         </button>
       </div>
     </div>
+  )
+}
+
+/**
+ * Mirror of CedarImportBanner — announces the reverse direction so buyers
+ * see the bidirectional interchange story on the same page. No lock-in.
+ */
+function CedarExportBanner() {
+  return (
+    <div className="card" style={{ padding: 16, display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12 }}>
+      <div>
+        <div style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>Take your policies back out</div>
+        <div style={{ fontSize: 12, color: "var(--text-2)", marginTop: 2 }}>
+          Every installed pack renders to Cedar — the AWS Verified Permissions
+          language. Click <strong>⤓ Cedar</strong> on any pack to download.
+          Bidirectional interchange by design.
+        </div>
+      </div>
+      <a href="/docs/schema" className="btn btn-ghost btn-sm">Schema docs →</a>
+    </div>
+  )
+}
+
+/**
+ * Per-tile Cedar download — fetches the rendered Cedar for one pack, saves
+ * as `{slug}.cedar`. No navigation; one-click from the list.
+ */
+function CedarPackDownload({ slug, getToken }: { slug: string; getToken: (() => Promise<string | null>) | null }) {
+  const { activeWorkspace } = useWorkspace()
+  const [busy, setBusy] = useState(false)
+
+  async function download() {
+    if (!activeWorkspace?.id) return
+    setBusy(true)
+    try {
+      const headers: Record<string, string> = {}
+      if (getToken) {
+        const token = await getToken()
+        if (token) headers["Authorization"] = `Bearer ${token}`
+      }
+      const res = await fetch(
+        `${API}/guard/registry/packs/${slug}/cedar?workspace_id=${activeWorkspace.id}`,
+        { headers },
+      )
+      if (!res.ok) return
+      const text = await res.text()
+      const blob = new Blob([text], { type: "text/plain;charset=utf-8" })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      a.download = `${slug}.cedar`
+      a.click()
+      URL.revokeObjectURL(url)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  return (
+    <button
+      onClick={download}
+      disabled={busy}
+      title="Download this pack as Cedar (AWS Verified Permissions language)"
+      className="btn btn-ghost btn-sm"
+      style={{ fontSize: 11.5 }}
+    >
+      {busy ? "…" : "⤓ Cedar"}
+    </button>
   )
 }

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -1902,6 +1902,24 @@ New tool calls are paused until the limit is raised. Contact your security team.
           and how policy changes propagate to every developer in real time.
         </p>
 
+        <div className="rounded-xl border border-indigo-200 bg-indigo-50/60 px-5 py-4 my-6">
+          <p className="text-xs font-bold uppercase tracking-widest text-indigo-700 mb-2">Guard Rule Schema v1 — bidirectional interchange</p>
+          <p className="text-sm text-stone-700 mb-3 leading-relaxed">
+            Guard rules speak two dialects: JSON (runtime) and Cedar (portability). Import from AWS Verified Permissions or any Cedar-native IAM stack; export any pack back to Cedar. No lock-in.
+          </p>
+          <div className="flex flex-wrap gap-2">
+            <a href="/docs/schema" className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-stone-200 text-xs text-stone-700 hover:border-indigo-400 hover:text-indigo-700 transition-colors">
+              Schema overview →
+            </a>
+            <a href="https://github.com/sseshachala/conductai/blob/main/docs/guard/schema.md" className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-stone-200 text-xs text-stone-700 hover:border-indigo-400 hover:text-indigo-700 transition-colors">
+              Full markdown reference →
+            </a>
+            <a href="https://github.com/sseshachala/conductai/blob/main/schemas/conduct-guard-rule.v1.json" className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-stone-200 text-xs text-stone-700 hover:border-indigo-400 hover:text-indigo-700 transition-colors font-mono">
+              conduct-guard-rule.v1.json →
+            </a>
+          </div>
+        </div>
+
         <SubHeading>Rule schema</SubHeading>
         <p className="text-stone-500 text-sm mb-3">Each rule in your policy JSON follows this shape:</p>
         <Pre>{`{

--- a/apps/web/src/app/(marketing)/docs/schema/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/schema/page.tsx
@@ -1,0 +1,166 @@
+export const metadata = {
+  title: "Guard Rule Schema — Docs | Conduct",
+  description:
+    "Conduct Guard rules speak two dialects: JSON at runtime, Cedar for portability. Bidirectional interchange, no lock-in.",
+}
+
+export default function GuardSchemaDocsPage() {
+  return (
+    <div className="max-w-3xl mx-auto px-6 py-16 w-full">
+      <div className="mb-2">
+        <a href="/docs" className="text-sm text-stone-400 hover:text-stone-600 transition-colors">
+          Docs
+        </a>
+        <span className="text-sm text-stone-300 mx-2">/</span>
+        <span className="text-sm text-stone-600">Guard Rule Schema</span>
+      </div>
+
+      <h1 className="text-3xl font-bold text-stone-900 mt-6 mb-2">Guard Rule Schema v1</h1>
+      <p className="text-stone-500 mb-4 leading-relaxed">
+        Guard rules speak two dialects: <strong>JSON</strong> for runtime evaluation, <strong>Cedar</strong> for portability. Both are semantically equivalent. Import your existing Cedar policies from AWS Verified Permissions or any Cedar-consuming IAM stack. Export any Conduct pack back to Cedar. No proprietary lock-in.
+      </p>
+
+      <div className="flex gap-3 mb-10 flex-wrap">
+        <a
+          href="https://github.com/sseshachala/conductai/blob/main/schemas/conduct-guard-rule.v1.json"
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-stone-300 text-sm text-stone-700 hover:bg-stone-50"
+        >
+          JSON Schema →
+        </a>
+        <a
+          href="https://github.com/sseshachala/conductai/blob/main/docs/guard/schema.md"
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md border border-stone-300 text-sm text-stone-700 hover:bg-stone-50"
+        >
+          Full reference →
+        </a>
+        <a
+          href="/packs"
+          className="inline-flex items-center gap-2 px-3 py-1.5 rounded-md bg-stone-900 text-white text-sm hover:bg-stone-700"
+        >
+          Try the packs →
+        </a>
+      </div>
+
+      <nav className="mb-10 border border-stone-200 rounded-xl px-5 py-4">
+        <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-3">On this page</p>
+        <ol className="flex flex-col gap-1.5 text-sm text-stone-600">
+          <li><a href="#why-two" className="hover:text-indigo-600 transition-colors">Why two dialects</a></li>
+          <li><a href="#example" className="hover:text-indigo-600 transition-colors">Same rule, two forms</a></li>
+          <li><a href="#interchange" className="hover:text-indigo-600 transition-colors">Bidirectional interchange</a></li>
+          <li><a href="#frameworks" className="hover:text-indigo-600 transition-colors">Framework tags</a></li>
+        </ol>
+      </nav>
+
+      <section id="why-two" className="mb-12">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Why two dialects</h2>
+        <p className="text-stone-600 leading-relaxed mb-3">
+          Different audiences read policies differently. Engineers want grep-friendly JSON that embeds cleanly in pack files. Auditors want human-readable Cedar with recognizable annotations. You want a promise: nothing here is stuck in a proprietary language.
+        </p>
+        <ul className="list-disc pl-6 text-stone-600 leading-relaxed space-y-1">
+          <li><strong>Runtime evaluates JSON</strong> — every pack file under <code className="text-xs bg-stone-100 px-1.5 py-0.5 rounded">apps/api/app/modules/guard/skill_packs/*.json</code> ships as JSON.</li>
+          <li><strong>Cedar is a view</strong> — rendered on demand from the same source. Auditors read it, security teams import policies from Cedar-native tools using it.</li>
+          <li><strong>Bidirectional and lossless</strong> — round-trip a rule through Cedar and back with no information loss on schema v1.</li>
+        </ul>
+      </section>
+
+      <section id="example" className="mb-12">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Same rule, two forms</h2>
+        <p className="text-stone-600 leading-relaxed mb-4">One PCI-DSS rule from the <code className="text-xs bg-stone-100 px-1.5 py-0.5 rounded">conduct-pci-dss</code> pack.</p>
+
+        <h3 className="text-sm font-semibold text-stone-700 mb-2">JSON (runtime)</h3>
+        <pre className="text-xs bg-stone-950 text-stone-100 rounded-lg p-4 overflow-x-auto mb-6">
+{`{
+  "id": "pci_pan_guard",
+  "description": "Block card number patterns (PCI DSS Req 3)",
+  "match_tool": "edit,write,bash",
+  "match_pattern": "\\\\b4[0-9]{12}(?:[0-9]{3})?\\\\b|\\\\b5[1-5][0-9]{14}\\\\b",
+  "action": "block",
+  "message": "Card number detected — never log or store PANs in plaintext.",
+  "severity": "critical",
+  "frameworks": ["PCI_DSS:3.4", "SOC2:CC6.1", "GDPR:Art32"],
+  "iso_control": "A.8.11"
+}`}
+        </pre>
+
+        <h3 className="text-sm font-semibold text-stone-700 mb-2">Cedar (portable)</h3>
+        <pre className="text-xs bg-stone-950 text-stone-100 rounded-lg p-4 overflow-x-auto mb-2">
+{`@id("pci_pan_guard")
+@description("Block card number patterns (PCI DSS Req 3)")
+@message("Card number detected — never log or store PANs in plaintext.")
+@severity("critical")
+@iso_control("A.8.11")
+@compliance("PCI_DSS:3.4", "SOC2:CC6.1", "GDPR:Art32")
+forbid (
+    principal is Agent,
+    action in [Action::"edit", Action::"write", Action::"bash"],
+    resource
+)
+when {
+    context.prompt matches "\\\\b4[0-9]{12}(?:[0-9]{3})?\\\\b|\\\\b5[1-5][0-9]{14}\\\\b"
+};`}
+        </pre>
+        <p className="text-xs text-stone-400 mb-2">
+          Get the live Cedar rendering with <code className="text-xs bg-stone-100 px-1.5 py-0.5 rounded">GET /guard/registry/packs/&#123;slug&#125;/cedar</code> or click <strong>⤓ Cedar</strong> on any pack tile at <a className="text-indigo-600 hover:underline" href="/packs">/packs</a>.
+        </p>
+      </section>
+
+      <section id="interchange" className="mb-12">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Bidirectional interchange</h2>
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+          <div className="border border-stone-200 rounded-xl p-5">
+            <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-2">Cedar → Guard</p>
+            <p className="text-sm text-stone-600 leading-relaxed mb-3">
+              Import Cedar JSON policies from AWS Verified Permissions, Dogwood, or any Cedar-native IAM stack.
+            </p>
+            <code className="block text-xs bg-stone-100 rounded p-2 text-stone-700">POST /guard/registry/import-cedar</code>
+          </div>
+          <div className="border border-stone-200 rounded-xl p-5">
+            <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-2">Guard → Cedar</p>
+            <p className="text-sm text-stone-600 leading-relaxed mb-3">
+              Render any installed pack as Cedar text — annotated with severity, ISO control, and compliance framework tags.
+            </p>
+            <code className="block text-xs bg-stone-100 rounded p-2 text-stone-700">GET /guard/registry/packs/&#123;slug&#125;/cedar</code>
+          </div>
+        </div>
+      </section>
+
+      <section id="frameworks" className="mb-16">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Framework tags</h2>
+        <p className="text-stone-600 leading-relaxed mb-4">
+          The <code className="text-xs bg-stone-100 px-1.5 py-0.5 rounded">frameworks</code> array is free-form but conventionally uses these prefixes for compliance-surface parity.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-stone-200 text-left text-xs uppercase tracking-widest text-stone-500">
+                <th className="py-2 pr-4">Prefix</th>
+                <th className="py-2 pr-4">Example</th>
+                <th className="py-2">Standard</th>
+              </tr>
+            </thead>
+            <tbody className="text-stone-700">
+              {[
+                ["PCI_DSS:",         "PCI_DSS:3.4",           "PCI Data Security Standard"],
+                ["SOC2:",            "SOC2:CC6.1",            "SOC 2 Trust Services Criteria"],
+                ["ISO_27001:",       "ISO_27001:A.8.24",      "ISO 27001 Annex A"],
+                ["ISO_42001:",       "ISO_42001:8.24",        "ISO 42001 (AI management)"],
+                ["GDPR:",            "GDPR:Art32",            "GDPR article"],
+                ["HIPAA:",           "HIPAA:164.308",         "HIPAA Security Rule"],
+                ["NIST_AI_RMF:",     "NIST_AI_RMF:MG-2.6",    "NIST AI Risk Management Framework"],
+                ["MITRE_ATLAS:",     "MITRE_ATLAS:AML.T0051", "MITRE ATLAS (adversarial ML)"],
+                ["OWASP_AGENTIC:",   "OWASP_AGENTIC:A01",     "OWASP Agentic Top 10"],
+                ["SR_11_7:",         "SR_11_7:V.A.1",         "Fed Reserve model risk"],
+              ].map(([prefix, ex, std]) => (
+                <tr key={prefix} className="border-b border-stone-100">
+                  <td className="py-2 pr-4 font-mono text-xs">{prefix}</td>
+                  <td className="py-2 pr-4 font-mono text-xs">{ex}</td>
+                  <td className="py-2">{std}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/docs/guard/schema.md
+++ b/docs/guard/schema.md
@@ -1,0 +1,155 @@
+# Conduct Guard Rule Schema v1
+
+Guard rules speak **two dialects**: JSON (runtime evaluation) and Cedar (portability / interchange). Both are semantically equivalent — you can round-trip your policies in either direction with zero information loss.
+
+- **Machine-readable JSON Schema:** [`schemas/conduct-guard-rule.v1.json`](../../schemas/conduct-guard-rule.v1.json)
+- **Import Cedar:** `POST /guard/registry/import-cedar` (Cedar JSON → Guard pack)
+- **Export Cedar:** `GET /guard/registry/packs/{slug}/cedar` (Guard pack → Cedar text) — or click **⤓ Cedar** on any pack tile at [/packs](/packs)
+
+## Why two dialects
+
+Different audiences read policies differently:
+
+- **Engineers + runtime** want JSON — grep-friendly, machine-generatable, embeds cleanly in pack files
+- **Auditors + security teams** want Cedar — human-readable, standard syntax, portable to AWS Verified Permissions and any Cedar-consuming ecosystem
+- **You** want no lock-in — bring your existing Cedar policies in; take your Guard packs out whenever you leave
+
+## Anatomy of a rule
+
+Every Guard rule matches on **what** (tool, path, prompt pattern) and decides **how** (block / warn / allow / audit / inject / approval). Metadata (severity, frameworks, iso_control) rides along for audit surfaces.
+
+```json
+{
+  "id": "pci_pan_guard",
+  "description": "Block card number patterns (PCI DSS Req 3)",
+  "match_tool": "edit,write,bash",
+  "match_pattern": "\\b4[0-9]{12}(?:[0-9]{3})?\\b|\\b5[1-5][0-9]{14}\\b",
+  "action": "block",
+  "message": "Card number detected — never log or store PANs in plaintext.",
+  "recommendation": "Tokenise PAN before storage. Use a PCI-compliant tokenisation service.",
+  "severity": "critical",
+  "persona_affinity": ["agent"],
+  "frameworks": ["PCI_DSS:3.4", "SOC2:CC6.1", "GDPR:Art32"],
+  "iso_control": "A.8.11",
+  "enforcement": {
+    "version": 1,
+    "proxy": "not_supported",
+    "hook": "conditional",
+    "mcp": "conditional",
+    "runtime": "not_supported",
+    "guarantee": "Blocks matching actions on supported surfaces.",
+    "requires": [
+      "A supported pre-tool hook is installed and invoked before the action",
+      "The agent calls MCP guard_check before acting"
+    ],
+    "known_limitations": [
+      "MCP cannot enforce actions the agent doesn't submit to guard_check"
+    ]
+  }
+}
+```
+
+The **same rule** rendered as Cedar:
+
+```cedar
+@id("pci_pan_guard")
+@description("Block card number patterns (PCI DSS Req 3)")
+@message("Card number detected — never log or store PANs in plaintext.")
+@recommendation("Tokenise PAN before storage. Use a PCI-compliant tokenisation service.")
+@severity("critical")
+@iso_control("A.8.11")
+@compliance("PCI_DSS:3.4", "SOC2:CC6.1", "GDPR:Art32")
+forbid (
+    principal is Agent,
+    action in [Action::"edit", Action::"write", Action::"bash"],
+    resource
+)
+when {
+    context.prompt matches "\\b4[0-9]{12}(?:[0-9]{3})?\\b|\\b5[1-5][0-9]{14}\\b"
+};
+```
+
+## Fields
+
+### Rule (required)
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | string | Stable identifier. Unique within pack. Referenced by overrides. |
+| `action` | enum | `block` \| `warn` \| `allow` \| `audit` \| `inject` \| `approval` |
+
+### Rule (optional)
+
+| Field | Type | Notes |
+|---|---|---|
+| `description` | string | Human summary — Cedar `@description`. |
+| `match_tool` | string | Comma-separated tool names (`edit,write,bash`). Empty or `*` = all. |
+| `match_pattern` | regex string | Matched against tool_input.prompt / body. |
+| `match_path_pattern` | regex string | Matched against tool_input.path (file ops). |
+| `message` | string | Shown to user on match. Cedar `@message`. |
+| `recommendation` | string | Remediation guidance. Cedar `@recommendation`. |
+| `severity` | enum | `low` \| `medium` \| `high` \| `critical`. Cedar `@severity`. |
+| `persona_affinity` | string[] | `agent` and/or `proxy`. Defaults to both if omitted. |
+| `frameworks` | string[] | Compliance tags (`PCI_DSS:3.4`, `SOC2:CC6.1`, `ISO_42001:8.24`, `MITRE_ATLAS:AML.T0051`, `OWASP_AGENTIC:A01`). Cedar `@compliance`. |
+| `iso_control` | string | ISO 27001/42001 control ID. Cedar `@iso_control`. |
+| `enforcement` | object | Surface-by-surface enforcement capability (see below). |
+
+### Enforcement metadata
+
+Per surface, the rule declares whether it can enforce (`hard`), advise (`conditional`), or is inapplicable (`not_supported`).
+
+| Surface | What it means |
+|---|---|
+| `proxy` | Guard LLM proxy — enforced on egress before hitting Anthropic/OpenAI/etc. |
+| `hook` | Pre-tool hooks in Claude Code / Cursor / Codex — enforced before local tool call fires. |
+| `mcp` | MCP `guard_check` — enforced when agent voluntarily calls it. |
+| `runtime` | Conduct workflow runtime — enforced during YAML playbook execution. |
+
+### Pack (bundles rules)
+
+| Field | Type | Notes |
+|---|---|---|
+| `slug` | string | URL-safe identifier (lowercase, hyphens). Required. |
+| `name` | string | Display name. Required. |
+| `version` | semver | `1.1.0` etc. Required. |
+| `tier` | enum | `free` \| `paid` \| `enterprise`. |
+| `description` | string | Pack summary. |
+| `ui` | object | Optional `{icon, subtitle, tags}` for the /packs tile. |
+| `rules` | rule[] | At least one. Required. |
+
+## Framework tag conventions
+
+The `frameworks` array is free-form but **strongly encouraged** to follow these prefixes for compliance surface parity:
+
+| Prefix | Example | Standard |
+|---|---|---|
+| `PCI_DSS:` | `PCI_DSS:3.4` | PCI Data Security Standard requirement |
+| `SOC2:` | `SOC2:CC6.1` | SOC 2 Trust Services Criteria |
+| `ISO_27001:` | `ISO_27001:A.8.24` | ISO 27001 Annex A control |
+| `ISO_42001:` | `ISO_42001:8.24` | ISO 42001 (AI management) control |
+| `GDPR:` | `GDPR:Art32` | GDPR article |
+| `HIPAA:` | `HIPAA:164.308` | HIPAA Security Rule section |
+| `NIST_AI_RMF:` | `NIST_AI_RMF:MG-2.6` | NIST AI Risk Management Framework |
+| `MITRE_ATLAS:` | `MITRE_ATLAS:AML.T0051` | MITRE ATLAS adversarial ML technique |
+| `OWASP_AGENTIC:` | `OWASP_AGENTIC:A01` | OWASP Agentic Top 10 |
+| `SR_11_7:` | `SR_11_7:V.A.1` | Federal Reserve model risk |
+
+## Cedar interchange
+
+The Cedar rendering preserves every rule field via annotations (`@id`, `@description`, `@message`, `@severity`, `@iso_control`, `@compliance`, `@recommendation`). Reverse import (`POST /guard/registry/import-cedar`) parses `forbid`/`permit` blocks + annotations back into Guard rule JSON.
+
+Round-trip is lossless for schema v1. Bring your existing Cedar policies from AWS Verified Permissions, Dogwood, or any IAM stack that speaks Cedar JSON.
+
+## Versioning
+
+Schema version = `v1`. Backward-incompatible changes will publish `v2` at a new `$id` and both stay available. Rule packs may declare a `$schema` reference to the specific version they target; runtime defaults to latest.
+
+## Extending
+
+Adding a new field to v1:
+1. Add to `schemas/conduct-guard-rule.v1.json` (mark it optional so old rules validate)
+2. Update the JSON→Cedar exporter to emit a matching `@` annotation
+3. Update the Cedar→JSON importer to parse the annotation back
+4. Update this doc's field table
+
+Removing or renaming = v2. Don't break v1 users.

--- a/schemas/conduct-guard-rule.v1.json
+++ b/schemas/conduct-guard-rule.v1.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://schemas.conductai.ai/conduct-guard-rule.v1.json",
+  "title": "Conduct Guard Rule Schema v1",
+  "description": "Machine-readable schema for a single Guard rule and a Guard pack (a bundle of rules). Guard rules are enforced across four surfaces: Guard proxy (LLM egress), pre-tool hooks (Claude Code / Cursor / Codex), MCP guard_check, and the workflow runtime. Rules are portable — the same rule renders to Cedar for AWS Verified Permissions ecosystems.",
+  "$defs": {
+    "action": {
+      "type": "string",
+      "enum": ["block", "warn", "allow", "audit", "inject", "approval"],
+      "description": "What Guard does when the rule matches. `block` refuses the tool call; `warn` surfaces a warning but proceeds; `allow` is an explicit permit; `audit` records without decision; `inject` prepends context to the prompt; `approval` pauses the run until a human approves."
+    },
+    "severity": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "critical"],
+      "description": "Severity tag used by dashboards + audit filters. No enforcement effect."
+    },
+    "persona": {
+      "type": "string",
+      "enum": ["agent", "proxy"],
+      "description": "Which persona the rule applies to. `agent` = local coding agent (Claude Code, Cursor). `proxy` = server-side LLM egress via Guard proxy."
+    },
+    "tier": {
+      "type": "string",
+      "enum": ["free", "paid", "enterprise"],
+      "description": "Pack distribution tier."
+    },
+    "enforcement": {
+      "type": "object",
+      "description": "Surface-by-surface enforcement capability for this rule. Runtime uses this to decide which surfaces can actually block vs advise.",
+      "properties": {
+        "version": { "type": "integer", "const": 1 },
+        "proxy":   { "type": "string", "enum": ["hard", "conditional", "not_supported"] },
+        "hook":    { "type": "string", "enum": ["hard", "conditional", "not_supported"] },
+        "mcp":     { "type": "string", "enum": ["hard", "conditional", "not_supported"] },
+        "runtime": { "type": "string", "enum": ["hard", "conditional", "not_supported"] },
+        "guarantee":         { "type": "string" },
+        "requires":          { "type": "array", "items": { "type": "string" } },
+        "known_limitations": { "type": "array", "items": { "type": "string" } }
+      },
+      "required": ["version"]
+    },
+    "rule": {
+      "type": "object",
+      "description": "One Guard rule. Evaluated at every tool call the rule's match_tool covers.",
+      "properties": {
+        "id":                 { "type": "string", "minLength": 1, "description": "Stable identifier. Unique within the pack. Referenced by GuardRuleOverride to disable or amend." },
+        "description":        { "type": "string", "description": "Human-readable summary — shown in dashboards + Cedar `@description` annotation." },
+        "match_tool":         { "type": "string", "description": "Comma-separated tool names the rule applies to (e.g. `edit,write,bash`). Empty or `*` means all tools." },
+        "match_pattern":      { "type": "string", "description": "Regex matched against the tool_input.prompt / body. Case-sensitive; anchors optional." },
+        "match_path_pattern": { "type": "string", "description": "Regex matched against the tool_input.path (file operations). Independent from `match_pattern`." },
+        "action":             { "$ref": "#/$defs/action" },
+        "message":            { "type": "string", "description": "Shown to the user when the rule fires. Appears in Cedar `@message` annotation." },
+        "recommendation":     { "type": "string", "description": "Remediation guidance. Appears in Cedar `@recommendation` annotation." },
+        "severity":           { "$ref": "#/$defs/severity" },
+        "persona_affinity":   { "type": "array", "items": { "$ref": "#/$defs/persona" }, "description": "Personas this rule applies to. Defaults to all if omitted." },
+        "frameworks":         { "type": "array", "items": { "type": "string" }, "description": "Compliance tags (e.g. `PCI_DSS:3.4`, `SOC2:CC6.1`, `ISO_42001:8.24`, `MITRE_ATLAS:AML.T0051`, `OWASP_AGENTIC:A01`). Appears in Cedar `@compliance` annotation." },
+        "iso_control":        { "type": "string", "description": "ISO 27001 / ISO 42001 control ID (e.g. `A.8.11`). Appears in Cedar `@iso_control` annotation." },
+        "enforcement":        { "$ref": "#/$defs/enforcement" }
+      },
+      "required": ["id", "action"]
+    },
+    "ui": {
+      "type": "object",
+      "description": "Optional presentation hints for the pack tile on /packs.",
+      "properties": {
+        "icon":     { "type": "string", "description": "Emoji or short glyph." },
+        "subtitle": { "type": "string" },
+        "tags":     { "type": "array", "items": { "type": "string" } }
+      }
+    },
+    "pack": {
+      "type": "object",
+      "description": "A Guard pack — a bundle of rules. Distributed as a JSON file under `apps/api/app/modules/guard/skill_packs/{slug}.json` or imported via the Cedar interchange endpoint.",
+      "properties": {
+        "slug":        { "type": "string", "pattern": "^[a-z0-9][a-z0-9-]*$", "description": "URL-safe pack identifier." },
+        "name":        { "type": "string" },
+        "version":     { "type": "string", "description": "Semver (e.g. `1.1.0`)." },
+        "tier":        { "$ref": "#/$defs/tier" },
+        "description": { "type": "string" },
+        "ui":          { "$ref": "#/$defs/ui" },
+        "rules":       { "type": "array", "items": { "$ref": "#/$defs/rule" }, "minItems": 1 }
+      },
+      "required": ["slug", "name", "version", "rules"]
+    }
+  },
+  "oneOf": [
+    { "$ref": "#/$defs/pack" },
+    { "$ref": "#/$defs/rule" }
+  ]
+}


### PR DESCRIPTION
Makes two facts visible and quotable: Guard rules speak two dialects (JSON at runtime, Cedar for portability), and Cedar interchange is bidirectional.

Deliverables:
- schemas/conduct-guard-rule.v1.json — machine-readable JSON Schema (draft 2020-12)
- docs/guard/schema.md — plain-language reference with framework tag conventions
- /docs/schema marketing page — same-rule side-by-side JSON and Cedar

Discoverability fixes on /packs:
- Detail page: rename View as Cedar to Export Cedar; add Download .cedar button
- List page: per-tile Cedar download button (one click, skips detail page)
- Mirror export banner next to import banner (bidirectional story on same scroll)

No backend changes. Pure surfacing + documentation.

Test plan:
- TSC clean
- JSON schema parses
- Marketing page at /docs/schema renders
- /packs tab=compliance shows ⤓ Cedar per tile
- /packs/{slug} shows Export Cedar and Download .cedar