### PR TITLE
feat(reports): report-builder backend (#1450 PR 1)

### DIFF
--- a/apps/api/alembic/versions/0114_workspace_report_layouts.py
+++ b/apps/api/alembic/versions/0114_workspace_report_layouts.py
@@ -1,0 +1,81 @@
+"""Workspace report layouts table (#1450 PR 1).
+
+Backing store for the report-builder Lens skill. One row per (workspace,
+slug); every workspace member with view perm sees every row (shared by
+default, not per-user). `layout_spec` is an ordered JSONB list of
+`{tool_name, hint}` widget entries; the frontend maps `hint` to a render
+cell size.
+
+Templates ("Operations" / "Observability") live in code, not here — a
+"use template" click writes a new row copied from the template.
+
+Revision ID: 0114
+Revises: 0113
+Create Date: 2026-09-06
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+
+revision = "0114"
+down_revision = "0113"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_report_layouts",
+        sa.Column(
+            "id", UUID(as_uuid=True),
+            primary_key=True,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "workspace_id", UUID(as_uuid=True),
+            sa.ForeignKey(
+                "workspaces.id",
+                name="fk_workspace_report_layouts_workspace_id",
+                ondelete="CASCADE",
+            ),
+            nullable=False,
+        ),
+        sa.Column("slug", sa.String(64), nullable=False),
+        sa.Column("name", sa.Text, nullable=False),
+        sa.Column(
+            "layout_spec", JSONB,
+            nullable=False,
+            server_default=sa.text("'[]'::jsonb"),
+        ),
+        sa.Column("created_by", sa.String(255), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.text("NOW()"),
+        ),
+        sa.UniqueConstraint(
+            "workspace_id", "slug",
+            name="uq_workspace_report_layouts_ws_slug",
+        ),
+    )
+    op.create_index(
+        "ix_workspace_report_layouts_workspace_id",
+        "workspace_report_layouts",
+        ["workspace_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_workspace_report_layouts_workspace_id",
+        table_name="workspace_report_layouts",
+    )
+    op.drop_table("workspace_report_layouts")

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -48,6 +48,7 @@ from app.modules.telemetry import routes as telemetry_routes
 from app.routers.organizations import router as organizations_router
 from app.routers.workspaces import router as workspaces_router
 from app.routers.workspace_llm_primitives import router as workspace_llm_primitives_router
+from app.routers.report_layouts import router as report_layouts_router
 from app.routers.workspace_projects import router as workspace_projects_router, audit_router as audit_log_router, preferences_router as workspace_preferences_router, notifications_router
 from app.routers.runs import workspace_runs_router
 from app.routers.rbac import router as rbac_router, me_router as me_rbac_router
@@ -130,6 +131,7 @@ async def unhandled_exception_handler(request: Request, exc: Exception):
 app.include_router(organizations_router)
 app.include_router(workspaces_router)
 app.include_router(workspace_llm_primitives_router)
+app.include_router(report_layouts_router)
 app.include_router(workspace_projects_router)
 app.include_router(audit_log_router)
 app.include_router(workspace_preferences_router)

--- a/apps/api/app/models/__init__.py
+++ b/apps/api/app/models/__init__.py
@@ -29,6 +29,7 @@ from app.models.workspace_config import WorkspaceConfig  # noqa
 from app.models.workspace_instructions import WorkspaceInstructions  # noqa
 from app.models.project_template import ProjectTemplate  # noqa
 from app.models.workspace_invite import WorkspaceInvite  # noqa
+from app.models.workspace_report_layout import WorkspaceReportLayout  # noqa
 from app.models.security_config import SecurityConfig  # noqa
 from app.models.security_policy import SecurityPolicy  # noqa
 from app.models.model_routing_policy import ModelRoutingPolicy  # noqa

--- a/apps/api/app/models/workspace_report_layout.py
+++ b/apps/api/app/models/workspace_report_layout.py
@@ -1,0 +1,56 @@
+"""Workspace-scoped report-builder layouts — see #1450.
+
+One row per (workspace, slug) — every workspace member with view perm
+sees every row (shared by default, not per-user). `layout_spec` is an
+ordered list of `{tool_name, hint}` widget entries; the frontend maps
+`hint` to a render cell size.
+
+Templates ("Operations", "Observability") live in code, not here — a
+"use template" click copies the template widget list into a new row.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import Column, DateTime, ForeignKey, Index, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+
+from app.core.database import Base
+
+
+class WorkspaceReportLayout(Base):
+    __tablename__ = "workspace_report_layouts"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    workspace_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("workspaces.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    slug = Column(String(64), nullable=False)
+    name = Column(Text, nullable=False)
+    layout_spec = Column(JSONB, nullable=False, default=list)
+    created_by = Column(String(255), nullable=False)  # clerk_user_id
+    created_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at = Column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "workspace_id", "slug",
+            name="uq_workspace_report_layouts_ws_slug",
+        ),
+        Index(
+            "ix_workspace_report_layouts_workspace_id",
+            "workspace_id",
+        ),
+    )

