### PR TITLE
feat(lens): canonical linkout on all bubble kinds (#1333 #8)

### DIFF
--- a/apps/web/src/components/glens/BlocksBubble.tsx
+++ b/apps/web/src/components/glens/BlocksBubble.tsx
@@ -215,12 +215,14 @@ export function BlocksBubble({
   warning,
   skill,
   understoodAs,
+  drilldown,
 }: {
   answer: string
   blocks: Block[]
   warning?: string
   skill?: string
   understoodAs?: string
+  drilldown?: { path: string; filters?: Record<string, string> }
 }) {
   return (
     <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
@@ -259,6 +261,17 @@ export function BlocksBubble({
         <div style={{ display: "flex", flexDirection: "column", gap: 16 }}>
           {blocks.map((block, i) => renderBlock(block, i))}
         </div>
+
+        {drilldown && (
+          <div style={{ marginTop: 12, textAlign: "right" }}>
+            <a
+              href={drilldown.path}
+              style={{ fontSize: 12, color: "var(--accent, #6366f1)", textDecoration: "none", fontWeight: 500 }}
+            >
+              View full &rarr;
+            </a>
+          </div>
+        )}
       </div>
     </div>
   )

--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -34,9 +34,9 @@ type Message =
   | { role: "user"; text: string }
   | { role: "assistant"; kind: "answer"; text: string; skill?: string; drilldown?: { path: string; filters?: Record<string, string> }; followups?: string[]; understoodAs?: string }
   | { role: "assistant"; kind: "streaming"; text: string }
-  | { role: "assistant"; kind: "dashboard"; spec: GlensDashboardSpec; sessionId: string }
+  | { role: "assistant"; kind: "dashboard"; spec: GlensDashboardSpec; sessionId: string; drilldown?: { path: string; filters?: Record<string, string> } }
   | { role: "assistant"; kind: "loading"; label?: string }
-  | { role: "assistant"; kind: "page"; answer: string; pageKind: string; pageData: Record<string, unknown>; warning?: string; skill: string }
+  | { role: "assistant"; kind: "page"; answer: string; pageKind: string; pageData: Record<string, unknown>; warning?: string; skill: string; drilldown?: { path: string; filters?: Record<string, string> } }
   | { role: "assistant"; kind: "policy_confirm"; answer: string; action: string; draft: Record<string, unknown>; mapping: PolicyMapping[]; targetRuleId?: string; sessionId: string; skill: string; warning?: string }
   | { role: "assistant"; kind: "action_confirm"; toolName: string; approvalRequestId: string; summary: string; warnings?: string[]; expiresAt?: string }
   | { role: "assistant"; kind: "run"; runId: string; workflowName: string; initialStatus: string }
@@ -699,10 +699,12 @@ function DashboardBubble({
   spec,
   sessionId,
   authFetch,
+  drilldown,
 }: {
   spec: GlensDashboardSpec
   sessionId: string
   authFetch: (url: string, options?: RequestInit) => Promise<Response>
+  drilldown?: { path: string; filters?: Record<string, string> }
 }) {
   return (
     <div style={{ display: "flex", justifyContent: "flex-start", marginBottom: 16, width: "100%" }}>
@@ -714,6 +716,16 @@ function DashboardBubble({
         padding: "16px",
       }}>
         <GlensDashboard spec={spec} sessionId={sessionId} authFetch={authFetch} />
+        {drilldown && (
+          <div style={{ marginTop: 12, textAlign: "right" }}>
+            <a
+              href={drilldown.path}
+              style={{ fontSize: 12, color: "var(--accent, #6366f1)", textDecoration: "none", fontWeight: 500 }}
+            >
+              View full &rarr;
+            </a>
+          </div>
+        )}
       </div>
     </div>
   )
@@ -1952,6 +1964,7 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
         pageData: data.page_data as Record<string, unknown>,
         warning: data.warning as string | undefined,
         skill: (data.skill as string) ?? "report",
+        drilldown: data.drilldown as { path: string; filters?: Record<string, string> } | undefined,
       }])
     } else if (data.blocks) {
       setMessages(prev => [...prev.slice(0, -1), {
@@ -1961,6 +1974,7 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
         warning: data.warning as string | undefined,
         skill: (data.skill as string) ?? "report",
         understoodAs: data.query_understood_as as string | undefined,
+        drilldown: data.drilldown as { path: string; filters?: Record<string, string> } | undefined,
       }])
     } else if (data.rows) {
       setMessages(prev => [...prev.slice(0, -1), {
@@ -1974,7 +1988,7 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
         understoodAs: data.query_understood_as as string | undefined,
       }])
     } else if (data.ready && data.spec) {
-      setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "dashboard", spec: data.spec as GlensDashboardSpec, sessionId: data.session_id as string }])
+      setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "dashboard", spec: data.spec as GlensDashboardSpec, sessionId: data.session_id as string, drilldown: data.drilldown as { path: string; filters?: Record<string, string> } | undefined }])
     } else {
       setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "answer", text: (data.answer as string) ?? "No answer returned.", skill: data.skill as string | undefined, drilldown: data.drilldown as { path: string; filters?: Record<string, string> } | undefined, followups: data.followups as string[] | undefined, understoodAs: data.query_understood_as as string | undefined }])
     }
