### PR TITLE
chore(nav): hide Reports left-nav until report builder ships

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -778,42 +778,47 @@ function AppShellInnerContent({
             collapsed={collapsed}
           />
 
-          {/* Reports — #1450 PR 5 (report builder + pinned reports) */}
-          <SideNavItem
-            href="/lens/report-builder"
-            label="Reports"
-            icon={<Icons.Spark />}
-            active={pathname.startsWith("/lens/report-builder")}
-            collapsed={collapsed}
-          />
-          {!collapsed && pinnedReports.length > 0 && (
-            <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 4, display: "flex", flexDirection: "column", gap: 1 }}>
-              {pinnedReports.map((r) => {
-                const href = `/lens/report-builder?slug=${encodeURIComponent(r.slug)}`
-                const active = false  // sub-items skip active tint; parent Reports link covers highlighting
-                return (
-                  <Link
-                    key={r.id}
-                    href={href}
-                    style={{
-                      display: "block",
-                      padding: "5px 10px",
-                      borderRadius: 7,
-                      fontSize: 13,
-                      fontWeight: active ? 600 : 400,
-                      color: active ? "var(--accent-text)" : "var(--text-3)",
-                      background: active ? "var(--accent-weak)" : "transparent",
-                      textDecoration: "none",
-                    }}
-                    onMouseEnter={(e: ReactMouseEvent<HTMLElement>) => { if (!active) (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)" }}
-                    onMouseLeave={(e: ReactMouseEvent<HTMLElement>) => { if (!active) (e.currentTarget as HTMLAnchorElement).style.background = "transparent" }}
-                    title={r.name}
-                  >
-                    {r.name}
-                  </Link>
-                )
-              })}
-            </div>
+          {/* Reports — #1450 PR 5. Hidden until report builder is built properly.
+              Re-enable by removing this false && guard once the surface ships. */}
+          {false && (
+            <>
+              <SideNavItem
+                href="/lens/report-builder"
+                label="Reports"
+                icon={<Icons.Spark />}
+                active={pathname.startsWith("/lens/report-builder")}
+                collapsed={collapsed}
+              />
+              {!collapsed && pinnedReports.length > 0 && (
+                <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 4, display: "flex", flexDirection: "column", gap: 1 }}>
+                  {pinnedReports.map((r) => {
+                    const href = `/lens/report-builder?slug=${encodeURIComponent(r.slug)}`
+                    const active = false
+                    return (
+                      <Link
+                        key={r.id}
+                        href={href}
+                        style={{
+                          display: "block",
+                          padding: "5px 10px",
+                          borderRadius: 7,
+                          fontSize: 13,
+                          fontWeight: active ? 600 : 400,
+                          color: active ? "var(--accent-text)" : "var(--text-3)",
+                          background: active ? "var(--accent-weak)" : "transparent",
+                          textDecoration: "none",
+                        }}
+                        onMouseEnter={(e: ReactMouseEvent<HTMLElement>) => { if (!active) (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)" }}
+                        onMouseLeave={(e: ReactMouseEvent<HTMLElement>) => { if (!active) (e.currentTarget as HTMLAnchorElement).style.background = "transparent" }}
+                        title={r.name}
+                      >
+                        {r.name}
+                      </Link>
+                    )
+                  })}
+                </div>
+              )}
+            </>
           )}
 
           {/* GOVERN group — Guard */}


### PR DESCRIPTION
## Summary

Hide the **Reports** left-nav entry until the report builder is production-ready. Wraps the `SideNavItem` + `pinnedReports` sub-list in `{false && (...)}` so the entry disappears from the sidebar without touching the underlying `/lens/report-builder` route or the `useState`/fetch plumbing.

Re-enable by removing the `false &&` guard once the surface ships.

## Why

Reports was landed as the first "chat generates a view → nav persists it" affordance under #1450 (PR 5) and epic #1333 (child #4 — *"Save this view" persists chat-generated views as nav entries*). The builder isn't finished yet — showing an in-progress entry in the nav creates a dead-end for users.

## Files

- `apps/web/src/components/AppShell.tsx` — single hunk, guard wraps the Reports block

## Test plan

- [ ] Load any authed page → Reports entry is not visible in the left nav
- [ ] `/lens/report-builder` route still reachable by direct URL (unchanged)
- [ ] Sidebar collapse/expand behaviour unchanged

Related: #1333, #1450