### PR TITLE
fix(runtime): in-process credential cache — kill silent broker-swallow + stale-token-on-resume

### DIFF
--- a/apps/api/app/core/credentials.py
+++ b/apps/api/app/core/credentials.py
@@ -129,16 +129,57 @@ def retrieve_credential(db, cred_token: str, handle: str) -> dict | None:
 
 
 def fetch_credential(cred_token: str, handle: str, api_url: str) -> dict:
-    """HTTP call to broker. Used by blocks running inside a run context."""
+    """Return decrypted credential dict for `handle`.
+
+    Cache-first: the executor populates a process-local snapshot at run
+    start (see `app.runtime.run_credentials`). In-process blocks hit the
+    snapshot and skip the HTTP round-trip entirely. Broker call remains
+    for out-of-process callers (CLI, remote workers) and for the small
+    window before the executor populates.
+
+    Non-200 broker responses used to return `{}` silently — that made a
+    stale cred_token (bug B on run resume) look identical to a missing
+    handle, and downstream brain_block raised MissingProviderKey with
+    misleading UX. We now log the failure so operators can see it.
+    """
+    from app.runtime.run_credentials import resolve as _cache_resolve
+
+    cached = _cache_resolve(cred_token, handle)
+    if cached is not None:
+        return cached
+
     import httpx
-    resp = httpx.post(
-        f"{api_url}/credentials/creds/retrieve",
-        json={"handle": handle},
-        headers={"X-Cred-Token": cred_token},
-        timeout=5.0,
-    )
+    try:
+        resp = httpx.post(
+            f"{api_url}/credentials/creds/retrieve",
+            json={"handle": handle},
+            headers={"X-Cred-Token": cred_token},
+            timeout=5.0,
+        )
+    except Exception as exc:
+        try:
+            import structlog
+            structlog.get_logger(__name__).warning(
+                "credentials.broker_fetch_exception",
+                handle=handle,
+                error=str(exc),
+                cred_token_prefix=(cred_token or "")[:12],
+            )
+        except Exception:
+            pass
+        return {}
     if resp.status_code == 200:
         return resp.json()
+    try:
+        import structlog
+        structlog.get_logger(__name__).warning(
+            "credentials.broker_fetch_failed",
+            handle=handle,
+            status=resp.status_code,
+            cred_token_prefix=(cred_token or "")[:12],
+        )
+    except Exception:
+        pass
     return {}
 
 

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -266,6 +266,17 @@ def execute_run(run_id: str):
             except Exception:
                 log.warning("run.cred_token_mint_failed", run_id=run_id)
 
+        # Populate the in-process cred cache so blocks skip the HTTP-to-self
+        # broker round-trip. This eliminates the intermittent MissingProviderKey
+        # class of failure where a broker 401/500 on a per-block fetch returned
+        # {} and looked like "no key configured" to brain_block. See
+        # app.runtime.run_credentials for cache lifecycle.
+        try:
+            from app.runtime.run_credentials import populate as _cred_cache_populate
+            _cred_cache_populate(_cred_token, dict(credentials._data))
+        except Exception as _cc_err:
+            log.warning("run.cred_cache_populate_failed", run_id=run_id, error=str(_cc_err))
+
         # Stamp agent_role_id on the run if CONDUCT_AGENT_TOKEN is in credentials.
         _env_vars_creds = credentials.get("env_vars") or {}
         if isinstance(_env_vars_creds, dict) and _env_vars_creds.get("CONDUCT_AGENT_TOKEN"):
@@ -473,6 +484,16 @@ def execute_run(run_id: str):
                     _inv_db.close()
             except Exception:
                 pass  # never let token cleanup crash the run
+
+        # Drop the in-process credential snapshot for this segment. Purge
+        # regardless of pause state — resume rebuilds it on the next
+        # execute_run() call via the populate step above.
+        try:
+            from app.runtime.run_credentials import purge as _cred_cache_purge
+            _cred_cache_purge(state.get("__cred_token__", "") or _cred_token)
+        except Exception:
+            pass
+
         db.close()
 
 