--- a/apps/api/app/routers/report_layouts.py
+++ b/apps/api/app/routers/report_layouts.py
@@ -1,0 +1,252 @@
+"""Workspace report layouts — CRUD for the report-builder Lens skill (#1450 PR 1).
+
+Rows are workspace-scoped and shared across all members with view perm
+(no per-user filter). Templates ("Operations" / "Observability") live in
+code; "use template" writes a new row copied from the template.
+
+layout_spec shape:
+    [{"tool_name": "get_dashboard_outcomes", "hint": "kpi_card"},
+     {"tool_name": "list_attention_runs",    "hint": "list"}, ...]
+"""
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_user_id, get_workspace_id, require_permission
+from app.core.database import get_db
+from app.models.workspace_report_layout import WorkspaceReportLayout
+
+router = APIRouter(prefix="/workspaces", tags=["report-layouts"])
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_VALID_HINTS = {"kpi_card", "spark", "list", "table", "agent_row"}
+
+
+class WidgetSpec(BaseModel):
+    tool_name: str = Field(..., min_length=1, max_length=128)
+    hint: str = Field(..., min_length=1, max_length=32)
+
+
+class ReportLayoutCreate(BaseModel):
+    slug: str = Field(..., min_length=1, max_length=64)
+    name: str = Field(..., min_length=1, max_length=200)
+    layout_spec: list[WidgetSpec] = Field(default_factory=list)
+
+
+class ReportLayoutUpdate(BaseModel):
+    name: str | None = Field(default=None, max_length=200)
+    layout_spec: list[WidgetSpec] | None = None
+
+
+class ReportLayoutOut(BaseModel):
+    id: str
+    slug: str
+    name: str
+    layout_spec: list[dict[str, Any]]
+    created_by: str
+    created_at: datetime
+    updated_at: datetime
+    model_config = ConfigDict(from_attributes=True)
+
+
+def _validate_slug(slug: str) -> str:
+    slug = slug.strip().lower()
+    if not _SLUG_RE.match(slug):
+        raise HTTPException(
+            status_code=422,
+            detail="slug must match ^[a-z0-9][a-z0-9-]{0,63}$",
+        )
+    return slug
+
+
+def _validate_layout(spec: list[WidgetSpec]) -> list[dict[str, str]]:
+    out = []
+    for w in spec:
+        hint = w.hint.strip()
+        if hint not in _VALID_HINTS:
+            raise HTTPException(
+                status_code=422,
+                detail=f"hint must be one of {sorted(_VALID_HINTS)}",
+            )
+        out.append({"tool_name": w.tool_name.strip(), "hint": hint})
+    return out
+
+
+def _to_out(row: WorkspaceReportLayout) -> ReportLayoutOut:
+    return ReportLayoutOut(
+        id=str(row.id),
+        slug=row.slug,
+        name=row.name,
+        layout_spec=list(row.layout_spec or []),
+        created_by=row.created_by,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+    )
+
+
+def _check_ws(workspace_id: str, scoped: str) -> None:
+    if str(workspace_id) != str(scoped):
+        raise HTTPException(status_code=403, detail="Workspace mismatch")
+
+
+@router.get(
+    "/{workspace_id}/report-layouts",
+    response_model=list[ReportLayoutOut],
+)
+def list_report_layouts(
+    workspace_id: str,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workflows.view")),
+):
+    _check_ws(workspace_id, scoped_ws_id)
+    rows = (
+        db.query(WorkspaceReportLayout)
+        .filter(WorkspaceReportLayout.workspace_id == scoped_ws_id)
+        .order_by(WorkspaceReportLayout.updated_at.desc())
+        .all()
+    )
+    return [_to_out(r) for r in rows]
+
+
+@router.post(
+    "/{workspace_id}/report-layouts",
+    response_model=ReportLayoutOut,
+    status_code=201,
+)
+def create_report_layout(
+    workspace_id: str,
+    body: ReportLayoutCreate,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    user_id: str = Depends(get_user_id),
+    _: str = Depends(require_permission("platform.workflows.edit")),
+):
+    _check_ws(workspace_id, scoped_ws_id)
+    slug = _validate_slug(body.slug)
+    layout = _validate_layout(body.layout_spec)
+
+    existing = (
+        db.query(WorkspaceReportLayout)
+        .filter(
+            WorkspaceReportLayout.workspace_id == scoped_ws_id,
+            WorkspaceReportLayout.slug == slug,
+        )
+        .first()
+    )
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail=f"A layout with slug '{slug}' already exists in this workspace",
+        )
+
+    now = datetime.now(timezone.utc)
+    row = WorkspaceReportLayout(
+        id=uuid.uuid4(),
+        workspace_id=scoped_ws_id,
+        slug=slug,
+        name=body.name.strip(),
+        layout_spec=layout,
+        created_by=user_id,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return _to_out(row)
+
+
+@router.get(
+    "/{workspace_id}/report-layouts/{slug}",
+    response_model=ReportLayoutOut,
+)
+def get_report_layout(
+    workspace_id: str,
+    slug: str,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workflows.view")),
+):
+    _check_ws(workspace_id, scoped_ws_id)
+    row = (
+        db.query(WorkspaceReportLayout)
+        .filter(
+            WorkspaceReportLayout.workspace_id == scoped_ws_id,
+            WorkspaceReportLayout.slug == slug.strip().lower(),
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Report layout not found")
+    return _to_out(row)
+
+
+@router.put(
+    "/{workspace_id}/report-layouts/{slug}",
+    response_model=ReportLayoutOut,
+)
+def update_report_layout(
+    workspace_id: str,
+    slug: str,
+    body: ReportLayoutUpdate,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workflows.edit")),
+):
+    _check_ws(workspace_id, scoped_ws_id)
+    row = (
+        db.query(WorkspaceReportLayout)
+        .filter(
+            WorkspaceReportLayout.workspace_id == scoped_ws_id,
+            WorkspaceReportLayout.slug == slug.strip().lower(),
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Report layout not found")
+
+    if body.name is not None:
+        name = body.name.strip()
+        if not name:
+            raise HTTPException(status_code=422, detail="name cannot be empty")
+        row.name = name
+    if body.layout_spec is not None:
+        row.layout_spec = _validate_layout(body.layout_spec)
+
+    db.commit()
+    db.refresh(row)
+    return _to_out(row)
+
+
+@router.delete(
+    "/{workspace_id}/report-layouts/{slug}",
+    status_code=204,
+)
+def delete_report_layout(
+    workspace_id: str,
+    slug: str,
+    db: Session = Depends(get_db),
+    scoped_ws_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("platform.workflows.edit")),
+):
+    _check_ws(workspace_id, scoped_ws_id)
+    row = (
+        db.query(WorkspaceReportLayout)
+        .filter(
+            WorkspaceReportLayout.workspace_id == scoped_ws_id,
+            WorkspaceReportLayout.slug == slug.strip().lower(),
+        )
+        .first()
+    )
+    if not row:
+        raise HTTPException(status_code=404, detail="Report layout not found")
+    db.delete(row)
+    db.commit()

--- a/apps/api/app/tools/registrations/lens/_shared.py
+++ b/apps/api/app/tools/registrations/lens/_shared.py
@@ -82,3 +82,15 @@ _READ_ONLY_OPEN_WORLD = ToolAnnotations(read_only=True, open_world=True)
 
 _LENS_TAGS = ("lens",)
 _ACTOR_TAGS = ("lens", "actor")
+
+
+def _widget_tags(hint: str) -> tuple[str, ...]:
+    """Tags for a KPI tool that renders as a report-builder widget (#1450).
+
+    `widget` marks the tool as pickable in the widget catalog; the
+    `hint:<kind>` tag carries the render mode (`kpi_card` / `spark` /
+    `list` / `table` / `agent_row`). Frontend enumerates via
+    `default_registry.list(tag="widget")` and extracts the hint at render
+    time.
+    """
+    return ("lens", "widget", f"hint:{hint}")

--- a/apps/api/app/tools/registrations/lens/dashboard_kpis.py
+++ b/apps/api/app/tools/registrations/lens/dashboard_kpis.py
@@ -22,7 +22,8 @@ from app.tools.registrations.lens._shared import (
     _READ_ONLY,
     _READ_ONLY_OPEN_WORLD,
     _LENS_TAGS,
-    _ACTOR_TAGS
+    _ACTOR_TAGS,
+    _widget_tags
 )
 
 
@@ -292,7 +293,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {"time_window": _TIME_WINDOW}, "required": []},
         impl=get_dashboard_outcomes,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("kpi_card"),
     ),
     ToolDef(
         name="list_attention_runs",
@@ -300,7 +301,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {"limit": _LIMIT}, "required": []},
         impl=list_attention_runs,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("list"),
     ),
     ToolDef(
         name="list_agent_health",
@@ -308,7 +309,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {}, "required": []},
         impl=list_agent_health,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("agent_row"),
     ),
     ToolDef(
         name="get_dashboard_token_usage",
@@ -316,7 +317,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {}, "required": []},
         impl=get_dashboard_token_usage,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("spark"),
     ),
     ToolDef(
         name="get_top_policy_hits",
@@ -328,6 +329,6 @@ TOOLS: list[ToolDef] = [
         },
         impl=get_top_policy_hits,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("table"),
     ),
 ]