@@ -2140,10 +2154,10 @@ export function GLensChatPage({ initialSessionId }: { initialSessionId?: string 
               return (
                 <div key={i}>
                   {msg.kind === "answer" && <AnswerBubble text={msg.text} skill={msg.skill} drilldown={msg.drilldown} followups={msg.followups} onFollowup={sendMessage} understoodAs={msg.understoodAs} />}
-                  {msg.kind === "dashboard" && <DashboardBubble spec={msg.spec} sessionId={msg.sessionId} authFetch={authFetch} />}
-                  {msg.kind === "blocks" && <BlocksBubble answer={msg.answer} blocks={msg.blocks as any} warning={msg.warning} skill={msg.skill} understoodAs={msg.understoodAs} />}
+                  {msg.kind === "dashboard" && <DashboardBubble spec={msg.spec} sessionId={msg.sessionId} authFetch={authFetch} drilldown={msg.drilldown} />}
+                  {msg.kind === "blocks" && <BlocksBubble answer={msg.answer} blocks={msg.blocks as any} warning={msg.warning} skill={msg.skill} understoodAs={msg.understoodAs} drilldown={msg.drilldown} />}
                   {msg.kind === "table" && <GenericTableBubble answer={msg.answer} columns={msg.columns as any} rows={msg.rows as any} warning={msg.warning} skill={msg.skill} drilldown={msg.drilldown} understoodAs={msg.understoodAs} />}
-                  {msg.kind === "page" && <GlensPageBubble answer={msg.answer} pageKind={msg.pageKind as any} data={msg.pageData} warning={msg.warning} />}
+                  {msg.kind === "page" && <GlensPageBubble answer={msg.answer} pageKind={msg.pageKind as any} data={msg.pageData} warning={msg.warning} drilldown={msg.drilldown} />}
                   {msg.kind === "action_confirm" && (
                     <ActionConfirmBubble
                       toolName={msg.toolName}

--- a/apps/web/src/components/glens/GlensPageBubble.tsx
+++ b/apps/web/src/components/glens/GlensPageBubble.tsx
@@ -555,11 +555,13 @@ export function GlensPageBubble({
   pageKind,
   data,
   warning,
+  drilldown,
 }: {
   answer: string
   pageKind: PageKind
   data: Record<string, unknown>
   warning?: string
+  drilldown?: { path: string; filters?: Record<string, string> }
 }) {
   return (
     <div style={{ maxWidth: "100%", marginBottom: 16 }}>
@@ -579,6 +581,16 @@ export function GlensPageBubble({
       {pageKind === "governance" && <GovernanceEmbed data={data} />}
       {pageKind === "activity"   && <ActivityEmbed data={data} />}
       {pageKind === "policies"   && <PoliciesEmbed data={data} />}
+      {drilldown && (
+        <div style={{ marginTop: 12, textAlign: "right" }}>
+          <a
+            href={drilldown.path}
+            style={{ fontSize: 12, color: "var(--accent, #6366f1)", textDecoration: "none", fontWeight: 500 }}
+          >
+            View full &rarr;
+          </a>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
`AnswerBubble` + `GenericTableBubble` already rendered `View full →` from the existing `drilldown` prop. Extends the pattern to the three bubble kinds that were missing it:

- **BlocksBubble** — accepts `drilldown`, renders link below block stack
- **GlensPageBubble** — link below embedded page
- **DashboardBubble** — link below `GlensDashboard` render

Also wires `msg.drilldown` through the assistant-push sites in `GLensChatPage` for kind `dashboard`, `blocks`, and `page`. Payloads already carried `data.drilldown` from the backend's `_build_drilldown()`; this closes the propagation gap.

Every Lens-rendered view now links to its canonical page in the app.

## Test plan
- [x] `tsc --noEmit` on `apps/web` — 0 errors
- [ ] Manual: ask a block-emitting question (e.g. dashboard KPIs) — link visible + navigates
- [ ] Manual: ask a page-embedded question (e.g. "show compliance") — link visible + navigates
- [ ] Manual: ask a dashboard-generating question — link visible + navigates

Closes #8 in epic #1333.