### PR TITLE
feat(marketing): Figma sweep — dark hero + indigo CTA across all marketing pages

### DIFF
--- a/apps/web/src/app/(marketing)/deployment/page.tsx
+++ b/apps/web/src/app/(marketing)/deployment/page.tsx
@@ -119,13 +119,13 @@ export default function DeploymentPage() {
           ))}
         </section>
 
-        <section className="text-center border-t border-stone-100 pt-16">
-          <p className="text-lg text-stone-600 max-w-xl mx-auto leading-relaxed mb-6">
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <p className="text-lg text-white max-w-xl mx-auto leading-relaxed mb-6">
             Not sure which fits? Start on SaaS, migrate to Docker or Kubernetes when compliance asks.
           </p>
           <Link
             href="/sign-up"
-            className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
           >
             Start Discovery — 14 days free
           </Link>

--- a/apps/web/src/app/(marketing)/evidence/page.tsx
+++ b/apps/web/src/app/(marketing)/evidence/page.tsx
@@ -140,18 +140,21 @@ export default function EvidencePage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">One receipt per action. Verifiable. Always.</h2>
+        {/* CTA — Figma indigo band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
+            One receipt per action. Verifiable. Always.
+          </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <Link
               href="/guard"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               See how Guard enforces →
             </Link>

--- a/apps/web/src/app/(marketing)/guard/page.tsx
+++ b/apps/web/src/app/(marketing)/guard/page.tsx
@@ -3,7 +3,6 @@ import { DecisionCard } from "@/components/marketing/facelift/DecisionCard"
 import { PolicySnippet } from "@/components/marketing/facelift/PolicySnippet"
 import { EvidenceReceipt } from "@/components/marketing/facelift/EvidenceReceipt"
 import { AgentSurfaceStrip } from "@/components/marketing/facelift/AgentSurfaceStrip"
-import { ThreatModelRow } from "@/components/marketing/facelift/ThreatModelRow"
 import { ActivityRow } from "@/components/marketing/facelift/ActivityRow"
 
 export const metadata = {
@@ -17,50 +16,37 @@ export default function GuardPage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero — Figma frame 11 */}
-        <section className="pt-20 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
-          <div>
-            <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
-              Guard
-            </p>
-            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
-              Runtime policy for every AI agent.
-            </h1>
-            <p className="text-lg text-stone-500 leading-relaxed mb-4">
-              Conduct Guard enforces runtime policy across any MCP-compatible AI agent, model gateway, and MCP
-              tool — before consequential actions execute.
-            </p>
-            <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-3">
-              Allow. Approve. Block. Prove.
-            </p>
-            <p className="text-sm sm:text-base font-semibold text-stone-700 mb-10">
-              Install in 10 minutes. Evidence for the CISO from day one.
-            </p>
-            <div className="flex flex-wrap gap-3">
-              <Link
-                href="/sign-up"
-                className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
-              >
-                Start Agent Discovery — 14 days free
-              </Link>
-              <Link
-                href="/book-demo"
-                className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
-              >
-                Book a Demo
-              </Link>
-            </div>
-          </div>
-          <div className="lg:pl-4">
-            <DecisionCard
-              agent="claude-code / deploy-agent"
-              action="deploy_production"
-              resource="payments-api"
-              policy="production-change-v4"
-              decision="APPROVE"
-              reason="Production deployment outside approved change window"
-              showButtons
-            />
+        {/* Hero — Figma frame 11: dark full-width band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-20 sm:py-24 bg-stone-950 mb-16">
+          <p className="text-xs font-mono font-bold uppercase tracking-widest text-indigo-400 mb-4">
+            Guard
+          </p>
+          <h1 className="text-4xl sm:text-5xl lg:text-6xl font-black tracking-tight text-white leading-[1.05] mb-6 max-w-3xl">
+            Runtime policy for every AI agent.
+          </h1>
+          <p className="text-lg text-stone-400 leading-relaxed mb-4 max-w-2xl">
+            Conduct Guard enforces runtime policy across any MCP-compatible AI agent, model gateway, and MCP
+            tool — before consequential actions execute.
+          </p>
+          <p className="text-sm font-mono font-bold text-indigo-300 tracking-wider mb-3">
+            Allow. Approve. Block. Prove.
+          </p>
+          <p className="text-sm sm:text-base font-semibold text-stone-300 mb-10 max-w-2xl">
+            Install in 10 minutes. Evidence for the CISO from day one.
+          </p>
+          <div className="flex flex-wrap gap-3">
+            <Link
+              href="/sign-up"
+              className="inline-block rounded-xl bg-indigo-600 text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-500 transition-colors"
+            >
+              Start Agent Discovery — 14 days free
+            </Link>
+            <Link
+              href="/book-demo"
+              className="inline-block rounded-xl border border-stone-700 bg-transparent text-stone-200 px-6 py-3 text-sm font-semibold hover:bg-stone-900 transition-colors"
+            >
+              Book a Demo
+            </Link>
           </div>
         </section>
 
@@ -197,61 +183,69 @@ export default function GuardPage() {
           </div>
         </section>
 
-        {/* What Guard does NOT protect */}
-        <section className="mb-20 border border-stone-200 rounded-2xl overflow-hidden">
-          <div className="px-6 py-5 bg-stone-50 border-b border-stone-200">
-            <h2 className="text-lg font-bold text-stone-900">One policy where your stack isn&apos;t one vendor&apos;s.</h2>
-            <p className="text-xs text-stone-400 mt-1">
-              Native platform controls stay in place. Guard applies one policy and evidence model <em>across</em> the mix of agent tools your team actually runs. Here&apos;s the scope Guard owns — and what we intentionally leave to the tools and data layers you already have.
-            </p>
-          </div>
-          <div className="px-6 py-2">
-            <ThreatModelRow
-              threat="Actions that bypass the hook, proxy, or MCP layer"
-              coverage="Not protected"
-              detail="Guard only evaluates actions routed through its enforcement surfaces. An agent that does not use the hook, proxy, or MCP layer is invisible to Guard."
-            />
-            <ThreatModelRow
-              threat="Pre-call prompt injection (before Guard sees the prompt)"
-              coverage="Partial"
-              detail="Guard evaluates the tool call after the model has decided to call it. Injection attacks that alter the model intent before tool selection are upstream of Guard."
-            />
-            <ThreatModelRow
-              threat="Consequential actions guarded by policy"
-              coverage="Protected"
-              detail="Refunds, deployments, network changes, secret reads — any action routed through Guard is evaluated before execution."
-            />
-            <ThreatModelRow
-              threat="Cross-agent correlation (Operations context)"
-              coverage="Not protected"
-              detail="Guard evaluates each action in isolation. Context from prior actions by other agents is not yet available. This is the Operations gap — planned."
-            />
-            <ThreatModelRow
-              threat="Audit trail integrity"
-              coverage="Protected"
-              detail="SHA-256 hash chain on every decision. Altered entries break verification."
-            />
-            <ThreatModelRow
-              threat="Model-layer attacks (adversarial inputs to the LLM itself)"
-              coverage="Partial"
-              detail="Guard includes a prompt-injection detection pack and pattern-based detectors. ML-based detection is not implemented."
-            />
+        {/* One policy where your stack isn't one vendor's — Figma frame 11: 4-card status grid */}
+        <section className="mb-20">
+          <h2 className="text-2xl font-bold text-stone-900 mb-3">One policy where your stack isn&apos;t one vendor&apos;s.</h2>
+          <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
+            Native platform controls stay in place. Guard applies one policy and evidence model across the mix
+            of agent tools your team actually runs. Every route through Guard: explicit about what remains
+            partial or planned.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            {[
+              {
+                status: "PROTECTED",
+                statusClass: "text-emerald-700 border-emerald-200 bg-emerald-50",
+                title: "Consequential actions guarded by policy",
+                detail: "Refunds, deployments, network changes, secret reads — any action routed through Guard is evaluated before execution.",
+              },
+              {
+                status: "PROTECTED",
+                statusClass: "text-emerald-700 border-emerald-200 bg-emerald-50",
+                title: "SHA-256 audit trail integrity",
+                detail: "Hash chain on every decision. Altered entries break verification.",
+              },
+              {
+                status: "PARTIAL",
+                statusClass: "text-amber-700 border-amber-200 bg-amber-50",
+                title: "Pre-call prompt injection",
+                detail: "Guard evaluates the tool call after the model has chosen it. Attacks that alter the model's intent before tool selection are upstream of Guard.",
+              },
+              {
+                status: "NOT PROTECTED",
+                statusClass: "text-stone-500 border-stone-200 bg-stone-50",
+                title: "Cross-agent correlation — planned",
+                detail: "Guard evaluates each action in isolation. Context from prior actions by other agents is not yet available. This is the Operations gap.",
+              },
+            ].map((c) => (
+              <div key={c.title} className="border border-stone-200 rounded-xl bg-white p-5 shadow-sm">
+                <span
+                  className={`inline-block text-[10px] font-mono font-bold uppercase tracking-widest border rounded px-2 py-0.5 mb-3 ${c.statusClass}`}
+                >
+                  {c.status}
+                </span>
+                <p className="font-semibold text-stone-900 mb-2 text-[15px]">{c.title}</p>
+                <p className="text-sm text-stone-500 leading-relaxed">{c.detail}</p>
+              </div>
+            ))}
           </div>
         </section>
 