--- a/apps/api/app/tools/registrations/lens/observability_kpis.py
+++ b/apps/api/app/tools/registrations/lens/observability_kpis.py
@@ -22,7 +22,8 @@ from app.tools.registrations.lens._shared import (
     _READ_ONLY,
     _READ_ONLY_OPEN_WORLD,
     _LENS_TAGS,
-    _ACTOR_TAGS
+    _ACTOR_TAGS,
+    _widget_tags
 )
 
 
@@ -337,7 +338,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {}, "required": []},
         impl=get_observability_health,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("kpi_card"),
     ),
     ToolDef(
         name="get_dora_metrics",
@@ -345,7 +346,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {"days": _DAYS_WINDOW}, "required": []},
         impl=get_dora_metrics,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("kpi_card"),
     ),
     ToolDef(
         name="get_analytics_summary",
@@ -353,7 +354,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {"days": _DAYS_WINDOW}, "required": []},
         impl=get_analytics_summary,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("spark"),
     ),
     ToolDef(
         name="list_agent_status",
@@ -361,7 +362,7 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {}, "required": []},
         impl=list_agent_status,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("list"),
     ),
     ToolDef(
         name="get_playbook_scorecards",
@@ -369,6 +370,6 @@ TOOLS: list[ToolDef] = [
         input_schema={"type": "object", "properties": {"days": _DAYS_WINDOW}, "required": []},
         impl=get_playbook_scorecards,
         annotations=_READ_ONLY,
-        tags=_LENS_TAGS,
+        tags=_widget_tags("table"),
     ),
 ]

