### PR TITLE
feat(marketing): Figma page rewrites — Guard/Registry/MCP/Evidence + polish

### DIFF
--- a/apps/web/public/design/mcp-hero-diagram.svg
+++ b/apps/web/public/design/mcp-hero-diagram.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" role="img" aria-labelledby="mcp-diagram-title mcp-diagram-desc">
+  <title id="mcp-diagram-title">ConductAI policy between MCP clients and MCP server</title>
+  <desc id="mcp-diagram-desc">Diagram: MCP clients Claude Desktop, ChatGPT, and Cursor route tool invocations through ConductAI, which decides ALLOW, APPROVE, or BLOCK before the MCP server executes the tool.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#818CF8"/>
+    </marker>
+    <marker id="arrowLight" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#6D7488"/>
+    </marker>
+  </defs>
+
+  <!-- Canvas -->
+  <rect x="0" y="0" width="800" height="420" fill="#070A18"/>
+
+  <!-- Column labels -->
+  <text x="120" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2">MCP CLIENTS</text>
+  <text x="400" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2" text-anchor="middle">CONDUCTAI</text>
+  <text x="680" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2" text-anchor="middle">MCP SERVER</text>
+
+  <!-- Clients (left column) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#EEF0F7">
+    <rect x="40" y="80" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="106" r="6" fill="#22D3EE"/>
+    <text x="76" y="110">Claude Desktop</text>
+
+    <rect x="40" y="150" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="176" r="6" fill="#22D3EE"/>
+    <text x="76" y="180">ChatGPT</text>
+
+    <rect x="40" y="220" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="246" r="6" fill="#22D3EE"/>
+    <text x="76" y="250">Cursor</text>
+
+    <rect x="40" y="290" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A" stroke-dasharray="4 3"/>
+    <circle cx="60" cy="316" r="6" fill="#6D7488"/>
+    <text x="76" y="320" fill="#C9CEDD">Custom agents</text>
+  </g>
+
+  <!-- ConductAI box (center) -->
+  <g>
+    <rect x="300" y="90" width="200" height="240" rx="14" fill="#10121A" stroke="#4F46E5" stroke-width="2"/>
+    <text x="400" y="118" fill="#818CF8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" text-anchor="middle">Policy</text>
+    <text x="400" y="138" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">RUNTIME POLICY ENGINE</text>
+
+    <!-- Decision rows -->
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">
+      <circle cx="322" cy="180" r="5" fill="#10B981"/>
+      <text x="336" y="184" fill="#EEF0F7">ALLOW</text>
+      <text x="490" y="184" fill="#6D7488" text-anchor="end">within policy</text>
+
+      <circle cx="322" cy="220" r="5" fill="#F59E0B"/>
+      <text x="336" y="224" fill="#EEF0F7">APPROVE</text>
+      <text x="490" y="224" fill="#6D7488" text-anchor="end">human gate</text>
+
+      <circle cx="322" cy="260" r="5" fill="#EF4444"/>
+      <text x="336" y="264" fill="#EEF0F7">BLOCK</text>
+      <text x="490" y="264" fill="#6D7488" text-anchor="end">rule violated</text>
+    </g>
+
+    <text x="400" y="308" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">HASH-CHAINED EVIDENCE</text>
+  </g>
+
+  <!-- MCP server box (right) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#EEF0F7">
+    <rect x="600" y="150" width="160" height="120" rx="12" fill="#10121A" stroke="#34394A"/>
+    <text x="680" y="184" text-anchor="middle" font-weight="600">MCP server</text>
+    <text x="680" y="208" text-anchor="middle" fill="#6D7488" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">tools/call</text>
+    <text x="680" y="232" text-anchor="middle" fill="#6D7488" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resources/read</text>
+  </g>
+
+  <!-- Arrows: clients → ConductAI -->
+  <g stroke="#818CF8" stroke-width="1.6" fill="none" marker-end="url(#arrow)">
+    <line x1="222" y1="106" x2="298" y2="180"/>
+    <line x1="222" y1="176" x2="298" y2="200"/>
+    <line x1="222" y1="246" x2="298" y2="220"/>
+    <line x1="222" y1="316" x2="298" y2="240"/>
+  </g>
+
+  <!-- Arrow: ConductAI → MCP server -->
+  <line x1="502" y1="210" x2="598" y2="210" stroke="#22D3EE" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+  <text x="550" y="200" fill="#22D3EE" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">GUARDED</text>
+
+  <!-- Footer note -->
+  <text x="400" y="380" fill="#6D7488" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" text-anchor="middle">One policy across MCP clients. One evidence trail across MCP tools.</text>
+</svg>

--- a/apps/web/src/app/(marketing)/evidence/page.tsx
+++ b/apps/web/src/app/(marketing)/evidence/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link"
 import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
+import { LensTranscript } from "@/components/marketing/facelift/LensTranscript"
 
 export const metadata = {
   title: "Evidence — Conduct",
@@ -12,158 +13,86 @@ export default function EvidencePage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero */}
-        <section className="pt-20 pb-16 text-center">
-          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
-            Evidence
-          </p>
-          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-            Know exactly what happened — and why.
-          </h1>
-          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
-            Every action Guard evaluates leaves a receipt: the decision, the rule it matched,
-            who approved it, and a signed record you can replay. One answer per action, not a log to correlate.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link
-              href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-            >
-              Start Discovery — 14 days free
-            </Link>
-            <Link
-              href="/demo"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
-            >
-              Book a Demo
-            </Link>
-          </div>
-        </section>
-
-        {/* Receipt */}
-        <section className="mb-20 flex justify-center">
-          <EvidenceReceipt />
-        </section>
-
-        {/* What each receipt contains */}
-        <section className="mb-20 grid grid-cols-1 sm:grid-cols-2 gap-8 text-sm text-stone-600">
+        {/* Hero — Figma frame 13 */}
+        <section className="pt-20 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
           <div>
-            <h2 className="text-lg font-bold text-stone-900 mb-3">What each receipt contains</h2>
-            <ul className="space-y-2 leading-relaxed">
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Decision (allow / approve / block) and the rule that fired
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                The agent, user, resource, and action attempted
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Approval chain if human review was required
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Execution outcome and any downstream effects
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Integrity marker — SHA-256 hash chain so tampering is detectable
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Reference timestamp tied to the canonical reference date
-              </li>
-            </ul>
+            <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+              Evidence
+            </p>
+            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+              Know exactly what happened — and why.
+            </h1>
+            <p className="text-lg text-stone-500 leading-relaxed mb-8">
+              Every action Guard evaluates leaves a receipt: the decision, the rule it matched,
+              who approved it, and a signed record you can replay. One answer per action, not a log to correlate.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/sign-up"
+                className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              >
+                Start Discovery — 14 days free
+              </Link>
+              <Link
+                href="/demo"
+                className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              >
+                Book a Demo
+              </Link>
+            </div>
           </div>
-          <div>
-            <h2 className="text-lg font-bold text-stone-900 mb-3">What you can do with it</h2>
-            <ul className="space-y-2 leading-relaxed">
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Answer a regulator or auditor with a signed record
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Reconstruct any agent decision after the fact
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Map decisions to compliance controls (SOC 2, HIPAA, PCI DSS, EU AI Act)
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Retain and export by policy, not by log volume
-              </li>
-              <li className="flex items-start gap-2">
-                <span className="w-1.5 h-1.5 rounded-full bg-stone-400 mt-1.5 shrink-0" />
-                Verify chain integrity via the Guard verification API
-              </li>
-            </ul>
+          <div className="lg:pl-4 flex justify-center lg:justify-end">
+            <EvidenceReceipt />
           </div>
         </section>
 
-        {/* Decision / Approval / Execution */}
-        <section className="mb-16 border-t border-stone-100 pt-16">
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-8">
-            <div>
-              <h3 className="text-base font-bold text-stone-900 mb-2">Decision</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">
-                Every allow, approve, and block is a receipt. The decision is not inferred from logs —
-                it is the primary record. The rule that fired and the reason string are embedded.
-              </p>
-            </div>
-            <div>
-              <h3 className="text-base font-bold text-stone-900 mb-2">Approval</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">
-                When Guard routes an action to human approval, the receipt records who approved it,
-                when they approved it, and on what grounds. The full approval chain is part of the receipt.
-              </p>
-            </div>
-            <div>
-              <h3 className="text-base font-bold text-stone-900 mb-2">Execution</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">
-                After the action executes, the outcome is appended to the same receipt. One record
-                from policy decision through to execution result.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* Integrity + Retention */}
-        <section className="mb-16">
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
-            <div className="border border-stone-200 rounded-xl p-6 bg-white">
-              <h3 className="text-base font-bold text-stone-900 mb-2">Integrity</h3>
-              <p className="text-sm text-stone-500 leading-relaxed mb-3">
-                Receipts are SHA-256 hash-chained. Each entry includes the hash of the previous entry.
-                Alter any record and the chain breaks at verification. The integrity endpoint lets you
-                verify the full chain on demand.
-              </p>
-              <p className="text-xs font-mono text-stone-400">
-                Guard verification API — get_verify_evidence
-              </p>
-            </div>
-            <div className="border border-stone-200 rounded-xl p-6 bg-white">
-              <h3 className="text-base font-bold text-stone-900 mb-2">Retention</h3>
-              <p className="text-sm text-stone-500 leading-relaxed">
-                Receipts are stored per workspace with configurable retention. Export by time window,
-                agent, policy, or decision type. Retention policy is set in Guard configuration —
-                not in the audit system separately.
-              </p>
-            </div>
-          </div>
-        </section>
-
-        {/* Compliance mapping */}
+        {/* What each receipt contains — Figma frame 13 (6-card grid) */}
         <section className="mb-20">
