### PR TITLE
feat(guard): trial teardown sweeper daemon

### DIFF
--- a/apps/api/app/modules/guard/trial_teardown.py
+++ b/apps/api/app/modules/guard/trial_teardown.py
@@ -1,0 +1,122 @@
+"""Trial teardown on real-provider connect (epic #1587 Round C).
+
+When a workspace on `plan='free_trial'` saves a real LLM-provider credential
+via `POST /credentials`, the trial has done its job. Deactivate the trial
+identity, drop the workspace-default rate-limit + spend-budget rows minted
+by `trial_seed.seed_trial`, and flip the plan back to `free`. Idempotent:
+safe to call on a workspace that never had a trial or has already been torn
+down. Never raises — a teardown failure must not block the credential save.
+
+The provider set starts at just `anthropic` — the only provider funded by
+`GUARD_TRIAL_ANTHROPIC_KEY` today. When Round D adds funded upstreams for
+other providers (openai, groq, ...), add each to `TRIAL_TEARDOWN_PROVIDERS`
+so connecting them also ends the trial.
+"""
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
+
+log = structlog.get_logger(__name__)
+
+# Services whose real-key connect signals "the trial has done its job".
+# Grows with Round D as funded upstreams land for more providers.
+TRIAL_TEARDOWN_PROVIDERS: set[str] = {"anthropic"}
+
+
+def teardown_trial(db: Session, workspace_id: str) -> bool:
+    """Deactivate any active trial artifacts on `workspace_id`. Idempotent.
+
+    Returns True if any row was actually changed, False if the workspace had
+    nothing to tear down (never on trial, or already torn down). Caller
+    commits. Never raises.
+    """
+    ws = str(workspace_id)
+    changed = False
+    try:
+        plan_res = db.execute(
+            text("UPDATE workspaces SET plan = 'free' WHERE id = :ws AND plan = :trial"),
+            {"ws": ws, "trial": TRIAL_PLAN},
+        )
+        if plan_res.rowcount:
+            changed = True
+
+        id_res = db.execute(
+            text("""
+                UPDATE agent_identities
+                SET lifecycle_state = 'expired'
+                WHERE workspace_id = :ws
+                  AND name = :name
+                  AND lifecycle_state = 'active'
+            """),
+            {"ws": ws, "name": TRIAL_IDENTITY_NAME},
+        )
+        if id_res.rowcount:
+            changed = True
+
+        rl_res = db.execute(
+            text("""
+                DELETE FROM guard_rate_limits
+                WHERE workspace_id = :ws AND agent_identity_id IS NULL
+            """),
+            {"ws": ws},
+        )
+        if rl_res.rowcount:
+            changed = True
+
+        sb_res = db.execute(
+            text("""
+                DELETE FROM guard_spend_budgets
+                WHERE workspace_id = :ws AND clerk_user_id IS NULL
+            """),
+            {"ws": ws},
+        )
+        if sb_res.rowcount:
+            changed = True
+
+        if changed:
+            log.info("guard.trial.torn_down", workspace_id=ws)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.trial.teardown_failed", workspace_id=ws, err=str(exc))
+        return False
+    return changed
+
+
+def sweep_expired_trials(db: Session) -> int:
+    """Tear down trials whose identity `expires_at` has passed. Idempotent.
+
+    Returns count of workspaces torn down. Called by the worker daemon on a
+    periodic interval. Never raises.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    try:
+        rows = db.execute(
+            text(
+                """
+                SELECT DISTINCT workspace_id
+                FROM agent_identities
+                WHERE name = :name
+                  AND lifecycle_state = 'active'
+                  AND expires_at IS NOT NULL
+                  AND expires_at < :now
+                """
+            ),
+            {"name": TRIAL_IDENTITY_NAME, "now": now},
+        ).fetchall()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.trial.sweep_query_failed", err=str(exc))
+        return 0
+
+    torn = 0
+    for (ws_id,) in rows:
+        if teardown_trial(db, str(ws_id)):
+            torn += 1
+    if torn:
+        db.commit()
+        log.info("guard.trial.sweep_swept", count=torn)
+    return torn

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -57,6 +57,7 @@ JUDGE_SAMPLE_RATE      = float(os.environ.get("ONLINE_EVAL_JUDGE_SAMPLE_RATE", "
 STALE_RUN_THRESHOLD_MINUTES        = int(os.environ.get("STALE_RUN_THRESHOLD_MINUTES", "20"))
 STALE_PENDING_THRESHOLD_MINUTES    = int(os.environ.get("STALE_PENDING_THRESHOLD_MINUTES", "10"))
 STALE_RUN_REAPER_INTERVAL          = int(os.environ.get("STALE_RUN_REAPER_INTERVAL", "120"))  # seconds
+TRIAL_TEARDOWN_INTERVAL            = int(os.environ.get("TRIAL_TEARDOWN_INTERVAL", "3600"))    # seconds
 AUTOMATION_PROJECT_RETENTION_DAYS  = int(os.environ.get("AUTOMATION_PROJECT_RETENTION_DAYS", "30"))
 
 
@@ -261,6 +262,24 @@ def _reaper_loop() -> None:
 
 # -- online eval scorer --------------------------------------------------------
 
+def _trial_teardown_loop() -> None:
+    """Daemon: periodically tear down trial workspaces whose identity has expired."""
+    from app.core.database import SessionLocal
+    from app.modules.guard.trial_teardown import sweep_expired_trials
+
+    log.info("trial_teardown.started", interval_seconds=TRIAL_TEARDOWN_INTERVAL)
+    while True:
+        time.sleep(TRIAL_TEARDOWN_INTERVAL)
+        try:
+            with SessionLocal() as db:
+                torn = sweep_expired_trials(db)
+            if torn:
+                log.info("trial_teardown.cycle", swept=torn)
+        except Exception:
+            log.exception("trial_teardown.loop_error")
+
+
+
 def _online_eval_loop() -> None:
     """Daemon thread: consume the online eval queue and score each completed run."""
     import random
@@ -384,6 +403,9 @@ def main() -> None:
 
     online_eval = threading.Thread(target=_online_eval_loop, daemon=True, name="online-eval")
     online_eval.start()
+
+    trial_teardown = threading.Thread(target=_trial_teardown_loop, daemon=True, name="trial-teardown")
+    trial_teardown.start()
 
     if CONCURRENCY == 1:
         _loop(0)

--- a/apps/api/tests/test_trial_teardown.py
+++ b/apps/api/tests/test_trial_teardown.py
@@ -115,12 +115,23 @@ from app.modules.guard.trial_teardown import sweep_expired_trials  # noqa: E402
 
 
 def test_sweep_tears_down_only_expired_trials(ws):
+    """Workspace-scoped assertions — the sweeper is global, but other tests may
+    have left unrelated trial rows in this shared test DB, so we can't assert
+    the sweep count. What matters: this workspace's fresh trial is untouched
+    before its expires_at, and torn down after."""
     ws_id, db = ws
     seed_trial(db, ws_id)
     db.commit()
 
-    # Nothing has expired yet — sweep is a no-op.
-    assert sweep_expired_trials(db) == 0
+    # Fresh trial has expires_at 7d out — this workspace should survive a sweep.
+    sweep_expired_trials(db)
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free_trial"
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "active"
 
     # Force this trial's identity into the past.
     db.execute(
@@ -136,16 +147,12 @@ def test_sweep_tears_down_only_expired_trials(ws):
     )
     db.commit()
 
-    assert sweep_expired_trials(db) == 1
-
+    # Now sweep — this workspace should be torn down.
+    sweep_expired_trials(db)
     plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
     assert plan == "free"
-
     lifecycle = db.execute(
         text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
         {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
     ).scalar()
     assert lifecycle == "expired"
-
-    # Second sweep finds nothing left to tear down.
-    assert sweep_expired_trials(db) == 0

--- a/apps/api/tests/test_trial_teardown.py
+++ b/apps/api/tests/test_trial_teardown.py
@@ -1,0 +1,151 @@
+"""Trial teardown self-check (epic #1587 Round C).
+
+Mirrors the fixture pattern in test_trial_seed.py — skip module when
+Postgres is unreachable, workspace cascade-deletes seeded rows on teardown.
+"""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial  # noqa: E402
+from app.modules.guard.trial_teardown import teardown_trial  # noqa: E402
+
+
+@pytest.fixture()
+def ws():
+    db = SessionLocal()
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, 'free', true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"trial-tear-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "now": now},
+    )
+    db.commit()
+    try:
+        yield ws_id, db
+    finally:
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+        db.commit()
+        db.close()
+
+
+def _count(db, sql: str, params: dict) -> int:
+    return db.execute(text(sql), params).scalar() or 0
+
+
+def test_teardown_removes_all_trial_artifacts(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    changed = teardown_trial(db, ws_id)
+    db.commit()
+    assert changed is True
+
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free"
+
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "expired"
+
+    assert _count(db, "SELECT COUNT(*) FROM guard_rate_limits WHERE workspace_id = :ws AND agent_identity_id IS NULL", {"ws": ws_id}) == 0
+    assert _count(db, "SELECT COUNT(*) FROM guard_spend_budgets WHERE workspace_id = :ws AND clerk_user_id IS NULL", {"ws": ws_id}) == 0
+
+
+def test_teardown_is_idempotent(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    assert teardown_trial(db, ws_id) is True
+    db.commit()
+    assert teardown_trial(db, ws_id) is False
+    db.commit()
+
+
+def test_teardown_noop_when_no_trial(ws):
+    """Workspace never had a trial — teardown returns False, nothing changes."""
+    ws_id, db = ws
+    plan_before = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert teardown_trial(db, ws_id) is False
+    db.commit()
+    plan_after = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan_before == plan_after == "free"
+
+
+from app.modules.guard.trial_teardown import sweep_expired_trials  # noqa: E402
+
+
+def test_sweep_tears_down_only_expired_trials(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    # Nothing has expired yet — sweep is a no-op.
+    assert sweep_expired_trials(db) == 0
+
+    # Force this trial's identity into the past.
+    db.execute(
+        text(
+            "UPDATE agent_identities SET expires_at = :past "
+            "WHERE workspace_id = :ws AND name = :name"
+        ),
+        {
+            "past": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "ws": ws_id,
+            "name": TRIAL_IDENTITY_NAME,
+        },
+    )
+    db.commit()
+
+    assert sweep_expired_trials(db) == 1
+
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free"
+
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "expired"
+
+    # Second sweep finds nothing left to tear down.
+    assert sweep_expired_trials(db) == 0


### PR DESCRIPTION
## Summary

Closes the loop on trial teardown — commits the previously uncommitted `teardown_trial()` primitive AND adds the missing time-based sweeper daemon.

Two triggers now flow through the same code path:

1. **Real-provider connect** (`teardown_trial`) — was coded, uncommitted since 2026-09-04 Round C. Called by the credential-save handler when a workspace on `free_trial` saves its own LLM key.
2. **Time-based expiry** (`sweep_expired_trials` + `_trial_teardown_loop`) — new. Worker daemon periodically finds trial identities where `expires_at IS NOT NULL AND expires_at < now()` and tears them down.

### What's added

- `apps/api/app/modules/guard/trial_teardown.py`
  - `teardown_trial(db, workspace_id) -> bool` — the primitive (workspaces.plan → 'free', agent_identities.lifecycle_state → 'expired', delete workspace-default rate-limits + spend-budgets). Idempotent, never raises.
  - `sweep_expired_trials(db) -> int` — queries and calls `teardown_trial()` for each expired trial identity.
- `apps/api/app/worker.py`
  - `TRIAL_TEARDOWN_INTERVAL` env-configurable constant (default 3600s).
  - `_trial_teardown_loop()` daemon.
  - Thread registered in `main()` alongside reaper/watchdog/online-eval.
- `apps/api/tests/test_trial_teardown.py`
  - `test_teardown_removes_all_trial_artifacts`
  - `test_teardown_is_idempotent`
  - `test_teardown_noop_when_no_trial`
  - `test_sweep_tears_down_only_expired_trials` (new)

### How to configure

- `TRIAL_TEARDOWN_INTERVAL=3600` (seconds) — default 1 hour.
- Trials naturally expire 7 days after seed (from `trial_seed.TRIAL_DAYS`).

## Test plan

- [ ] CI green (tests skip locally when Postgres unreachable; ratchet + drift checks stay clean)
- [ ] `feat/trial-teardown-sweeper` deploys to Render — verify log line `trial_teardown.started interval_seconds=3600` appears in worker startup
- [ ] Insert a synthetic expired trial identity in staging → wait one interval → verify `trial_teardown.cycle swept=1` log + workspace plan reverted to 'free'
- [ ] Real-provider connect path: save an Anthropic key on a trial workspace → verify identity flips to 'expired' immediately (unchanged behavior)

Refs #1712 — Track 1 quick win 1/3.