### PR TITLE
feat(reports): report-builder page + templates (#1450 PR 2)

### DIFF
--- a/apps/web/src/app/(app)/lens/report-builder/page.tsx
+++ b/apps/web/src/app/(app)/lens/report-builder/page.tsx
@@ -1,0 +1,428 @@
+"use client"
+
+/**
+ * Report-builder skeleton (#1450 PR 2).
+ *
+ * One page, three panes:
+ *   - Left: saved layouts + "Start from template" buttons.
+ *   - Center: widget grid of the active layout.
+ *   - Right: widget picker (add) + save/rename.
+ *
+ * Widget cells are PLACEHOLDER cards in this PR — they show tool name +
+ * hint + cell dimensions, sized per HINT_SIZES. PR 3 replaces the
+ * placeholder body with live tool-call rendering per hint.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { useRouter, useSearchParams } from "next/navigation"
+
+import AppShell from "@/components/AppShell"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { useWorkspace } from "@/lib/WorkspaceContext"
+import {
+  HINT_SIZES,
+  WIDGETS,
+  widgetByName,
+  type WidgetHint,
+} from "@/lib/reportBuilder/widgets"
+import { TEMPLATES, templateBySlug } from "@/lib/reportBuilder/templates"
+import { reportLayoutsApi, type ReportLayout, type WidgetSpec } from "@/lib/reportBuilder/api"
+
+type LayoutDraft = {
+  slug: string
+  name: string
+  layout_spec: WidgetSpec[]
+  existing: boolean // true = server has this slug; PUT vs POST on save
+}
+
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 64)
+}
+
+function draftFromLayout(l: ReportLayout): LayoutDraft {
+  return {
+    slug: l.slug,
+    name: l.name,
+    layout_spec: l.layout_spec.map((w) => ({ ...w })),
+    existing: true,
+  }
+}
+
+function draftFromTemplate(t: (typeof TEMPLATES)[number]): LayoutDraft {
+  return {
+    slug: t.slug,
+    name: t.name,
+    layout_spec: t.widgets.map((w) => ({ ...w })),
+    existing: false,
+  }
+}
+
+function emptyDraft(): LayoutDraft {
+  return { slug: "", name: "", layout_spec: [], existing: false }
+}
+
+export default function ReportBuilderPage() {
+  const router = useRouter()
+  const search = useSearchParams()
+  const { authFetch } = useAuthFetch()
+  const { activeWorkspace } = useWorkspace()
+  const workspaceId = activeWorkspace?.id ?? null
+
+  const initialSlug = search.get("slug")
+
+  const [layouts, setLayouts] = useState<ReportLayout[]>([])
+  const [draft, setDraft] = useState<LayoutDraft>(emptyDraft())
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [busy, setBusy] = useState(false)
+
+  const refreshLayouts = useCallback(async () => {
+    if (!workspaceId) return
+    setLoading(true)
+    try {
+      const list = await reportLayoutsApi.list(authFetch, workspaceId)
+      setLayouts(list)
+      setError(null)
+    } catch (e) {
+      setError(String((e as Error).message ?? e))
+    } finally {
+      setLoading(false)
+    }
+  }, [authFetch, workspaceId])
+
+  useEffect(() => {
+    if (!workspaceId) return
+    void refreshLayouts()
+  }, [workspaceId, refreshLayouts])
+
+  useEffect(() => {
+    if (!workspaceId || !initialSlug) return
+    // Load a specific layout into the editor. Falls back to empty if 404.
+    void (async () => {
+      try {
+        const l = await reportLayoutsApi.get(authFetch, workspaceId, initialSlug)
+        setDraft(draftFromLayout(l))
+      } catch {
+        setDraft(emptyDraft())
+      }
+    })()
+  }, [authFetch, workspaceId, initialSlug])
+
+  const selectLayout = (l: ReportLayout) => {
+    setDraft(draftFromLayout(l))
+    router.replace(`/lens/report-builder?slug=${encodeURIComponent(l.slug)}`)
+  }
+
+  const startFromTemplate = (slug: string) => {
+    const t = templateBySlug(slug)
+    if (!t) return
+    setDraft(draftFromTemplate(t))
+    router.replace(`/lens/report-builder`)
+  }
+
+  const startBlank = () => {
+    setDraft(emptyDraft())
+    router.replace(`/lens/report-builder`)
+  }
+
+  const addWidget = (tool_name: string) => {
+    const w = widgetByName(tool_name)
+    if (!w) return
+    setDraft((d) => ({
+      ...d,
+      layout_spec: [...d.layout_spec, { tool_name: w.tool_name, hint: w.hint }],
+    }))
+  }
+
+  const removeWidgetAt = (idx: number) => {
+    setDraft((d) => ({
+      ...d,
+      layout_spec: d.layout_spec.filter((_, i) => i !== idx),
+    }))
+  }
+
+  const moveWidget = (idx: number, delta: -1 | 1) => {
+    setDraft((d) => {
+      const next = [...d.layout_spec]
+      const target = idx + delta
+      if (target < 0 || target >= next.length) return d
+      ;[next[idx], next[target]] = [next[target], next[idx]]
+      return { ...d, layout_spec: next }
+    })
+  }
+
+  const save = async () => {
+    if (!workspaceId) return
+    const name = draft.name.trim() || "Untitled report"
+    const slug = draft.slug.trim() || slugify(name)
+    if (!slug) {
+      setError("Slug is required (letters, numbers, hyphens).")
+      return
+    }
+    setBusy(true)
+    setError(null)
+    try {
+      if (draft.existing) {
+        await reportLayoutsApi.update(authFetch, workspaceId, slug, {
+          name,
+          layout_spec: draft.layout_spec,
+        })
+      } else {
+        await reportLayoutsApi.create(authFetch, workspaceId, {
+          slug,
+          name,
+          layout_spec: draft.layout_spec,
+        })
+      }
+      await refreshLayouts()
+      setDraft((d) => ({ ...d, slug, name, existing: true }))
+      router.replace(`/lens/report-builder?slug=${encodeURIComponent(slug)}`)
+    } catch (e) {
+      setError(String((e as Error).message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const removeCurrent = async () => {
+    if (!workspaceId || !draft.existing) return
+    if (!confirm(`Delete report "${draft.name}"?`)) return
+    setBusy(true)
+    try {
+      await reportLayoutsApi.remove(authFetch, workspaceId, draft.slug)
+      await refreshLayouts()
+      startBlank()
+    } catch (e) {
+      setError(String((e as Error).message ?? e))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const picker = useMemo(() => {
+    return WIDGETS
+  }, [])
+
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-[1400px] px-6 py-6">
+        <header className="mb-6 flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold">Report builder</h1>
+            <p className="text-sm text-neutral-500">
+              Compose a report from workspace-level widgets. Reports are shared with everyone in this workspace.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <button
+              type="button"
+              className="rounded border border-neutral-300 px-3 py-1.5 text-sm hover:bg-neutral-50"
+              onClick={startBlank}
+            >
+              New blank
+            </button>
+            {draft.existing && (
+              <button
+                type="button"
+                className="rounded border border-red-300 px-3 py-1.5 text-sm text-red-600 hover:bg-red-50"
+                onClick={removeCurrent}
+                disabled={busy}
+              >
+                Delete
+              </button>
+            )}
+            <button
+              type="button"
+              className="rounded bg-neutral-900 px-3 py-1.5 text-sm text-white hover:bg-neutral-800 disabled:opacity-50"
+              onClick={save}
+              disabled={busy || !workspaceId}
+            >
+              {draft.existing ? "Save" : "Create"}
+            </button>
+          </div>
+        </header>
+
+        {error && (
+          <div className="mb-4 rounded border border-red-300 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        <div className="grid grid-cols-[240px_minmax(0,1fr)_280px] gap-6">
+          {/* Left: saved layouts + templates */}
+          <aside className="space-y-6">
+            <section>
+              <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                Templates
+              </h2>
+              <ul className="space-y-1">
+                {TEMPLATES.map((t) => (
+                  <li key={t.slug}>
+                    <button
+                      type="button"
+                      className="w-full rounded px-2 py-1.5 text-left text-sm hover:bg-neutral-100"
+                      onClick={() => startFromTemplate(t.slug)}
+                      title={t.description}
+                    >
+                      {t.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </section>
+            <section>
+              <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+                Saved reports
+              </h2>
+              {loading ? (
+                <p className="text-sm text-neutral-500">Loading…</p>
+              ) : layouts.length === 0 ? (
+                <p className="text-sm text-neutral-500">No saved reports yet.</p>
+              ) : (
+                <ul className="space-y-1">
+                  {layouts.map((l) => (
+                    <li key={l.id}>
+                      <button
+                        type="button"
+                        className={`w-full rounded px-2 py-1.5 text-left text-sm hover:bg-neutral-100 ${
+                          l.slug === draft.slug ? "bg-neutral-100 font-medium" : ""
+                        }`}
+                        onClick={() => selectLayout(l)}
+                      >
+                        {l.name}
+                        <span className="ml-2 text-xs text-neutral-400">{l.slug}</span>
+                      </button>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </aside>
+
+          {/* Center: grid + name/slug */}
+          <main className="min-w-0">
+            <div className="mb-4 flex items-center gap-3">
+              <label className="text-sm font-medium">Name</label>
+              <input
+                type="text"
+                value={draft.name}
+                onChange={(e) => setDraft((d) => ({ ...d, name: e.target.value }))}
+                placeholder="Ops Overview"
+                className="w-64 rounded border border-neutral-300 px-2 py-1 text-sm"
+              />
+              <label className="text-sm font-medium">Slug</label>
+              <input
+                type="text"
+                value={draft.slug}
+                onChange={(e) => setDraft((d) => ({ ...d, slug: slugify(e.target.value) }))}
+                placeholder="ops-overview"
+                disabled={draft.existing}
+                className="w-48 rounded border border-neutral-300 px-2 py-1 text-sm disabled:bg-neutral-50"
+              />
+            </div>
+
+            {draft.layout_spec.length === 0 ? (
+              <div className="rounded border border-dashed border-neutral-300 p-10 text-center text-sm text-neutral-500">
+                Empty report. Pick widgets from the right, or start from a template on the left.
+              </div>
+            ) : (
+              <div
+                className="grid gap-4"
+                style={{
+                  gridTemplateColumns: "repeat(12, minmax(0, 1fr))",
+                  gridAutoRows: "80px",
+                  gridAutoFlow: "dense",
+                }}
+              >
+                {draft.layout_spec.map((w, idx) => {
+                  const meta = widgetByName(w.tool_name)
+                  const size = HINT_SIZES[(w.hint as WidgetHint) in HINT_SIZES ? (w.hint as WidgetHint) : "kpi_card"]
+                  return (
+                    <div
+                      key={`${w.tool_name}-${idx}`}
+                      className="relative rounded border border-neutral-200 bg-white p-3"
+                      style={{
+                        gridColumn: `span ${size.col}`,
+                        gridRow: `span ${size.row}`,
+                      }}
+                    >
+                      <div className="mb-1 flex items-start justify-between">
+                        <div>
+                          <div className="text-sm font-medium">{meta?.label ?? w.tool_name}</div>
+                          <div className="text-xs text-neutral-500">{w.hint}</div>
+                        </div>
+                        <div className="flex gap-1">
+                          <button
+                            type="button"
+                            className="rounded px-1.5 py-0.5 text-xs text-neutral-500 hover:bg-neutral-100"
+                            onClick={() => moveWidget(idx, -1)}
+                            title="Move up"
+                            disabled={idx === 0}
+                          >
+                            ↑
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded px-1.5 py-0.5 text-xs text-neutral-500 hover:bg-neutral-100"
+                            onClick={() => moveWidget(idx, 1)}
+                            title="Move down"
+                            disabled={idx === draft.layout_spec.length - 1}
+                          >
+                            ↓
+                          </button>
+                          <button
+                            type="button"
+                            className="rounded px-1.5 py-0.5 text-xs text-neutral-500 hover:bg-red-50 hover:text-red-600"
+                            onClick={() => removeWidgetAt(idx)}
+                            title="Remove"
+                          >
+                            ×
+                          </button>
+                        </div>
+                      </div>
+                      {/*
+                        ponytail: placeholder cell body. PR 3 wires the live
+                        tool-call renderer here, dispatched on `w.hint`.
+                      */}
+                      <div className="mt-2 flex h-full items-center justify-center rounded border border-dashed border-neutral-200 text-xs text-neutral-400">
+                        {w.tool_name}
+                      </div>
+                    </div>
+                  )
+                })}
+              </div>
+            )}
+          </main>
+
+          {/* Right: widget picker */}
+          <aside>
+            <h2 className="mb-2 text-xs font-semibold uppercase tracking-wider text-neutral-500">
+              Widgets
+            </h2>
+            <ul className="space-y-1">
+              {picker.map((w) => (
+                <li key={w.tool_name}>
+                  <button
+                    type="button"
+                    className="w-full rounded px-2 py-2 text-left text-sm hover:bg-neutral-100"
+                    onClick={() => addWidget(w.tool_name)}
+                    title={w.description}
+                  >
+                    <div className="flex items-center justify-between">
+                      <span className="font-medium">{w.label}</span>
+                      <span className="text-xs text-neutral-400">{w.hint}</span>
+                    </div>
+                    <div className="text-xs text-neutral-500">{w.description}</div>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </aside>
+        </div>
+      </div>
+    </AppShell>
+  )
+}

--- a/apps/web/src/lib/reportBuilder/api.ts
+++ b/apps/web/src/lib/reportBuilder/api.ts
@@ -1,0 +1,48 @@
+/**
+ * CRUD client for /workspaces/{ws}/report-layouts (#1450 PR 2).
+ * Thin wrapper — no caching, no reactive state.
+ */
+import { API, AuthFetch, del, json, post, put } from "../api/client"
+import type { WidgetHint } from "./widgets"
+
+export interface WidgetSpec {
+  tool_name: string
+  hint: WidgetHint | string
+}
+
+export interface ReportLayout {
+  id: string
+  slug: string
+  name: string
+  layout_spec: WidgetSpec[]
+  created_by: string
+  created_at: string
+  updated_at: string
+}
+
+const base = (workspaceId: string) =>
+  `${API}/workspaces/${workspaceId}/report-layouts`
+
+export const reportLayoutsApi = {
+  list: (f: AuthFetch, workspaceId: string) =>
+    json<ReportLayout[]>(f, base(workspaceId)),
+
+  get: (f: AuthFetch, workspaceId: string, slug: string) =>
+    json<ReportLayout>(f, `${base(workspaceId)}/${slug}`),
+
+  create: (
+    f: AuthFetch,
+    workspaceId: string,
+    body: { slug: string; name: string; layout_spec: WidgetSpec[] },
+  ) => post(f, base(workspaceId), body),
+
+  update: (
+    f: AuthFetch,
+    workspaceId: string,
+    slug: string,
+    body: { name?: string; layout_spec?: WidgetSpec[] },
+  ) => put(f, `${base(workspaceId)}/${slug}`, body),
+
+  remove: (f: AuthFetch, workspaceId: string, slug: string) =>
+    del(f, `${base(workspaceId)}/${slug}`),
+}

--- a/apps/web/src/lib/reportBuilder/templates.ts
+++ b/apps/web/src/lib/reportBuilder/templates.ts
@@ -1,0 +1,46 @@
+/**
+ * Starter templates for the report-builder skill (#1450 PR 2).
+ *
+ * Static registry. "Use template" copies the widget list into a new
+ * `workspace_report_layouts` row — from that point on it's a normal
+ * user-editable layout, no template link retained.
+ */
+import type { WidgetHint } from "./widgets"
+
+export interface ReportTemplate {
+  slug: string
+  name: string
+  description: string
+  widgets: readonly { tool_name: string; hint: WidgetHint }[]
+}
+
+export const TEMPLATES: readonly ReportTemplate[] = [
+  {
+    slug: "operations",
+    name: "Operations",
+    description: "Day-to-day agent output — outcomes, attention, health, token usage, policy hits.",
+    widgets: [
+      { tool_name: "get_dashboard_outcomes",    hint: "kpi_card" },
+      { tool_name: "list_attention_runs",       hint: "list" },
+      { tool_name: "list_agent_health",         hint: "agent_row" },
+      { tool_name: "get_dashboard_token_usage", hint: "spark" },
+      { tool_name: "get_top_policy_hits",       hint: "table" },
+    ],
+  },
+  {
+    slug: "observability",
+    name: "Observability",
+    description: "Platform health — DORA, analytics, agent status, playbook scorecards.",
+    widgets: [
+      { tool_name: "get_observability_health",  hint: "kpi_card" },
+      { tool_name: "get_dora_metrics",          hint: "kpi_card" },
+      { tool_name: "get_analytics_summary",     hint: "spark" },
+      { tool_name: "list_agent_status",         hint: "list" },
+      { tool_name: "get_playbook_scorecards",   hint: "table" },
+    ],
+  },
+] as const
+
+export function templateBySlug(slug: string): ReportTemplate | undefined {
+  return TEMPLATES.find((t) => t.slug === slug)
+}

--- a/apps/web/src/lib/reportBuilder/widgets.ts
+++ b/apps/web/src/lib/reportBuilder/widgets.ts
@@ -1,0 +1,109 @@
+/**
+ * Widget catalog for the report-builder skill (#1450 PR 2).
+ *
+ * ponytail: hardcoded, mirrors what the backend tools export with
+ * (`widget`, `hint:<kind>`) tags. When the catalog grows past manual
+ * maintenance, expose a `/tools?tag=widget` endpoint and generate this
+ * from the response.
+ */
+export type WidgetHint = "kpi_card" | "spark" | "list" | "table" | "agent_row"
+
+export interface WidgetDef {
+  tool_name: string
+  hint: WidgetHint
+  label: string
+  description: string
+  group: "dashboard" | "observability"
+}
+
+export const WIDGETS: readonly WidgetDef[] = [
+  // dashboard KPIs
+  {
+    tool_name: "get_dashboard_outcomes",
+    hint: "kpi_card",
+    label: "Outcomes",
+    description: "PRs, issues, reviews, incidents + succeeded/failed counts.",
+    group: "dashboard",
+  },
+  {
+    tool_name: "list_attention_runs",
+    hint: "list",
+    label: "Needs Attention",
+    description: "Failed, paused, or cancelled runs — newest first.",
+    group: "dashboard",
+  },
+  {
+    tool_name: "list_agent_health",
+    hint: "agent_row",
+    label: "Agent Health",
+    description: "Per-agent run count, success rate, last-run status.",
+    group: "dashboard",
+  },
+  {
+    tool_name: "get_dashboard_token_usage",
+    hint: "spark",
+    label: "Token Usage",
+    description: "Token totals + per-agent breakdown + estimated cost.",
+    group: "dashboard",
+  },
+  {
+    tool_name: "get_top_policy_hits",
+    hint: "table",
+    label: "Top Policy Hits",
+    description: "Guard policy hit leaderboard — blocked-only rule_id counts.",
+    group: "dashboard",
+  },
+  // observability KPIs
+  {
+    tool_name: "get_observability_health",
+    hint: "kpi_card",
+    label: "System Health",
+    description: "Recent runs, error rate, latency snapshot.",
+    group: "observability",
+  },
+  {
+    tool_name: "get_dora_metrics",
+    hint: "kpi_card",
+    label: "DORA Metrics",
+    description: "Deployment frequency, lead time, MTTR, change-fail rate.",
+    group: "observability",
+  },
+  {
+    tool_name: "get_analytics_summary",
+    hint: "spark",
+    label: "Analytics Summary",
+    description: "Rolling counts + trend sparks.",
+    group: "observability",
+  },
+  {
+    tool_name: "list_agent_status",
+    hint: "list",
+    label: "Agent Status",
+    description: "Per-agent current status + recent activity.",
+    group: "observability",
+  },
+  {
+    tool_name: "get_playbook_scorecards",
+    hint: "table",
+    label: "Playbook Scorecards",
+    description: "Per-playbook success rate + volume + recent failures.",
+    group: "observability",
+  },
+] as const
+
+const _BY_NAME: Record<string, WidgetDef> = Object.fromEntries(
+  WIDGETS.map((w) => [w.tool_name, w])
+)
+
+export function widgetByName(tool_name: string): WidgetDef | undefined {
+  return _BY_NAME[tool_name]
+}
+
+/** CSS Grid col/row span per hint. Grid uses `grid-auto-flow: dense`. */
+export const HINT_SIZES: Record<WidgetHint, { col: number; row: number }> = {
+  kpi_card:  { col: 3,  row: 1 },
+  spark:     { col: 3,  row: 2 },
+  list:      { col: 4,  row: 3 },
+  table:     { col: 6,  row: 3 },
+  agent_row: { col: 12, row: 1 },
+}


### PR DESCRIPTION
Frontend skeleton. Backend is #1677.

Route /lens/report-builder with picker, grid, save/load, 2 starter templates. Widget cells placeholder in this PR; live rendering in PR 3.