### PR TITLE
fix(lens): block LLM self-confirm in same turn (#1708) + credential-broker fix

### DIFF
--- a/apps/api/app/core/credentials.py
+++ b/apps/api/app/core/credentials.py
@@ -129,16 +129,57 @@ def retrieve_credential(db, cred_token: str, handle: str) -> dict | None:
 
 
 def fetch_credential(cred_token: str, handle: str, api_url: str) -> dict:
-    """HTTP call to broker. Used by blocks running inside a run context."""
+    """Return decrypted credential dict for `handle`.
+
+    Cache-first: the executor populates a process-local snapshot at run
+    start (see `app.runtime.run_credentials`). In-process blocks hit the
+    snapshot and skip the HTTP round-trip entirely. Broker call remains
+    for out-of-process callers (CLI, remote workers) and for the small
+    window before the executor populates.
+
+    Non-200 broker responses used to return `{}` silently — that made a
+    stale cred_token (bug B on run resume) look identical to a missing
+    handle, and downstream brain_block raised MissingProviderKey with
+    misleading UX. We now log the failure so operators can see it.
+    """
+    from app.runtime.run_credentials import resolve as _cache_resolve
+
+    cached = _cache_resolve(cred_token, handle)
+    if cached is not None:
+        return cached
+
     import httpx
-    resp = httpx.post(
-        f"{api_url}/credentials/creds/retrieve",
-        json={"handle": handle},
-        headers={"X-Cred-Token": cred_token},
-        timeout=5.0,
-    )
+    try:
+        resp = httpx.post(
+            f"{api_url}/credentials/creds/retrieve",
+            json={"handle": handle},
+            headers={"X-Cred-Token": cred_token},
+            timeout=5.0,
+        )
+    except Exception as exc:
+        try:
+            import structlog
+            structlog.get_logger(__name__).warning(
+                "credentials.broker_fetch_exception",
+                handle=handle,
+                error=str(exc),
+                cred_token_prefix=(cred_token or "")[:12],
+            )
+        except Exception:
+            pass
+        return {}
     if resp.status_code == 200:
         return resp.json()
+    try:
+        import structlog
+        structlog.get_logger(__name__).warning(
+            "credentials.broker_fetch_failed",
+            handle=handle,
+            status=resp.status_code,
+            cred_token_prefix=(cred_token or "")[:12],
+        )
+    except Exception:
+        pass
     return {}
 
 

--- a/apps/api/app/mcp/server.py
+++ b/apps/api/app/mcp/server.py
@@ -57,6 +57,13 @@ class MCPContext:
     user_email: str | None = None
     session_id: str | None = None
     resolved_token: str = ""      # raw Bearer — guard_enable echoes it back to the user
+    # Set of approval_request_ids proposed earlier in the CURRENT LLM tool
+    # loop. Populated by Lens's `_resolve_tools` after each dispatch; read by
+    # the actor confirm/cancel tools to reject same-turn self-confirmation
+    # (LLM must wait for a real user reply before deciding a proposal it
+    # just created). Left None for adapters that don't run a multi-turn tool
+    # loop — the guard is a no-op for them.
+    pending_action_ids_this_turn: set[str] | None = None
 
 
 def _ok(msg_id: Any, result: dict[str, Any]) -> dict[str, Any]:

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -590,10 +590,15 @@ def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tup
     msgs = list(messages)
     tool_calls_made: list[tuple[str, dict]] = []
 
+    # Same-turn self-confirmation guard (#1465 follow-up): if the LLM emits
+    # a proposal + a confirm_pending_action for that proposal's id in the
+    # same tool loop, the confirm tool refuses. Populated below after each
+    # dispatch by scanning results for `confirm_required` envelopes.
     lens_ctx = MCPContext(
         workspace_id=executor.workspace_id,
         clerk_user_id="system:lens",
         surface="lens",
+        pending_action_ids_this_turn=set(),
     )
 
     def _bound_dispatcher(name: str, args_json: str) -> str:
@@ -619,6 +624,15 @@ def _resolve_tools(messages: list[dict], system: str, executor: Executor) -> tup
             results,
         ):
             log.debug("glens.tool", name=name_and_input[0], result_len=len(result))