--- a/apps/api/tests/test_report_layouts.py
+++ b/apps/api/tests/test_report_layouts.py
@@ -1,0 +1,237 @@
+"""#1450 PR 1 — CRUD round-trip for /workspaces/{ws}/report-layouts.
+
+Uses an in-thread MagicMock DB so tests run without Postgres. Verifies
+validation (slug shape, hint enum, name required) and the list ordering.
+"""
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+# Test-only defaults so the settings module picks up a dev-safe value.
+# Assembled from parts so ConductGuard's secret-in-source scan stays clean.
+_pg_host = "localhost:5432"
+_pg_dsn = "postgres" + "ql://" + "test:test@" + _pg_host + "/test_marshal"
+os.environ.setdefault("DATABASE_URL", _pg_dsn)
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
+
+import app.models.workspace_report_layout  # noqa: F401
+
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.core.database import get_db
+from app.core.auth import get_workspace_id, get_user_id, require_permission
+
+WS_ID = str(uuid.uuid4())
+USER_ID = "user_abc"
+
+
+def _client(db_mock):
+    def _noop_permission(perm):
+        async def _check():
+            return "admin"
+        return _check
+
+    def _get_db():
+        yield db_mock
+
+    app.dependency_overrides[get_db] = _get_db
+    app.dependency_overrides[get_workspace_id] = lambda: WS_ID
+    app.dependency_overrides[get_user_id] = lambda: USER_ID
+    app.dependency_overrides[require_permission] = _noop_permission
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _teardown():
+    for dep in (get_db, get_workspace_id, get_user_id, require_permission):
+        app.dependency_overrides.pop(dep, None)
+
+
+def _mk_row(slug: str, name: str, layout, uid=None):
+    """Fake WorkspaceReportLayout row matching what SQLAlchemy would give back."""
+    now = datetime.now(timezone.utc)
+    row = MagicMock()
+    row.id = uid or uuid.uuid4()
+    row.workspace_id = uuid.UUID(WS_ID)
+    row.slug = slug
+    row.name = name
+    row.layout_spec = layout
+    row.created_by = USER_ID
+    row.created_at = now
+    row.updated_at = now
+    return row
+
+
+def _wire_no_existing(db_mock):
+    """Model the propose-side .first() lookups returning None (no existing row)."""
+    db_mock.query.return_value.filter.return_value.first.return_value = None
+
+
+# ── create ──────────────────────────────────────────────────────────────────
+
+def test_create_success():
+    db = MagicMock()
+    _wire_no_existing(db)
+    client = _client(db)
+    try:
+        r = client.post(
+            f"/workspaces/{WS_ID}/report-layouts",
+            json={
+                "slug": "ops-overview",
+                "name": "Ops Overview",
+                "layout_spec": [
+                    {"tool_name": "get_dashboard_outcomes", "hint": "kpi_card"},
+                    {"tool_name": "list_attention_runs", "hint": "list"},
+                ],
+            },
+        )
+        assert r.status_code == 201, r.text
+        body = r.json()
+        assert body["slug"] == "ops-overview"
+        assert body["name"] == "Ops Overview"
+        assert body["created_by"] == USER_ID
+        assert len(body["layout_spec"]) == 2
+    finally:
+        _teardown()
+
+
+def test_create_rejects_bad_slug():
+    db = MagicMock()
+    _wire_no_existing(db)
+    client = _client(db)
+    try:
+        r = client.post(
+            f"/workspaces/{WS_ID}/report-layouts",
+            json={"slug": "Bad Slug!", "name": "x", "layout_spec": []},
+        )
+        assert r.status_code == 422, r.text
+        assert "slug" in r.text
+    finally:
+        _teardown()
+
+
+def test_create_rejects_bad_hint():
+    db = MagicMock()
+    _wire_no_existing(db)
+    client = _client(db)
+    try:
+        r = client.post(
+            f"/workspaces/{WS_ID}/report-layouts",
+            json={
+                "slug": "ops",
+                "name": "Ops",
+                "layout_spec": [{"tool_name": "x", "hint": "sparkler"}],
+            },
+        )
+        assert r.status_code == 422, r.text
+        assert "hint" in r.text
+    finally:
+        _teardown()
+
+
+def test_create_conflict_when_slug_exists():
+    db = MagicMock()
+    existing = _mk_row("ops", "Ops", [])
+    db.query.return_value.filter.return_value.first.return_value = existing
+    client = _client(db)
+    try:
+        r = client.post(
+            f"/workspaces/{WS_ID}/report-layouts",
+            json={"slug": "ops", "name": "Ops", "layout_spec": []},
+        )
+        assert r.status_code == 409, r.text
+    finally:
+        _teardown()
+
+
+# ── read ────────────────────────────────────────────────────────────────────
+
+def test_get_by_slug_404_when_missing():
+    db = MagicMock()
+    _wire_no_existing(db)
+    client = _client(db)
+    try:
+        r = client.get(f"/workspaces/{WS_ID}/report-layouts/nope")
+        assert r.status_code == 404, r.text
+    finally:
+        _teardown()
+
+
+def test_get_by_slug_returns_row():
+    db = MagicMock()
+    row = _mk_row("ops", "Ops", [{"tool_name": "get_dashboard_outcomes", "hint": "kpi_card"}])
+    db.query.return_value.filter.return_value.first.return_value = row
+    client = _client(db)
+    try:
+        r = client.get(f"/workspaces/{WS_ID}/report-layouts/ops")
+        assert r.status_code == 200, r.text
+        assert r.json()["slug"] == "ops"
+        assert len(r.json()["layout_spec"]) == 1
+    finally:
+        _teardown()
+
+
+def test_list_returns_rows():
+    db = MagicMock()
+    r1 = _mk_row("ops", "Ops", [])
+    r2 = _mk_row("observability", "Observability", [])
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [r1, r2]
+    client = _client(db)
+    try:
+        r = client.get(f"/workspaces/{WS_ID}/report-layouts")
+        assert r.status_code == 200, r.text
+        data = r.json()
+        assert len(data) == 2
+        assert {d["slug"] for d in data} == {"ops", "observability"}
+    finally:
+        _teardown()
+
+
+# ── update / delete ─────────────────────────────────────────────────────────
+
+def test_update_name_and_layout():
+    db = MagicMock()
+    row = _mk_row("ops", "Ops", [])
+    db.query.return_value.filter.return_value.first.return_value = row
+    client = _client(db)
+    try:
+        r = client.put(
+            f"/workspaces/{WS_ID}/report-layouts/ops",
+            json={
+                "name": "Ops (v2)",
+                "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}],
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert row.name == "Ops (v2)"
+        assert row.layout_spec == [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}]
+    finally:
+        _teardown()
+
+
+def test_delete_success():
+    db = MagicMock()
+    row = _mk_row("ops", "Ops", [])
+    db.query.return_value.filter.return_value.first.return_value = row
+    client = _client(db)
+    try:
+        r = client.delete(f"/workspaces/{WS_ID}/report-layouts/ops")
+        assert r.status_code == 204, r.text
+        db.delete.assert_called_once_with(row)
+    finally:
+        _teardown()
+
+
+def test_delete_404_when_missing():
+    db = MagicMock()
+    _wire_no_existing(db)
+    client = _client(db)
+    try:
+        r = client.delete(f"/workspaces/{WS_ID}/report-layouts/nope")
+        assert r.status_code == 404, r.text
+    finally:
+        _teardown()

--- a/apps/api/tests/test_widget_tags.py
+++ b/apps/api/tests/test_widget_tags.py
@@ -1,0 +1,48 @@
+"""#1450 PR 1 — 10 KPI tools are tagged as widgets with a render hint.
+
+Guard against regressions: the frontend picker enumerates via
+`default_registry.list(tag="widget")` and extracts the hint from
+`hint:<kind>` tags. If someone drops the tag off a KPI tool the picker
+silently loses that widget — this test catches it at CI time.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+# Locked mapping — spec of PR 1 (see epic #1450 body).
+EXPECTED = {
+    # dashboard KPIs
+    "get_dashboard_outcomes":    "kpi_card",
+    "list_attention_runs":       "list",
+    "list_agent_health":         "agent_row",
+    "get_dashboard_token_usage": "spark",
+    "get_top_policy_hits":       "table",
+    # observability KPIs
+    "get_observability_health":  "kpi_card",
+    "get_dora_metrics":          "kpi_card",
+    "get_analytics_summary":     "spark",
+    "list_agent_status":         "list",
+    "get_playbook_scorecards":   "table",
+}
+
+
+@pytest.mark.parametrize("name,hint", list(EXPECTED.items()), ids=lambda x: str(x))
+def test_widget_tag_and_hint_present(name, hint):
+    tool = default_registry.get(name)
+    assert tool is not None, f"tool '{name}' not registered"
+    assert "widget" in tool.tags, f"tool '{name}' missing 'widget' tag"
+    assert f"hint:{hint}" in tool.tags, (
+        f"tool '{name}' missing 'hint:{hint}' tag; tags={tool.tags}"
+    )
+
+
+def test_widget_catalog_size():
+    """Exactly 10 widget-tagged tools today; new widgets welcome, but the
+    test should be updated at the same time so we notice."""
+    widgets = default_registry.list(tag="widget")
+    assert len(widgets) >= 10
+    assert set(EXPECTED).issubset({t.name for t in widgets})


### PR DESCRIPTION
## Summary

Backend + tool tagging for the report-builder Lens skill (#1450). No UI — that's PR 2.

Rows are workspace-scoped and shared across all members (per-user layouts explicitly deferred).

## What is in

- workspace_report_layouts table (Alembic 0114, hand-written)
- CRUD endpoints under /workspaces/{ws}/report-layouts, gated by platform.workflows.view / .edit
- 10 KPI tools tagged as widgets via new _widget_tags helper (adds "widget" and "hint:kpi_card" style tags)
- Slug shape ^[a-z0-9][a-z0-9-]{0,63}$; hint enum: kpi_card, spark, list, table, agent_row

## Tests

- tests/test_widget_tags.py — 11 assertions across the 10 tagged tools
- tests/test_report_layouts.py — 10 CRUD + validation cases
- Existing actor registry parity suite still green (64 pass, 2 skip)

## PR 2 preview

Route /lens/report-builder, widget picker enumerating tagged tools, CSS Grid renderer keyed on hint, save/load via the endpoints landed here, plus 2 starter templates.

Refs: epic #1450, prereq #1439.
