### PR TITLE
feat(marketing): apply Figma visual system across public site

### DIFF
--- a/apps/web/src/app/(marketing)/evidence/page.tsx
+++ b/apps/web/src/app/(marketing)/evidence/page.tsx
@@ -34,7 +34,7 @@ export default function EvidencePage() {
                 Start Discovery — 14 days free
               </Link>
               <Link
-                href="/demo"
+                href="/book-demo"
                 className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
               >
                 Book a Demo

--- a/apps/web/src/app/(marketing)/guard/page.tsx
+++ b/apps/web/src/app/(marketing)/guard/page.tsx
@@ -44,7 +44,7 @@ export default function GuardPage() {
                 Start Agent Discovery — 14 days free
               </Link>
               <Link
-                href="/demo"
+                href="/book-demo"
                 className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
               >
                 Book a Demo

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -7,7 +7,7 @@ export default function MarketingLayout({ children }: { children: React.ReactNod
   const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   return (
     <WorkspaceProvider clerkEnabled={clerkEnabled}>
-      <div className="min-h-screen bg-white flex flex-col">
+      <div className="marketing-v2 min-h-screen bg-white flex flex-col">
         <MarketingNav />
         <main className="flex-1">{children}</main>
         <MarketingFooter />
@@ -110,10 +110,10 @@ function DevelopersDropdown() {
 
 function MarketingNav() {
   return (
-    <header className="sticky top-0 bg-white/95 backdrop-blur-sm z-50 border-b border-stone-100">
+    <header className="marketing-nav sticky top-0 bg-white/95 backdrop-blur-sm z-50 border-b border-stone-100">
       <div className="px-6 py-4 flex items-center justify-between max-w-6xl mx-auto w-full">
-        <a href="/">
-          <img src="/logo.png" alt="Conduct AI" className="h-10 w-auto" />
+        <a href="/" className="marketing-wordmark" aria-label="Conduct AI home">
+          conduct<span>.ai</span>
         </a>
         <nav className="hidden md:flex items-center gap-6">
           <ProductDropdown />
@@ -203,11 +203,13 @@ function MarketingFooter() {
   ]
 
   return (
-    <footer className="border-t border-stone-100 py-10 px-6 bg-white">
+    <footer className="marketing-footer border-t border-stone-100 py-10 px-6 bg-white">
       <div className="max-w-6xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between gap-8 mb-10">
           <div>
-            <img src="/logo.png" alt="Conduct AI" className="h-8 w-auto mb-3" />
+            <a href="/" className="marketing-wordmark inline-block mb-3" aria-label="Conduct AI home">
+              conduct<span>.ai</span>
+            </a>
             <p className="text-sm text-stone-400 max-w-xs leading-relaxed">
               Runtime policy for AI agent stacks.
             </p>

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -37,7 +37,7 @@ export default function MCPPage() {
                 Start Discovery — 14 days free
               </Link>
               <Link
-                href="/demo"
+                href="/book-demo"
                 className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
               >
                 Book a Demo
@@ -218,4 +218,3 @@ export default function MCPPage() {
     </div>
   )
 }
-

--- a/apps/web/src/app/(marketing)/registry/page.tsx
+++ b/apps/web/src/app/(marketing)/registry/page.tsx
@@ -102,7 +102,7 @@ export default function RegistryPage() {
               Start Discovery — 14 days free
             </Link>
             <Link
-              href="/demo"
+              href="/book-demo"
               className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
             >
               Book a Demo

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -2,6 +2,175 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ConductAI marketing port — Figma pages 10–14.
+   Scoped so authenticated console and non-ported marketing routes retain
+   their existing presentation. */
+.marketing-v2 {
+  --mkt-canvas: #ffffff;
+  --mkt-subtle: #f7f8fc;
+  --mkt-ink: #10121a;
+  --mkt-muted: #6d7488;
+  --mkt-line: #e5e7ef;
+  --mkt-line-strong: #34394a;
+  --mkt-night: #070a18;
+  --mkt-night-panel: #101426;
+  --mkt-indigo: #4f46e5;
+  --mkt-indigo-hover: #4338ca;
+  --mkt-cyan: #22d3ee;
+  --mkt-green: #10b981;
+  --mkt-amber: #f59e0b;
+  --mkt-red: #ef4444;
+  background: var(--mkt-canvas);
+  color: var(--mkt-ink);
+}
+
+.marketing-v2 .marketing-nav {
+  position: sticky;
+  top: 0;
+  border: 0;
+  background: rgba(255,255,255,.86);
+  padding: 24px clamp(16px, 4vw, 40px);
+  backdrop-filter: blur(18px);
+}
+
+.marketing-v2 .marketing-nav > div {
+  max-width: 1200px;
+  min-height: 72px;
+  padding: 10px 22px;
+  border: 1px solid var(--mkt-line);
+  border-radius: 999px;
+  background: rgba(255,255,255,.96);
+  box-shadow: 0 14px 40px rgba(16,18,26,.06);
+}
+
+.marketing-wordmark {
+  color: var(--mkt-ink);
+  font-size: 18px;
+  font-weight: 750;
+  letter-spacing: -.035em;
+  text-decoration: none;
+}
+
+.marketing-wordmark span { color: var(--mkt-indigo); }
+
+.marketing-v2 .marketing-nav nav a {
+  color: #34394a;
+  font-size: 13px;
+}
+
+.marketing-v2 .marketing-nav a[href="/discovery"] {
+  min-height: 48px;
+  padding-inline: 22px;
+  border: 1px solid var(--mkt-line-strong);
+  border-radius: 999px;
+  background: var(--mkt-indigo);
+  color: #fff;
+}
+
+.marketing-v2 .marketing-nav a[href="/discovery"]:hover,
+.marketing-v2 a[href="/sign-up"]:hover { background: var(--mkt-indigo-hover); }
+
+.marketing-v2 main > .min-h-screen > main {
+  max-width: 1200px;
+  padding-inline: clamp(20px, 5vw, 64px);
+}
+
+.marketing-v2 main > .min-h-screen > main > section:first-child {
+  margin-inline: calc(clamp(20px, 5vw, 64px) * -1);
+  padding: 86px clamp(20px, 5vw, 64px);
+  border-radius: 24px;
+  background: var(--mkt-subtle);
+}
+
+.marketing-v2 h1 {
+  color: var(--mkt-ink) !important;
+  font-size: clamp(44px, 5vw, 64px) !important;
+  font-weight: 750 !important;
+  letter-spacing: -.045em !important;
+  line-height: 1.02 !important;
+}
+
+.marketing-v2 h2 {
+  color: var(--mkt-ink);
+  font-size: clamp(30px, 3.2vw, 42px);
+  font-weight: 720;
+  letter-spacing: -.035em;
+  line-height: 1.08;
+}
+
+.marketing-v2 .text-stone-900 { color: var(--mkt-ink) !important; }
+.marketing-v2 .text-stone-700,
+.marketing-v2 .text-stone-600,
+.marketing-v2 .text-stone-500,
+.marketing-v2 .text-stone-400 { color: var(--mkt-muted) !important; }
+.marketing-v2 .bg-stone-50 { background-color: var(--mkt-subtle) !important; }
+.marketing-v2 .border-stone-100,
+.marketing-v2 .border-stone-200 { border-color: var(--mkt-line) !important; }
+
+.marketing-v2 main a[href="/sign-up"],
+.marketing-v2 main a[href="/discovery"] {
+  border: 1px solid var(--mkt-line-strong);
+  border-radius: 999px !important;
+  background: var(--mkt-indigo) !important;
+  color: #fff !important;
+  padding: 15px 24px;
+}
+
+.marketing-v2 main a[href="/demo"],
+.marketing-v2 main a[href="/book-demo"] {
+  border: 1px solid var(--mkt-line);
+  border-radius: 999px !important;
+  background: #fff;
+  color: var(--mkt-indigo) !important;
+  padding: 15px 24px;
+}
+
+.marketing-v2 .bg-stone-950 {
+  background: var(--mkt-night) !important;
+  border-radius: 24px !important;
+}
+
+.marketing-v2 .bg-stone-900 { background: var(--mkt-night-panel) !important; }
+.marketing-v2 .border-stone-700,
+.marketing-v2 .border-stone-800 { border-color: var(--mkt-line-strong) !important; }
+.marketing-v2 .bg-stone-950 h2,
+.marketing-v2 .bg-stone-950 h3,
+.marketing-v2 .bg-stone-950 .text-white { color: #fff !important; }
+.marketing-v2 .bg-stone-950 .text-stone-400 { color: #c9cedd !important; }
+.marketing-v2 .text-emerald-400,
+.marketing-v2 .text-emerald-600 { color: var(--mkt-green) !important; }
+.marketing-v2 .text-amber-400,
+.marketing-v2 .text-amber-500 { color: var(--mkt-amber) !important; }
+.marketing-v2 .text-red-600 { color: var(--mkt-red) !important; }
+.marketing-v2 .text-indigo-600 { color: var(--mkt-indigo) !important; }
+
+.marketing-v2 main section { scroll-margin-top: 130px; }
+
+.marketing-v2 main section [class*="rounded-xl"],
+.marketing-v2 main section [class*="rounded-2xl"] {
+  border-radius: 18px;
+}
+
+.marketing-v2 .marketing-footer {
+  border-color: var(--mkt-line);
+  padding-top: 64px;
+  padding-bottom: 44px;
+}
+
+@media (max-width: 767px) {
+  .marketing-v2 .marketing-nav { padding: 12px; }
+  .marketing-v2 .marketing-nav > div {
+    min-height: 60px;
+    padding: 8px 14px;
+  }
+  .marketing-v2 h1 { font-size: 42px !important; }
+  .marketing-v2 h2 { font-size: 30px; }
+  .marketing-v2 main > .min-h-screen > main > section:first-child {
+    padding-top: 56px;
+    padding-bottom: 56px;
+  }
+}
+
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap');
 
 :root {

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -9,7 +9,7 @@ import { CapabilityStatus, type CapabilityItem, type CapStatus } from "@/compone
 
 export default function HomePage() {
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div className="marketing-v2 min-h-screen bg-white flex flex-col">
       <Nav />
       <main className="flex-1">
         <HeroSection />
@@ -35,10 +35,10 @@ function Nav() {
   const [mobileOpen, setMobileOpen] = useState(false)
 
   return (
-    <header className="sticky top-0 bg-white/95 backdrop-blur-sm z-50 border-b border-stone-100">
+    <header className="marketing-nav sticky top-0 bg-white/95 backdrop-blur-sm z-50 border-b border-stone-100">
       <div className="px-4 sm:px-6 py-3 sm:py-4 flex items-center justify-between max-w-6xl mx-auto w-full">
-        <a href="/">
-          <img src="/logo.png" alt="Conduct AI" className="h-8 sm:h-10 w-auto" />
+        <a href="/" className="marketing-wordmark" aria-label="Conduct AI home">
+          conduct<span>.ai</span>
         </a>
 
         {/* Desktop nav */}
@@ -905,11 +905,13 @@ function PageFooter() {
   ]
 
   return (
-    <footer className="border-t border-stone-100 py-10 px-4 sm:px-6 bg-white">
+    <footer className="marketing-footer border-t border-stone-100 py-10 px-4 sm:px-6 bg-white">
       <div className="max-w-6xl mx-auto">
         <div className="flex flex-col md:flex-row justify-between gap-8 mb-10">
           <div className="shrink-0">
-            <img src="/logo.png" alt="Conduct AI" className="h-8 w-auto mb-3" />
+            <a href="/" className="marketing-wordmark inline-block mb-3" aria-label="Conduct AI home">
+              conduct<span>.ai</span>
+            </a>
             <p className="text-sm text-stone-400 max-w-xs leading-relaxed">
               Runtime policy for AI agent stacks.
             </p>

--- a/docs/design/figma-five-page-handoff.md
+++ b/docs/design/figma-five-page-handoff.md
@@ -14,6 +14,8 @@
 ## Exported assets
 
 - Design tokens: [`docs/design/figma/tokens.json`](figma/tokens.json)
+- Resolved CSS variables: [`docs/design/figma/tokens.css`](figma/tokens.css)
+- Route and Figma-node manifest: [`docs/design/figma/manifest.json`](figma/manifest.json)
 - PNG references:
   - [Home](figma/exports/home.png)
   - [Guard](figma/exports/guard.png)
@@ -141,5 +143,12 @@ Marketing tiles that stay as HTML/CSS components (do not screenshot):
 - Pages are responsive and usable at common mobile, tablet, and desktop widths.
 - Decision states and capability-status labels retain their precise semantic meaning.
 - No unsupported marketing claims are introduced.
+
+## Source implementation
+
+The Figma visual system is implemented through the scoped `marketing-v2`
+theme in `apps/web/src/app/globals.css`. The home page and every route in
+the shared marketing layout inherit it automatically, including future
+marketing pages. Authenticated console routes remain unaffected.
 - Every in-product surface in the Screenshot inventory table is implemented from a real capture in `docs/design/figma/screenshots/`, not redrawn from the mockup.
 - MCP hero is an SVG diagram, not a screenshot of a fake UI shell.

--- a/docs/design/figma/manifest.json
+++ b/docs/design/figma/manifest.json
@@ -1,0 +1,26 @@
+{
+  "source": {
+    "fileKey": "UktEyWiEqTWrkmJUaF2aco",
+    "url": "https://www.figma.com/design/UktEyWiEqTWrkmJUaF2aco"
+  },
+  "frames": [
+    {"page": "10 Website Port / Home", "nodeId": "39:2", "route": "/", "reference": "exports/home.png"},
+    {"page": "11 Website Port / Guard", "nodeId": "40:2", "route": "/guard", "reference": "exports/guard.png"},
+    {"page": "12 Website Port / Registry", "nodeId": "41:2", "route": "/registry", "reference": "exports/registry.png"},
+    {"page": "13 Website Port / Evidence", "nodeId": "42:2", "route": "/evidence", "reference": "exports/evidence.png"},
+    {"page": "14 Website Port / MCP", "nodeId": "43:2", "route": "/mcp-gateway", "reference": "exports/mcp.png"}
+  ],
+  "implementation": {
+    "scopeClass": "marketing-v2 (all public marketing routes)",
+    "sharedShell": "apps/web/src/app/(marketing)/layout.tsx",
+    "globalTokens": "apps/web/src/app/globals.css",
+    "copySourceOfTruth": "repository",
+    "visualSourceOfTruth": "figma"
+  },
+  "rules": [
+    "Preserve existing website copy and positioning.",
+    "Use Figma for visual design, layout, components, color, and responsive behavior.",
+    "Do not use emoji as interface icons; use custom SVGs.",
+    "Do not turn product-interface mockups into flattened screenshots."
+  ]
+}

--- a/docs/design/figma/tokens.css
+++ b/docs/design/figma/tokens.css
@@ -1,0 +1,67 @@
+/* Generated from ConductAI Figma variables.
+ * Source: https://www.figma.com/design/UktEyWiEqTWrkmJUaF2aco
+ * Collections: ConductAI / Primitives, Dimensions, Color
+ */
+:root {
+  --neutral-0: #ffffff;
+  --neutral-50: #f7f8fc;
+  --neutral-100: #eef0f7;
+  --neutral-300: #c9cedd;
+  --neutral-500: #6d7488;
+  --neutral-700: #34394a;
+  --neutral-900: #10121a;
+  --navy-950: #070a18;
+  --indigo-100: #e7e9ff;
+  --indigo-400: #818cf8;
+  --indigo-500: #6366f1;
+  --indigo-600: #4f46e5;
+  --cyan-100: #cffafe;
+  --cyan-400: #22d3ee;
+  --cyan-500: #06b6d4;
+  --green-500: #10b981;
+  --amber-500: #f59e0b;
+  --red-500: #ef4444;
+  --spacing-1: 4px;
+  --spacing-2: 8px;
+  --spacing-3: 12px;
+  --spacing-4: 16px;
+  --spacing-6: 24px;
+  --spacing-8: 32px;
+  --spacing-12: 48px;
+  --spacing-16: 64px;
+  --spacing-24: 96px;
+  --radius-sm: 8px;
+  --radius-md: 12px;
+  --radius-lg: 20px;
+  --radius-full: 9999px;
+  --color-bg-canvas: var(--neutral-0);
+  --color-bg-subtle: var(--neutral-50);
+  --color-bg-elevated: var(--neutral-0);
+  --color-bg-brand: var(--indigo-600);
+  --color-bg-runtime: var(--navy-950);
+  --color-text-primary: var(--neutral-900);
+  --color-text-secondary: var(--neutral-500);
+  --color-text-on-brand: var(--neutral-0);
+  --color-text-brand: var(--indigo-600);
+  --color-border-default: var(--neutral-100);
+  --color-border-strong: var(--neutral-300);
+  --color-runtime-activity: var(--cyan-500);
+  --color-decision-allow: var(--green-500);
+  --color-decision-approve: var(--amber-500);
+  --color-decision-block: var(--red-500);
+}
+
+[data-theme="dark"] {
+  --color-bg-canvas: var(--navy-950);
+  --color-bg-subtle: var(--neutral-900);
+  --color-bg-elevated: var(--neutral-700);
+  --color-bg-brand: var(--indigo-400);
+  --color-bg-runtime: var(--navy-950);
+  --color-text-primary: var(--neutral-0);
+  --color-text-secondary: var(--neutral-300);
+  --color-text-on-brand: var(--navy-950);
+  --color-text-brand: var(--indigo-400);
+  --color-border-default: var(--neutral-700);
+  --color-border-strong: var(--neutral-500);
+  --color-runtime-activity: var(--cyan-400);
+}


### PR DESCRIPTION
## Summary

Implements the ConductAI Figma marketing visual system in source code and applies it across the public marketing site.

### Source changes

- Adds a shared `marketing-v2` theme for all marketing routes
- Ports the floating pill navigation and Conduct wordmark
- Applies the indigo/cyan runtime palette, larger editorial typography, rounded actions, midnight runtime sections, updated cards, spacing, and footer
- Keeps the authenticated console design isolated
- Corrects the four ported page demo links to the implemented `/book-demo` route
- Preserves existing product copy, claims, and positioning

### Figma exports

- Existing five full-page PNG references remain under `docs/design/figma/exports/`
- Existing DTCG token export remains at `docs/design/figma/tokens.json`
- Adds resolved CSS variables at `docs/design/figma/tokens.css`
- Adds exact Figma node-to-route mapping at `docs/design/figma/manifest.json`
- Updates the implementation handoff with the source-code mapping

### Pages used as design anchors

| Figma frame | Route |
| --- | --- |
| 10 Website Port / Home | / |
| 11 Website Port / Guard | /guard |
| 12 Website Port / Registry | /registry |
| 13 Website Port / Evidence | /evidence |
| 14 Website Port / MCP | /mcp-gateway |

All other public marketing pages inherit the same shared visual system through the marketing layout.

### Rules retained

- Existing repository copy and positioning remain the source of truth
- Figma controls visual design, layout, components, color, and responsive behavior
- No emoji as interface icons; use custom SVGs
- Product UI remains structured HTML/CSS rather than flattened screenshots

### Verification

- `npx tsc --noEmit` passes
- `npm run build` completes successfully
- Existing repository lint warnings remain; this change introduces no build or type errors

Figma: https://www.figma.com/design/UktEyWiEqTWrkmJUaF2aco