+        # Register any pending-action ids returned by proposal tools so a
+        # follow-up confirm_pending_action/cancel_pending_action in the
+        # NEXT iteration of this same tool loop is refused.
+        for _id, result_str in results:
+            envelope = _parse_json_dict(result_str)
+            if envelope and envelope.get("confirm_required"):
+                aid = envelope.get("approval_request_id")
+                if isinstance(aid, str):
+                    lens_ctx.pending_action_ids_this_turn.add(aid)
         msgs.extend(client.make_tool_results_turn(results))
 
     return msgs, None, tool_calls_made

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -266,6 +266,17 @@ def execute_run(run_id: str):
             except Exception:
                 log.warning("run.cred_token_mint_failed", run_id=run_id)
 
+        # Populate the in-process cred cache so blocks skip the HTTP-to-self
+        # broker round-trip. This eliminates the intermittent MissingProviderKey
+        # class of failure where a broker 401/500 on a per-block fetch returned
+        # {} and looked like "no key configured" to brain_block. See
+        # app.runtime.run_credentials for cache lifecycle.
+        try:
+            from app.runtime.run_credentials import populate as _cred_cache_populate
+            _cred_cache_populate(_cred_token, dict(credentials._data))
+        except Exception as _cc_err:
+            log.warning("run.cred_cache_populate_failed", run_id=run_id, error=str(_cc_err))
+
         # Stamp agent_role_id on the run if CONDUCT_AGENT_TOKEN is in credentials.
         _env_vars_creds = credentials.get("env_vars") or {}
         if isinstance(_env_vars_creds, dict) and _env_vars_creds.get("CONDUCT_AGENT_TOKEN"):
@@ -473,6 +484,16 @@ def execute_run(run_id: str):
                     _inv_db.close()
             except Exception:
                 pass  # never let token cleanup crash the run
+
+        # Drop the in-process credential snapshot for this segment. Purge
+        # regardless of pause state — resume rebuilds it on the next
+        # execute_run() call via the populate step above.
+        try:
+            from app.runtime.run_credentials import purge as _cred_cache_purge
+            _cred_cache_purge(state.get("__cred_token__", "") or _cred_token)
+        except Exception:
+            pass
+
         db.close()
 
 

--- a/apps/api/app/runtime/run_credentials.py
+++ b/apps/api/app/runtime/run_credentials.py
@@ -1,0 +1,50 @@
+"""Process-local credential cache for in-process runtime callers.
+
+The executor fetches every workspace credential from the DB once at run
+start (`get_all_credentials`). Blocks then re-fetched each handle they
+needed via HTTP round-trip to `POST /credentials/creds/retrieve` — one
+per handle per block, using the run's `cred_token` for auth.
+
+That per-block broker call was two things at once:
+
+1. Redundant — the worker already has decrypted creds in memory.
+2. A silent-failure surface — `fetch_credential` swallows any non-200
+   into an empty dict, which downstream (brain_block, etc.) then reads
+   as "no key configured" and raises MissingProviderKey. Seen live on
+   run resume when the cred_token had been invalidated by the previous
+   segment's finally-block (bug B in the audit).
+
+This module holds the decrypted creds in a process-local dict keyed by
+the run's cred_token. `fetch_credential` consults this cache first and
+only falls through to the broker for out-of-process callers (CLI, remote
+workers, or the vanishingly rare cache-miss window).
+
+Populated at executor init, purged when the segment ends. Nothing here
+touches state / DB — pause/resume gets a fresh populate on the next
+segment.
+"""
+from __future__ import annotations
+
+# cred_token -> {handle: decrypted-creds-dict}
+_CACHE: dict[str, dict[str, dict]] = {}
+
+
+def populate(cred_token: str, credentials: dict[str, dict]) -> None:
+    """Snapshot the decrypted credential map for this run segment."""
+    if not cred_token:
+        return
+    _CACHE[cred_token] = dict(credentials)
+
+
+def resolve(cred_token: str, handle: str) -> dict | None:
+    """Cache lookup. Returns None on miss so callers can fall back to broker."""
+    if not cred_token:
+        return None
+    return _CACHE.get(cred_token, {}).get(handle)
+
+
+def purge(cred_token: str) -> None:
+    """Drop the snapshot when the segment finishes."""
+    if not cred_token:
+        return
+    _CACHE.pop(cred_token, None)

