### PR TITLE
fix(dashboard): Needs Attention Approve/Reject 404 — wrong URL (#1672)

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -278,8 +278,12 @@ function PriorityItem({
   async function handleApproval(approved: boolean) {
     setApproveError(null)
     try {
+      // The approve endpoint lives under the workflow-scoped router
+      // (POST /workflows/{workflow_id}/runs/{run_id}/approve). AttentionRun
+      // already carries workflow_id — using the workspace-scoped /runs prefix
+      // 404s for every row, not just expired ones (#1672).
       const res = await authFetch(
-        `${API}/runs/${run.run_id}/approve`,
+        `${API}/workflows/${run.workflow_id}/runs/${run.run_id}/approve`,
         { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ decision: approved ? "approved" : "rejected" }) }
       )
       if (!res.ok) {


### PR DESCRIPTION
## Root cause
The Needs Attention widget's Approve/Reject buttons posted to `POST /runs/{run_id}/approve`. That endpoint doesn't exist. The only registered approve route is workflow-nested:

```
POST /workflows/{workflow_id}/runs/{run_id}/approve    (runs.py:581)
```

FastAPI returned **404 Not Found** for every request — not just expired approvals. The screenshot in #1672 showed 'Not Found' on a row that was still legitimately `awaiting`.

## Fix
One-line URL change in `PriorityItem`. `AttentionRun` already carries `workflow_id` (used in the sibling 'View run' link on the same row), so no API/type changes.

Closes #1672.

## Test plan
- [x] `tsc --noEmit` on `apps/web`
- [ ] Manual: dashboard → click Approve on an awaiting row → run resumes (200), row shows 'Approved' chip
- [ ] Manual: click Reject → run rejected, row shows 'Rejected' chip
- [ ] Manual: click Approve on already-resumed row → 409 with inline "already resumed" (matches existing backend error surface)