### PR TITLE
feat(reports): Lens chat tools for report builder (#1450 PR 4)

### DIFF
--- a/apps/api/app/modules/glens/actor/registrations/__init__.py
+++ b/apps/api/app/modules/glens/actor/registrations/__init__.py
@@ -6,6 +6,7 @@ from app.modules.glens.actor.registrations import deactivate_agent_identity  # n
 from app.modules.glens.actor.registrations import decide_approval  # noqa: F401
 from app.modules.glens.actor.registrations import install_pack  # noqa: F401
 from app.modules.glens.actor.registrations import invite_member  # noqa: F401
+from app.modules.glens.actor.registrations import propose_report  # noqa: F401
 from app.modules.glens.actor.registrations import run_workflow  # noqa: F401
 from app.modules.glens.actor.registrations import toggle_policy  # noqa: F401 — registers enable_policy + disable_policy
 from app.modules.glens.actor.registrations import update_budget  # noqa: F401

--- a/apps/api/app/modules/glens/actor/registrations/propose_report.py
+++ b/apps/api/app/modules/glens/actor/registrations/propose_report.py
@@ -1,0 +1,156 @@
+"""#1450 PR 4 — Lens actor: save a report layout to the workspace.
+
+Two-step: `propose` validates name / widgets / slug (auto-derived from
+name if not passed) and rejects on conflict; `execute` writes the row to
+`workspace_report_layouts` — same INSERT as `POST /workspaces/{ws}/report-layouts`.
+
+Return payload includes the `/lens/report-builder?slug=X` URL so the
+chat surface can render a clickable link on confirm.
+
+Report shape emerges from the widget count:
+- 1 widget  → "Basic" (one-widget quick share)
+- 2+ widgets → "Operational" / "Observability" / custom
+
+The tool doesn't care about shape — it's an LLM-side prompt concept.
+"""
+from __future__ import annotations
+
+import re
+import uuid as _uuid
+from datetime import datetime, timezone
+from typing import Any
+
+import structlog
+
+from app.modules.glens.actor.registry import default_action_registry
+from app.modules.glens.actor.types import ActionCtx, ActionSpec, ProposeResult
+
+log = structlog.get_logger()
+
+
+_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9-]{0,63}$")
+_VALID_HINTS = {"kpi_card", "spark", "list", "table", "agent_row"}
+
+
+def _slugify(text: str) -> str:
+    s = text.strip().lower()
+    s = re.sub(r"[^a-z0-9-]+", "-", s)
+    s = re.sub(r"-+", "-", s).strip("-")
+    return s[:64]
+
+
+def _validate_widgets(raw: Any) -> tuple[list[dict[str, str]] | None, str | None]:
+    """Return (normalized, error) — normalized is a list of {tool_name, hint}."""
+    if not isinstance(raw, list) or not raw:
+        return None, "layout_spec must be a non-empty list"
+    from app.tools.registry import default_registry
+
+    valid_tools = {t.name for t in default_registry.list(tag="widget")}
+    out: list[dict[str, str]] = []
+    for i, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            return None, f"layout_spec[{i}] must be an object"
+        tool_name = str(entry.get("tool_name") or "").strip()
+        hint = str(entry.get("hint") or "").strip()
+        if not tool_name:
+            return None, f"layout_spec[{i}].tool_name required"
+        if tool_name not in valid_tools:
+            return None, f"layout_spec[{i}].tool_name '{tool_name}' is not a widget-tagged tool"
+        if hint not in _VALID_HINTS:
+            return None, f"layout_spec[{i}].hint must be one of {sorted(_VALID_HINTS)}"
+        out.append({"tool_name": tool_name, "hint": hint})
+    return out, None
+
+
+def _propose_report(ctx: ActionCtx, args: dict[str, Any]) -> ProposeResult:
+    name = str(args.get("name") or "").strip()
+    if not name:
+        return ProposeResult(rejected=True, reason="name required", summary="", resolved_input={})
+    if len(name) > 200:
+        return ProposeResult(rejected=True, reason="name too long (max 200)", summary="", resolved_input={})
+
+    slug_arg = args.get("slug")
+    slug = str(slug_arg).strip().lower() if slug_arg else _slugify(name)
+    if not _SLUG_RE.match(slug):
+        return ProposeResult(
+            rejected=True,
+            reason="slug must match ^[a-z0-9][a-z0-9-]{0,63}$",
+            summary="", resolved_input={},
+        )
+
+    widgets, err = _validate_widgets(args.get("layout_spec"))
+    if err or widgets is None:
+        return ProposeResult(rejected=True, reason=err or "invalid widgets",
+                             summary="", resolved_input={})
+
+    try:
+        ws_uuid = _uuid.UUID(ctx.workspace_id)
+    except ValueError:
+        return ProposeResult(rejected=True, reason="Invalid workspace",
+                             summary="", resolved_input={})
+
+    from app.models.workspace_report_layout import WorkspaceReportLayout
+
+    existing = (
+        ctx.db.query(WorkspaceReportLayout)
+        .filter(
+            WorkspaceReportLayout.workspace_id == ws_uuid,
+            WorkspaceReportLayout.slug == slug,
+        )
+        .first()
+    )
+    if existing:
+        return ProposeResult(
+            rejected=True,
+            reason=f"A report with slug '{slug}' already exists in this workspace (name: '{existing.name}')",
+            summary="", resolved_input={},
+        )
+
+    summary = f"Save report '{name}' as /{slug} with {len(widgets)} widget(s)"
+    return ProposeResult(
+        summary=summary,
+        resolved_input={"name": name, "slug": slug, "layout_spec": widgets},
+    )
+
+
+def _execute_report(ctx: ActionCtx, resolved: dict[str, Any]) -> dict[str, Any]:
+    from app.models.workspace_report_layout import WorkspaceReportLayout
+
+    ws_uuid = _uuid.UUID(ctx.workspace_id)
+    now = datetime.now(timezone.utc)
+
+    row = WorkspaceReportLayout(
+        id=_uuid.uuid4(),
+        workspace_id=ws_uuid,
+        slug=resolved["slug"],
+        name=resolved["name"],
+        layout_spec=resolved["layout_spec"],
+        created_by=ctx.clerk_user_id or "lens.actor",
+        created_at=now,
+        updated_at=now,
+    )
+    ctx.db.add(row)
+    ctx.db.commit()
+
+    return {
+        "id": str(row.id),
+        "slug": row.slug,
+        "name": row.name,
+        "widgets_count": len(resolved["layout_spec"]),
+        "url": f"/lens/report-builder?slug={row.slug}",
+        "saved": True,
+    }
+
+
+default_action_registry.register(ActionSpec(
+    name="propose_report",
+    guard_permission="platform.workflows.edit",
+    propose=_propose_report,
+    execute=_execute_report,
+    description=(
+        "Save a report layout to the workspace. Two-step: returns a "
+        "pending action for the user to confirm; the confirm click "
+        "inserts the workspace_report_layouts row and returns the "
+        "/lens/report-builder?slug=X URL."
+    ),
+))

