### PR TITLE
feat(lens): context awareness — pathname injection + per-page chips (#C1 + #C2)

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -775,6 +775,8 @@ async def glens_chat_stream(
     # (gpt-4o-mini fabricated "August 26" when today was "2026-08-27").
     today_display = _now.strftime("%A, %B %-d, %Y") + " UTC"
     system = _SYSTEM.format(today=today, today_display=today_display)
+    if req.page_context:
+        system += f"\n\nUser is currently viewing `{req.page_context}`. Prefer answers scoped to that page when ambiguous."
     llm_messages = _build_llm_messages(session_messages)
 
     loop = asyncio.get_running_loop()

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -50,6 +50,21 @@ const DEFAULT_SUGGESTIONS = [
   "Show recent blocks",
 ]
 
+// #C2 — per-page opener chips. First matching regex wins. Empty match falls
+// through to /glens/opener data-grounded chips → DEFAULT_SUGGESTIONS.
+const PAGE_SUGGESTIONS: Array<{ match: RegExp; chips: string[] }> = [
+  { match: /^\/runs\/[^/]+/,             chips: ["Why did this fail?", "Compare to last run", "Show block trace", "Cost breakdown"] },
+  { match: /^\/workflows\/[^/]+\/canvas/, chips: ["Explain this workflow", "Recent runs", "Which blocks fail most?"] },
+  { match: /^\/workflows\/[^/]+/,        chips: ["Explain this workflow", "Recent failures", "Who runs this most?"] },
+  { match: /^\/workflows\/?$/,           chips: ["Which workflows failed today?", "Most-run workflows", "Longest-running workflows"] },
+  { match: /^\/theguard\/policies/,      chips: ["Which rules block the most?", "Show rules with no hits", "Rules changed this week"] },
+  { match: /^\/theguard\/spend/,         chips: ["Top spenders this month", "Budgets near limit", "Cost by AI tool"] },
+  { match: /^\/theguard\/discovery/,     chips: ["Unguarded agents", "Coverage by framework", "High-risk agents"] },
+  { match: /^\/compliance/,              chips: ["Overall compliance grade", "Which frameworks are we missing?", "ASI control status"] },
+  { match: /^\/logs\/guard/,             chips: ["Show blocks today", "Warnings by tool", "Events by user"] },
+  { match: /^\/marketplace/,             chips: ["Recommend packs for us", "What's installed?", "Newest packs"] },
+]
+
 const SKILL_LABELS: Record<string, string> = {
   report:       "Lens ·Report",
   analytics:    "Lens ·Analytics",
@@ -1781,14 +1796,20 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialSessionId, workspaceId])
 
-  // Load data-grounded opener chips
+  // Load data-grounded opener chips — page-specific chips (#C2) win over
+  // /glens/opener; opener wins over DEFAULT_SUGGESTIONS.
   useEffect(() => {
+    const pageMatch = pathname ? PAGE_SUGGESTIONS.find(p => p.match.test(pathname)) : null
+    if (pageMatch) {
+      setSuggestions(pageMatch.chips)
+      return
+    }
     if (!workspaceId) return
     authFetch(`${API}/glens/opener`)
       .then(r => r.ok ? r.json() : null)
       .then(d => { if (d?.chips?.length) setSuggestions(d.chips) })
       .catch(() => {})
-  }, [workspaceId, authFetch])
+  }, [workspaceId, authFetch, pathname])
 
   // Scroll to bottom on new messages
   useEffect(() => {

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -2,7 +2,7 @@
 import { API } from "@/lib/api"
 
 import { useEffect, useRef, useState } from "react"
-import { useRouter } from "next/navigation"
+import { useRouter, usePathname } from "next/navigation"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { useLensEvent } from "@/hooks/useLensEvent"
 import { useLensSessionStream, type LensSessionStream } from "@/hooks/useLensSessionStream"
@@ -1734,6 +1734,7 @@ function ChatInput({ onSubmit, disabled }: { onSubmit: (t: string) => void; disa
 export function GLensChatPage({ initialSessionId }: { initialSessionId?: string } = {}) {
   const { authFetch, workspaceId } = useAuthFetch()
   const router = useRouter()
+  const pathname = usePathname()
 
   const [sessions, setSessions] = useState<GLensSession[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)
@@ -1969,6 +1970,7 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
     try {
       const body: Record<string, unknown> = { message: text }
       if (activeId) body.session_id = activeId
+      if (pathname) body.page_context = pathname
 
       const res = await authFetch(`${API}/glens/chat/stream`, {
         method: "POST",


### PR DESCRIPTION
## Summary
Ships two items from #1217 (Lens 2c: context awareness):

- **#C1 pathname injection** — frontend passes ``usePathname()`` in the ``/glens/chat/stream`` body; backend appends "User is currently viewing \`{path}\`. Prefer answers scoped to that page when ambiguous." to the system prompt.
- **#C2 per-page opener chips** — 10-route ``PAGE_SUGGESTIONS`` map (runs, workflows, canvas, policies, spend, discovery, compliance, logs, marketplace). First matching regex wins; falls through to ``/glens/opener`` then ``DEFAULT_SUGGESTIONS``.

Closes #C1 + #C2 checkboxes on #1217. Only ``#C3`` (bubble-prefill) still open — blocked on #1215.

## Test plan
- [x] TypeScript check passes
- [x] Server-side ``page_context`` field was already on ``ChatRequest`` — just plumbed
- [ ] Manual smoke: visit ``/runs/{id}`` in prod → opener chips show "Why did this fail?", "Compare to last run", etc.
- [ ] Manual smoke: ask a question on ``/workflows/{id}`` → answer references the current workflow when ambiguous