--- a/apps/api/app/tools/registrations/lens/actor.py
+++ b/apps/api/app/tools/registrations/lens/actor.py
@@ -23,10 +23,27 @@ from app.tools.types import ToolAnnotations, ToolDef
 from app.tools.registrations.lens._shared import _actor_impl, _ACTOR_TAGS
 
 
+_SAME_TURN_MSG = (
+    "This action was proposed in the same turn — wait for the user to reply "
+    "'yes' or click Confirm before calling this tool."
+)
+
+
 def _confirm_pending_action_impl(ctx, pending_action_id: str) -> dict[str, Any]:
     """LLM-callable confirm — same server logic as the ActionConfirmBubble
     button. Enforces proposer identity + session_id match so a compromised
-    LLM in another session can't decide this one's pending actions."""
+    LLM in another session can't decide this one's pending actions.
+
+    Also rejects same-turn self-confirmation: if the LLM emitted a proposal
+    tool_use and a confirm tool_use in the same tool loop iteration, the
+    proposal's id will be in `ctx.pending_action_ids_this_turn` and this
+    call is rejected as 409. Forces a real user round-trip before the
+    action can fire.
+    """
+    same_turn_ids = getattr(ctx, "pending_action_ids_this_turn", None)
+    if same_turn_ids is not None and pending_action_id in same_turn_ids:
+        return {"error": _SAME_TURN_MSG, "status_code": 409}
+
     from app.core.database import SessionLocal
     from app.modules.glens.actor.helpers import ConfirmError, dispatch_confirm
 
@@ -52,7 +69,12 @@ def _confirm_pending_action_impl(ctx, pending_action_id: str) -> dict[str, Any]:
 def _cancel_pending_action_impl(
     ctx, pending_action_id: str, reason: str | None = None,
 ) -> dict[str, Any]:
-    """LLM-callable cancel — same server logic as the Cancel button."""
+    """LLM-callable cancel — same server logic as the Cancel button. Also
+    rejects same-turn self-cancellation (mirrors confirm)."""
+    same_turn_ids = getattr(ctx, "pending_action_ids_this_turn", None)
+    if same_turn_ids is not None and pending_action_id in same_turn_ids:
+        return {"error": _SAME_TURN_MSG, "status_code": 409}
+
     from app.core.database import SessionLocal
     from app.modules.glens.actor.helpers import ConfirmError, dispatch_cancel
 

--- a/apps/api/tests/glens/test_actor_chat_confirm.py
+++ b/apps/api/tests/glens/test_actor_chat_confirm.py
@@ -197,3 +197,101 @@ def test_agent_proposed_by_synthetic_user_id_also_lenient():
         session_id=None,
     )
     _enforce_ownership(row, clerk_user_id="user_real_human", session_id=None)
+
+
+# ── Same-turn self-confirm guard (#1465 follow-up) ─────────────────────────
+
+def test_confirm_rejected_when_id_proposed_in_same_turn():
+    """LLM emits `run_workflow` + `confirm_pending_action(id)` in the SAME
+    tool loop iteration. Lens's tool loop registers the id in
+    ctx.pending_action_ids_this_turn; the confirm tool must refuse with 409
+    without calling dispatch_confirm."""
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    ctx = MCPContext(
+        workspace_id=_CTX.workspace_id,
+        clerk_user_id=_CTX.clerk_user_id,
+        user_email=_CTX.user_email,
+        session_id=_CTX.session_id,
+        surface="lens",
+        pending_action_ids_this_turn={"a1"},
+    )
+
+    with patch("app.modules.glens.actor.helpers.dispatch_confirm") as mock_dispatch:
+        out = _confirm_pending_action_impl(ctx, "a1")
+
+    mock_dispatch.assert_not_called()
+    assert out["status_code"] == 409
+    assert "same turn" in out["error"]
+
+
+def test_cancel_rejected_when_id_proposed_in_same_turn():
+    from app.tools.registrations.lens.actor import _cancel_pending_action_impl
+
+    ctx = MCPContext(
+        workspace_id=_CTX.workspace_id,
+        clerk_user_id=_CTX.clerk_user_id,
+        user_email=_CTX.user_email,
+        session_id=_CTX.session_id,
+        surface="lens",
+        pending_action_ids_this_turn={"a1"},
+    )
+
+    with patch("app.modules.glens.actor.helpers.dispatch_cancel") as mock_dispatch:
+        out = _cancel_pending_action_impl(ctx, "a1")
+
+    mock_dispatch.assert_not_called()
+    assert out["status_code"] == 409
+
+
+def test_confirm_allowed_when_id_not_in_same_turn_set():
+    """Different id in the set → real dispatch runs. This is the natural-
+    language 'yes' path on a NEW user turn (fresh ctx, empty set)."""
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    ctx = MCPContext(
+        workspace_id=_CTX.workspace_id,
+        clerk_user_id=_CTX.clerk_user_id,
+        user_email=_CTX.user_email,
+        session_id=_CTX.session_id,
+        surface="lens",
+        pending_action_ids_this_turn={"other-id"},
+    )
+
+    fake_payload = {
+        "executed": True, "cached": False,
+        "action_id": "a1", "tool_name": "run_workflow",
+        "status": "approved", "result": {"run_id": "r1"},
+    }
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_confirm", return_value=fake_payload) as mock_dispatch:
+        out = _confirm_pending_action_impl(ctx, "a1")
+
+    mock_dispatch.assert_called_once()
+    assert out["executed"] is True
+
+
+def test_confirm_allowed_when_ctx_has_no_same_turn_set():
+    """HTTP/stdio adapters don't populate the set. Field is None → guard
+    is a no-op, dispatch runs normally."""
+    from app.tools.registrations.lens.actor import _confirm_pending_action_impl
+
+    ctx = MCPContext(
+        workspace_id=_CTX.workspace_id,
+        clerk_user_id=_CTX.clerk_user_id,
+        user_email=_CTX.user_email,
+        session_id=_CTX.session_id,
+        surface="stdio",
+        pending_action_ids_this_turn=None,
+    )
+
+    fake_payload = {
+        "executed": True, "cached": False,
+        "action_id": "a1", "tool_name": "run_workflow",
+        "status": "approved", "result": {"run_id": "r1"},
+    }
+    with patch("app.core.database.SessionLocal", return_value=SimpleNamespace(close=lambda: None)), \
+         patch("app.modules.glens.actor.helpers.dispatch_confirm", return_value=fake_payload):
+        out = _confirm_pending_action_impl(ctx, "a1")
+
+    assert out["executed"] is True

--- a/apps/api/tests/test_run_credentials_cache.py
+++ b/apps/api/tests/test_run_credentials_cache.py
@@ -1,0 +1,90 @@
+"""Cache-first credential fetch — kills the intermittent MissingProviderKey
+on run resume.
+
+Before: every block called fetch_credential -> HTTP broker call. Any
+non-200 (broker restart, cred_token invalidated by prior segment) got
+swallowed as {} and looked identical to "no key configured", so
+brain_block raised MissingProviderKey and blamed the user's env.
+
+After: executor populates a process-local snapshot at run init. Blocks
+read the snapshot; broker is fallback for CLI / out-of-process only.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("REDIS_URL", "redis://localhost:6379")
+os.environ.setdefault("ANTHROPIC_API_KEY", "sk-test")
+os.environ.setdefault("ENCRYPTION_KEY", "test-key-32-bytes-long-xxxxxxxx!")
+
+for _m in ["structlog", "redis", "sentry_sdk", "app.core.pii"]:
+    sys.modules.setdefault(_m, MagicMock())
+
+from app.runtime import run_credentials  # noqa: E402
+from app.core.credentials import fetch_credential  # noqa: E402
+
+
+class TestCacheLifecycle:
+    def test_populate_then_resolve_returns_snapshot(self):
+        run_credentials.populate("cond_cred_test_1", {"anthropic": {"api_key": "sk-real"}})
+        assert run_credentials.resolve("cond_cred_test_1", "anthropic") == {"api_key": "sk-real"}
+        run_credentials.purge("cond_cred_test_1")
+
+    def test_purge_evicts_snapshot(self):
+        run_credentials.populate("cond_cred_test_2", {"anthropic": {"api_key": "sk-x"}})
+        run_credentials.purge("cond_cred_test_2")
+        assert run_credentials.resolve("cond_cred_test_2", "anthropic") is None
+
+    def test_resolve_miss_returns_none_not_empty_dict(self):
+        # Callers distinguish "not cached" (None -> fall back to broker) from
+        # "explicitly empty handle" ({} -> handle exists but has no fields).
+        assert run_credentials.resolve("cond_cred_never_populated", "anthropic") is None
+
+    def test_populate_with_empty_token_is_noop(self):
+        # Guards against caching under "" key which would pollute the cache
+        # for every subsequent empty-token call.
+        run_credentials.populate("", {"anthropic": {"api_key": "leak"}})
+        assert run_credentials.resolve("", "anthropic") is None
+
+
+class TestFetchCredentialCacheFirst:
+    def test_cache_hit_skips_httpx_call(self):
+        run_credentials.populate("cond_cred_hot_1", {"anthropic": {"api_key": "sk-cached"}})
+        try:
+            with patch("httpx.post") as mock_post:
+                result = fetch_credential("cond_cred_hot_1", "anthropic", "http://api")
+                assert result == {"api_key": "sk-cached"}
+                mock_post.assert_not_called()
+        finally:
+            run_credentials.purge("cond_cred_hot_1")
+
+    def test_cache_miss_falls_back_to_broker(self):
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 200
+            mock_post.return_value.json.return_value = {"api_key": "sk-broker"}
+            result = fetch_credential("cond_cred_miss", "anthropic", "http://api")
+            assert result == {"api_key": "sk-broker"}
+            mock_post.assert_called_once()
+
+    def test_broker_non_200_returns_empty(self):
+        # Existing behaviour — brain_block's fallback ladder still handles
+        # empty. The new log line (not asserted here) makes the failure
+        # visible for operators.
+        with patch("httpx.post") as mock_post:
+            mock_post.return_value.status_code = 401
+            result = fetch_credential("cond_cred_bad_token", "anthropic", "http://api")
+            assert result == {}
+
+    def test_broker_exception_returns_empty_instead_of_crashing(self):
+        with patch("httpx.post", side_effect=Exception("connection reset")):
+            result = fetch_credential("cond_cred_exc", "anthropic", "http://api")
+            assert result == {}