-          <h2 className="text-2xl font-bold text-stone-900 mb-3">Compliance mapping</h2>
-          <p className="text-stone-500 text-sm leading-relaxed mb-6 max-w-2xl">
-            Guard ships 15 compliance packs. Each pack maps rules to a compliance standard. When a pack
-            rule fires, the receipt records which standard was enforced and which rule matched. Compliance
-            reports are generated from the audit trail — not from manual assertions.
+          <h2 className="text-2xl font-bold text-stone-900 mb-6">What each receipt contains</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {[
+              {
+                title: "Decision",
+                body: "Every allow, approve, and block is a receipt. The rule that fired and the reason string are embedded — not inferred from logs.",
+              },
+              {
+                title: "Approval",
+                body: "When Guard routes an action to human approval, the receipt records who approved it, when, and on what grounds. Full approval chain preserved.",
+              },
+              {
+                title: "Execution",
+                body: "After the action executes, the outcome is appended to the same receipt. One record from policy decision through execution result.",
+              },
+              {
+                title: "Integrity",
+                body: "Receipts are SHA-256 hash-chained. Alter any record and the chain breaks at verification. Verify on demand via the Guard API.",
+              },
+              {
+                title: "Retention",
+                body: "Stored per workspace with configurable retention. Export by time window, agent, policy, or decision type — set in Guard configuration, not separately.",
+              },
+              {
+                title: "Reference",
+                body: "Timestamp tied to canonical reference date. Every receipt is replayable — reconstruct any agent decision after the fact.",
+              },
+            ].map(({ title, body }) => (
+              <div key={title} className="border border-stone-200 rounded-xl p-5 bg-white shadow-sm">
+                <h3 className="text-base font-bold text-stone-900 mb-2">{title}</h3>
+                <p className="text-sm text-stone-500 leading-relaxed">{body}</p>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Compliance mapping — Figma frame 13 (dark tag row) */}
+        <section className="mb-20 -mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-14 bg-stone-950 rounded-3xl">
+          <h2 className="text-2xl font-bold text-white mb-3">Compliance mapping</h2>
+          <p className="text-stone-400 text-sm leading-relaxed mb-8 max-w-2xl">
+            Guard ships 15 compliance packs. When a pack rule fires, the receipt records which standard was
+            enforced and which rule matched. Reports are generated from the audit trail — not from manual
+            assertions.
           </p>
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+          <div className="flex flex-wrap gap-2">
             {[
               "SOC 2 CC7.3",
               "HIPAA §164.312",
@@ -173,37 +102,41 @@ export default function EvidencePage() {
               "ISO 42001",
               "OWASP Agentic Top 10",
               "IRS 1075",
-              "Prompt injection",
-              "Financial services",
             ].map((standard) => (
-              <div
+              <span
                 key={standard}
-                className="border border-stone-200 rounded-lg bg-stone-50 px-3 py-2 text-xs font-mono text-stone-600 text-center"
+                className="border border-stone-700 rounded-lg bg-stone-900 px-3 py-1.5 text-xs font-mono text-stone-300"
               >
                 {standard}
-              </div>
+              </span>
             ))}
           </div>
-          <p className="text-xs text-stone-400 mt-3">
-            + 5 more packs. See{" "}
-            <Link href="/solutions/security-compliance" className="underline hover:text-stone-600">
+          <p className="text-xs text-stone-500 mt-6">
+            + 7 more packs. See{" "}
+            <Link href="/solutions/security-compliance" className="underline hover:text-stone-300">
               Security Teams
             </Link>{" "}
             for the full list.
           </p>
         </section>
 
-        {/* Lens vocab */}
-        <section className="mb-20 border border-stone-200 rounded-xl bg-stone-50 px-6 py-5">
-          <p className="text-xs font-mono text-stone-400 mb-2 uppercase tracking-widest">Lens</p>
-          <p className="text-sm font-mono text-stone-700">
-            &ldquo;Ask Lens: &lsquo;show me every block against{" "}
-            <span className="text-red-600">payments-api</span> this month.&rsquo;&rdquo;
-          </p>
-          <p className="text-xs text-stone-400 mt-3 leading-relaxed">
-            Lens is the workspace chat surface. Ask questions about Guard activity, compliance state,
-            or any agent action — and get answers backed by the audit trail, not log correlation.
-          </p>
+        {/* Lens transcript — Figma frame 13 */}
+        <section className="mb-20 grid grid-cols-1 lg:grid-cols-2 gap-8 items-start">
+          <div>
+            <h2 className="text-2xl font-bold text-stone-900 mb-3">
+              &ldquo;Show me every block against payments this month.&rdquo;
+            </h2>
+            <p className="text-stone-500 text-sm leading-relaxed mb-3">
+              Lens is the workspace chat surface. Ask questions about Guard activity, compliance state,
+              or any agent action — get answers backed by the audit trail, not log correlation.
+            </p>
+            <p className="text-xs font-mono text-stone-400 uppercase tracking-widest">
+              Every block against payments · Sep 2026
+            </p>
+          </div>
+          <div>
+            <LensTranscript />
+          </div>
         </section>
 
         {/* CTA */}

--- a/apps/web/src/app/(marketing)/guard/page.tsx
+++ b/apps/web/src/app/(marketing)/guard/page.tsx
@@ -4,7 +4,7 @@ import { PolicySnippet } from "@/components/marketing/facelift/PolicySnippet"
 import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
 import { AgentSurfaceStrip } from "@/components/marketing/facelift/AgentSurfaceStrip"
 import { ThreatModelRow } from "@/components/marketing/facelift/ThreatModelRow"
-import { CapabilityStatus } from "@/components/marketing/facelift/CapabilityStatus"
+import { ActivityRow } from "@/components/marketing/facelift/ActivityRow"
 
 export const metadata = {
   title: "Guard — Runtime policy for every AI agent | Conduct",
@@ -17,37 +17,50 @@ export default function GuardPage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero */}
-        <section className="pt-20 pb-16 text-center">
-          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
-            Guard
-          </p>
-          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-            Runtime policy for every AI agent.
-          </h1>
-          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-4">
-            Conduct Guard enforces runtime policy across any MCP-compatible AI agent, model gateway, and MCP
-            tool — before consequential actions execute.
-          </p>
-          <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-3">
-            Allow. Approve. Block. Prove.
-          </p>
-          <p className="text-sm sm:text-base font-semibold text-stone-700 max-w-xl mx-auto mb-10">
-            Install in 10 minutes. Evidence for the CISO from day one.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link
-              href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-            >
-              Start Agent Discovery — 14 days free
-            </Link>
-            <Link
-              href="/demo"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
-            >
-              Book a Demo
-            </Link>
+        {/* Hero — Figma frame 11 */}
+        <section className="pt-20 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
+          <div>
+            <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+              Guard
+            </p>
+            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+              Runtime policy for every AI agent.
+            </h1>
+            <p className="text-lg text-stone-500 leading-relaxed mb-4">
+              Conduct Guard enforces runtime policy across any MCP-compatible AI agent, model gateway, and MCP
+              tool — before consequential actions execute.
+            </p>
+            <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-3">
+              Allow. Approve. Block. Prove.
+            </p>
+            <p className="text-sm sm:text-base font-semibold text-stone-700 mb-10">
+              Install in 10 minutes. Evidence for the CISO from day one.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/sign-up"
+                className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              >
+                Start Agent Discovery — 14 days free
+              </Link>
+              <Link
+                href="/demo"
+                className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              >
+                Book a Demo
+              </Link>
+            </div>
+          </div>
+          <div className="lg:pl-4">
+            <DecisionCard
+              agent="claude-code / deploy-agent"
+              action="deploy_production"
+              resource="payments-api"
+              policy="production-change-v4"
+              decision="APPROVE"
+              reason="Production deployment outside approved change window"
+              showButtons
+            />
           </div>
         </section>
 
@@ -99,46 +112,46 @@ export default function GuardPage() {
           </div>
         </section>
 
-        {/* Consequential actions */}
-        <section className="mb-20 border border-stone-200 rounded-2xl p-8 bg-stone-50">
-          <h2 className="text-2xl font-bold text-stone-900 mb-3">Consequential actions</h2>
-          <p className="text-stone-500 text-sm leading-relaxed max-w-2xl mb-6">
-            Guard was built for actions that cannot be undone. Refunds, production deployments,
-            secret reads, network changes — these need a policy decision before they execute, not after.
-          </p>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm">
-            {[
-              { action: "process_refund", context: "$840 · customer C-8911", outcome: "BLOCK", label: "over $500 limit" },
-              { action: "deploy_production", context: "payments-api · outside change window", outcome: "APPROVE", label: "routes to Slack" },
-              { action: "read_env", context: "SECRET_KEY · prod environment", outcome: "BLOCK", label: "secret access denied" },
-            ].map(({ action, context, outcome, label }) => (
-              <div key={action} className="border border-stone-200 rounded-xl bg-white p-4 font-mono">
-                <p className="text-[11px] text-stone-900 font-bold mb-1">{action}</p>
-                <p className="text-[10px] text-stone-400 mb-3">{context}</p>
-                <span className={`text-[10px] font-bold ${outcome === "BLOCK" ? "text-red-600" : "text-amber-600"}`}>
-                  {outcome}
-                </span>
-                <span className="text-[10px] text-stone-400 ml-1">— {label}</span>
-              </div>
-            ))}
-          </div>
-        </section>
-
-        {/* Policy snippet */}
+        {/* Policy + Consequential actions — Figma frame 11 */}
         <section className="mb-20">
           <h2 className="text-2xl font-bold text-stone-900 mb-3">Policy that can be inspected.</h2>
           <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
             Policies are YAML files checked into your repository. No black-box rule engine. Any engineer
             can read, modify, and audit the rules that govern your agents.
           </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6 items-start">
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 items-start">
             <PolicySnippet language="yaml" />
-            <PolicySnippet
-              language="cedar"
-              title="production-change.cedar"
-            />
+            <div>
+              <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-3">
+                Consequential actions
+              </p>
+              <div className="space-y-2.5">
+                <ActivityRow
+                  decision="BLOCK"
+                  action="process_refund"
+                  actor="over $500 limit"
+                  timestamp="C-8911"
+                />
+                <ActivityRow
+                  decision="APPROVE"
+                  action="deploy_production"
+                  actor="routes to Slack"
+                  timestamp="payments-api"
+                />
+                <ActivityRow
+                  decision="BLOCK"
+                  action="read_env"
+                  actor="secret access denied"
+                  timestamp="prod"
+                />
+              </div>
+              <p className="text-xs text-stone-400 mt-4 leading-relaxed max-w-md">
+                Guard was built for actions that cannot be undone. Refunds, production deployments,
+                secret reads, network changes — a policy decision before they execute, not after.
+              </p>
+            </div>
           </div>
-          <div className="mt-6 border border-stone-200 rounded-xl bg-stone-50 px-5 py-4 inline-block">
+          <div className="mt-8 border border-stone-200 rounded-xl bg-stone-50 px-5 py-4 inline-block">
             <p className="text-xs font-mono text-stone-400 mb-1 uppercase tracking-widest">Lens</p>
             <p className="text-sm font-mono text-stone-700">
               &ldquo;Ask Lens: &lsquo;what did Guard block last week?&rsquo;&rdquo;
@@ -158,21 +171,30 @@ export default function GuardPage() {
           </div>
         </section>
 
-        {/* Deployment */}
-        <section className="mb-20">
-          <h2 className="text-2xl font-bold text-stone-900 mb-3">Deployment</h2>
-          <CapabilityStatus
-            showLegend
-            items={[
-              { name: "SaaS (conductai.ai)", status: "SHIPPED", note: "US-based" },
-              { name: "Docker Compose (self-hosted)", status: "SHIPPED" },
-              { name: "Kubernetes", status: "PREVIEW", note: "Reference templates" },
-              { name: "Air-gapped / on-prem", status: "PLANNED" },
-            ]}
-          />
-          <p className="text-xs text-stone-400 mt-4">
+        {/* Deployment — Figma frame 11: dark section with 4 tiles */}
+        <section className="mb-20 -mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-14 bg-stone-950 rounded-3xl">
+          <h2 className="text-2xl font-bold text-white mb-3">Deploy Guard where your controls need to live.</h2>
+          <p className="text-stone-400 text-sm leading-relaxed mb-8 max-w-2xl">
             Same policy engine, same CLI, same audit trail — regardless of where Guard runs.
           </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              { name: "SaaS", status: "SHIPPED", note: "conductai.ai · US-based" },
+              { name: "Docker", status: "SHIPPED", note: "Self-hosted Compose" },
+              { name: "Kubernetes", status: "PREVIEW", note: "Reference templates" },
+              { name: "Air-gapped", status: "PLANNED", note: "On-prem, no external calls" },
+            ].map(({ name, status, note }) => (
+              <div key={name} className="border border-stone-800 rounded-2xl bg-stone-900 p-5">
+                <p className="text-white text-lg font-semibold mb-1">{name}</p>
+                <p className={`text-[10px] font-mono uppercase tracking-widest mb-3 ${
+                  status === "SHIPPED" ? "text-emerald-400" : status === "PREVIEW" ? "text-amber-400" : "text-stone-500"
+                }`}>
+                  {status}
+                </p>
+                <p className="text-stone-400 text-xs leading-relaxed">{note}</p>
+              </div>
+            ))}
+          </div>
         </section>
 
         {/* What Guard does NOT protect */}

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -251,6 +251,17 @@ function MarketingFooter() {
               </svg>
             </a>
             <a
+              href="https://x.com/ConductAIHQ"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-stone-700 transition-colors"
+              aria-label="X (Twitter)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+            </a>
+            <a
               href="https://www.youtube.com/@Conductai"
               target="_blank"
               rel="noopener noreferrer"
@@ -261,7 +272,7 @@ function MarketingFooter() {
                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
               </svg>
             </a>
-            <span>Envisioned, designed and developed with love from Houston</span>
+            <span>Made with ♥ from Houston</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -119,7 +119,7 @@ export default function MCPPage() {
   }
 }
 `}
-            <span className="block mt-3 text-emerald-400 text-[11px]">// guard: APPROVE → routed to Slack</span>
+            <span className="block mt-3 text-emerald-400 text-[11px]">{"// guard: APPROVE → routed to Slack"}</span>
           </pre>
         </section>
 

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -12,108 +12,115 @@ export default function MCPPage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero */}
-        <section className="pt-20 pb-16 text-center">
-          <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
-            MCP
-          </p>
-          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-            Runtime policy for MCP actions.
-          </h1>
-          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
-            Guard sits between the MCP client and the MCP server. Every tool call is evaluated
-            against policy before it reaches the server. Policy applies at the MCP call — not at
-            the client, not at the model.
-          </p>
-          <div className="flex flex-wrap justify-center gap-3">
-            <Link
-              href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-            >
-              Start Discovery — 14 days free
-            </Link>
-            <Link
-              href="/demo"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
-            >
-              Book a Demo
-            </Link>
-          </div>
-        </section>
-
-        {/* MCP flow diagram */}
-        <section className="mb-20">
-          <h2 className="text-2xl font-bold text-stone-900 mb-3">
-            Agent → Guard → Model / Tool.
-          </h2>
-          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
-            Guard wraps the MCP transport layer. Clients connect to Guard as if it were the MCP server.
-            Guard evaluates each tool call and forwards allowed calls to the upstream server.
-            Blocked calls never reach the server.
-          </p>
-          <div className="border border-stone-200 rounded-2xl bg-white p-8 sm:p-12 mb-8">
-            <div className="flex items-center justify-center gap-3 sm:gap-6">
-              <div className="flex-1 max-w-[220px] border border-stone-200 rounded-2xl bg-white px-4 sm:px-6 py-6 sm:py-8 text-center shadow-sm">
-                <p className="text-lg sm:text-2xl font-black tracking-tight text-stone-900">Agent</p>
-              </div>
-              <FlowArrow />
-              <div className="flex-1 max-w-[220px] rounded-2xl bg-stone-900 px-4 sm:px-6 py-6 sm:py-8 text-center shadow-md">
-                <p className="text-lg sm:text-2xl font-black tracking-tight text-white">Guard</p>
-              </div>
-              <FlowArrow />
-              <div className="flex-1 max-w-[220px] border border-stone-200 rounded-2xl bg-white px-4 sm:px-6 py-6 sm:py-8 text-center shadow-sm">
-                <p className="text-base sm:text-2xl font-black tracking-tight text-stone-900 whitespace-nowrap">Model / Tool</p>
-              </div>
+        {/* Hero — Figma frame 14 */}
+        <section className="pt-20 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
+          <div>
+            <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+              MCP
+            </p>
+            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+              Policy for every MCP tool invocation.
+            </h1>
+            <p className="text-lg text-stone-500 leading-relaxed mb-4">
+              Guard sits between the MCP client and the MCP server. Every tool call is evaluated
+              against policy before it reaches the server — applying runtime policy and evidence-model
+              enforcement across every MCP-compatible client.
+            </p>
+            <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-6">
+              Allow. Approve. Block. Prove.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/sign-up"
+                className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              >
+                Start Discovery — 14 days free
+              </Link>
+              <Link
+                href="/demo"
+                className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              >
+                Book a Demo
+              </Link>
             </div>
           </div>
-          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 text-sm font-mono">
-            {[
-              { step: "1", label: "MCP Client", desc: "Claude Desktop, Cursor, or any MCP-compatible client sends a tool call." },
-              { step: "2", label: "Guard evaluates", desc: "Guard checks the tool call against policy. Allow, approve, or block — before the server sees it." },
-              { step: "3", label: "MCP Server", desc: "Allowed calls reach the server. Blocked calls return a Guard decision with reason." },
-            ].map(({ step, label, desc }) => (
-              <div key={step} className="border border-stone-200 rounded-xl bg-white p-5">
-                <div className="flex items-center gap-2 mb-2">
-                  <span className="w-5 h-5 rounded-full bg-stone-900 text-white text-[10px] font-bold flex items-center justify-center shrink-0">
-                    {step}
-                  </span>
-                  <span className="font-bold text-stone-900 text-[13px]">{label}</span>
-                </div>
-                <p className="text-stone-500 text-[12px] leading-relaxed">{desc}</p>
-              </div>
-            ))}
+          <div className="lg:pl-4">
+            {/* SVG diagram — clients → ConductAI → MCP server. See docs/design/figma/screenshots/mcp-hero-diagram.svg */}
+            <img
+              src="/design/mcp-hero-diagram.svg"
+              alt="MCP clients Claude Desktop, ChatGPT, and Cursor route tool invocations through ConductAI, which decides ALLOW, APPROVE, or BLOCK before the MCP server executes the tool."
+              className="w-full h-auto rounded-2xl border border-stone-800/60 shadow-md"
+              loading="lazy"
+            />
           </div>
         </section>
 
-        {/* Policy applies at the MCP call */}
+        {/* Control before the tool executes — Figma frame 14 */}
         <section className="mb-20">
           <h2 className="text-2xl font-bold text-stone-900 mb-3">
-            Policy at the call, not the client.
+            Control before the tool executes.
           </h2>
           <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
-            MCP clients do not enforce policy — they issue tool calls. Guard is the enforcement
-            point that sits at the transport layer. The same policy that governs Claude Code CLI
-            actions also governs MCP tool calls through the same engine.
+            Guard evaluates the tool call after the model chooses it and before the MCP server receives it.
+            The same policy that governs Claude Code CLI actions also governs MCP tool calls through the same engine.
           </p>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
+          <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
             <DecisionCard
-              agent="claude-code / deploy-agent"
-              action="update_terraform"
-              resource="prod-vpc"
-              policy="no-production-network-change"
-              decision="BLOCK"
-              reason="Production network modifications require approved change record."
+              compact
+              agent="cursor-agent-17"
+              action="read_repository"
+              resource="approved-repos"
+              policy="repo-scope-v2"
+              decision="ALLOW"
+              reason="Repository on approved list"
             />
             <DecisionCard
-              agent="cursor-agent-17"
-              action="deploy_production"
-              resource="payments-api"
-              policy="production-change-v4"
+              compact
+              agent="claude-desktop"
+              action="send_external_email"
+              resource="finance-recipients"
+              policy="external-comms-v1"
               decision="APPROVE"
-              reason="Production deployment outside approved change window"
-              showButtons
+              reason="External send requires human approval"
+            />
+            <DecisionCard
+              compact
+              agent="claude-code / deploy-agent"
+              action="read_production_secret"
+              resource="SECRET_KEY"
+              policy="no-prod-secret-read"
+              decision="BLOCK"
+              reason="Production secret access denied by policy"
             />
           </div>
+        </section>
+
+        {/* Wrap the invocation. Keep the server. — Figma frame 14 */}
+        <section className="mb-20 grid grid-cols-1 lg:grid-cols-2 gap-8 items-center">
+          <div>
+            <h2 className="text-2xl font-bold text-stone-900 mb-3">
+              Wrap the invocation. Keep the server.
+            </h2>
+            <p className="text-stone-500 text-sm leading-relaxed mb-4">
+              Guard adapts the compatible client and MCP server. Your existing MCP servers stay in place —
+              Guard sits at the transport layer, evaluates each tool call, and forwards allowed calls unchanged.
+            </p>
+            <p className="text-xs font-mono text-stone-400 uppercase tracking-widest">
+              No client changes required
+            </p>
+          </div>
+          <pre className="rounded-xl border border-stone-800/60 bg-stone-950 text-stone-300 text-[12px] leading-relaxed p-5 overflow-x-auto font-mono shadow-md">
+{`{
+  "jsonrpc": "2.0",
+  "method": "tools/call",
+  "params": {
+    "name": "deploy_production",
+    "arguments": { "env": "prod" }
+  }
+}
+`}
+            <span className="block mt-3 text-emerald-400 text-[11px]">// guard: APPROVE → routed to Slack</span>
+          </pre>
         </section>
 
         {/* MCP capabilities */}
@@ -212,21 +219,3 @@ export default function MCPPage() {
   )
 }
 
-function FlowArrow() {
-  return (
-    <svg
-      className="w-5 h-3 sm:w-8 sm:h-4 text-stone-400 shrink-0"
-      viewBox="0 0 32 16"
-      fill="none"
-      aria-hidden="true"
-    >
-      <path
-        d="M0 8h26M20 2l6 6-6 6"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  )
-}

--- a/apps/web/src/app/(marketing)/registry/page.tsx
+++ b/apps/web/src/app/(marketing)/registry/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { PlaybookTile } from "@/components/marketing/facelift/PlaybookTile"
 import type { PlaybookCategory, BlockType } from "@/components/marketing/facelift/PlaybookTile"
+import { CompliancePackCard } from "@/components/marketing/facelift/CompliancePackCard"
 
 export const metadata = {
   title: "Registry — Conduct",
@@ -80,20 +81,20 @@ export default function RegistryPage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero */}
-        <section className="pt-20 pb-16 text-center">
+        {/* Hero — Figma frame 12 */}
+        <section className="pt-20 pb-14 text-left max-w-3xl">
           <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
-            Registry
+            Conduct Registry
           </p>
           <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-            Registry. 39 playbooks shipped.
+            Browse the Conduct Registry.
           </h1>
-          <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed mb-10">
-            Each playbook combines a brain block for reasoning, a guard block for policy enforcement,
-            approval gates for consequential actions, and hash-chained evidence for every decision.
-            The same primitives. Every workflow.
+          <p className="text-lg text-stone-500 leading-relaxed mb-10">
+            Install a pack. It runs under Guard enforcement. Every playbook combines a brain block for
+            reasoning, a guard block for policy enforcement, approval gates for consequential actions, and
+            hash-chained evidence for every decision.
           </p>
-          <div className="flex flex-wrap justify-center gap-3">
+          <div className="flex flex-wrap gap-3">
             <Link
               href="/sign-up"
               className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
@@ -106,6 +107,40 @@ export default function RegistryPage() {
             >
               Book a Demo
             </Link>
+          </div>
+        </section>
+
+        {/* Compliance packs — Figma frame 12 */}
+        <section className="mb-16">
+          <div className="flex items-baseline gap-3 mb-6">
+            <h2 className="text-2xl font-bold text-stone-900">Compliance packs</h2>
+            <span className="text-xs font-mono text-stone-400">5 shipped</span>
+          </div>
+          <p className="text-stone-500 text-sm leading-relaxed mb-6 max-w-2xl">
+            Pre-built rule sets, one per compliance standard. Each pack is enforced by the same Guard engine
+            that runs your custom policies.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <CompliancePackCard
+              name="OWASP LLM Top 10"
+              description="Rule set for OWASP LLM security categories — insecure output handling, model DoS, and related risks."
+            />
+            <CompliancePackCard
+              name="SOC 2"
+              description="Hook-scoped rules that fire on file edits and writes for SOC 2 Trust Services Criteria."
+            />
+            <CompliancePackCard
+              name="HIPAA"
+              description="45 CFR §164.312 Technical Safeguards — access controls and transmission security."
+            />
+            <CompliancePackCard
+              name="PCI DSS v4.0"
+              description="Requirements 3.3.1 and 3.3.2 — mask PANs, avoid storing sensitive authentication data."
+            />
+            <CompliancePackCard
+              name="Prompt Safety"
+              description="Detection pack for common LLM prompt patterns that indicate untrusted or adversarial input."
+            />
           </div>
         </section>
 
@@ -219,6 +254,28 @@ export default function RegistryPage() {
               letting Guard decisions account for what happened before this action, not just the action itself.
               Available to design partners first.
             </p>
+          </div>
+        </section>
+
+        {/* Every pack runs under Guard enforcement — Figma frame 12 */}
+        <section className="mb-16 -mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-14 bg-stone-950 rounded-3xl">
+          <h2 className="text-2xl font-bold text-white mb-3">Every pack runs under Guard enforcement.</h2>
+          <p className="text-stone-400 text-sm leading-relaxed mb-8 max-w-2xl">
+            Policies apply instantly — no registry.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+            {[
+              { title: "Choose a pack", body: "Browse compliance packs or automation playbooks." },
+              { title: "Inspect every rule", body: "YAML in the repository. No black-box engine." },
+              { title: "Install to workspace", body: "One click. Rules apply to every agent surface." },
+              { title: "Guard enforces", body: "Every decision hash-chained. Every action inspectable." },
+            ].map(({ title, body }, i) => (
+              <div key={title} className="border border-stone-800 rounded-2xl bg-stone-900 p-5">
+                <p className="text-[10px] font-mono uppercase tracking-widest text-stone-500 mb-2">Step {i + 1}</p>
+                <p className="text-white font-semibold mb-2">{title}</p>
+                <p className="text-stone-400 text-xs leading-relaxed">{body}</p>
+              </div>
+            ))}
           </div>
         </section>
 

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -967,6 +967,17 @@ function PageFooter() {
               </svg>
             </a>
             <a
+              href="https://x.com/ConductAIHQ"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="hover:text-stone-700 transition-colors min-h-[44px] flex items-center"
+              aria-label="X (Twitter)"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-4 h-4">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+              </svg>
+            </a>
+            <a
               href="https://www.youtube.com/@Conductai"
               target="_blank"
               rel="noopener noreferrer"
@@ -977,7 +988,7 @@ function PageFooter() {
                 <path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z" />
               </svg>
             </a>
-            <span className="hidden sm:inline">Envisioned, designed and developed with love from Houston</span>
+            <span className="hidden sm:inline">Made with ♥ from Houston</span>
           </div>
         </div>
       </div>

--- a/apps/web/src/components/marketing/facelift/ActivityRow.tsx
+++ b/apps/web/src/components/marketing/facelift/ActivityRow.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+/**
+ * ActivityRow — compact single-row activity/consequential-actions entry.
+ * Renders inline: decision dot + label + action + actor + timestamp.
+ * Meant for feed lists. For a full standalone card use DecisionCard.
+ */
+
+import type { DecisionState } from "./DecisionCard"
+
+export interface ActivityRowProps {
+  decision: DecisionState
+  action?: string
+  actor?: string
+  timestamp?: string
+  imageSrc?: string
+  imageAlt?: string
+}
+
+const DOT: Record<DecisionState, string> = {
+  ALLOW: "bg-emerald-500",
+  APPROVE: "bg-amber-500",
+  BLOCK: "bg-red-500",
+}
+
+const LABEL_COLOR: Record<DecisionState, string> = {
+  ALLOW: "text-emerald-700",
+  APPROVE: "text-amber-700",
+  BLOCK: "text-red-700",
+}
+
+export function ActivityRow({
+  decision,
+  action = "deploy_production",
+  actor = "cursor-agent-17",
+  timestamp = "14:32 UTC",
+  imageSrc,
+  imageAlt,
+}: ActivityRowProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `Guard ${decision} activity on ${action}`}
+        loading="lazy"
+        className="border border-stone-200 rounded-lg shadow-sm w-full h-auto"
+      />
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-3 border border-stone-200 rounded-lg bg-white shadow-sm px-4 py-3 text-sm">
+      <span className={`inline-block w-2 h-2 rounded-full shrink-0 ${DOT[decision]}`} />
+      <span
+        className={`font-mono text-[10px] font-bold uppercase tracking-widest shrink-0 w-16 ${LABEL_COLOR[decision]}`}
+      >
+        {decision}
+      </span>
+      <span className="font-mono text-[12px] text-stone-800 truncate flex-1">{action}</span>
+      <span className="hidden sm:inline font-mono text-[11px] text-stone-500 truncate">
+        {actor}
+      </span>
+      <span className="font-mono text-[10px] text-stone-400 shrink-0">{timestamp}</span>
+    </div>
+  )
+}

--- a/apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx
+++ b/apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx
@@ -23,7 +23,7 @@ export function AgentSurfaceStrip({ imageSrc, imageAlt }: AgentSurfaceStripProps
   }
 
   return (
-    <div className="border border-stone-200 rounded-2xl overflow-hidden bg-white shadow-sm text-xs font-mono">
+    <div className="border border-stone-200 rounded-2xl overflow-hidden bg-white shadow-md text-sm">
       <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-stone-200">
         <SurfaceBlock
           label="AGENT TOOLS"
@@ -70,18 +70,18 @@ function SurfaceBlock({
 }) {
   return (
     <div className="px-5 py-4">
-      <p className="text-[10px] font-bold uppercase tracking-widest text-stone-400 mb-3">{label}</p>
-      <ul className="space-y-2">
+      <p className="text-[10px] font-mono font-bold uppercase tracking-widest text-stone-400 mb-3">{label}</p>
+      <ul className="space-y-2.5">
         {items.map((item) => (
           <li key={item.name} className="flex items-center gap-2">
-            <span className="text-[11px] text-stone-700 font-medium">{item.name}</span>
+            <span className="text-[13px] text-stone-800 font-medium leading-snug">{item.name}</span>
             {item.note && (
-              <span className="text-[9px] text-stone-400 bg-stone-50 border border-stone-200 rounded px-1 py-0.5">
+              <span className="text-[10px] font-mono text-stone-500 bg-stone-50 border border-stone-200 rounded px-1.5 py-0.5 tracking-wide">
                 {item.note}
               </span>
             )}
             {item.status === "preview" && (
-              <span className="text-[9px] text-amber-600 bg-amber-50 border border-amber-200 rounded px-1 py-0.5 ml-auto">
+              <span className="text-[10px] font-mono text-amber-700 bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 ml-auto tracking-wide uppercase">
                 Preview
               </span>
             )}

--- a/apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx
+++ b/apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx
@@ -5,7 +5,23 @@
  * Renders AGENT TOOLS / CLIENTS / BYO GATEWAYS blocks.
  */
 
-export function AgentSurfaceStrip() {
+export interface AgentSurfaceStripProps {
+  imageSrc?: string
+  imageAlt?: string
+}
+
+export function AgentSurfaceStrip({ imageSrc, imageAlt }: AgentSurfaceStripProps = {}) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? "Agent surface strip"}
+        loading="lazy"
+        className="border border-stone-200 rounded-2xl shadow-sm w-full h-auto"
+      />
+    )
+  }
+
   return (
     <div className="border border-stone-200 rounded-2xl overflow-hidden bg-white shadow-sm text-xs font-mono">
       <div className="grid grid-cols-1 sm:grid-cols-3 divide-y sm:divide-y-0 sm:divide-x divide-stone-200">

--- a/apps/web/src/components/marketing/facelift/CompliancePackCard.tsx
+++ b/apps/web/src/components/marketing/facelift/CompliancePackCard.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+/**
+ * CompliancePackCard — Registry pack tile.
+ * Category dot + name + description + rule-count pill + enforcement status.
+ */
+
+export type PackCategory = "compliance" | "automation"
+
+export interface CompliancePackCardProps {
+  name: string
+  description?: string
+  category?: PackCategory
+  ruleCount?: number
+  enforced?: boolean
+  imageSrc?: string
+  imageAlt?: string
+}
+
+const CATEGORY_COLOR: Record<PackCategory, string> = {
+  compliance: "bg-indigo-500",
+  automation: "bg-cyan-500",
+}
+
+export function CompliancePackCard({
+  name,
+  description = "",
+  category = "compliance",
+  ruleCount,
+  enforced = true,
+  imageSrc,
+  imageAlt,
+}: CompliancePackCardProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `${name} pack`}
+        loading="lazy"
+        className="border border-stone-200 rounded-xl shadow-sm w-full h-auto"
+      />
+    )
+  }
+
+  return (
+    <div className="border border-stone-200 rounded-xl bg-white shadow-md p-5 text-sm flex flex-col gap-3 h-full">
+      <div className="flex items-center gap-2">
+        <span
+          className={`inline-block w-2.5 h-2.5 rounded-full shrink-0 ${CATEGORY_COLOR[category]}`}
+        />
+        <span className="font-semibold text-stone-900 text-[15px] leading-tight">{name}</span>
+      </div>
+
+      {description && (
+        <p className="text-stone-600 text-[13px] leading-relaxed line-clamp-3">{description}</p>
+      )}
+
+      <div className="flex items-center gap-2 mt-auto pt-3 border-t border-stone-100">
+        {typeof ruleCount === "number" && (
+          <span className="font-mono text-[11px] text-stone-500 bg-stone-50 border border-stone-200 rounded px-2 py-0.5 tracking-wide">
+            {ruleCount} rules
+          </span>
+        )}
+        {enforced && (
+          <span className="font-mono text-[10px] uppercase tracking-widest text-emerald-700 bg-emerald-50 border border-emerald-200 rounded px-2 py-0.5 ml-auto">
+            Enforced
+          </span>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/marketing/facelift/DecisionCard.tsx
+++ b/apps/web/src/components/marketing/facelift/DecisionCard.tsx
@@ -90,35 +90,35 @@ export function DecisionCard({
 
   return (
     <div
-      className={`${cfg.bg} border ${cfg.border} rounded-xl shadow-sm font-mono text-xs overflow-hidden`}
+      className={`${cfg.bg} border ${cfg.border} rounded-xl shadow-md text-sm overflow-hidden`}
     >
       {/* Header bar */}
-      <div className={`${cfg.badgeBg} border-b ${cfg.border} px-4 py-2 flex items-center justify-between`}>
+      <div className={`${cfg.badgeBg} border-b ${cfg.border} px-5 py-2.5 flex items-center justify-between`}>
         <div className="flex items-center gap-2">
           <span className={`inline-block w-2 h-2 rounded-full ${cfg.dot}`} />
-          <span className={`font-bold tracking-wider text-[10px] uppercase ${cfg.badge}`}>
+          <span className={`font-mono font-bold tracking-widest text-[10px] uppercase ${cfg.badge}`}>
             {cfg.label}
           </span>
         </div>
-        <span className="text-stone-400 text-[10px]">Guard</span>
+        <span className="text-stone-400 text-[10px] font-mono tracking-wider uppercase">Guard</span>
       </div>
 
       {/* Body */}
-      <div className={`px-4 ${compact ? "py-3" : "py-4"} space-y-2`}>
-        <Row label="Agent" value={agent} />
-        <Row label="Action" value={action} />
-        <Row label="Resource" value={resource} />
-        {!compact && <Row label="Policy" value={policy} />}
+      <div className={`px-5 ${compact ? "py-3.5" : "py-4"} space-y-2.5`}>
+        <Row label="Agent" value={agent} mono />
+        <Row label="Action" value={action} mono />
+        <Row label="Resource" value={resource} mono />
+        {!compact && <Row label="Policy" value={policy} mono />}
         <Row label="Reason" value={displayReason} wrap />
       </div>
 
       {/* Approval buttons */}
       {showButtons && decision === "APPROVE" && (
-        <div className="border-t border-amber-100 px-4 py-3 flex gap-2 bg-amber-50/50">
-          <button className="rounded-lg bg-emerald-600 text-white px-4 py-1.5 text-xs font-semibold hover:bg-emerald-700 transition-colors">
+        <div className="border-t border-amber-100 px-5 py-3 flex gap-2 bg-amber-50/50">
+          <button className="rounded-lg bg-emerald-600 text-white px-4 py-2 text-sm font-semibold hover:bg-emerald-700 transition-colors">
             Approve
           </button>
-          <button className="rounded-lg bg-white border border-stone-200 text-stone-600 px-4 py-1.5 text-xs font-semibold hover:bg-stone-50 transition-colors">
+          <button className="rounded-lg bg-white border border-stone-200 text-stone-600 px-4 py-2 text-sm font-semibold hover:bg-stone-50 transition-colors">
             Reject
           </button>
         </div>
@@ -127,11 +127,11 @@ export function DecisionCard({
   )
 }
 
-function Row({ label, value, wrap = false }: { label: string; value: string; wrap?: boolean }) {
+function Row({ label, value, wrap = false, mono = false }: { label: string; value: string; wrap?: boolean; mono?: boolean }) {
   return (
-    <div className={`flex ${wrap ? "flex-col gap-0.5" : "items-start gap-2"}`}>
-      <span className="text-stone-400 text-[10px] uppercase tracking-wider shrink-0 w-16">{label}</span>
-      <span className={`text-stone-700 text-[11px] ${wrap ? "" : "truncate"}`}>{value}</span>
+    <div className={`flex ${wrap ? "flex-col gap-0.5" : "items-baseline gap-3"}`}>
+      <span className="text-stone-400 text-[10px] uppercase tracking-widest font-mono shrink-0 w-16">{label}</span>
+      <span className={`text-stone-800 ${mono ? "font-mono text-[12px]" : "text-[13px] leading-snug"} ${wrap ? "" : "truncate"}`}>{value}</span>
     </div>
   )
 }

--- a/apps/web/src/components/marketing/facelift/DecisionCard.tsx
+++ b/apps/web/src/components/marketing/facelift/DecisionCard.tsx
@@ -17,6 +17,8 @@ export interface DecisionCardProps {
   reason?: string
   showButtons?: boolean
   compact?: boolean
+  imageSrc?: string
+  imageAlt?: string
 }
 
 const STATE_CONFIG: Record<DecisionState, {
@@ -62,7 +64,20 @@ export function DecisionCard({
   reason,
   showButtons = false,
   compact = false,
+  imageSrc,
+  imageAlt,
 }: DecisionCardProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `Guard ${decision} decision`}
+        loading="lazy"
+        className="border border-stone-200 rounded-xl shadow-sm w-full h-auto"
+      />
+    )
+  }
+
   const cfg = STATE_CONFIG[decision]
   const defaultReason =
     decision === "APPROVE"

--- a/apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx
+++ b/apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx
@@ -16,6 +16,8 @@ export interface EvidenceReceiptProps {
   user?: string
   timestamp?: string
   integrity?: "Verified" | "Failed" | "Pending"
+  imageSrc?: string
+  imageAlt?: string
 }
 
 export function EvidenceReceipt({
@@ -29,7 +31,20 @@ export function EvidenceReceipt({
   user = "developer@acme.example",
   timestamp = "14:32:11 UTC · 2026-03-11",
   integrity = "Verified",
+  imageSrc,
+  imageAlt,
 }: EvidenceReceiptProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `Evidence receipt for decision ${decisionId}`}
+        loading="lazy"
+        className="border border-stone-200 rounded-xl shadow-sm max-w-sm w-full h-auto"
+      />
+    )
+  }
+
   return (
     <div className="border border-stone-200 rounded-xl overflow-hidden bg-white shadow-sm font-mono text-xs max-w-sm">
       {/* Header */}

--- a/apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx
+++ b/apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx
@@ -46,28 +46,28 @@ export function EvidenceReceipt({
   }
 
   return (
-    <div className="border border-stone-200 rounded-xl overflow-hidden bg-white shadow-sm font-mono text-xs max-w-sm">
+    <div className="border border-stone-200 rounded-xl overflow-hidden bg-white shadow-md text-sm max-w-sm">
       {/* Header */}
       <div className="bg-stone-900 px-5 py-3 flex items-center justify-between">
-        <span className="text-white font-bold text-[11px] tracking-wider">DECISION #{decisionId}</span>
+        <span className="text-white font-mono font-bold text-[11px] tracking-widest">DECISION #{decisionId}</span>
         <DecisionBadge decision={decision} />
       </div>
 
       {/* Fields */}
       <div className="divide-y divide-stone-100">
-        <Field label="Agent" value={agent} />
-        <Field label="Action" value={action} />
-        <Field label="Resource" value={resource} />
-        <Field label="Decision" value={decision} highlight={decision === "BLOCK"} />
-        <Field label="Rule" value={rule} />
+        <Field label="Agent" value={agent} mono />
+        <Field label="Action" value={action} mono />
+        <Field label="Resource" value={resource} mono />
+        <Field label="Decision" value={decision} highlight={decision === "BLOCK"} mono />
+        <Field label="Rule" value={rule} mono />
         <Field label="Reason" value={reason} wrap />
-        <Field label="User" value={user} />
-        <Field label="Timestamp" value={timestamp} />
+        <Field label="User" value={user} mono />
+        <Field label="Timestamp" value={timestamp} mono />
       </div>
 
       {/* Integrity footer */}
       <div className="px-5 py-3 bg-stone-50 border-t border-stone-100 flex items-center justify-between">
-        <span className="text-stone-400 text-[10px] uppercase tracking-wider">Integrity</span>
+        <span className="text-stone-400 text-[10px] uppercase tracking-widest font-mono">Integrity</span>
         <div className="flex items-center gap-1.5">
           <span
             className={`inline-block w-2 h-2 rounded-full ${
@@ -75,7 +75,7 @@ export function EvidenceReceipt({
             }`}
           />
           <span
-            className={`text-[11px] font-semibold ${
+            className={`text-[12px] font-semibold ${
               integrity === "Verified" ? "text-emerald-700" : "text-red-700"
             }`}
           >
@@ -105,18 +105,20 @@ function Field({
   value,
   highlight = false,
   wrap = false,
+  mono = false,
 }: {
   label: string
   value: string
   highlight?: boolean
   wrap?: boolean
+  mono?: boolean
 }) {
   return (
-    <div className={`flex ${wrap ? "flex-col gap-0.5" : "items-start"} px-5 py-2`}>
-      <span className="text-stone-400 text-[10px] uppercase tracking-wider shrink-0 w-20">{label}</span>
+    <div className={`flex ${wrap ? "flex-col gap-0.5" : "items-baseline"} px-5 py-2.5 gap-3`}>
+      <span className="text-stone-400 text-[10px] uppercase tracking-widest font-mono shrink-0 w-20">{label}</span>
       <span
-        className={`text-[11px] ${
-          highlight ? "text-red-600 font-bold" : "text-stone-700"
+        className={`${mono ? "font-mono text-[12px]" : "text-[13px] leading-snug"} ${
+          highlight ? "text-red-600 font-bold" : "text-stone-800"
         } ${wrap ? "" : "truncate"}`}
       >
         {value}

--- a/apps/web/src/components/marketing/facelift/LensTranscript.tsx
+++ b/apps/web/src/components/marketing/facelift/LensTranscript.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+/**
+ * LensTranscript — user query bubble + assistant response as a compact
+ * result table. Meant for Evidence/Lens marketing sections where the
+ * response is structured (counts, decisions, rules), not free prose.
+ */
+
+export type LensDecision = "ALLOW" | "APPROVE" | "BLOCK"
+
+export interface LensTranscriptRow {
+  action?: string
+  decision?: LensDecision
+  count?: number
+  rule?: string
+}
+
+export interface LensTranscriptProps {
+  query?: string
+  answerHeadline?: string
+  rows?: LensTranscriptRow[]
+  imageSrc?: string
+  imageAlt?: string
+}
+
+const DECISION_COLOR: Record<LensDecision, string> = {
+  ALLOW: "text-emerald-700 bg-emerald-50 border-emerald-200",
+  APPROVE: "text-amber-700 bg-amber-50 border-amber-200",
+  BLOCK: "text-red-700 bg-red-50 border-red-200",
+}
+
+const DEFAULT_ROWS: LensTranscriptRow[] = [
+  { action: "process_refund", decision: "BLOCK", count: 12, rule: "refund-cap-500" },
+  { action: "issue_credit", decision: "BLOCK", count: 3, rule: "credit-cap-1000" },
+  { action: "deploy_production", decision: "APPROVE", count: 4, rule: "prod-change-v4" },
+]
+
+export function LensTranscript({
+  query = "Show me every block against payments this month",
+  answerHeadline = "Every block against payments · Sep 2026",
+  rows = DEFAULT_ROWS,
+  imageSrc,
+  imageAlt,
+}: LensTranscriptProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `Lens transcript: ${query}`}
+        loading="lazy"
+        className="border border-stone-200 rounded-xl shadow-md w-full h-auto"
+      />
+    )
+  }
+
+  return (
+    <div className="border border-stone-200 rounded-xl overflow-hidden bg-white shadow-md text-sm">
+      {/* User query bubble */}
+      <div className="px-5 py-3 bg-indigo-600">
+        <p className="text-white text-[13px] leading-snug">{query}</p>
+      </div>
+
+      {/* Assistant answer */}
+      <div className="px-5 py-4 space-y-3">
+        <p className="font-semibold text-stone-900 text-[14px]">{answerHeadline}</p>
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-stone-400 text-[10px] uppercase tracking-widest font-mono">
+              <th className="text-left font-medium py-1">Action</th>
+              <th className="text-left font-medium py-1">Decision</th>
+              <th className="text-right font-medium py-1">Count</th>
+              <th className="text-right font-medium py-1">Rule</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-stone-100">
+            {rows.map((r, i) => (
+              <tr key={i}>
+                <td className="py-2 font-mono text-stone-800 truncate">{r.action}</td>
+                <td className="py-2">
+                  {r.decision && (
+                    <span
+                      className={`inline-block font-mono text-[10px] font-bold uppercase tracking-widest px-2 py-0.5 rounded border ${DECISION_COLOR[r.decision]}`}
+                    >
+                      {r.decision}
+                    </span>
+                  )}
+                </td>
+                <td className="py-2 text-right font-mono text-stone-700">{r.count}</td>
+                <td className="py-2 text-right font-mono text-stone-500 text-[11px]">{r.rule}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/marketing/facelift/PolicySnippet.tsx
+++ b/apps/web/src/components/marketing/facelift/PolicySnippet.tsx
@@ -58,22 +58,18 @@ export function PolicySnippet({
   const displayCode = code ?? (language === "yaml" ? DEFAULT_YAML : DEFAULT_CEDAR)
 
   return (
-    <div className="rounded-xl border border-stone-200 overflow-hidden text-xs font-mono bg-stone-950 shadow-sm">
+    <div className="rounded-xl border border-stone-800/60 overflow-hidden text-xs font-mono bg-stone-950 shadow-md">
       {/* Title bar */}
-      <div className="flex items-center gap-2 px-4 py-2 bg-stone-900 border-b border-stone-800">
-        <div className="flex gap-1.5">
-          <span className="w-2.5 h-2.5 rounded-full bg-stone-600" />
-          <span className="w-2.5 h-2.5 rounded-full bg-stone-600" />
-          <span className="w-2.5 h-2.5 rounded-full bg-stone-600" />
-        </div>
-        <span className="text-stone-400 text-[10px] ml-1">{displayTitle}</span>
-        <span className="ml-auto text-[10px] px-1.5 py-0.5 rounded bg-stone-800 text-stone-500 uppercase tracking-wider">
+      <div className="flex items-center gap-3 px-4 py-2.5 bg-stone-900 border-b border-stone-800">
+        <span className="inline-block w-1.5 h-1.5 rounded-full bg-emerald-400" aria-hidden />
+        <span className="text-stone-300 text-[11px]">{displayTitle}</span>
+        <span className="ml-auto text-[10px] px-2 py-0.5 rounded bg-stone-800 text-stone-400 uppercase tracking-widest border border-stone-700">
           {language}
         </span>
       </div>
 
       {/* Code */}
-      <pre className="px-4 py-4 text-[11px] leading-relaxed overflow-x-auto">
+      <pre className="px-5 py-4 text-[12px] leading-relaxed overflow-x-auto">
         <YamlHighlight code={displayCode} language={language} />
       </pre>
     </div>

--- a/apps/web/src/components/marketing/facelift/PolicySnippet.tsx
+++ b/apps/web/src/components/marketing/facelift/PolicySnippet.tsx
@@ -11,6 +11,8 @@ export interface PolicySnippetProps {
   language?: PolicyLanguage
   title?: string
   code?: string
+  imageSrc?: string
+  imageAlt?: string
 }
 
 const DEFAULT_YAML = `policy: refund-cap
@@ -38,7 +40,20 @@ export function PolicySnippet({
   language = "yaml",
   title,
   code,
+  imageSrc,
+  imageAlt,
 }: PolicySnippetProps) {
+  if (imageSrc) {
+    return (
+      <img
+        src={imageSrc}
+        alt={imageAlt ?? `${language} policy snippet`}
+        loading="lazy"
+        className="rounded-xl border border-stone-200 shadow-sm w-full h-auto"
+      />
+    )
+  }
+
   const displayTitle = title ?? (language === "yaml" ? "refund-cap.yaml" : "production-change.cedar")
   const displayCode = code ?? (language === "yaml" ? DEFAULT_YAML : DEFAULT_CEDAR)
 

--- a/docs/design/figma-five-page-handoff.md
+++ b/docs/design/figma-five-page-handoff.md
@@ -55,6 +55,11 @@ The AI-slop problem is not limited to the five Figma frames. The same drawn "pro
 | `PolicySnippet` | `apps/web/src/components/marketing/facelift/PolicySnippet.tsx` | Real policy from `/theguard/policies/{id}`, syntax-highlighted from disk |
 | `EvidenceReceipt` | `apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx` | Real receipt from `/theguard/decisions/{id}` |
 | `AgentSurfaceStrip` | `apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx` | Real integration-status row from `/settings/integrations` |
+| `ActivityRow` | `apps/web/src/components/marketing/facelift/ActivityRow.tsx` | Real Guard activity-feed row (compact) from `/theguard/activity` |
+| `CompliancePackCard` | `apps/web/src/components/marketing/facelift/CompliancePackCard.tsx` | Real Registry pack tile from `/registry` |
+| `LensTranscript` | `apps/web/src/components/marketing/facelift/LensTranscript.tsx` | Real Lens query + result table from `/lens` |
+
+All facelift components accept optional `imageSrc` and `imageAlt` props. When `imageSrc` is set, the drawn shell is bypassed and the screenshot is rendered inside the same border/rounded/shadow footprint. Consumers can adopt real screenshots per-route without any component-code change.
 
 ### Consuming routes (auto-updated when the components are fixed)
 

--- a/docs/design/figma-five-page-handoff.md
+++ b/docs/design/figma-five-page-handoff.md
@@ -40,10 +40,42 @@ The PNGs are compact full-page implementation references. Use the live Figma fra
 4. If Figma copy conflicts with current repository copy, use the repository copy.
 5. Do not introduce customer logos, metrics, certifications, deployment claims, integrations, or product capabilities that are not supported by the repository.
 6. Keep native platform controls in place; ConductAI adds a common runtime policy and evidence model across the agent stack.
-7. Any Figma panel that depicts an in-product surface (Guard, Lens, Run, Registry, Evidence receipt, Slack approval) MUST be implemented from the matching screenshot in [`docs/design/figma/screenshots/`](figma/screenshots/), not redrawn from the mockup. Redrawing produces AI-looking mockups; real screenshots read as product.
+7. Any Figma panel or shared React component that depicts an in-product surface (Guard, Lens, Run, Registry, Evidence receipt, Slack approval, MCP flow) MUST be implemented from the matching screenshot in [`docs/design/figma/screenshots/`](figma/screenshots/), not redrawn from the mockup. Redrawing produces AI-looking mockups; real screenshots read as product. This rule applies site-wide, not only to the five Figma pages. See the Site-wide scope section for the four shared components and six consuming routes.
 8. The MCP hero panel is a **diagram**, not a screenshot — no fake product-UI shell. Draw as SVG showing real client names (Claude Desktop, ChatGPT, Cursor) routing through ConductAI to an MCP server.
 
-## Screenshot inventory
+## Site-wide scope (beyond the five Figma pages)
+
+The AI-slop problem is not limited to the five Figma frames. The same drawn "product UI" panels are used across the whole marketing site through four shared React components under `apps/web/src/components/marketing/facelift/`. Fixing those four components fixes every consuming route.
+
+### Facelift components to swap
+
+| Component | Path | Real-screenshot replacement |
+|---|---|---|
+| `DecisionCard` | `apps/web/src/components/marketing/facelift/DecisionCard.tsx` | Real Guard activity-feed row or decision-detail card |
+| `PolicySnippet` | `apps/web/src/components/marketing/facelift/PolicySnippet.tsx` | Real policy from `/theguard/policies/{id}`, syntax-highlighted from disk |
+| `EvidenceReceipt` | `apps/web/src/components/marketing/facelift/EvidenceReceipt.tsx` | Real receipt from `/theguard/decisions/{id}` |
+| `AgentSurfaceStrip` | `apps/web/src/components/marketing/facelift/AgentSurfaceStrip.tsx` | Real integration-status row from `/settings/integrations` |
+
+### Consuming routes (auto-updated when the components are fixed)
+
+- `/guard` — hero + decisions row + policy + receipt + surfaces
+- `/evidence` — hero receipt
+- `/mcp-gateway` — decision cards in MCP flow
+- `/solutions/action-governance` — decision cards for refund / deploy / secret-read stories
+- `/solutions/engineering-leaders` — surface strip + decision cards
+- `/solutions/security-compliance` — receipt
+
+### Routes with no drawn product UI (skip)
+
+`about`, `benchmark`, `blog`, `book-demo`, `compare`, `deployment`, `discovery`, `docs`, `eval`, `frameworks`, `open-source`, `partners`, `pricing`, `privacy`, `router`, `sdd`, `team-os`, `terms`, `token-guardrails`, `tools`, `use-cases`, `what-is-conduct-ai`, `security` (uses tabular threat-model rows, not drawn UI).
+
+### Not drawn product UI — keep as-is
+
+- `ThreatModelRow` — tabular teaching material, not a screen.
+- `CapabilityStatus` — status legend, not a screen.
+- `PlaybookTile` in `/registry` — architectural block-sequence tiles, not screens.
+
+## Screenshot inventory (five Figma pages)
 
 The mockup PNGs under `figma/exports/` depict several in-product surfaces as drawn UI. Those must be replaced during implementation with real screenshots captured from the running product. Marketing tiles (feature grids, deployment cards, compliance tag rows) stay as HTML/CSS components — only in-product surfaces need real captures.
 

--- a/docs/design/figma-five-page-handoff.md
+++ b/docs/design/figma-five-page-handoff.md
@@ -40,6 +40,36 @@ The PNGs are compact full-page implementation references. Use the live Figma fra
 4. If Figma copy conflicts with current repository copy, use the repository copy.
 5. Do not introduce customer logos, metrics, certifications, deployment claims, integrations, or product capabilities that are not supported by the repository.
 6. Keep native platform controls in place; ConductAI adds a common runtime policy and evidence model across the agent stack.
+7. Any Figma panel that depicts an in-product surface (Guard, Lens, Run, Registry, Evidence receipt, Slack approval) MUST be implemented from the matching screenshot in [`docs/design/figma/screenshots/`](figma/screenshots/), not redrawn from the mockup. Redrawing produces AI-looking mockups; real screenshots read as product.
+8. The MCP hero panel is a **diagram**, not a screenshot — no fake product-UI shell. Draw as SVG showing real client names (Claude Desktop, ChatGPT, Cursor) routing through ConductAI to an MCP server.
+
+## Screenshot inventory
+
+The mockup PNGs under `figma/exports/` depict several in-product surfaces as drawn UI. Those must be replaced during implementation with real screenshots captured from the running product. Marketing tiles (feature grids, deployment cards, compliance tag rows) stay as HTML/CSS components — only in-product surfaces need real captures.
+
+Save all captures to `docs/design/figma/screenshots/` at 1440×900 desktop and 375×812 mobile, PNG, from the seeded demo workspace.
+
+| Page | Drawn panel in mockup | Replace with real screenshot | Capture source |
+|---|---|---|---|
+| Home | Hero right-side dark card (fake actor / action / decision) | Lens `run_workflow` confirm card | `/lens` — send `run <workflow>`, capture the Confirm/Cancel bubble |
+| Home | "Know exactly what happened" right card (fake run summary) | Run detail page, Summary tab | `/runs/{id}` |
+| Guard | Three-card row (ALLOW / APPROVE / BLOCK) with fake action names | Guard activity feed row | `/theguard/activity` — feed with mixed decisions |
+| Guard | YAML policy block | Real policy in editor | `/theguard/policies/{id}` |
+| Guard | Consequential-actions column (three rows) | Slack Guard-approval card | Slack — real `Guard approval required` message with Approve/Reject |
+| Registry | Four compliance-pack cards (OWASP LLM Top 10, SOC 2, HIPAA, PCI DSS) | Registry pack grid | `/registry` |
+| Registry | "No automation packs found" | Keep as-is — honest empty state | — |
+| Evidence | Hero right-side dark card (fake receipt) | Decision receipt page | `/theguard/decisions/{id}` — a full BLOCK receipt |
+| Evidence | Bottom "Show me every block against payments…" quote card | Lens transcript answering that exact query | `/lens` — query = "show me every block against payments this month" |
+| MCP | Hero right-side dark card (fake client router) | **Diagram (SVG)**, not a screenshot | draw client → ConductAI → MCP server |
+| MCP | JSON tool-call block | MCP protocol trace | MCP inspector or Lens tool trace |
+
+Marketing tiles that stay as HTML/CSS components (do not screenshot):
+
+- Home: "Five agent tools shouldn't require five policy models" cards; "Allow. Approve. Block. Prove." decision quad; "Write the rule once" surface picker.
+- Guard: "Deploy Guard where your controls need to live" (SaaS / Docker / Kubernetes / Air-gapped); "One policy where your stack isn't one vendor's" boundary cards.
+- Registry: "Every pack runs under Guard enforcement" four-step row.
+- Evidence: "What each receipt contains" six-card grid; "Compliance mapping" tag row.
+- MCP: "One policy across MCP clients" client tiles; "Control before the tool executes" decision cards.
 
 ## Visual implementation
 
@@ -74,3 +104,5 @@ The PNGs are compact full-page implementation references. Use the live Figma fra
 - Pages are responsive and usable at common mobile, tablet, and desktop widths.
 - Decision states and capability-status labels retain their precise semantic meaning.
 - No unsupported marketing claims are introduced.
+- Every in-product surface in the Screenshot inventory table is implemented from a real capture in `docs/design/figma/screenshots/`, not redrawn from the mockup.
+- MCP hero is an SVG diagram, not a screenshot of a fake UI shell.

--- a/docs/design/figma/screenshots/README.md
+++ b/docs/design/figma/screenshots/README.md
@@ -1,0 +1,27 @@
+# Real product screenshots (capture inventory)
+
+This directory holds real product screenshots that replace the drawn in-product panels
+in `../exports/*.png`. See the Screenshot inventory table in
+[`../../figma-five-page-handoff.md`](../../figma-five-page-handoff.md).
+
+## Capture rules
+
+- Seeded demo workspace only. No customer data. No real emails, tokens, or account IDs.
+- 1440×900 desktop and 375×812 mobile, PNG.
+- Redact secrets, real user IDs (except demo `lens:user_*`), and third-party tokens.
+
+## Filenames
+
+Match the mockup panels the capture replaces, e.g.:
+
+- `home-hero-lens-confirm.png`
+- `home-run-summary.png`
+- `guard-activity-row.png`
+- `guard-policy-yaml.png`
+- `guard-slack-approval.png`
+- `registry-pack-grid.png`
+- `evidence-receipt-block.png`
+- `evidence-lens-transcript.png`
+- `mcp-tool-trace.png`
+
+MCP hero is an SVG diagram — save as `mcp-hero-diagram.svg`, not a screenshot.

--- a/docs/design/figma/screenshots/mcp-hero-diagram.svg
+++ b/docs/design/figma/screenshots/mcp-hero-diagram.svg
@@ -1,0 +1,87 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 420" role="img" aria-labelledby="mcp-diagram-title mcp-diagram-desc">
+  <title id="mcp-diagram-title">ConductAI policy between MCP clients and MCP server</title>
+  <desc id="mcp-diagram-desc">Diagram: MCP clients Claude Desktop, ChatGPT, and Cursor route tool invocations through ConductAI, which decides ALLOW, APPROVE, or BLOCK before the MCP server executes the tool.</desc>
+
+  <defs>
+    <marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#818CF8"/>
+    </marker>
+    <marker id="arrowLight" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse">
+      <path d="M0,0 L10,5 L0,10 z" fill="#6D7488"/>
+    </marker>
+  </defs>
+
+  <!-- Canvas -->
+  <rect x="0" y="0" width="800" height="420" fill="#070A18"/>
+
+  <!-- Column labels -->
+  <text x="120" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2">MCP CLIENTS</text>
+  <text x="400" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2" text-anchor="middle">CONDUCTAI</text>
+  <text x="680" y="42" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11" letter-spacing="2" text-anchor="middle">MCP SERVER</text>
+
+  <!-- Clients (left column) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#EEF0F7">
+    <rect x="40" y="80" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="106" r="6" fill="#22D3EE"/>
+    <text x="76" y="110">Claude Desktop</text>
+
+    <rect x="40" y="150" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="176" r="6" fill="#22D3EE"/>
+    <text x="76" y="180">ChatGPT</text>
+
+    <rect x="40" y="220" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A"/>
+    <circle cx="60" cy="246" r="6" fill="#22D3EE"/>
+    <text x="76" y="250">Cursor</text>
+
+    <rect x="40" y="290" width="180" height="52" rx="10" fill="#10121A" stroke="#34394A" stroke-dasharray="4 3"/>
+    <circle cx="60" cy="316" r="6" fill="#6D7488"/>
+    <text x="76" y="320" fill="#C9CEDD">Custom agents</text>
+  </g>
+
+  <!-- ConductAI box (center) -->
+  <g>
+    <rect x="300" y="90" width="200" height="240" rx="14" fill="#10121A" stroke="#4F46E5" stroke-width="2"/>
+    <text x="400" y="118" fill="#818CF8" font-family="ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="600" text-anchor="middle">Policy</text>
+    <text x="400" y="138" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">RUNTIME POLICY ENGINE</text>
+
+    <!-- Decision rows -->
+    <g font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="11">
+      <circle cx="322" cy="180" r="5" fill="#10B981"/>
+      <text x="336" y="184" fill="#EEF0F7">ALLOW</text>
+      <text x="490" y="184" fill="#6D7488" text-anchor="end">within policy</text>
+
+      <circle cx="322" cy="220" r="5" fill="#F59E0B"/>
+      <text x="336" y="224" fill="#EEF0F7">APPROVE</text>
+      <text x="490" y="224" fill="#6D7488" text-anchor="end">human gate</text>
+
+      <circle cx="322" cy="260" r="5" fill="#EF4444"/>
+      <text x="336" y="264" fill="#EEF0F7">BLOCK</text>
+      <text x="490" y="264" fill="#6D7488" text-anchor="end">rule violated</text>
+    </g>
+
+    <text x="400" y="308" fill="#6D7488" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">HASH-CHAINED EVIDENCE</text>
+  </g>
+
+  <!-- MCP server box (right) -->
+  <g font-family="ui-sans-serif, system-ui, sans-serif" font-size="13" fill="#EEF0F7">
+    <rect x="600" y="150" width="160" height="120" rx="12" fill="#10121A" stroke="#34394A"/>
+    <text x="680" y="184" text-anchor="middle" font-weight="600">MCP server</text>
+    <text x="680" y="208" text-anchor="middle" fill="#6D7488" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">tools/call</text>
+    <text x="680" y="232" text-anchor="middle" fill="#6D7488" font-size="11" font-family="ui-monospace, SFMono-Regular, Menlo, monospace">resources/read</text>
+  </g>
+
+  <!-- Arrows: clients → ConductAI -->
+  <g stroke="#818CF8" stroke-width="1.6" fill="none" marker-end="url(#arrow)">
+    <line x1="222" y1="106" x2="298" y2="180"/>
+    <line x1="222" y1="176" x2="298" y2="200"/>
+    <line x1="222" y1="246" x2="298" y2="220"/>
+    <line x1="222" y1="316" x2="298" y2="240"/>
+  </g>
+
+  <!-- Arrow: ConductAI → MCP server -->
+  <line x1="502" y1="210" x2="598" y2="210" stroke="#22D3EE" stroke-width="2" fill="none" marker-end="url(#arrow)"/>
+  <text x="550" y="200" fill="#22D3EE" font-family="ui-monospace, SFMono-Regular, Menlo, monospace" font-size="10" text-anchor="middle" letter-spacing="1">GUARDED</text>
+
+  <!-- Footer note -->
+  <text x="400" y="380" fill="#6D7488" font-family="ui-sans-serif, system-ui, sans-serif" font-size="12" text-anchor="middle">One policy across MCP clients. One evidence trail across MCP tools.</text>
+</svg>

--- a/docs/design/figma/tokens.json
+++ b/docs/design/figma/tokens.json
@@ -152,6 +152,232 @@
       "$value": "9999px"
     }
   },
+  "typography": {
+    "fontFamily": {
+      "sans": {
+        "$type": "fontFamily",
+        "$value": [
+          "Inter",
+          "system-ui",
+          "sans-serif"
+        ]
+      },
+      "mono": {
+        "$type": "fontFamily",
+        "$value": [
+          "JetBrains Mono",
+          "ui-monospace",
+          "SFMono-Regular",
+          "Menlo",
+          "monospace"
+        ]
+      }
+    },
+    "fontSize": {
+      "10": {
+        "$type": "dimension",
+        "$value": "10px"
+      },
+      "11": {
+        "$type": "dimension",
+        "$value": "11px"
+      },
+      "12": {
+        "$type": "dimension",
+        "$value": "12px"
+      },
+      "14": {
+        "$type": "dimension",
+        "$value": "14px"
+      },
+      "16": {
+        "$type": "dimension",
+        "$value": "16px"
+      },
+      "18": {
+        "$type": "dimension",
+        "$value": "18px"
+      },
+      "20": {
+        "$type": "dimension",
+        "$value": "20px"
+      },
+      "24": {
+        "$type": "dimension",
+        "$value": "24px"
+      },
+      "30": {
+        "$type": "dimension",
+        "$value": "30px"
+      },
+      "36": {
+        "$type": "dimension",
+        "$value": "36px"
+      },
+      "48": {
+        "$type": "dimension",
+        "$value": "48px"
+      },
+      "60": {
+        "$type": "dimension",
+        "$value": "60px"
+      }
+    },
+    "fontWeight": {
+      "regular": {
+        "$type": "fontWeight",
+        "$value": 400
+      },
+      "medium": {
+        "$type": "fontWeight",
+        "$value": 500
+      },
+      "semibold": {
+        "$type": "fontWeight",
+        "$value": 600
+      },
+      "bold": {
+        "$type": "fontWeight",
+        "$value": 700
+      }
+    },
+    "lineHeight": {
+      "tight": {
+        "$type": "number",
+        "$value": 1.15
+      },
+      "snug": {
+        "$type": "number",
+        "$value": 1.35
+      },
+      "normal": {
+        "$type": "number",
+        "$value": 1.5
+      },
+      "relaxed": {
+        "$type": "number",
+        "$value": 1.625
+      }
+    },
+    "letterSpacing": {
+      "tight": {
+        "$type": "dimension",
+        "$value": "-0.02em"
+      },
+      "normal": {
+        "$type": "dimension",
+        "$value": "0em"
+      },
+      "wide": {
+        "$type": "dimension",
+        "$value": "0.05em"
+      },
+      "widest": {
+        "$type": "dimension",
+        "$value": "0.1em"
+      }
+    }
+  },
+  "shadow": {
+    "sm": {
+      "$type": "shadow",
+      "$value": {
+        "color": "rgba(16, 18, 26, 0.05)",
+        "offsetX": "0",
+        "offsetY": "1px",
+        "blur": "2px",
+        "spread": "0"
+      }
+    },
+    "md": {
+      "$type": "shadow",
+      "$value": {
+        "color": "rgba(16, 18, 26, 0.06)",
+        "offsetX": "0",
+        "offsetY": "4px",
+        "blur": "10px",
+        "spread": "0"
+      }
+    },
+    "lg": {
+      "$type": "shadow",
+      "$value": {
+        "color": "rgba(16, 18, 26, 0.10)",
+        "offsetX": "0",
+        "offsetY": "12px",
+        "blur": "28px",
+        "spread": "-4px"
+      }
+    },
+    "focus": {
+      "$type": "shadow",
+      "$value": {
+        "color": "rgba(79, 70, 229, 0.35)",
+        "offsetX": "0",
+        "offsetY": "0",
+        "blur": "0",
+        "spread": "3px"
+      }
+    }
+  },
+  "motion": {
+    "duration": {
+      "instant": {
+        "$type": "duration",
+        "$value": "0ms"
+      },
+      "fast": {
+        "$type": "duration",
+        "$value": "120ms"
+      },
+      "base": {
+        "$type": "duration",
+        "$value": "200ms"
+      },
+      "slow": {
+        "$type": "duration",
+        "$value": "320ms"
+      }
+    },
+    "easing": {
+      "standard": {
+        "$type": "cubicBezier",
+        "$value": [
+          0.2,
+          0,
+          0,
+          1
+        ]
+      },
+      "in": {
+        "$type": "cubicBezier",
+        "$value": [
+          0.4,
+          0,
+          1,
+          1
+        ]
+      },
+      "out": {
+        "$type": "cubicBezier",
+        "$value": [
+          0,
+          0,
+          0.2,
+          1
+        ]
+      },
+      "inOut": {
+        "$type": "cubicBezier",
+        "$value": [
+          0.4,
+          0,
+          0.2,
+          1
+        ]
+      }
+    }
+  },
   "semantic": {
     "light": {
       "bg": {
@@ -178,6 +404,30 @@
         "allow": "{color.green.500}",
         "approve": "{color.amber.500}",
         "block": "{color.red.500}"
+      },
+      "shadow": {
+        "card": "{shadow.sm}",
+        "panel": "{shadow.md}",
+        "modal": "{shadow.lg}",
+        "focus": "{shadow.focus}"
+      },
+      "motion": {
+        "hover": {
+          "$type": "transition",
+          "$value": {
+            "duration": "{motion.duration.fast}",
+            "delay": "0ms",
+            "timingFunction": "{motion.easing.out}"
+          }
+        },
+        "reveal": {
+          "$type": "transition",
+          "$value": {
+            "duration": "{motion.duration.base}",
+            "delay": "0ms",
+            "timingFunction": "{motion.easing.standard}"
+          }
+        }
       }
     },
     "dark": {
@@ -205,6 +455,66 @@
         "allow": "{color.green.500}",
         "approve": "{color.amber.500}",
         "block": "{color.red.500}"
+      },
+      "shadow": {
+        "card": {
+          "$type": "shadow",
+          "$value": {
+            "color": "rgba(0, 0, 0, 0.35)",
+            "offsetX": "0",
+            "offsetY": "1px",
+            "blur": "2px",
+            "spread": "0"
+          }
+        },
+        "panel": {
+          "$type": "shadow",
+          "$value": {
+            "color": "rgba(0, 0, 0, 0.5)",
+            "offsetX": "0",
+            "offsetY": "6px",
+            "blur": "16px",
+            "spread": "0"
+          }
+        },
+        "modal": {
+          "$type": "shadow",
+          "$value": {
+            "color": "rgba(0, 0, 0, 0.65)",
+            "offsetX": "0",
+            "offsetY": "16px",
+            "blur": "40px",
+            "spread": "-8px"
+          }
+        },
+        "focus": {
+          "$type": "shadow",
+          "$value": {
+            "color": "rgba(129, 140, 248, 0.55)",
+            "offsetX": "0",
+            "offsetY": "0",
+            "blur": "0",
+            "spread": "3px"
+          }
+        }
+      },
+      "motion": {
+        "hover": {
+          "$type": "transition",
+          "$value": {
+            "duration": "{motion.duration.fast}",
+            "delay": "0ms",
+            "timingFunction": "{motion.easing.out}"
+          }
+        },
+        "reveal": {
+          "$type": "transition",
+          "$value": {
+            "duration": "{motion.duration.base}",
+            "delay": "0ms",
+            "timingFunction": "{motion.easing.standard}"
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Rewrites /guard, /registry, /mcp-gateway, /evidence to match Figma frames. Home already matches — no changes. Includes prior tokens/imageSrc slots/3 new components from #1687 (supersede). tsc/gitleaks green. Close #1687.