### PR TITLE
feat(guard): Agentic Tool-Call Policy Schema v1.1 + engine mapping table (closes #1647)

### DIFF
--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -1903,9 +1903,9 @@ New tool calls are paused until the limit is raised. Contact your security team.
         </p>
 
         <div className="rounded-xl border border-indigo-200 bg-indigo-50/60 px-5 py-4 my-6">
-          <p className="text-xs font-bold uppercase tracking-widest text-indigo-700 mb-2">Guard Rule Schema v1 — bidirectional interchange</p>
+          <p className="text-xs font-bold uppercase tracking-widest text-indigo-700 mb-2">Agentic Tool-Call Policy Schema v1 — the open category</p>
           <p className="text-sm text-stone-700 mb-3 leading-relaxed">
-            Guard rules speak two dialects: JSON (runtime) and Cedar (portability). Import from AWS Verified Permissions or any Cedar-native IAM stack; export any pack back to Cedar. No lock-in.
+            A distinct policy shape: rules that govern what an AI agent may do when it invokes a tool. Two dialects — JSON at runtime, Cedar for portability. Bidirectional interchange with AWS Verified Permissions and any Cedar-native IAM stack. No lock-in.
           </p>
           <div className="flex flex-wrap gap-2">
             <a href="/docs/schema" className="inline-flex items-center gap-1.5 px-3 py-1.5 rounded-md bg-white border border-stone-200 text-xs text-stone-700 hover:border-indigo-400 hover:text-indigo-700 transition-colors">

--- a/apps/web/src/app/(marketing)/docs/schema/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/schema/page.tsx
@@ -1,7 +1,7 @@
 export const metadata = {
-  title: "Guard Rule Schema — Docs | Conduct",
+  title: "Agentic Tool-Call Policy Schema — Docs | Conduct",
   description:
-    "Conduct Guard rules speak two dialects: JSON at runtime, Cedar for portability. Bidirectional interchange, no lock-in.",
+    "The open schema for a distinct policy category: rules that govern what an AI agent is allowed to do when it invokes a tool. Bidirectional Cedar interchange, no lock-in.",
 }
 
 export default function GuardSchemaDocsPage() {
@@ -12,12 +12,15 @@ export default function GuardSchemaDocsPage() {
           Docs
         </a>
         <span className="text-sm text-stone-300 mx-2">/</span>
-        <span className="text-sm text-stone-600">Guard Rule Schema</span>
+        <span className="text-sm text-stone-600">Agentic Tool-Call Policy Schema</span>
       </div>
 
-      <h1 className="text-3xl font-bold text-stone-900 mt-6 mb-2">Guard Rule Schema v1</h1>
+      <h1 className="text-3xl font-bold text-stone-900 mt-6 mb-2">Agentic Tool-Call Policy Schema v1</h1>
       <p className="text-stone-500 mb-4 leading-relaxed">
-        Guard rules speak two dialects: <strong>JSON</strong> for runtime evaluation, <strong>Cedar</strong> for portability. Both are semantically equivalent. Import your existing Cedar policies from AWS Verified Permissions or any Cedar-consuming IAM stack. Export any Conduct pack back to Cedar. No proprietary lock-in.
+        <strong>A distinct policy category.</strong> OPA/Rego is generic policy. Cedar is authorization. Kyverno is K8s admission. Sentinel is Terraform. This is the schema for the shape none of them target: rules that govern what an AI agent is allowed to do when it invokes a tool (file edit, shell, HTTP, MCP tool call, workflow action).
+      </p>
+      <p className="text-stone-500 mb-4 leading-relaxed">
+        Rules speak two dialects: <strong>JSON</strong> for runtime evaluation, <strong>Cedar</strong> for portability. Both semantically equivalent. Import existing Cedar policies from AWS Verified Permissions; export any Conduct pack back to Cedar. No lock-in.
       </p>
 
       <div className="flex gap-3 mb-10 flex-wrap">
@@ -44,12 +47,33 @@ export default function GuardSchemaDocsPage() {
       <nav className="mb-10 border border-stone-200 rounded-xl px-5 py-4">
         <p className="text-xs font-bold uppercase tracking-widest text-stone-400 mb-3">On this page</p>
         <ol className="flex flex-col gap-1.5 text-sm text-stone-600">
+          <li><a href="#category" className="hover:text-indigo-600 transition-colors">Why a distinct category</a></li>
           <li><a href="#why-two" className="hover:text-indigo-600 transition-colors">Why two dialects</a></li>
           <li><a href="#example" className="hover:text-indigo-600 transition-colors">Same rule, two forms</a></li>
           <li><a href="#interchange" className="hover:text-indigo-600 transition-colors">Bidirectional interchange</a></li>
           <li><a href="#frameworks" className="hover:text-indigo-600 transition-colors">Framework tags</a></li>
+          <li><a href="#mapping" className="hover:text-indigo-600 transition-colors">Mapping to other policy languages</a></li>
+          <li><a href="#extensible" className="hover:text-indigo-600 transition-colors">Extensible (v1.1)</a></li>
         </ol>
       </nav>
+
+      <section id="category" className="mb-12">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Why a distinct category</h2>
+        <p className="text-stone-600 leading-relaxed mb-3">
+          Policy engines already exist. None target the shape we need. The industry has good tools for adjacent problems:
+        </p>
+        <ul className="list-disc pl-6 text-stone-600 leading-relaxed space-y-1 mb-3">
+          <li><strong>OPA/Rego</strong> — generic policy over arbitrary JSON input</li>
+          <li><strong>Cedar</strong> — authorization (who can do what to which resource)</li>
+          <li><strong>Kyverno</strong> — Kubernetes admission control</li>
+          <li><strong>Sentinel</strong> — HashiCorp infra provisioning</li>
+          <li><strong>XACML</strong> — enterprise access control (legacy)</li>
+          <li><strong>MITRE ATLAS / OWASP Agentic Top 10</strong> — threat catalogs, not enforceable rules</li>
+        </ul>
+        <p className="text-stone-600 leading-relaxed">
+          <strong>Agentic Tool-Call Policy is its own shape.</strong> The actor is an autonomous AI agent, the object is a tool invocation, decisions land in milliseconds pre-execution, and portability across enforcement surfaces (proxy, hooks, MCP, runtime) is table-stakes. This schema names that shape. See the <a href="#mapping" className="text-indigo-600 hover:underline">mapping table below</a> for how our vocabulary aligns with each of the above.
+        </p>
+      </section>
 
       <section id="why-two" className="mb-12">
         <h2 className="text-xl font-bold text-stone-900 mb-3">Why two dialects</h2>
@@ -160,6 +184,98 @@ when {
             </tbody>
           </table>
         </div>
+      </section>
+
+      <section id="mapping" className="mb-16">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Mapping to other policy languages</h2>
+        <p className="text-stone-600 leading-relaxed mb-4">
+          The underlying concepts overlap. What differs is the shape of the object being governed — none of the standards below were designed for agentic tool invocations. This table shows how our fields correspond so teams already using these engines see the alignment.
+        </p>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="border-b border-stone-200 text-left uppercase tracking-widest text-stone-500">
+                <th className="py-2 pr-3">Concept</th>
+                <th className="py-2 pr-3">Ours</th>
+                <th className="py-2 pr-3">OPA/Rego</th>
+                <th className="py-2 pr-3">Kyverno</th>
+                <th className="py-2 pr-3">Sentinel</th>
+                <th className="py-2 pr-3">Cedar</th>
+                <th className="py-2 pr-3">XACML</th>
+                <th className="py-2">MITRE ATLAS</th>
+              </tr>
+            </thead>
+            <tbody className="text-stone-700">
+              {[
+                ["Rule id",         "id",                                  "package + rule",           "policy metadata name",       "policy name",             "policy id",                     "PolicyId",                "technique ID"],
+                ["Decision",        "action",                              "deny / allow sets",        "validate.deny / mutate",     "main = rule bool",        "forbid / permit",               "Effect Deny/Permit",      "control category"],
+                ["Actor",           "persona_affinity + match.mcp_tool",   "input.subject",            "resource kind",              "input.subject",           "principal is <Type>",           "Subject",                 "technique target"],
+                ["Resource",        "match.tool + match.path_pattern",     "input.resource",           "match.resources.kinds",      "input.resource",          "resource",                      "Resource",                "attack surface"],
+                ["Match cond.",     "match.pattern (regex)",               "contains / startswith",    "match.resources.selector",   "matches function",        "when { ... } clause",           "Condition element",       "detection signature"],
+                ["Severity",        "severity enum",                       "annotation",               "policy.severity",            "metadata",                "@severity annotation",          "Obligation",              "severity rating"],
+                ["Compliance",      "frameworks[] tags",                   "annotation",               "policy.categories",          "metadata",                "@compliance annotation",        "Obligation reference",    "technique IDs"],
+                ["Metadata",        "annotations.<namespace>",             "package doc",              "annotations",                "scope description",       "@<name> annotation",            "attributes",              "technique references"],
+                ["Enforcement pt.", "enforcement.{proxy,hook,mcp,runtime}", "evaluator context",       "policy webhook",             "Terraform stage",         "authorization boundary",        "PDP context",             "detection layer"],
+              ].map((row) => (
+                <tr key={row[0]} className="border-b border-stone-100 align-top">
+                  {row.map((cell, i) => (
+                    <td key={i} className={i === 0 ? "py-2 pr-3 font-semibold" : (i <= 1 ? "py-2 pr-3 font-mono text-[11px]" : "py-2 pr-3 text-stone-600")}>
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+        <p className="text-xs text-stone-500 mt-3 leading-relaxed">
+          <strong>What this is saying:</strong> vocabulary overlap is high; problem shape differs. OPA governs arbitrary JSON. Kyverno governs K8s resources. Sentinel governs Terraform plans. Cedar governs authorization requests. <strong>Ours governs agentic tool invocations</strong> — an object shape none of the above are optimized for.
+        </p>
+        <p className="text-xs text-stone-500 mt-2 leading-relaxed">
+          <strong>What we don't try to do:</strong> we're not building a general policy engine. Runtime enforcement stays Conduct-specific. What ships is a portable <em>representation</em> — via Cedar for interchange, JSON Schema for tooling, and namespaced annotations for round-tripping foreign metadata.
+        </p>
+      </section>
+
+      <section id="extensible" className="mb-16">
+        <h2 className="text-xl font-bold text-stone-900 mb-3">Extensible (v1.1)</h2>
+        <p className="text-stone-600 leading-relaxed mb-4">
+          Two optional additions on top of v1. Backward compat: every v1 rule stays valid.
+        </p>
+
+        <h3 className="text-sm font-semibold text-stone-700 mb-2">Extensible <code className="bg-stone-100 px-1.5 py-0.5 rounded">match</code> map</h3>
+        <p className="text-stone-600 text-sm leading-relaxed mb-2">
+          Put every match dimension under a single map. Custom keys (e.g. <code className="bg-stone-100 px-1.5 py-0.5 rounded">mcp_server</code>, <code className="bg-stone-100 px-1.5 py-0.5 rounded">webhook_source</code>) allowed; surfaces that don't understand a key ignore it.
+        </p>
+        <pre className="text-xs bg-stone-950 text-stone-100 rounded-lg p-4 overflow-x-auto mb-6">
+{`{
+  "id": "block_prod_writes",
+  "action": "block",
+  "match": {
+    "tool":         "write,edit,bash",
+    "pattern":      "PROD_SECRET",
+    "path_pattern": "^prod/config\\\\.yaml$",
+    "http_method":  "POST",
+    "mcp_tool":     "guard_check"
+  }
+}`}
+        </pre>
+
+        <h3 className="text-sm font-semibold text-stone-700 mb-2">Namespaced <code className="bg-stone-100 px-1.5 py-0.5 rounded">annotations</code> map</h3>
+        <p className="text-stone-600 text-sm leading-relaxed mb-2">
+          Free-form metadata by namespace. Runtime ignores unknown namespaces; exporters pass them through (Cedar → <code className="bg-stone-100 px-1.5 py-0.5 rounded">@annotation</code>, OPA → package comments, custom → your own tooling).
+        </p>
+        <pre className="text-xs bg-stone-950 text-stone-100 rounded-lg p-4 overflow-x-auto">
+{`{
+  "id": "block_prod_writes",
+  "action": "block",
+  "annotations": {
+    "cedar":       { "principal_type": "Agent" },
+    "opa":         { "package": "conduct.pci" },
+    "kyverno":     { "match_kinds": ["Pod"] },
+    "custom.acme": "internal-tracker-#1234"
+  }
+}`}
+        </pre>
       </section>
     </div>
   )

--- a/docs/guard/schema.md
+++ b/docs/guard/schema.md
@@ -1,4 +1,8 @@
-# Conduct Guard Rule Schema v1
+# Agentic Tool-Call Policy Schema v1
+
+*Formerly "Guard Rule Schema" — same shape, sharper name.* This is the schema for a distinct policy category: rules that govern what an AI agent is allowed to do when it invokes a tool (file edit, shell, HTTP, MCP tool call, workflow action).
+
+**Why the category matters:** OPA/Rego is generic policy. Cedar is authorization. Kyverno is K8s admission. Sentinel is Terraform. **Agentic Tool-Call Policy is its own shape** — the actor is an autonomous AI agent, the object is a tool invocation, decisions land in milliseconds pre-execution, and portability across enforcement surfaces (proxy, hooks, MCP, runtime) is table-stakes. This schema is what that shape looks like.
 
 Guard rules speak **two dialects**: JSON (runtime evaluation) and Cedar (portability / interchange). Both are semantically equivalent — you can round-trip your policies in either direction with zero information loss.
 
@@ -140,9 +144,72 @@ The Cedar rendering preserves every rule field via annotations (`@id`, `@descrip
 
 Round-trip is lossless for schema v1. Bring your existing Cedar policies from AWS Verified Permissions, Dogwood, or any IAM stack that speaks Cedar JSON.
 
+## v1.1 additions (extensible match + annotations)
+
+Two optional additions keep v1 backward compat while giving room to grow.
+
+### Extensible `match` map
+
+Instead of hardcoding `match_tool`, `match_pattern`, `match_path_pattern`, put every dimension under a `match` object. Runtime reads whichever keys it understands and **matches when every populated dimension matches** the invocation.
+
+```json
+{
+  "id": "block_prod_writes",
+  "action": "block",
+  "match": {
+    "tool":         "write,edit,bash",
+    "pattern":      "PROD_SECRET",
+    "path_pattern": "^prod/config\\.yaml$",
+    "http_method":  "POST",
+    "mcp_tool":     "guard_check"
+  }
+}
+```
+
+v1 top-level `match_tool` / `match_pattern` / `match_path_pattern` stay valid — they become sugar that folds into `match.tool` etc. at eval time. Custom dimensions (e.g. `mcp_server`, `webhook_source`) are also allowed; unknown keys are ignored by surfaces that don't understand them.
+
+### Namespaced `annotations` map
+
+Free-form metadata namespaced by key. Runtime ignores unknown namespaces; exporters pass them through.
+
+```json
+{
+  "id": "block_prod_writes",
+  "action": "block",
+  "annotations": {
+    "cedar":       { "principal_type": "Agent" },
+    "opa":         { "package": "conduct.pci" },
+    "kyverno":     { "match_kinds": ["Pod"] },
+    "custom.acme": "internal-tracker-#1234"
+  }
+}
+```
+
+Use this to carry framework-specific metadata around your rules without polluting the core shape. Cedar exporter emits them as `@annotation`; OPA exporter (future) as package doc comments; import from other systems keeps their metadata intact.
+
+## How this schema maps to other policy languages
+
+Agentic Tool-Call Policy has its own shape, but the vocabulary overlaps with adjacent standards. Here's how our fields correspond so teams already using other engines can see the alignment.
+
+| Concept | Ours | OPA/Rego | Kyverno | Sentinel | Cedar | XACML | MITRE ATLAS |
+|---|---|---|---|---|---|---|---|
+| Rule identifier | `id` | package + rule name | policy metadata name | policy name | policy id | PolicyId | technique ID (e.g. `AML.T0051`) |
+| Decision | `action` (block/warn/allow/audit/inject/approval) | `deny` / `allow` sets | `validate.deny` / `mutate` | `main = rule { ... }` bool | `forbid` / `permit` | `Effect="Deny"/"Permit"` | control category |
+| Subject/actor | `persona_affinity` + `match.mcp_tool` | `input.subject` | resource kind | `input.subject` | `principal is <Type>` | `Subject` | technique target |
+| Object/resource | `match.tool` + `match.path_pattern` | `input.resource` | `match.resources.kinds` | `input.resource` | `resource` | `Resource` | attack surface |
+| Match condition | `match.pattern` (regex) | `contains` / `startswith` in Rego expr | `match.resources.selector` | `matches` function | `when { ... }` clause | `Condition` element | detection signature |
+| Severity | `severity` (low/medium/high/critical) | annotation | policy.severity | metadata | `@severity` annotation | `Obligation` | severity rating |
+| Compliance mapping | `frameworks[]` (`PCI_DSS:3.4` etc.) | annotation | policy.categories | metadata | `@compliance` annotation | `Obligation` reference | technique IDs |
+| Metadata roundtrip | `annotations.<ns>` | package doc | annotations | scope description | `@<name>` annotation | attributes | technique references |
+| Enforcement surface | `enforcement.{proxy,hook,mcp,runtime}` | evaluator context | policy webhook | Terraform run stage | authorization boundary | PDP context | detection layer |
+
+**What this table is saying:** the underlying concepts are the same across the industry. What differs is the *shape* of the primary object being governed: OPA governs arbitrary JSON input; Kyverno governs K8s resources; Sentinel governs Terraform plans; Cedar governs authorization requests. **Ours governs agentic tool invocations** — an object shape none of the above are optimized for.
+
+**What we don't try to do:** we're not building a general-purpose policy engine. Runtime enforcement stays Conduct-specific. What ships is a portable *representation* — via Cedar for interchange, JSON Schema for tooling, and annotations for round-tripping foreign metadata.
+
 ## Versioning
 
-Schema version = `v1`. Backward-incompatible changes will publish `v2` at a new `$id` and both stay available. Rule packs may declare a `$schema` reference to the specific version they target; runtime defaults to latest.
+Schema version = `v1` (with v1.1 additions above). Backward-incompatible changes will publish `v2` at a new `$id` and both stay available. Rule packs may declare a `$schema` reference to the specific version they target; runtime defaults to latest.
 
 ## Extending
 

--- a/schemas/conduct-guard-rule.v1.json
+++ b/schemas/conduct-guard-rule.v1.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://schemas.conductai.ai/conduct-guard-rule.v1.json",
-  "title": "Conduct Guard Rule Schema v1",
-  "description": "Machine-readable schema for a single Guard rule and a Guard pack (a bundle of rules). Guard rules are enforced across four surfaces: Guard proxy (LLM egress), pre-tool hooks (Claude Code / Cursor / Codex), MCP guard_check, and the workflow runtime. Rules are portable — the same rule renders to Cedar for AWS Verified Permissions ecosystems.",
+  "title": "Agentic Tool-Call Policy Schema v1",
+  "description": "Machine-readable schema for the Agentic Tool-Call Policy category: rules that govern what an AI agent is allowed to do when it invokes a tool (file edit, shell, HTTP, MCP tool call, workflow action). Enforced across four Conduct surfaces (Guard proxy, pre-tool hooks, MCP guard_check, workflow runtime) and portable to Cedar for AWS Verified Permissions ecosystems. Distinct from generic policy engines (OPA/Rego), authorization languages (Cedar), and infra-specific frameworks (Kyverno, Sentinel) — this is the schema for agentic tool-call policy.",
   "$defs": {
     "action": {
       "type": "string",
@@ -23,6 +23,24 @@
       "type": "string",
       "enum": ["free", "paid", "enterprise"],
       "description": "Pack distribution tier."
+    },
+    "match": {
+      "type": "object",
+      "description": "Extensible match dimensions. Runtime reads whichever dimensions it understands and ignores the rest — a rule matches when EVERY populated dimension matches the invocation. Standard dimensions listed below; callers can add custom keys (e.g. `mcp_server`, `webhook_source`) for domain-specific matching.",
+      "additionalProperties": { "type": ["string", "array", "object"] },
+      "properties": {
+        "tool":         { "type": "string", "description": "Comma-separated tool names (e.g. `edit,write,bash`). Empty or `*` means all." },
+        "pattern":      { "type": "string", "description": "Regex matched against tool_input.prompt / body." },
+        "path_pattern": { "type": "string", "description": "Regex matched against tool_input.path (file operations)." },
+        "http_method":  { "type": "string", "description": "HTTP verb for API-request rules (e.g. `POST`)." },
+        "mcp_tool":     { "type": "string", "description": "MCP tool name for MCP-native rules." },
+        "workflow_event": { "type": "string", "description": "Workflow event name for runtime-triggered rules." }
+      }
+    },
+    "annotations": {
+      "type": "object",
+      "description": "Namespaced free-form metadata. Runtime ignores unknown namespaces; exporters pass them through to their target format (Cedar → @annotation, Rego → package comment, Kyverno → labels). Keys are namespace strings (`cedar`, `opa`, `kyverno`, `custom.<name>`); values are arbitrary JSON.",
+      "additionalProperties": true
     },
     "enforcement": {
       "type": "object",
@@ -45,9 +63,11 @@
       "properties": {
         "id":                 { "type": "string", "minLength": 1, "description": "Stable identifier. Unique within the pack. Referenced by GuardRuleOverride to disable or amend." },
         "description":        { "type": "string", "description": "Human-readable summary — shown in dashboards + Cedar `@description` annotation." },
-        "match_tool":         { "type": "string", "description": "Comma-separated tool names the rule applies to (e.g. `edit,write,bash`). Empty or `*` means all tools." },
-        "match_pattern":      { "type": "string", "description": "Regex matched against the tool_input.prompt / body. Case-sensitive; anchors optional." },
-        "match_path_pattern": { "type": "string", "description": "Regex matched against the tool_input.path (file operations). Independent from `match_pattern`." },
+        "match":              { "$ref": "#/$defs/match" },
+        "match_tool":         { "type": "string", "description": "v1 sugar for match.tool. Comma-separated tool names (e.g. `edit,write,bash`). Runtime folds this into `match.tool` at eval time." },
+        "match_pattern":      { "type": "string", "description": "v1 sugar for match.pattern. Regex matched against the tool_input.prompt / body." },
+        "match_path_pattern": { "type": "string", "description": "v1 sugar for match.path_pattern. Regex matched against tool_input.path." },
+        "annotations":        { "$ref": "#/$defs/annotations" },
         "action":             { "$ref": "#/$defs/action" },
         "message":            { "type": "string", "description": "Shown to the user when the rule fires. Appears in Cedar `@message` annotation." },
         "recommendation":     { "type": "string", "description": "Remediation guidance. Appears in Cedar `@recommendation` annotation." },


### PR DESCRIPTION
Follow-up to #1646 (base v1 schema). Adds v1.1 extensions + engine mapping table + category rename.

Includes cherry-picked commits from #1646 so this can merge independently once #1646 lands or in place of it.

Changes:
- Schema v1.1: optional match map for extensible dimensions (http_method, mcp_tool, custom keys) + namespaced annotations map for cross-engine metadata roundtrip
- Mapping table: nine-dimension comparison across OPA Rego, Kyverno, Sentinel, Cedar, XACML, MITRE ATLAS (docs/guard/schema.md + /docs/schema page)
- Category rename: Guard Rule Schema is what we ship; Agentic Tool-Call Policy Schema is the category we own

Backward compat: every v1 rule still validates. Schema id unchanged. No runtime semantic changes.

Closes #1647