--- a/apps/api/app/runtime/run_credentials.py
+++ b/apps/api/app/runtime/run_credentials.py
@@ -1,0 +1,50 @@
+"""Process-local credential cache for in-process runtime callers.
+
+The executor fetches every workspace credential from the DB once at run
+start (`get_all_credentials`). Blocks then re-fetched each handle they
+needed via HTTP round-trip to `POST /credentials/creds/retrieve` — one
+per handle per block, using the run's `cred_token` for auth.
+
+That per-block broker call was two things at once:
+
+1. Redundant — the worker already has decrypted creds in memory.
+2. A silent-failure surface — `fetch_credential` swallows any non-200
+   into an empty dict, which downstream (brain_block, etc.) then reads
+   as "no key configured" and raises MissingProviderKey. Seen live on
+   run resume when the cred_token had been invalidated by the previous
+   segment's finally-block (bug B in the audit).
+
+This module holds the decrypted creds in a process-local dict keyed by
+the run's cred_token. `fetch_credential` consults this cache first and
+only falls through to the broker for out-of-process callers (CLI, remote
+workers, or the vanishingly rare cache-miss window).
+
+Populated at executor init, purged when the segment ends. Nothing here
+touches state / DB — pause/resume gets a fresh populate on the next
+segment.
+"""
+from __future__ import annotations
+
+# cred_token -> {handle: decrypted-creds-dict}
+_CACHE: dict[str, dict[str, dict]] = {}
+
+
+def populate(cred_token: str, credentials: dict[str, dict]) -> None:
+    """Snapshot the decrypted credential map for this run segment."""
+    if not cred_token:
+        return
+    _CACHE[cred_token] = dict(credentials)
+
+
+def resolve(cred_token: str, handle: str) -> dict | None:
+    """Cache lookup. Returns None on miss so callers can fall back to broker."""
+    if not cred_token:
+        return None
+    return _CACHE.get(cred_token, {}).get(handle)
+
+
+def purge(cred_token: str) -> None:
+    """Drop the snapshot when the segment finishes."""
+    if not cred_token:
+        return
+    _CACHE.pop(cred_token, None)

