### PR TITLE
feat(lens): invite_member actor tool (#1301, closes #1639)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -5,6 +5,7 @@ entries via `app.tools.registrations.lens`).
 from app.modules.glens.actor.registrations import deactivate_agent_identity  # noqa: F401
 from app.modules.glens.actor.registrations import decide_approval  # noqa: F401
 from app.modules.glens.actor.registrations import install_pack  # noqa: F401
+from app.modules.glens.actor.registrations import invite_member  # noqa: F401
 from app.modules.glens.actor.registrations import run_workflow  # noqa: F401
 from app.modules.glens.actor.registrations import toggle_policy  # noqa: F401 — registers enable_policy + disable_policy
 from app.modules.glens.actor.registrations import update_budget  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/invite_member.py
+++ b/apps/api/app/modules/glens/actor/registrations/invite_member.py
@@ -1,0 +1,153 @@
+"""#1301 — Lens actor: invite a new workspace member by email.
+
+Two-step: `propose` validates the email + role, rejects if already a
+member or has a pending invite. `execute` inserts the `workspace_invites`
+row, fires the Clerk org invitation, and sends the templated email — the
+same fanout as `POST /projects/{ws}/members` uses (`invite_member` is a
+thin wrapper over that endpoint's helpers, not a parallel implementation).
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+from sqlalchemy import text
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+def _propose_invite_member(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    email = str(args.get("email") or "").strip().lower()
+    role = str(args.get("role") or "").strip()
+
+    if not email or "@" not in email:
+        return ProposeResult(rejected=True, reason="email required (must contain '@')",
+                             summary="", resolved_input={})
+    if not role:
+        return ProposeResult(rejected=True, reason="role required",
+                             summary="", resolved_input={})
+
+    from app.core.auth import find_clerk_user_id_by_email, get_valid_roles
+
+    if role not in get_valid_roles(ctx.db):
+        return ProposeResult(rejected=True, reason=f"Invalid role '{role}'",
+                             summary="", resolved_input={})
+
+    ws = ctx.workspace_id
+
+    existing_clerk_id = find_clerk_user_id_by_email(email)
+    if existing_clerk_id:
+        already = ctx.db.execute(text("""
+            SELECT 1 FROM workspace_users
+            WHERE workspace_id = :ws AND clerk_user_id = :uid
+        """), {"ws": ws, "uid": existing_clerk_id}).fetchone()
+        if already:
+            return ProposeResult(
+                rejected=True,
+                reason=f"'{email}' is already a member of this workspace",
+                summary="", resolved_input={},
+            )
+
+    pending = ctx.db.execute(text("""
+        SELECT 1 FROM workspace_invites
+        WHERE workspace_id = :ws AND invited_email = :email AND accepted_at IS NULL
+    """), {"ws": ws, "email": email}).fetchone()
+    if pending:
+        return ProposeResult(
+            rejected=True,
+            reason=f"An invite for '{email}' is already pending",
+            summary="", resolved_input={},
+        )
+
+    summary = f"Invite '{email}' as {role}"
+    return ProposeResult(
+        summary=summary,
+        resolved_input={"email": email, "role": role},
+    )
+
+
+def _execute_invite_member(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    """Insert the invite row, fire the Clerk fanout + templated email.
+
+    Uses the same helpers as `POST /projects/{ws}/members` — importing them
+    keeps the two paths behavior-identical without duplicating the Clerk
+    call or the email template."""
+    from app.core.auth import get_clerk_user_email, get_role_description
+    from app.core.config import settings
+    from app.core.email import send_template_email
+    from app.routers.projects import _audit, _send_clerk_invite
+
+    email = resolved["email"]
+    role = resolved["role"]
+    ws = ctx.workspace_id
+    inviter = ctx.clerk_user_id
+    now = datetime.now(timezone.utc)
+
+    invite_id = ctx.db.execute(text("""
+        INSERT INTO workspace_invites (workspace_id, invited_email, role, invited_by, created_at)
+        VALUES (:ws, :email, :role, :invited_by, :now)
+        ON CONFLICT (workspace_id, invited_email)
+        DO UPDATE SET role = EXCLUDED.role,
+                      invited_by = EXCLUDED.invited_by,
+                      created_at = EXCLUDED.created_at,
+                      accepted_at = NULL
+        RETURNING id
+    """), {"ws": ws, "email": email, "role": role,
+           "invited_by": inviter, "now": now}).fetchone()[0]
+
+    inviter_email = get_clerk_user_email(inviter) if inviter else None
+    _audit(ctx.db, workspace_id=ws, actor_id=inviter or "lens.actor",
+           actor_email=inviter_email, actor_role="admin",
+           action="member.invited", resource_type="invite",
+           resource_id=email, meta={"role": role, "invite_id": str(invite_id),
+                                    "via": "lens.actor"})
+    ctx.db.commit()
+
+    _send_clerk_invite(ctx.db, ws, email, role, invite_id=str(invite_id))
+
+    ws_row = ctx.db.execute(text("SELECT name FROM workspaces WHERE id = :id"),
+                            {"id": ws}).fetchone()
+    workspace_name = ws_row.name if ws_row else "your workspace"
+
+    email_sent = send_template_email(
+        slug="workspace_invite",
+        to=email,
+        context={
+            "workspace_name": workspace_name,
+            "invited_by_email": inviter_email or "",
+            "role": role,
+            "role_description": get_role_description(role, ctx.db),
+            "app_url": getattr(settings, "app_url", ""),
+            "workspace_id": ws,
+            "guard_invite_cmd": "",
+        },
+        workspace_id=ws,
+        db=ctx.db,
+    )
+
+    return {
+        "invite_id": str(invite_id),
+        "email": email,
+        "role": role,
+        "email_sent": bool(email_sent),
+        "invited": True,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="invite_member",
+    guard_permission="platform.members.manage",
+    propose=_propose_invite_member,
+    execute=_execute_invite_member,
+    description=(
+        "Invite a new member to the workspace by email. Two-step: returns a "
+        "pending action for the user to confirm; the confirm click inserts "
+        "the workspace_invites row, fires the Clerk org invitation, and "
+        "sends the templated email."
+    ),
+))

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -184,6 +184,33 @@ TOOLS: list[ToolDef] = [
         tags=_ACTOR_TAGS,
     ),
     ToolDef(
+        name="invite_member",
+        description=(
+            "Invite a new member to the workspace by email. Two-step: returns "
+            "a pending action for the user to confirm; the confirm click "
+            "inserts the workspace_invites row, fires the Clerk org invitation, "
+            "and sends the templated email. Guard policy "
+            "platform.members.manage still applies."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string",
+                    "description": "Email address of the person to invite.",
+                },
+                "role": {
+                    "type": "string",
+                    "description": "Workspace role (admin, developer, security, viewer).",
+                },
+            },
+            "required": ["email", "role"],
+        },
+        impl=_actor_impl("invite_member"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=True),
+        tags=_ACTOR_TAGS,
+    ),
+    ToolDef(
         name="enable_policy",
         description=(
             "Enable a Guard policy rule by rule_id. Two-step: returns a pending "

--- a/apps/api/tests/glens/test_actor_invite_member.py
+++ b/apps/api/tests/glens/test_actor_invite_member.py
@@ -1,0 +1,125 @@
+"""#1301 — actor ActionSpec + ToolDef parity for invite_member.
+
+Propose-path only; live-DB confirm+dispatch is covered by the actor
+substrate integration suite.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _no_existing_member_or_invite(ctx):
+    """Wire ctx.db so both existence checks return None."""
+    ctx.db.execute.return_value.fetchone.return_value = None
+
+
+def test_invite_member_actionspec_registered():
+    spec = default_action_registry.get("invite_member")
+    assert spec is not None
+    assert spec.guard_permission == "platform.members.manage"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_invite_member_tooldef_registered():
+    tool = default_registry.get("invite_member")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_propose_rejects_empty_email():
+    spec = default_action_registry.get("invite_member")
+    out = spec.propose(_ctx(), {"email": "", "role": "viewer"})
+    assert out.rejected
+    assert "email required" in (out.reason or "")
+
+
+def test_propose_rejects_malformed_email():
+    spec = default_action_registry.get("invite_member")
+    out = spec.propose(_ctx(), {"email": "not-an-email", "role": "viewer"})
+    assert out.rejected
+    assert "email required" in (out.reason or "")
+
+
+def test_propose_rejects_empty_role():
+    spec = default_action_registry.get("invite_member")
+    out = spec.propose(_ctx(), {"email": "new@example.com", "role": ""})
+    assert out.rejected
+    assert "role required" in (out.reason or "")
+
+
+def test_propose_rejects_invalid_role():
+    spec = default_action_registry.get("invite_member")
+    ctx = _ctx()
+    with patch("app.core.auth.get_valid_roles",
+               return_value={"admin", "developer", "viewer"}):
+        out = spec.propose(ctx, {"email": "new@example.com", "role": "wizard"})
+    assert out.rejected
+    assert "Invalid role 'wizard'" in (out.reason or "")
+
+
+def test_propose_rejects_already_a_member():
+    spec = default_action_registry.get("invite_member")
+    ctx = _ctx()
+    ctx.db.execute.return_value.fetchone.return_value = SimpleNamespace()
+    with patch("app.core.auth.get_valid_roles",
+               return_value={"admin", "viewer"}), \
+         patch("app.core.auth.find_clerk_user_id_by_email",
+               return_value="user_existing"):
+        out = spec.propose(ctx, {"email": "existing@example.com", "role": "viewer"})
+    assert out.rejected
+    assert "already a member" in (out.reason or "")
+
+
+def test_propose_rejects_pending_invite():
+    spec = default_action_registry.get("invite_member")
+    ctx = _ctx()
+    # find_clerk_user_id_by_email → None skips membership check;
+    # pending invite check is the only execute()
+    ctx.db.execute.return_value.fetchone.return_value = SimpleNamespace()
+    with patch("app.core.auth.get_valid_roles",
+               return_value={"admin", "viewer"}), \
+         patch("app.core.auth.find_clerk_user_id_by_email",
+               return_value=None):
+        out = spec.propose(ctx, {"email": "pending@example.com", "role": "viewer"})
+    assert out.rejected
+    assert "already pending" in (out.reason or "")
+
+
+def test_propose_success_shape():
+    spec = default_action_registry.get("invite_member")
+    ctx = _ctx()
+    _no_existing_member_or_invite(ctx)
+    with patch("app.core.auth.get_valid_roles",
+               return_value={"admin", "developer", "viewer"}), \
+         patch("app.core.auth.find_clerk_user_id_by_email",
+               return_value=None):
+        out = spec.propose(ctx, {"email": "New@Example.com", "role": "developer"})
+    assert not out.rejected
+    assert out.summary == "Invite 'new@example.com' as developer"
+    assert out.resolved_input == {"email": "new@example.com", "role": "developer"}


### PR DESCRIPTION
## Summary

Wraps the existing `POST /projects/{ws}/members` endpoint as a Lens actor tool. No new endpoint, no design decision — the endpoint at `apps/api/app/routers/projects.py:664` already handles workspace_invites row + Clerk org invitation + templated email + audit end-to-end. Lens actor just reuses `_send_clerk_invite` and `_audit` from that module.

Closes the last child of epic #1282 (Lens as actor).

## Behavior

- **Propose** rejects: empty/malformed email, empty/invalid role, already-a-member, pending-invite. Summary format: `Invite '<email>' as <role>`.
- **Execute** inserts `workspace_invites`, audits as `via='lens.actor'`, fires Clerk org invitation (fire-and-forget), sends `workspace_invite` email template.
- Two-step confirm/reject same as sibling actor tools (#1300 `install_pack`, #1302 `update_budget`, etc.).
- Guard permission: `platform.members.manage` (same as HTTP endpoint).

## Test plan

- [x] 9 unit tests — ActionSpec + ToolDef registered; propose rejects empty/malformed email, empty/invalid role, existing member, pending invite; success shape.
- [x] All 44 actor tests in `tests/glens/test_actor_*.py` still pass.
- [ ] Live smoke via Lens: `invite <email> as viewer` → confirm card → verify workspace_invites row + email fires.

## Closes

- Closes #1301 (Lens actor: invite_member)
- Closes #1639 (Clerk integration design — resolved by reusing existing helpers)