### PR TITLE
feat(lens): global "Ask Lens" bar in top-nav (#1333 #5)

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -221,6 +221,9 @@ function AppShellInnerContent({
   const [paletteActive, setPaletteActive] = useState(0)
   const paletteInputRef = useRef<HTMLInputElement>(null)
 
+  // Global "Ask Lens" bar
+  const [askLensQuery, setAskLensQuery] = useState("")
+
   // Team rename/create/delete state
   const [creatingTeam, setCreatingTeam] = useState(false)
   const [newTeamValue, setNewTeamValue] = useState("")
@@ -1112,28 +1115,48 @@ function AppShellInnerContent({
 
           {/* Right cluster */}
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexShrink: 0 }}>
-            {/* Search / command palette trigger */}
-            <button
-              onClick={() => { setPaletteOpen(true); setPaletteQuery(""); setPaletteActive(0) }}
-              style={{
-                display: "flex", alignItems: "center", gap: 6,
-                padding: "5px 10px", borderRadius: 8,
-                border: "1px solid var(--border)",
-                background: "var(--surface-2)",
-                cursor: "pointer", fontSize: 13,
-                color: "var(--text-3)",
-              }}
-              onMouseEnter={(e: ReactMouseEvent<HTMLElement>) => (e.currentTarget.style.borderColor = "var(--border-2)")}
-              onMouseLeave={(e: ReactMouseEvent<HTMLElement>) => (e.currentTarget.style.borderColor = "var(--border)")}
-            >
-              <Icons.Search />
-              <span>Search</span>
-              <kbd style={{
-                fontSize: 10.5, padding: "1px 5px", borderRadius: 4,
-                background: "var(--surface-3)", border: "1px solid var(--border-2)",
-                color: "var(--text-muted)", fontFamily: "inherit",
-              }}>⌘K</kbd>
-            </button>
+            {/* Global "Ask Lens" bar (#1333 #5) — hidden while on /lens (Lens has its own composer). */}
+            {!pathname?.startsWith("/lens") && (
+              <form
+                onSubmit={(e) => {
+                  e.preventDefault()
+                  const q = askLensQuery.trim()
+                  if (!q) return
+                  router.push(`/lens?q=${encodeURIComponent(q)}`)
+                  setAskLensQuery("")
+                }}
+                style={{
+                  display: "flex", alignItems: "center", gap: 6,
+                  padding: "3px 10px", borderRadius: 8,
+                  border: "1px solid var(--border)",
+                  background: "var(--surface-2)",
+                  width: 280,
+                }}
+              >
+                <Icons.Sparkles />
+                <input
+                  type="text"
+                  value={askLensQuery}
+                  onChange={(e) => setAskLensQuery(e.target.value)}
+                  placeholder="Ask Lens…"
+                  aria-label="Ask Lens"
+                  style={{
+                    flex: 1, background: "transparent", border: "none",
+                    outline: "none", color: "var(--text)", fontSize: 13,
+                  }}
+                />
+                <button
+                  type="button"
+                  onClick={() => { setPaletteOpen(true); setPaletteQuery(""); setPaletteActive(0) }}
+                  title="Command palette"
+                  style={{
+                    padding: "1px 5px", borderRadius: 4, border: "1px solid var(--border-2)",
+                    background: "var(--surface-3)", color: "var(--text-muted)",
+                    fontFamily: "inherit", fontSize: 10.5, cursor: "pointer",
+                  }}
+                >⌘K</button>
+              </form>
+            )}
 
             {/* Bell / notifications */}
             <div ref={notifRef} style={{ position: "relative" }}>

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -2,7 +2,7 @@
 import { API } from "@/lib/api"
 
 import { useEffect, useRef, useState } from "react"
-import { useRouter, usePathname } from "next/navigation"
+import { useRouter, usePathname, useSearchParams } from "next/navigation"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { useLensEvent } from "@/hooks/useLensEvent"
 import { useLensSessionStream, type LensSessionStream } from "@/hooks/useLensSessionStream"
@@ -1750,6 +1750,21 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
   const { authFetch, workspaceId } = useAuthFetch()
   const router = useRouter()
   const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const askedFromUrlRef = useRef<string | null>(null)
+
+  // Auto-send when arriving with ?q=… from the global "Ask Lens" bar (#1333 #5).
+  // Ref-guard so React Strict-mode double-mount doesn't fire twice, and clean
+  // the query out of the URL after the send so refresh doesn't re-trigger.
+  useEffect(() => {
+    const q = searchParams?.get("q")
+    if (!q) return
+    if (askedFromUrlRef.current === q) return
+    askedFromUrlRef.current = q
+    void sendMessage(q)
+    router.replace("/lens")
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams])
 
   const [sessions, setSessions] = useState<GLensSession[]>([])
   const [activeId, setActiveId] = useState<string | null>(null)


### PR DESCRIPTION
## Summary
Replaces the top-nav Search button with a 280px inline input labeled **"Ask Lens…"**. Submitting navigates to `/lens?q=<encoded>`; `GLensChatPage` watches `searchParams`, auto-sends once (ref-guarded against Strict-mode double-mount), and cleans the query out of the URL so refresh doesn't re-trigger.

- Bar hides on `/lens` itself (Lens already has a composer)
- ⌘K palette shortcut preserved via the embedded button on the bar's right edge
- Positioning: right cluster of AppShell topbar, next to the bell + user chip

## Test plan
- [x] `tsc --noEmit` on `apps/web` — 0 errors
- [ ] Manual: type "how many workflows failed today?" from a random page, land on `/lens`, message auto-sent and cleared from URL
- [ ] Manual: refresh `/lens?q=…` after auto-send doesn't re-send
- [ ] Manual: ⌘K still opens palette
- [ ] Manual: on `/lens` the bar is absent

Closes #5 in epic #1333.