### PR TITLE
feat(lens): secret masking on outbound stream (#1214 #S3)

### DIFF
--- a/apps/api/app/modules/glens/masking.py
+++ b/apps/api/app/modules/glens/masking.py
@@ -1,0 +1,45 @@
+"""Secret masking for Lens outbound text (#1214 #S3).
+
+Applied at the SSE `done` boundary in chat.py before the assistant answer
+is streamed to the client AND before it's persisted to the session. Any
+prefixed-key that leaks through a tool response ends up masked in both
+the UI and the durable transcript.
+
+The patterns are intentionally conservative — match well-known key
+prefixes with a length floor, leave everything else alone. Adding
+unbounded heuristics (base64-y strings, high-entropy tokens) risks
+masking real content and is out of scope for this pass.
+"""
+from __future__ import annotations
+
+import re
+
+
+# Ordered by specificity: more-specific prefixes first so "sk-ant-" wins
+# over the generic "sk-" pattern.
+_SECRET_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
+    ("anthropic",  re.compile(r"sk-ant-[A-Za-z0-9_\-]{20,}")),
+    ("openai",     re.compile(r"sk-(?!ant-)[A-Za-z0-9_\-]{20,}")),
+    ("github-pat", re.compile(r"ghp_[A-Za-z0-9]{20,}")),
+    ("github-oauth", re.compile(r"gho_[A-Za-z0-9]{20,}")),
+    ("github-server", re.compile(r"ghs_[A-Za-z0-9]{20,}")),
+    ("github-refresh", re.compile(r"ghr_[A-Za-z0-9]{20,}")),
+    ("slack-bot",  re.compile(r"xoxb-[A-Za-z0-9\-]{20,}")),
+    ("slack-user", re.compile(r"xoxp-[A-Za-z0-9\-]{20,}")),
+    ("aws-akid",   re.compile(r"AKIA[0-9A-Z]{16}")),
+    ("google-api", re.compile(r"AIza[0-9A-Za-z_\-]{35}")),
+    # Conduct-internal tokens
+    ("conduct-agent", re.compile(r"cond_agt_[A-Za-z0-9_\-]{20,}")),
+    ("conduct-run",   re.compile(r"cond_run_[A-Za-z0-9_\-]{20,}")),
+    ("conduct-cred",  re.compile(r"cond_cred_[A-Za-z0-9_\-]{20,}")),
+]
+
+
+def mask_secrets(text: str) -> str:
+    """Return `text` with recognised secret substrings replaced by a
+    labelled placeholder. Idempotent — running twice is a no-op."""
+    if not text:
+        return text
+    for label, pat in _SECRET_PATTERNS:
+        text = pat.sub(f"[REDACTED:{label}]", text)
+    return text

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -20,6 +20,7 @@ from sqlalchemy.orm import Session
 from app.core.auth import get_workspace_id, require_permission
 from app.core.database import get_db
 from app.modules.glens.executor import Executor
+from app.modules.glens.masking import mask_secrets
 from app.modules.glens.models import GlensChatSession
 from app.tools import registrations as _tool_registrations  # noqa: F401  # side-effect: populate default_registry before TOOLS derives
 
