### PR TITLE
refactor(lens): migrate get_discovery_summary tool to free function (epic #1655 PR 1/9)

### DIFF
--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -350,58 +350,6 @@ class Executor:
 
     # ── Discovery ─────────────────────────────────────────────────────────────
 
-    def _tool_get_discovery_summary(self):
-        ws_uuid = uuid.UUID(self.workspace_id)
-        agents = self.db.query(DiscoveredAgent).filter(
-            DiscoveredAgent.workspace_id == ws_uuid
-        ).all()
-
-        total = len(agents)
-        under_guard = sum(1 for a in agents if a.under_guard)
-
-        by_framework: dict[str, int] = {}
-        for a in agents:
-            fw = a.framework or "unknown"
-            by_framework[fw] = by_framework.get(fw, 0) + 1
-
-        def _risk_level(score: int | None) -> str:
-            if score is None:
-                return "Unknown"
-            if score >= 70:
-                return "High"
-            if score >= 40:
-                return "Medium"
-            return "Low"
-
-        high_risk = [
-            {"name": a.name, "framework": a.framework, "risk_score": a.risk_score,
-             "under_guard": a.under_guard, "location": a.location}
-            for a in agents if (a.risk_score or 0) >= 70
-        ]
-
-        return {
-            "total": total,
-            "under_guard": under_guard,
-            "missing": total - under_guard,
-            "coverage_pct": round(under_guard / total * 100) if total else 0,
-            "by_framework": [{"framework": fw, "count": cnt} for fw, cnt in sorted(by_framework.items())],
-            "high_risk": high_risk,
-            "agents": [
-                {
-                    "name": a.name,
-                    "framework": a.framework,
-                    "source": a.source,
-                    "location": a.location,
-                    "risk_score": a.risk_score,
-                    "risk_level": _risk_level(a.risk_score),
-                    "under_guard": a.under_guard,
-                    "proxy_routed": a.proxy_routed,
-                    "last_seen_at": a.last_seen_at.isoformat() if a.last_seen_at else None,
-                }
-                for a in agents
-            ],
-        }
-
     # ── Compliance ────────────────────────────────────────────────────────────
 
     def _tool_get_compliance_status(self):

--- a/apps/api/app/tools/registrations/lens/discovery.py
+++ b/apps/api/app/tools/registrations/lens/discovery.py
@@ -29,6 +29,70 @@ from app.tools.registrations.lens._shared import (
 
 
 # ── Free-function tool implementations ─────────────────────────────────
+def _risk_level(score: int | None) -> str:
+    if score is None:
+        return "Unknown"
+    if score >= 70:
+        return "High"
+    if score >= 40:
+        return "Medium"
+    return "Low"
+
+
+def get_discovery_summary(ctx):
+    """Discovered agents inventory — total, coverage, high-risk agents,
+    per-framework breakdown. Migrated from Executor._tool_get_discovery_summary
+    (epic #1655)."""
+    import uuid as _uuid
+    from app.core.database import SessionLocal
+    from app.modules.guard.models import DiscoveredAgent
+    db = SessionLocal()
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+        agents = db.query(DiscoveredAgent).filter(
+            DiscoveredAgent.workspace_id == ws_uuid
+        ).all()
+
+        total = len(agents)
+        under_guard = sum(1 for a in agents if a.under_guard)
+
+        by_framework: dict[str, int] = {}
+        for a in agents:
+            fw = a.framework or "unknown"
+            by_framework[fw] = by_framework.get(fw, 0) + 1
+
+        high_risk = [
+            {"name": a.name, "framework": a.framework, "risk_score": a.risk_score,
+             "under_guard": a.under_guard, "location": a.location}
+            for a in agents if (a.risk_score or 0) >= 70
+        ]
+
+        return {
+            "total": total,
+            "under_guard": under_guard,
+            "missing": total - under_guard,
+            "coverage_pct": round(under_guard / total * 100) if total else 0,
+            "by_framework": [{"framework": fw, "count": cnt} for fw, cnt in sorted(by_framework.items())],
+            "high_risk": high_risk,
+            "agents": [
+                {
+                    "name": a.name,
+                    "framework": a.framework,
+                    "source": a.source,
+                    "location": a.location,
+                    "risk_score": a.risk_score,
+                    "risk_level": _risk_level(a.risk_score),
+                    "under_guard": a.under_guard,
+                    "proxy_routed": a.proxy_routed,
+                    "last_seen_at": a.last_seen_at.isoformat() if a.last_seen_at else None,
+                }
+                for a in agents
+            ],
+        }
+    finally:
+        db.close()
+
+
 def list_discovered_agents(ctx, framework: str | None = None, since: str | None = None):
     """Discovered AI agents in the workspace — name, framework, source,
     risk_score, under_guard, proxy_routed. Optional framework filter (e.g.
@@ -77,7 +141,7 @@ TOOLS: list[ToolDef] = [
         name="get_discovery_summary",
         description="Discovered agents inventory — total, coverage, high-risk agents, per-framework breakdown.",
         input_schema={"type": "object", "properties": {}, "required": []},
-        impl=_impl("get_discovery_summary"),
+        impl=get_discovery_summary,
         annotations=_READ_ONLY,
         tags=_LENS_TAGS,
     ),


### PR DESCRIPTION
## Summary
First PR in the epic #1655 migration. Moves ``Executor._tool_get_discovery_summary`` into a top-level ``get_discovery_summary(ctx)`` in ``apps/api/app/tools/registrations/lens/discovery.py`` — the file where its ``ToolDef`` already lives.

Changes:
- Extract the previously-nested ``_risk_level`` helper to module level in ``discovery.py``.
- Add ``get_discovery_summary(ctx)`` as a top-level function beside the existing ``list_discovered_agents`` (same shape — matches the pattern new tools already use).
- Rewire ``ToolDef.impl`` from ``_impl(\"get_discovery_summary\")`` to ``get_discovery_summary`` directly — removes shim indirection + per-call ``SessionLocal()`` opened by the shim.
- Delete ``_tool_get_discovery_summary`` from ``executor.py``.

Proves the pattern including the **nested-helper case** (relevant for the governance PR later where ``_status`` and ``_grade`` also need extraction).

## Test plan
- [x] AST syntax check on both files
- [x] Live smoke: called ``tool.impl(ctx)`` against local Postgres with fake workspace_id; returns identical shape (``total``, ``under_guard``, ``missing``, ``coverage_pct``, ``by_framework``, ``high_risk``, ``agents``)
- [x] ``impl.__module__`` confirms it's the new location
- [ ] CI green

## Metrics
- ``executor.py``: -53 LOC (one method + nested helper gone)
- ``discovery.py``: +65 LOC (new function + module-level helper)
- Net: +12 (all the removed indirection stays gone; net grows only because Executor method bodies were more compact due to shared ``self.db``)

## Next PRs
2/9 policies (2 tools), 3/9 marketplace, 4/9 workflows, 5/9 workspace, 6/9 ops, 7/9 governance, 8/9 guard_core, 9/9 cleanup (delete ``_impl`` + shrink Executor).