-        {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">Put runtime policy in front of your agents.</h2>
+        {/* CTA — Figma indigo band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
+            Put runtime policy in front of your agents.
+          </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Agent Discovery — 14 days free
             </Link>
             <a
               href="https://github.com/sseshachala/conductai"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               View the open-source runtime →
             </a>

--- a/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
+++ b/apps/web/src/app/(marketing)/mcp-gateway/page.tsx
@@ -12,33 +12,33 @@ export default function MCPPage() {
     <div className="min-h-screen bg-white">
       <main className="max-w-5xl mx-auto px-6">
 
-        {/* Hero — Figma frame 14 */}
-        <section className="pt-20 pb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
+        {/* Hero — Figma frame 14: dark full-width band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-20 sm:py-24 bg-stone-950 mb-16 grid grid-cols-1 lg:grid-cols-2 gap-10 items-center">
           <div>
-            <p className="text-xs font-mono font-bold uppercase tracking-widest text-stone-400 mb-4">
+            <p className="text-xs font-mono font-bold uppercase tracking-widest text-indigo-400 mb-4">
               MCP
             </p>
-            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-stone-900 leading-[1.05] mb-6">
+            <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-white leading-[1.05] mb-6">
               Policy for every MCP tool invocation.
             </h1>
-            <p className="text-lg text-stone-500 leading-relaxed mb-4">
+            <p className="text-lg text-stone-400 leading-relaxed mb-4">
               Guard sits between the MCP client and the MCP server. Every tool call is evaluated
               against policy before it reaches the server — applying runtime policy and evidence-model
               enforcement across every MCP-compatible client.
             </p>
-            <p className="text-sm font-mono font-bold text-stone-700 tracking-wider mb-6">
+            <p className="text-sm font-mono font-bold text-indigo-300 tracking-wider mb-6">
               Allow. Approve. Block. Prove.
             </p>
             <div className="flex flex-wrap gap-3">
               <Link
                 href="/sign-up"
-                className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+                className="inline-block rounded-xl bg-indigo-600 text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-500 transition-colors"
               >
                 Start Discovery — 14 days free
               </Link>
               <Link
                 href="/book-demo"
-                className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+                className="inline-block rounded-xl border border-stone-700 bg-transparent text-stone-200 px-6 py-3 text-sm font-semibold hover:bg-stone-900 transition-colors"
               >
                 Book a Demo
               </Link>
@@ -49,7 +49,7 @@ export default function MCPPage() {
             <img
               src="/design/mcp-hero-diagram.svg"
               alt="MCP clients Claude Desktop, ChatGPT, and Cursor route tool invocations through ConductAI, which decides ALLOW, APPROVE, or BLOCK before the MCP server executes the tool."
-              className="w-full h-auto rounded-2xl border border-stone-800/60 shadow-md"
+              className="w-full h-auto rounded-2xl border border-stone-800 shadow-md"
               loading="lazy"
             />
           </div>
@@ -194,20 +194,21 @@ export default function MCPPage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+        {/* CTA — Figma indigo band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
             Policy at the MCP call. Not the client.
           </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <Link
               href="/guard"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               See how Guard works →
             </Link>

--- a/apps/web/src/app/(marketing)/open-source/page.tsx
+++ b/apps/web/src/app/(marketing)/open-source/page.tsx
@@ -161,18 +161,18 @@ export default function OpenSourcePage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">Start with the source.</h2>
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">Start with the source.</h2>
           <div className="flex flex-wrap justify-center gap-3">
             <a
               href="https://github.com/sseshachala/conductai"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               View on GitHub →
             </a>
             <Link
               href="/deployment"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               Deployment options →
             </Link>

--- a/apps/web/src/app/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(marketing)/pricing/page.tsx
@@ -243,25 +243,25 @@ export default function PricingPage() {
           </div>
         </section>
 
-        {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-14">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+        {/* CTA — Figma indigo band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4 max-w-2xl mx-auto">
             Not sure which tier fits?
           </h2>
-          <p className="text-stone-500 max-w-xl mx-auto mb-6 leading-relaxed">
+          <p className="text-indigo-100 max-w-xl mx-auto mb-8 leading-relaxed">
             Start on Free — govern up to 3 agents in an afternoon. Upgrade when your fleet grows,
             or talk to us about design-partner terms if you're deploying at scale early.
           </p>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start free
             </Link>
             <Link
               href="/book-demo"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               Talk to sales →
             </Link>

--- a/apps/web/src/app/(marketing)/registry/page.tsx
+++ b/apps/web/src/app/(marketing)/registry/page.tsx
@@ -280,22 +280,25 @@ export default function RegistryPage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">Start with Discovery. Add playbooks as you go.</h2>
-          <p className="text-stone-500 text-sm mb-8 max-w-lg mx-auto leading-relaxed">
+        {/* CTA — Figma indigo band */}
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-4 max-w-2xl mx-auto">
+            Start with Discovery. Add playbooks as you go.
+          </h2>
+          <p className="text-indigo-100 text-sm mb-8 max-w-lg mx-auto leading-relaxed">
             Discovery maps what your agents are doing today. Playbooks extend that into governed, repeatable
             automation — with policy at every step.
           </p>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <a
               href="https://github.com/sseshachala/conductai"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               View the open-source runtime →
             </a>

--- a/apps/web/src/app/(marketing)/security/page.tsx
+++ b/apps/web/src/app/(marketing)/security/page.tsx
@@ -233,10 +233,10 @@ export default function SecurityPage() {
           </p>
         </section>
 
-        <section className="text-center border-t border-stone-100 pt-16">
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
           <Link
             href="/sign-up"
-            className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+            className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
           >
             Start Discovery — 14 days free
           </Link>

--- a/apps/web/src/app/(marketing)/solutions/action-governance/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/action-governance/page.tsx
@@ -137,20 +137,20 @@ export default function ActionGovernancePage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
             Govern the action, not the aftermath.
           </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <Link
               href="/guard"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               See how Guard works →
             </Link>

--- a/apps/web/src/app/(marketing)/solutions/engineering-leaders/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/engineering-leaders/page.tsx
@@ -154,20 +154,20 @@ export default function EngineeringAgentsPage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
             Consistent policy. Every agent. Every action.
           </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <Link
               href="/guard"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               See how Guard works →
             </Link>

--- a/apps/web/src/app/(marketing)/solutions/security-compliance/page.tsx
+++ b/apps/web/src/app/(marketing)/solutions/security-compliance/page.tsx
@@ -184,20 +184,20 @@ export default function SecurityTeamsPage() {
         </section>
 
         {/* CTA */}
-        <section className="mb-20 text-center border-t border-stone-100 pt-16">
-          <h2 className="text-2xl font-bold text-stone-900 mb-4">
+        <section className="-mx-6 sm:-mx-10 lg:-mx-20 px-6 sm:px-10 lg:px-20 py-16 sm:py-24 bg-indigo-600 mb-0 text-center">
+          <h2 className="text-2xl sm:text-3xl font-bold text-white tracking-tight mb-6 max-w-2xl mx-auto">
             Runtime enforcement. Signed evidence. Honest scope.
           </h2>
           <div className="flex flex-wrap justify-center gap-3">
             <Link
               href="/sign-up"
-              className="inline-block rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors"
+              className="inline-block rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors"
             >
               Start Discovery — 14 days free
             </Link>
             <Link
               href="/security"
-              className="inline-block rounded-xl border border-stone-200 bg-white text-stone-700 px-6 py-3 text-sm font-semibold hover:bg-stone-50 transition-colors"
+              className="inline-block rounded-xl border border-indigo-300 bg-transparent text-white px-6 py-3 text-sm font-semibold hover:bg-indigo-700 transition-colors"
             >
               View full threat model →
             </Link>

--- a/apps/web/src/app/(marketing)/use-cases/page.tsx
+++ b/apps/web/src/app/(marketing)/use-cases/page.tsx
@@ -411,15 +411,17 @@ function Detail({ c }: { c: UseCase }) {
 
 function BottomCta() {
   return (
-    <section className="max-w-3xl mx-auto px-6 py-20 text-center border-t border-stone-100">
-      <h2 className="text-3xl sm:text-4xl font-black tracking-tight text-stone-900 leading-tight mb-4">
-        Not sure which one is you?
-      </h2>
-      <p className="text-lg text-stone-500 leading-relaxed mb-8">
-        Most teams land in three at once. Pick the one that hurts the most today.
-        The other two will be on the same Guard install.
-      </p>
-      <CtaLink className="rounded-xl bg-stone-900 text-white px-6 py-3 text-sm font-semibold hover:bg-stone-700 transition-colors" />
+    <section className="px-6 py-16 sm:py-24 bg-indigo-600 text-center">
+      <div className="max-w-3xl mx-auto">
+        <h2 className="text-3xl sm:text-4xl font-black tracking-tight text-white leading-tight mb-4">
+          Not sure which one is you?
+        </h2>
+        <p className="text-lg text-indigo-100 leading-relaxed mb-8">
+          Most teams land in three at once. Pick the one that hurts the most today.
+          The other two will be on the same Guard install.
+        </p>
+        <CtaLink className="rounded-xl bg-white text-indigo-700 px-6 py-3 text-sm font-semibold hover:bg-indigo-50 transition-colors" />
+      </div>
     </section>
   )
 }


### PR DESCRIPTION
Applies Figma dark-hero + indigo-CTA pattern (from #1700) across every marketing page with a final CTA. Guard/MCP get dark hero bands; Guard boundary → 4-card status grid; indigo CTAs on Guard, MCP, Registry, Evidence, Pricing, Use-cases, Deployment, Open-source, Security, and all 3 Solutions pages. 12 files, all locked copy preserved. tsc/lint/gitleaks green.