--- a/apps/api/tests/test_run_credentials_cache.py
+++ b/apps/api/tests/test_run_credentials_cache.py
@@ -1,0 +1,90 @@
+"""Cache-first credential fetch — kills the intermittent MissingProviderKey
+on run resume.
+
+Before: every block called fetch_credential -> HTTP broker call. Any
+non-200 (broker restart, cred_token invalidated by prior segment) got
+swallowed as {} and looked identical to "no key configured", so
+brain_block raised MissingProviderKey and blamed the user's env.
+
+After: executor populates a process-local snapshot at run init. Blocks
+read the snapshot; broker is fallback for CLI / out-of-process only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
+os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
+
+for _m in ["structlog", "redis", "sentry_sdk", "app.core.pii"]:
+    sys.modules.setdefault(_m, MagicMock())
+
+from app.runtime import run_credentials  # noqa: E402
+from app.core.credentials import fetch_credential  # noqa: E402
+
+
+class TestCacheLifecycle:
+    def test_populate_then_resolve_returns_snapshot(self):
+        run_credentials.populate("cond_cred_test_1", {"anthropic": {"api_key": "sk-real"}})
+        assert run_credentials.resolve("cond_cred_test_1", "anthropic") == {"api_key": "sk-real"}
+        run_credentials.purge("cond_cred_test_1")
+
+    def test_purge_evicts_snapshot(self):
+        run_credentials.populate("cond_cred_test_2", {"anthropic": {"api_key": "sk-x"}})
+        run_credentials.purge("cond_cred_test_2")
+        assert run_credentials.resolve("cond_cred_test_2", "anthropic") is None
+
+    def test_resolve_miss_returns_none_not_empty_dict(self):
+        # Callers distinguish "not cached" (None -> fall back to broker) from
+        # "explicitly empty handle" ({} -> handle exists but has no fields).
+        assert run_credentials.resolve("cond_cred_never_populated", "anthropic") is None
+
+    def test_populate_with_empty_token_is_noop(self):
+        # Guards against caching under "" key which would pollute the cache
+        # for every subsequent empty-token call.
+        run_credentials.populate("", {"anthropic": {"api_key": "leak"}})
+        assert run_credentials.resolve("", "anthropic") is None
+
+
+class TestFetchCredentialCacheFirst:
+    def test_cache_hit_skips_httpx_call(self):
+        run_credentials.populate("cond_cred_hot_1", {"anthropic": {"api_key": "sk-cached"}})
+        try:
+            with patch("httpx.post") as mock_post:
+                result = fetch_credential("cond_cred_hot_1", "anthropic", "http://api")
+                assert result == {"api_key": "sk-cached"}
+                mock_post.assert_not_called()
+        finally:
+            run_credentials.purge("cond_cred_hot_1")
+
+    def test_cache_miss_falls_back_to_broker(self):
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {"api_key": "sk-broker"}
+            result = fetch_credential("cond_cred_miss", "anthropic", "http://api")
+            assert result == {"api_key": "sk-broker"}
+            mock_post.assert_called_once()
+
+    def test_broker_non_200_returns_empty(self):
+        # Existing behaviour — brain_block's fallback ladder still handles
+        # empty. The new log line (not asserted here) makes the failure
+        # visible for operators.
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 401
+            result = fetch_credential("cond_cred_bad_token", "anthropic", "http://api")
+            assert result == {}
+
+    def test_broker_exception_returns_empty_instead_of_crashing(self):
+        with patch("httpx.post", side_effect=Exception("connection reset")):
+            result = fetch_credential("cond_cred_exc", "anthropic", "http://api")
+            assert result == {}


### PR DESCRIPTION
## Missed the squash of #1686

PR #1686 (\`34b6dedd\`) merged before this commit landed. Same worktree, same bug family, but this is the load-bearing fix — the actor-ident + Slack unfurl piece in #1686 was polish, this one kills the intermittent \`MissingProviderKey\` on run resume.

## Symptom

Same workflow \`a39909a0-d5a6-4ee5-a1a4-546755761f18\`, two runs behaving differently:

- \`97aaf78c-6410-4856-8170-2a9ca9030519\` — paused after block 2, resumed, block 3 (\`report_outcome\`) succeeded end-to-end
- \`440c3a68-76ec-491b-b509-8496af368abd\` — paused after block 2, resumed, block 3 raised \`MissingProviderKey\` (\`ANTHROPIC_API_KEY is not set for anthropic model 'claude-sonnet-4-6'\`) after **74 seconds** with no LLM call ever made

Not LLM non-determinism. The failure is in the credential-fetch path *before* any model is touched.

## Root cause — two co-conspirators, one fix

**Bug A — silent swallow.** \`fetch_credential\` (\`apps/api/app/core/credentials.py:131\`) collapsed every non-200 broker response into \`{}\` with zero telemetry:

\`\`\`python
if resp.status_code == 200:
    return resp.json()
return {}    # ← 401, 500, timeout, TokenRevoked — all indistinguishable, all silent
\`\`\`

\`brain_block\`'s key-resolution ladder then read \`{}\` as \"no key configured\" and raised, blaming the user's env.

**Bug B — stale token on resume.** The executor's finally-block invalidates the previous segment's \`cred_token\` (\`executor.py:453+\` comment). If a block in the resumed segment hit the broker with the state-recovered stale token before a fresh one was minted, broker returned 401 → (A) swallowed → boom.

## Correct fix

Eliminate the per-block broker round-trip for in-process callers.

The executor already fetches every workspace credential once via \`get_all_credentials()\` at run start. New module \`apps/api/app/runtime/run_credentials.py\` snapshots that map into a **process-local dict keyed by \`cred_token\`**:

- **Populated** at executor init (after \`_mint_cred_token\`, before block dispatch)
- **Purged** in the finally-block (segment end)
- **\`fetch_credential\` consults the snapshot first**; broker remains as fallback for out-of-process callers (CLI, remote workers) and for the vanishing cache-miss window

Same executor init runs on every segment including resume, so segment N always gets a fresh snapshot. **Bug B disappears as a side-effect** of removing the failure surface — the broker is never hit for in-process blocks, so a stale token can't 401.

\`fetch_credential\` also grows structured log lines on both broker exception and non-200 responses so operators can *see* the failure class when the broker fallback DOES fire — Bug A safety net for CLI callers who still use the broker.

## Files

| File | Change |
|---|---|
| \`apps/api/app/runtime/run_credentials.py\` | **new** — 50 LOC, populate/resolve/purge |
| \`apps/api/app/runtime/executor.py\` | +21 LOC — populate after mint, purge in finally |
| \`apps/api/app/core/credentials.py\` | +48/-7 LOC — cache-first fetch, structured logging on failure |
| \`apps/api/tests/test_run_credentials_cache.py\` | **new** — 90 LOC, 8 tests |

## Tests

- Cache lifecycle: populate → resolve → purge, empty-token no-op, miss returns None (not {}) so callers can distinguish
- \`fetch_credential\` cache-hit skips httpx entirely (mock \`httpx.post\` asserts not_called)
- Cache-miss falls back to broker
- Broker exception + non-200 both return \`{}\` without crashing

**8/8 pass.**

## Zero API changes

Every existing \`fetch_credential(...)\` caller in \`blocks/*.py\` picks up the fix with no migration.

## Post-merge live smoke

Re-trigger the failing workflow. Block 3 should no longer hit \`MissingProviderKey\`. If broker fallback fires (out-of-process callers), the new \`credentials.broker_fetch_failed\` / \`credentials.broker_fetch_exception\` log lines will show it in Render.