--- a/apps/api/app/tools/registrations/lens/__init__.py
+++ b/apps/api/app/tools/registrations/lens/__init__.py
@@ -37,6 +37,7 @@ from app.tools.registrations.lens import (
     ops,
     policies,
     primitives,
+    report_builder,
     runs,
     workflows,
     workspace,
@@ -56,6 +57,7 @@ _ALL_TOOLS = [
     *governance.TOOLS,
     *dashboard_kpis.TOOLS,
     *observability_kpis.TOOLS,
+    *report_builder.TOOLS,
     *actor.TOOLS,
     *capabilities.TOOLS,
 ]

--- a/apps/api/app/tools/registrations/lens/report_builder.py
+++ b/apps/api/app/tools/registrations/lens/report_builder.py
@@ -1,0 +1,158 @@
+"""Lens tool registrations — report_builder domain (#1450 PR 4).
+
+Three tools that let Lens compose and save a report layout via chat:
+
+- `list_report_widgets` — read: catalog of widget-tagged tools + hints.
+- `list_report_templates` — read: 2 starter templates (Operations,
+  Observability). "Basic" (one-widget quick share) is not a static
+  template — Lens picks 1 widget for the ask and calls propose_report.
+- `propose_report` — actor: two-step confirm; writes to
+  `workspace_report_layouts`. Returns the `/lens/report-builder?slug=X`
+  URL on confirm so chat can render a clickable link.
+
+Prompt hint: when the user says "build me a report" without specifying,
+Lens offers three shapes — Basic, Operational, Observability. Basic maps
+to a 1-widget report chosen from `list_report_widgets`; the other two
+seed from `list_report_templates`.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from app.tools.registrations.lens._shared import _actor_impl, _ACTOR_TAGS, _LENS_TAGS
+from app.tools.types import ToolAnnotations, ToolDef
+
+
+# ── Static template registry (mirror of apps/web/src/lib/reportBuilder/templates.ts)
+#
+# ponytail: duplicated across TS + Python. The two files change rarely
+# and are small enough that a shared JSON isn't worth wiring. If the
+# template set grows beyond ~5, hoist to a single JSON both sides read.
+_TEMPLATES: list[dict[str, Any]] = [
+    {
+        "slug": "operations",
+        "name": "Operations",
+        "description": "Day-to-day agent output — outcomes, attention, health, token usage, policy hits.",
+        "widgets": [
+            {"tool_name": "get_dashboard_outcomes",    "hint": "kpi_card"},
+            {"tool_name": "list_attention_runs",       "hint": "list"},
+            {"tool_name": "list_agent_health",         "hint": "agent_row"},
+            {"tool_name": "get_dashboard_token_usage", "hint": "spark"},
+            {"tool_name": "get_top_policy_hits",       "hint": "table"},
+        ],
+    },
+    {
+        "slug": "observability",
+        "name": "Observability",
+        "description": "Platform health — DORA, analytics, agent status, playbook scorecards.",
+        "widgets": [
+            {"tool_name": "get_observability_health",  "hint": "kpi_card"},
+            {"tool_name": "get_dora_metrics",          "hint": "kpi_card"},
+            {"tool_name": "get_analytics_summary",     "hint": "spark"},
+            {"tool_name": "list_agent_status",         "hint": "list"},
+            {"tool_name": "get_playbook_scorecards",   "hint": "table"},
+        ],
+    },
+]
+
+
+# ── Free-function tool impls ────────────────────────────────────────────────
+
+def list_report_widgets(ctx) -> dict[str, Any]:  # noqa: ARG001
+    """Return the widget catalog — every tool tagged `widget` with its render hint.
+
+    Lens uses this to pick a widget for the "Basic" (one-widget) report
+    shape, or to add extra widgets on top of a template.
+    """
+    from app.tools.registry import default_registry
+
+    widgets = []
+    for t in default_registry.list(tag="widget"):
+        hint = next((tag.split(":", 1)[1] for tag in t.tags if tag.startswith("hint:")), None)
+        widgets.append({
+            "tool_name": t.name,
+            "hint": hint,
+            "description": t.description,
+        })
+    return {"widgets": widgets, "count": len(widgets)}
+
+
+def list_report_templates(ctx) -> dict[str, Any]:  # noqa: ARG001
+    """Return the 2 static report templates (Operations, Observability).
+
+    Lens uses these to seed multi-widget reports on shape choice. The
+    "Basic" shape (one widget) is not a template — pick a widget from
+    `list_report_widgets` instead.
+    """
+    return {"templates": _TEMPLATES, "count": len(_TEMPLATES)}
+
+
+TOOLS: list[ToolDef] = [
+    ToolDef(
+        name="list_report_widgets",
+        description=(
+            "List every widget-tagged tool with its render hint — the catalog Lens "
+            "picks from when composing a report. Use for the 'Basic' one-widget "
+            "shape, or when adding widgets on top of a template. Read-only."
+        ),
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=list_report_widgets,
+        annotations=ToolAnnotations(read_only=True),
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="list_report_templates",
+        description=(
+            "List the static report templates (Operations, Observability). Each "
+            "template is an ordered widget list Lens can pass straight to "
+            "propose_report. Basic (one-widget) is not a template — pick from "
+            "list_report_widgets instead."
+        ),
+        input_schema={"type": "object", "properties": {}, "required": []},
+        impl=list_report_templates,
+        annotations=ToolAnnotations(read_only=True),
+        tags=_LENS_TAGS,
+    ),
+    ToolDef(
+        name="propose_report",
+        description=(
+            "Save a workspace report layout. Two-step: returns a pending action "
+            "for the user to confirm; the confirm click inserts the row and "
+            "returns the /lens/report-builder?slug=X URL. Slug is optional — "
+            "auto-derived from name if omitted. Fails on slug conflict; retry "
+            "with a different slug or reuse the existing report."
+        ),
+        input_schema={
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "Human-readable report name, e.g. 'Ops Overview'.",
+                },
+                "layout_spec": {
+                    "type": "array",
+                    "description": "Ordered widget list. Each item = {tool_name, hint}.",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "tool_name": {"type": "string"},
+                            "hint": {
+                                "type": "string",
+                                "enum": ["kpi_card", "spark", "list", "table", "agent_row"],
+                            },
+                        },
+                        "required": ["tool_name", "hint"],
+                    },
+                },
+                "slug": {
+                    "type": "string",
+                    "description": "Optional URL slug. Auto-derived from name if omitted.",
+                },
+            },
+            "required": ["name", "layout_spec"],
+        },
+        impl=_actor_impl("propose_report"),
+        annotations=ToolAnnotations(read_only=False, destructive=False, idempotent=False),
+        tags=_ACTOR_TAGS,
+    ),
+]

--- a/apps/api/tests/glens/test_actor_propose_report.py
+++ b/apps/api/tests/glens/test_actor_propose_report.py
@@ -1,0 +1,172 @@
+"""#1450 PR 4 — actor ActionSpec + ToolDef parity for propose_report.
+
+Propose-path only; live-DB confirm+dispatch covered by the shared
+substrate suite.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from app.modules.glens.actor import default_action_registry, ActionCtx
+from app.modules.glens.actor import registrations  # noqa: F401 — populate registry
+from app.tools import registrations as _tool_registrations  # noqa: F401
+from app.tools.registry import default_registry
+
+
+_WS = "00000000-0000-0000-0000-000000000000"
+
+
+def _ctx(**over):
+    base = dict(
+        db=MagicMock(),
+        workspace_id=_WS,
+        clerk_user_id="user_abc",
+        user_email="user@example.com",
+        session_id=None,
+        agent_identity_id=None,
+        surface="lens",
+    )
+    base.update(over)
+    return ActionCtx(**base)
+
+
+def _no_existing(ctx):
+    ctx.db.query.return_value.filter.return_value.first.return_value = None
+
+
+def _fake_conflict(ctx, name="Ops"):
+    ctx.db.query.return_value.filter.return_value.first.return_value = SimpleNamespace(name=name)
+
+
+def test_propose_report_actionspec_registered():
+    spec = default_action_registry.get("propose_report")
+    assert spec is not None
+    assert spec.guard_permission == "platform.workflows.edit"
+    assert callable(spec.propose)
+    assert callable(spec.execute)
+
+
+def test_propose_report_tooldef_registered():
+    tool = default_registry.get("propose_report")
+    assert tool is not None
+    assert "lens" in tool.tags
+    assert "actor" in tool.tags
+    assert tool.annotations.read_only is False
+
+
+def test_reject_empty_name():
+    spec = default_action_registry.get("propose_report")
+    out = spec.propose(_ctx(), {"name": "", "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}]})
+    assert out.rejected
+    assert "name required" in (out.reason or "")
+
+
+def test_reject_bad_slug():
+    spec = default_action_registry.get("propose_report")
+    out = spec.propose(_ctx(), {
+        "name": "Ops",
+        "slug": "Bad Slug!",
+        "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}],
+    })
+    assert out.rejected
+    assert "slug" in (out.reason or "").lower()
+
+
+def test_reject_empty_layout():
+    spec = default_action_registry.get("propose_report")
+    out = spec.propose(_ctx(), {"name": "Ops", "layout_spec": []})
+    assert out.rejected
+    assert "layout_spec" in (out.reason or "")
+
+
+def test_reject_unknown_tool():
+    spec = default_action_registry.get("propose_report")
+    ctx = _ctx()
+    _no_existing(ctx)
+    out = spec.propose(ctx, {
+        "name": "Ops",
+        "layout_spec": [{"tool_name": "made_up_tool", "hint": "kpi_card"}],
+    })
+    assert out.rejected
+    assert "not a widget-tagged tool" in (out.reason or "")
+
+
+def test_reject_bad_hint():
+    spec = default_action_registry.get("propose_report")
+    ctx = _ctx()
+    _no_existing(ctx)
+    out = spec.propose(ctx, {
+        "name": "Ops",
+        "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "sparkler"}],
+    })
+    assert out.rejected
+    assert "hint" in (out.reason or "")
+
+
+def test_reject_slug_conflict():
+    spec = default_action_registry.get("propose_report")
+    ctx = _ctx()
+    _fake_conflict(ctx, name="Existing Ops")
+    out = spec.propose(ctx, {
+        "name": "Ops",
+        "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}],
+    })
+    assert out.rejected
+    assert "already exists" in (out.reason or "")
+
+
+def test_success_derives_slug_from_name():
+    spec = default_action_registry.get("propose_report")
+    ctx = _ctx()
+    _no_existing(ctx)
+    out = spec.propose(ctx, {
+        "name": "Ops Overview",
+        "layout_spec": [
+            {"tool_name": "get_dashboard_outcomes", "hint": "kpi_card"},
+            {"tool_name": "list_attention_runs",    "hint": "list"},
+        ],
+    })
+    assert not out.rejected, out.reason
+    assert out.resolved_input["name"] == "Ops Overview"
+    assert out.resolved_input["slug"] == "ops-overview"
+    assert len(out.resolved_input["layout_spec"]) == 2
+    assert "2 widget" in out.summary
+
+
+def test_success_with_explicit_slug():
+    spec = default_action_registry.get("propose_report")
+    ctx = _ctx()
+    _no_existing(ctx)
+    out = spec.propose(ctx, {
+        "name": "Ops",
+        "slug": "custom-slug",
+        "layout_spec": [{"tool_name": "get_dora_metrics", "hint": "kpi_card"}],
+    })
+    assert not out.rejected, out.reason
+    assert out.resolved_input["slug"] == "custom-slug"
+
+
+# ── Read-tool smoke ─────────────────────────────────────────────────────────
+
+def test_list_report_widgets_returns_10_entries():
+    tool = default_registry.get("list_report_widgets")
+    assert tool is not None
+    payload = tool.impl(_ctx())
+    assert payload["count"] >= 10
+    names = {w["tool_name"] for w in payload["widgets"]}
+    assert "get_dashboard_outcomes" in names
+    assert "get_dora_metrics" in names
+    # every widget has a hint extracted from tags
+    for w in payload["widgets"]:
+        assert w["hint"] in {"kpi_card", "spark", "list", "table", "agent_row"}
+
+
+def test_list_report_templates_returns_two():
+    tool = default_registry.get("list_report_templates")
+    assert tool is not None
+    payload = tool.impl(_ctx())
+    slugs = {t["slug"] for t in payload["templates"]}
+    assert slugs == {"operations", "observability"}
+    for t in payload["templates"]:
+        assert len(t["widgets"]) >= 1


### PR DESCRIPTION
Backend only. Three Lens tools that let the LLM build reports via chat.

- list_report_widgets (read): catalog of every widget-tagged tool + hint.
- list_report_templates (read): 2 static templates (Operations, Observability).
- propose_report (actor, two-step confirm): validates and saves to workspace_report_layouts, returns /lens/report-builder?slug=X URL.

Basic (one-widget) shape emerges naturally — LLM picks 1 widget from the catalog + calls propose_report. No shape param on the tools.

12 unit tests. Parity harness auto-covers propose_report.