### PR TITLE
feat(reports): widget renderers (#1450 PR 3)

### DIFF
--- a/apps/web/src/app/(app)/lens/report-builder/page.tsx
+++ b/apps/web/src/app/(app)/lens/report-builder/page.tsx
@@ -26,6 +26,8 @@ import {
 } from "@/lib/reportBuilder/widgets"
 import { TEMPLATES, templateBySlug } from "@/lib/reportBuilder/templates"
 import { reportLayoutsApi, type ReportLayout, type WidgetSpec } from "@/lib/reportBuilder/api"
+import { useReportData } from "@/lib/reportBuilder/fetchers"
+import { WidgetRenderer } from "@/lib/reportBuilder/renderers"
 
 type LayoutDraft = {
   slug: string
@@ -73,11 +75,16 @@ export default function ReportBuilderPage() {
 
   const initialSlug = search.get("slug")
 
+  // #1450 PR 3: live widget data fetch (batches /dashboard once, obs endpoints
+  // per unique tool). Re-runs on layout changes via toolNames join key.
+
   const [layouts, setLayouts] = useState<ReportLayout[]>([])
   const [draft, setDraft] = useState<LayoutDraft>(emptyDraft())
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [busy, setBusy] = useState(false)
+
+  const reportData = useReportData(authFetch, workspaceId, draft.layout_spec)
 
   const refreshLayouts = useCallback(async () => {
     if (!workspaceId) return
@@ -383,12 +390,8 @@ export default function ReportBuilderPage() {
                           </button>
                         </div>
                       </div>
-                      {/*
-                        ponytail: placeholder cell body. PR 3 wires the live
-                        tool-call renderer here, dispatched on `w.hint`.
-                      */}
-                      <div className="mt-2 flex h-full items-center justify-center rounded border border-dashed border-neutral-200 text-xs text-neutral-400">
-                        {w.tool_name}
+                      <div className="mt-2 h-full min-h-0 overflow-hidden">
+                        <WidgetRenderer hint={w.hint} state={reportData.get(w.tool_name)} />
                       </div>
                     </div>
                   )

--- a/apps/web/src/lib/reportBuilder/fetchers.ts
+++ b/apps/web/src/lib/reportBuilder/fetchers.ts
@@ -1,0 +1,278 @@
+/**
+ * Widget data fetchers for the report-builder skill (#1450 PR 3).
+ *
+ * Each of the 10 widgets maps to an existing REST endpoint that already
+ * powers /dashboard and /observability. This layer:
+ *   - dedupes calls when multiple widgets share an endpoint (five
+ *     dashboard KPIs all read from GET /dashboard — one fetch, five reads)
+ *   - shapes each response into a `WidgetData` union the renderer can
+ *     switch on without re-shaping per widget
+ *
+ * ponytail: no swr/react-query, no cache invalidation. The
+ * `useReportData` hook re-fetches on layout change and mount, which is
+ * all we need for a page that has no live updates.
+ */
+import { useEffect, useMemo, useState } from "react"
+
+import { API } from "../api/client"
+import type { AuthFetch } from "../api/client"
+import type { WidgetSpec } from "./api"
+
+// ── Response shapes (subset of DashboardOut / analytics endpoints) ──────────
+
+export interface OutcomeStats {
+  prs_opened: number
+  issues_triaged: number
+  reviews_completed: number
+  incidents_investigated: number
+  successful_automations: number
+  failed_automations: number
+}
+
+export interface AttentionRun {
+  run_id: string
+  workflow_id: string
+  workflow_name: string
+  status: string
+  triggered_by: string | null
+  trigger_summary: string | null
+  created_at: string
+}
+
+export interface AgentHealth {
+  workflow_id: string
+  name: string
+  playbook_slug: string | null
+  run_count: number
+  succeeded_count: number
+  failed_count: number
+  success_rate: number
+  last_run_status: string | null
+  last_run_at: string | null
+}
+
+export interface TokenUsage {
+  total_input_tokens: number
+  total_output_tokens: number
+  estimated_cost_usd: number
+  per_agent?: { name: string; input_tokens: number; output_tokens: number; cost_usd: number }[]
+}
+
+export interface PolicyHit {
+  rule_id: string
+  count: number
+}
+
+export interface DashboardResp {
+  outcomes: OutcomeStats
+  needs_attention: AttentionRun[]
+  agent_health: AgentHealth[]
+  token_usage: TokenUsage
+  guard_snapshot: { top_policy_hits?: PolicyHit[] }
+}
+
+export interface ObservabilityHealth {
+  runs_last_hour: number
+  runs_last_24h: number
+  error_rate: number
+  p95_latency_ms: number | null
+}
+
+export interface DoraStat {
+  deployment_frequency: number
+  lead_time_hours: number | null
+  mttr_hours: number | null
+  change_failure_rate: number
+}
+
+export interface AnalyticsSummary {
+  window_days: number
+  total_runs: number
+  succeeded: number
+  failed: number
+  success_rate: number
+  total_cost_usd: number
+}
+
+export interface AgentStatus {
+  name: string
+  status: string
+  last_run_at: string | null
+  run_count_24h: number
+}
+
+export interface PlaybookScorecard {
+  playbook_slug: string
+  run_count: number
+  succeeded: number
+  failed: number
+  success_rate: number
+  avg_cost_usd: number | null
+}
+
+// ── Widget data union ──────────────────────────────────────────────────────
+
+export type WidgetData =
+  | { tool: "get_dashboard_outcomes";    data: OutcomeStats }
+  | { tool: "list_attention_runs";       data: AttentionRun[] }
+  | { tool: "list_agent_health";         data: AgentHealth[] }
+  | { tool: "get_dashboard_token_usage"; data: TokenUsage }
+  | { tool: "get_top_policy_hits";       data: PolicyHit[] }
+  | { tool: "get_observability_health";  data: ObservabilityHealth }
+  | { tool: "get_dora_metrics";          data: DoraStat }
+  | { tool: "get_analytics_summary";     data: AnalyticsSummary }
+  | { tool: "list_agent_status";         data: AgentStatus[] }
+  | { tool: "get_playbook_scorecards";   data: PlaybookScorecard[] }
+
+// ── Endpoint map (source of the dedup) ─────────────────────────────────────
+
+const DASHBOARD_TOOLS = new Set([
+  "get_dashboard_outcomes",
+  "list_attention_runs",
+  "list_agent_health",
+  "get_dashboard_token_usage",
+  "get_top_policy_hits",
+])
+
+async function fetchJson<T>(f: AuthFetch, url: string): Promise<T> {
+  const res = await f(url)
+  if (!res.ok) throw new Error(`${url}: ${res.status}`)
+  return res.json() as Promise<T>
+}
+
+function shapeFromDashboard(tool: string, dash: DashboardResp): WidgetData {
+  switch (tool) {
+    case "get_dashboard_outcomes":
+      return { tool: "get_dashboard_outcomes", data: dash.outcomes }
+    case "list_attention_runs":
+      return { tool: "list_attention_runs", data: (dash.needs_attention || []).slice(0, 5) }
+    case "list_agent_health":
+      return { tool: "list_agent_health", data: dash.agent_health || [] }
+    case "get_dashboard_token_usage":
+      return { tool: "get_dashboard_token_usage", data: dash.token_usage }
+    case "get_top_policy_hits":
+      return {
+        tool: "get_top_policy_hits",
+        data: (dash.guard_snapshot?.top_policy_hits || []).slice(0, 10),
+      }
+  }
+  throw new Error(`unknown dashboard tool: ${tool}`)
+}
+
+async function fetchNonDashboard(
+  f: AuthFetch,
+  tool: string,
+): Promise<WidgetData> {
+  switch (tool) {
+    case "get_observability_health":
+      return {
+        tool: "get_observability_health",
+        data: await fetchJson<ObservabilityHealth>(f, `${API}/observability/summary`),
+      }
+    case "get_dora_metrics":
+      return {
+        tool: "get_dora_metrics",
+        data: await fetchJson<DoraStat>(f, `${API}/analytics/dora`),
+      }
+    case "get_analytics_summary":
+      return {
+        tool: "get_analytics_summary",
+        data: await fetchJson<AnalyticsSummary>(f, `${API}/analytics/summary`),
+      }
+    case "list_agent_status":
+      return {
+        tool: "list_agent_status",
+        data: await fetchJson<AgentStatus[]>(f, `${API}/observability/agents`),
+      }
+    case "get_playbook_scorecards":
+      return {
+        tool: "get_playbook_scorecards",
+        data: await fetchJson<PlaybookScorecard[]>(f, `${API}/analytics/scorecards`),
+      }
+  }
+  throw new Error(`unknown tool: ${tool}`)
+}
+
+// ── React hook ─────────────────────────────────────────────────────────────
+
+export type WidgetLoadState =
+  | { status: "loading" }
+  | { status: "error"; error: string }
+  | { status: "ok"; data: WidgetData }
+
+export function useReportData(
+  authFetch: AuthFetch,
+  workspaceId: string | null,
+  layout: WidgetSpec[],
+): Map<string, WidgetLoadState> {
+  const [byTool, setByTool] = useState<Map<string, WidgetLoadState>>(new Map())
+
+  const toolNames = useMemo(() => layout.map((w) => w.tool_name), [layout])
+  const key = toolNames.join(",")
+
+  useEffect(() => {
+    if (!workspaceId || toolNames.length === 0) {
+      setByTool(new Map())
+      return
+    }
+
+    let cancelled = false
+    const next = new Map<string, WidgetLoadState>()
+    for (const t of toolNames) next.set(t, { status: "loading" })
+    setByTool(new Map(next))
+
+    const needsDashboard = toolNames.some((t) => DASHBOARD_TOOLS.has(t))
+    const others = Array.from(new Set(toolNames.filter((t) => !DASHBOARD_TOOLS.has(t))))
+
+    const dashboardPromise = needsDashboard
+      ? fetchJson<DashboardResp>(authFetch, `${API}/dashboard`)
+      : Promise.resolve<DashboardResp | null>(null)
+
+    dashboardPromise
+      .then((dash) => {
+        if (cancelled) return
+        if (dash) {
+          for (const t of toolNames) {
+            if (!DASHBOARD_TOOLS.has(t)) continue
+            try {
+              next.set(t, { status: "ok", data: shapeFromDashboard(t, dash) })
+            } catch (e) {
+              next.set(t, { status: "error", error: String((e as Error).message) })
+            }
+          }
+          setByTool(new Map(next))
+        }
+      })
+      .catch((e) => {
+        if (cancelled) return
+        for (const t of toolNames) {
+          if (DASHBOARD_TOOLS.has(t)) {
+            next.set(t, { status: "error", error: String((e as Error).message) })
+          }
+        }
+        setByTool(new Map(next))
+      })
+
+    for (const t of others) {
+      fetchNonDashboard(authFetch, t)
+        .then((wd) => {
+          if (cancelled) return
+          next.set(t, { status: "ok", data: wd })
+          setByTool(new Map(next))
+        })
+        .catch((e) => {
+          if (cancelled) return
+          next.set(t, { status: "error", error: String((e as Error).message) })
+          setByTool(new Map(next))
+        })
+    }
+
+    return () => {
+      cancelled = true
+    }
+    // key is the dependency signal — re-fetch when layout changes.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key, workspaceId])
+
+  return byTool
+}

--- a/apps/web/src/lib/reportBuilder/renderers.tsx
+++ b/apps/web/src/lib/reportBuilder/renderers.tsx
@@ -1,0 +1,292 @@
+/**
+ * Widget renderers for the report-builder skill (#1450 PR 3).
+ *
+ * One component per `hint`, dispatched by `<WidgetRenderer>`. Each takes
+ * a `WidgetLoadState` and renders loading / error / data states.
+ *
+ * ponytail: no charting library. `spark` and `agent_row` show headline
+ * numbers, not sparkline SVGs. Upgrade the visualization when tools
+ * start returning time series.
+ */
+import type { WidgetData, WidgetLoadState } from "./fetchers"
+
+function fmtInt(n: number | null | undefined): string {
+  if (n == null) return "—"
+  if (Math.abs(n) >= 1000) return `${(n / 1000).toFixed(1)}k`
+  return String(n)
+}
+
+function fmtUsd(n: number | null | undefined): string {
+  if (n == null) return "—"
+  return `$${n.toFixed(2)}`
+}
+
+function fmtPct(n: number | null | undefined): string {
+  if (n == null) return "—"
+  return `${(n * 100).toFixed(0)}%`
+}
+
+function fmtWhen(ts: string | null | undefined): string {
+  if (!ts) return "—"
+  const d = new Date(ts)
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+}
+
+// ── loading / error primitives ─────────────────────────────────────────────
+
+function LoadingBody() {
+  return (
+    <div className="flex h-full min-h-16 items-center justify-center text-xs text-neutral-400">
+      Loading…
+    </div>
+  )
+}
+
+function ErrorBody({ error }: { error: string }) {
+  return (
+    <div className="flex h-full min-h-16 items-center justify-center px-3 text-center text-xs text-red-500">
+      {error}
+    </div>
+  )
+}
+
+// ── KPI card ───────────────────────────────────────────────────────────────
+
+interface KpiTile { label: string; value: string; sub?: string }
+
+function KpiTiles({ tiles }: { tiles: KpiTile[] }) {
+  return (
+    <div className="grid grid-cols-3 gap-3 text-center">
+      {tiles.map((t) => (
+        <div key={t.label} className="rounded bg-neutral-50 px-2 py-2">
+          <div className="text-xl font-semibold">{t.value}</div>
+          <div className="mt-0.5 text-[10px] uppercase tracking-wide text-neutral-500">{t.label}</div>
+          {t.sub && <div className="mt-0.5 text-[10px] text-neutral-400">{t.sub}</div>}
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function KpiCardBody({ data }: { data: WidgetData }) {
+  if (data.tool === "get_dashboard_outcomes") {
+    const o = data.data
+    return (
+      <KpiTiles
+        tiles={[
+          { label: "PRs",      value: fmtInt(o.prs_opened) },
+          { label: "Issues",   value: fmtInt(o.issues_triaged) },
+          { label: "Reviews",  value: fmtInt(o.reviews_completed) },
+          { label: "Incidents",value: fmtInt(o.incidents_investigated) },
+          { label: "Succeeded",value: fmtInt(o.successful_automations) },
+          { label: "Failed",   value: fmtInt(o.failed_automations) },
+        ]}
+      />
+    )
+  }
+  if (data.tool === "get_observability_health") {
+    const o = data.data
+    return (
+      <KpiTiles
+        tiles={[
+          { label: "Runs 1h",   value: fmtInt(o.runs_last_hour) },
+          { label: "Runs 24h",  value: fmtInt(o.runs_last_24h) },
+          { label: "Error Rate",value: fmtPct(o.error_rate) },
+          { label: "P95 latency", value: o.p95_latency_ms == null ? "—" : `${o.p95_latency_ms} ms` },
+        ]}
+      />
+    )
+  }
+  if (data.tool === "get_dora_metrics") {
+    const d = data.data
+    return (
+      <KpiTiles
+        tiles={[
+          { label: "Deploys/wk", value: fmtInt(d.deployment_frequency) },
+          { label: "Lead time",  value: d.lead_time_hours == null ? "—" : `${d.lead_time_hours.toFixed(1)} h` },
+          { label: "MTTR",       value: d.mttr_hours == null ? "—" : `${d.mttr_hours.toFixed(1)} h` },
+          { label: "Change fail",value: fmtPct(d.change_failure_rate) },
+        ]}
+      />
+    )
+  }
+  return null
+}
+
+// ── Spark (headline + delta stand-in) ──────────────────────────────────────
+
+function SparkBody({ data }: { data: WidgetData }) {
+  if (data.tool === "get_dashboard_token_usage") {
+    const t = data.data
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <div className="text-3xl font-semibold">{fmtUsd(t.estimated_cost_usd)}</div>
+        <div className="mt-1 text-[11px] uppercase tracking-wide text-neutral-500">Est. cost</div>
+        <div className="mt-2 text-xs text-neutral-500">
+          {fmtInt(t.total_input_tokens)} in · {fmtInt(t.total_output_tokens)} out
+        </div>
+      </div>
+    )
+  }
+  if (data.tool === "get_analytics_summary") {
+    const a = data.data
+    return (
+      <div className="flex flex-col items-center justify-center">
+        <div className="text-3xl font-semibold">{fmtInt(a.total_runs)}</div>
+        <div className="mt-1 text-[11px] uppercase tracking-wide text-neutral-500">
+          Runs ({a.window_days}d)
+        </div>
+        <div className="mt-2 text-xs text-neutral-500">
+          {fmtPct(a.success_rate)} success · {fmtUsd(a.total_cost_usd)}
+        </div>
+      </div>
+    )
+  }
+  return null
+}
+
+// ── List ───────────────────────────────────────────────────────────────────
+
+function ListBody({ data }: { data: WidgetData }) {
+  if (data.tool === "list_attention_runs") {
+    const rows = data.data
+    if (rows.length === 0) return <div className="text-xs text-neutral-500">Nothing needs attention.</div>
+    return (
+      <ul className="divide-y divide-neutral-100 text-xs">
+        {rows.map((r) => (
+          <li key={r.run_id} className="py-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate font-medium">{r.workflow_name}</span>
+              <span className="shrink-0 rounded bg-neutral-100 px-1.5 py-0.5 text-[10px] uppercase text-neutral-600">
+                {r.status}
+              </span>
+            </div>
+            <div className="text-neutral-500">{fmtWhen(r.created_at)}</div>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+  if (data.tool === "list_agent_status") {
+    const rows = data.data
+    if (rows.length === 0) return <div className="text-xs text-neutral-500">No agents.</div>
+    return (
+      <ul className="divide-y divide-neutral-100 text-xs">
+        {rows.slice(0, 8).map((r) => (
+          <li key={r.name} className="py-2">
+            <div className="flex items-center justify-between gap-2">
+              <span className="truncate font-medium">{r.name}</span>
+              <span className="shrink-0 text-neutral-500">{r.status}</span>
+            </div>
+            <div className="text-neutral-500">
+              {fmtInt(r.run_count_24h)} runs · last {fmtWhen(r.last_run_at)}
+            </div>
+          </li>
+        ))}
+      </ul>
+    )
+  }
+  return null
+}
+
+// ── Table ──────────────────────────────────────────────────────────────────
+
+function TableBody({ data }: { data: WidgetData }) {
+  if (data.tool === "get_top_policy_hits") {
+    const rows = data.data
+    if (rows.length === 0) return <div className="text-xs text-neutral-500">No policy hits.</div>
+    return (
+      <table className="w-full text-xs">
+        <thead className="border-b border-neutral-200 text-left text-neutral-500">
+          <tr>
+            <th className="py-1.5 font-normal">Rule</th>
+            <th className="py-1.5 text-right font-normal">Blocked</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-neutral-100">
+          {rows.slice(0, 8).map((r) => (
+            <tr key={r.rule_id}>
+              <td className="py-1.5 pr-2">{r.rule_id}</td>
+              <td className="py-1.5 text-right font-medium">{fmtInt(r.count)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  }
+  if (data.tool === "get_playbook_scorecards") {
+    const rows = data.data
+    if (rows.length === 0) return <div className="text-xs text-neutral-500">No playbook runs.</div>
+    return (
+      <table className="w-full text-xs">
+        <thead className="border-b border-neutral-200 text-left text-neutral-500">
+          <tr>
+            <th className="py-1.5 font-normal">Playbook</th>
+            <th className="py-1.5 text-right font-normal">Runs</th>
+            <th className="py-1.5 text-right font-normal">Success</th>
+            <th className="py-1.5 text-right font-normal">Cost</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-neutral-100">
+          {rows.slice(0, 8).map((r) => (
+            <tr key={r.playbook_slug}>
+              <td className="py-1.5 pr-2 font-medium">{r.playbook_slug}</td>
+              <td className="py-1.5 text-right">{fmtInt(r.run_count)}</td>
+              <td className="py-1.5 text-right">{fmtPct(r.success_rate)}</td>
+              <td className="py-1.5 text-right">{fmtUsd(r.avg_cost_usd)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  }
+  return null
+}
+
+// ── Agent row (horizontal cards) ───────────────────────────────────────────
+
+function AgentRowBody({ data }: { data: WidgetData }) {
+  if (data.tool !== "list_agent_health") return null
+  const rows = data.data
+  if (rows.length === 0) return <div className="text-xs text-neutral-500">No agents.</div>
+  return (
+    <div className="flex gap-3 overflow-x-auto pb-1">
+      {rows.slice(0, 12).map((r) => (
+        <div
+          key={r.workflow_id}
+          className="min-w-[160px] shrink-0 rounded border border-neutral-200 px-3 py-2 text-xs"
+        >
+          <div className="truncate font-medium">{r.name}</div>
+          <div className="mt-1 flex items-center justify-between text-neutral-500">
+            <span>{fmtInt(r.run_count)} runs</span>
+            <span>{fmtPct(r.success_rate)}</span>
+          </div>
+          <div className="mt-0.5 text-[10px] text-neutral-400">
+            last {fmtWhen(r.last_run_at)} · {r.last_run_status ?? "—"}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+// ── Dispatcher ─────────────────────────────────────────────────────────────
+
+export function WidgetRenderer({
+  hint,
+  state,
+}: {
+  hint: string
+  state: WidgetLoadState | undefined
+}) {
+  if (!state || state.status === "loading") return <LoadingBody />
+  if (state.status === "error") return <ErrorBody error={state.error} />
+  switch (hint) {
+    case "kpi_card":  return <KpiCardBody  data={state.data} />
+    case "spark":     return <SparkBody    data={state.data} />
+    case "list":      return <ListBody     data={state.data} />
+    case "table":     return <TableBody    data={state.data} />
+    case "agent_row": return <AgentRowBody data={state.data} />
+    default:          return <ErrorBody error={`Unknown hint: ${hint}`} />
+  }
+}


### PR DESCRIPTION
Live data for all 10 widgets. Wires the report-builder grid to existing insights endpoints; no new backend.

useReportData batches /dashboard once for the 5 dashboard KPIs, calls each observability endpoint per unique tool. 5 hint renderers (kpi_card, spark, list, table, agent_row) with loading/error/empty states.