@@ -832,7 +833,7 @@ async def glens_chat_stream(
                     yield f"data: {json.dumps({'type': 'token', 'text': evt['text']})}\n\n"
 
                 elif evt.get("type") == "done":
-                    answer = evt["answer"]
+                    answer = mask_secrets(evt["answer"])
                     # Persist envelopes alongside the answer so session
                     # restore (#1480 PR 12) can rehydrate the right bubble
                     # kind — otherwise refresh loses ActionConfirmBubble /

--- a/apps/api/tests/glens/test_masking.py
+++ b/apps/api/tests/glens/test_masking.py
@@ -1,0 +1,81 @@
+"""Secret masking for Lens outbound text (#1214 #S3)."""
+from __future__ import annotations
+
+from app.modules.glens.masking import mask_secrets
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────
+# Fake tokens built at runtime to sidestep the repo's static secret
+# scanner tripping on literal AWS/Anthropic/OpenAI prefixes.
+_OPENAI = "sk-" + "proj" + "1234567890abcdef1234567890"
+_ANTHROPIC = "sk-" + "ant-api03-" + "abc123def456ghi789jkl012mno345"
+_AWS = "AKIA" + "0" * 16
+_GHP = "ghp_" + "1234567890abcdefghij1234567890abcd"
+_XOXB = "xoxb-" + "1234-5678-abcdefghijklmnop"
+_CAG = "cond_agt_" + "1234567890abcdef1234567890"
+
+
+def test_empty_and_none_are_passthrough():
+    assert mask_secrets("") == ""
+    assert mask_secrets(None) is None  # type: ignore[arg-type]
+
+
+def test_no_secrets_is_passthrough():
+    assert mask_secrets("Hello, this is a normal sentence.") == "Hello, this is a normal sentence."
+
+
+def test_openai_key_masked():
+    out = mask_secrets(f"key is {_OPENAI} got it")
+    assert _OPENAI not in out
+    assert "[REDACTED:openai]" in out
+
+
+def test_anthropic_beats_generic_sk():
+    # Anthropic pattern must match before the "sk-" one so the label is right.
+    out = mask_secrets(f"token={_ANTHROPIC}")
+    assert "[REDACTED:anthropic]" in out
+    assert _ANTHROPIC not in out
+
+
+def test_github_pat_masked():
+    out = mask_secrets(f"gh: {_GHP} end")
+    assert _GHP not in out
+    assert "[REDACTED:github-pat]" in out
+
+
+def test_slack_bot_masked():
+    out = mask_secrets(f"slack {_XOXB} end")
+    assert "[REDACTED:slack-bot]" in out
+
+
+def test_aws_akid_masked():
+    out = mask_secrets(f"aws {_AWS} here")
+    assert "[REDACTED:aws-akid]" in out
+    assert _AWS not in out
+
+
+def test_conduct_agent_token_masked():
+    out = mask_secrets(f"token {_CAG} done")
+    assert _CAG not in out
+    assert "[REDACTED:conduct-agent]" in out
+
+
+def test_multiple_secrets_in_one_string():
+    txt = f"openai={_OPENAI} github={_GHP}"
+    out = mask_secrets(txt)
+    assert "[REDACTED:openai]" in out
+    assert "[REDACTED:github-pat]" in out
+    assert _OPENAI not in out
+    assert _GHP not in out
+
+
+def test_idempotent():
+    once = mask_secrets(_OPENAI)
+    twice = mask_secrets(once)
+    assert once == twice
+
+
+def test_short_prefix_lookalike_not_matched():
+    # "sk-abc" is under the 20-char floor — leave alone (avoid false positives on prose)
+    out = mask_secrets("mention sk-abc here")
+    assert "sk-abc" in out


### PR DESCRIPTION
## Summary
Adds `mask_secrets()` applied at the SSE `done` boundary in `chat.py` — the assistant answer is masked once, then reused for both the client payload and the persisted session transcript. Belt-and-braces defense against a tool response ever echoing back a raw provider or Conduct token.

## Patterns (specificity-ordered)
- Anthropic — `sk-ant-…`
- OpenAI — `sk-…`
- GitHub — `ghp_/gho_/ghs_/ghr_`
- Slack — `xoxb-/xoxp-`
- AWS AKID — `AKIA…`
- Google API — `AIza…`
- Conduct — `cond_agt_/cond_run_/cond_cred_`

20-char post-prefix length floor keeps prose lookalikes like `sk-abc` alone. Idempotent by construction.

## Test plan
- [x] 11 unit tests: empty passthrough, per-provider match, anthropic-beats-generic-sk ordering, multi-secret, idempotence, false-positive guard
- [ ] CI green

Closes #S3 in epic #1214.