### PR DESCRIPTION
## Summary

Two independent bugs surfaced during Sep-07 demo work:

- **#1708** (lens): LLM self-confirmed `run_workflow` in the same tool turn — ActionConfirmBubble rendered as "Approved" with no buttons, user never got to say yes.
- Runtime credential-broker fix: `brain_block` raised intermittent `MissingProviderKey` on paused-and-resumed runs. `fetch_credential` swallowed every non-200 broker response into `{}`; on resume the executor's per-block cred_token invalidation could hit the broker with a stale token before the new segment established a fresh one → 401 → silently swallowed → key-resolution ladder read `{}` as "no key configured".

Both commits live on `fix/lens-approval-followups-part2`. Bundled since they share the branch and both are HITL/runtime followups.

## Fix — #1708

Thread a per-turn `pending_action_ids_this_turn: set[str]` through `MCPContext`. Lens's `_resolve_tools` registers any `confirm_required` envelope's `approval_request_id` after each dispatch. `confirm_pending_action` and `cancel_pending_action` refuse (409) any id in the set — forces a real user round-trip before the LLM can decide a proposal it just created.

- HTTP `POST /glens/actions/{id}/confirm` unaffected (fresh request = fresh empty set)
- Natural-language "yes" on a NEW user turn works (fresh tool loop = fresh empty set)
- Non-Lens adapters pass `None` → guard is a no-op

## Fix — runtime credentials

Cache workspace credentials in-process at executor startup so per-block broker round-trips are eliminated. Same-run resume reuses the cached creds instead of racing the broker with a stale token.

## Test plan

- [x] `pytest tests/glens/` — 258 passed, 20 skipped
- [ ] Live: `run self_driving_network_approval_demo` in Lens → ActionConfirmBubble renders with active Confirm/Cancel buttons (not "Approved")
- [ ] Live: reply "yes" on the bubble → workflow fires via `confirm_pending_action`
- [ ] Live: HTTP `POST /glens/actions/{id}/confirm` still works via button click
- [ ] Live: run a paused-and-resumed workflow through 3+ brain blocks → no `MissingProviderKey`

Closes #1708