### PR TITLE
feat(guard): block-receipt deep-link + Lens seed + hook printer (#1712 Track 1)

### DIFF
--- a/apps/api/alembic/versions/0116_guard_audit_share_token_hash.py
+++ b/apps/api/alembic/versions/0116_guard_audit_share_token_hash.py
@@ -1,0 +1,31 @@
+"""Add share_token_hash to guard_audit_events for anonymous trial receipts (#1712 Track 1).
+
+Column is nullable and stays NULL for workspace-authenticated blocks. Trial
+blocks store sha256(cond_bkr_*) so an anonymous signup user can view their
+own block receipt via /api/guard/blocks/public/{id}/{token}.
+
+Revision ID: 0116
+Revises: 0115
+Create Date: 2026-09-07
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0116"
+down_revision = "0115"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "guard_audit_events",
+        sa.Column("share_token_hash", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("guard_audit_events", "share_token_hash")

--- a/apps/api/app/guard/audit.py
+++ b/apps/api/app/guard/audit.py
@@ -123,12 +123,20 @@ def record(
     conductai_workflow_id: str | None = None, hook_session_id: str | None = None,
     evaluated_rules: list[dict] | None = None, defense_score: int | None = None,
     routing_meta: dict | None = None,
+    receipt_id: str | None = None,
+    share_token_hash: str | None = None,
 ) -> None:
     """Background task — best-effort audit write, never blocks the response.
 
     Writes one row to guard_audit_events with tokens, cost, rule, decision,
     and provenance metadata. On BLOCK decisions, also fires a Slack notification
-    via events.notify_guard_block (best-effort — swallows failures)."""
+    via events.notify_guard_block (best-effort — swallows failures).
+
+    `receipt_id` is a pre-minted row id so the caller can return
+    `receipt_url` in the block response before this background task runs.
+    `share_token_hash` (sha256 of a raw short-lived token) is populated
+    only for trial calls, so the anonymous public receipt endpoint can
+    authorize a stranger reading their own block."""
     db = SessionLocal()
     try:
         set_workspace_rls(db, workspace_id)
@@ -137,9 +145,16 @@ def record(
             # ponytail: blocked call — estimate what vendor would have consumed
             in_tokens, out_tokens = _estimate_input_tokens(body), 0
         cost_usd = _compute_cost(provider, model, in_tokens, out_tokens)
+        # Mint id in Python — pgcrypto/gen_random_uuid isn't guaranteed to be
+        # loaded on every deploy, so we don't rely on it. Caller may pre-mint
+        # (block path) so the response can reference the row before the
+        # background write lands.
+        import uuid as _uuid
+        row_id = receipt_id or str(_uuid.uuid4())
         db.execute(
             text("""
                 INSERT INTO guard_audit_events (
+                  id,
                   workspace_id, clerk_user_id, ai_tool, tool_call,
                   source, provider, model,
                   decision, rule_id, ts,
@@ -148,8 +163,10 @@ def record(
                   conductai_run_id, conductai_workflow, conductai_workflow_id,
                   hook_session_id,
                   evaluated_rules, defense_score,
-                  routing_meta
+                  routing_meta,
+                  share_token_hash
                 ) VALUES (
+                  CAST(:row_id AS uuid),
                   :ws, :uid, :ai, NULL,
                   'proxy', :prov, :model,
                   :dec, :rid, :ts,
@@ -158,10 +175,12 @@ def record(
                   :run_id, :workflow, :workflow_id,
                   :hook_session_id,
                   CAST(:eval AS jsonb), :score,
-                  CAST(:routing AS jsonb)
+                  CAST(:routing AS jsonb),
+                  :share_token_hash
                 )
             """),
             {
+                "row_id": row_id,
                 "ws": workspace_id, "uid": clerk_user_id,
                 "ai": ai_tool,
                 "prov": provider, "model": model,
@@ -178,6 +197,7 @@ def record(
                 "eval": json.dumps(evaluated_rules) if evaluated_rules else None,
                 "score": defense_score,
                 "routing": json.dumps(routing_meta) if routing_meta else None,
+                "share_token_hash": share_token_hash,
             },
         )
         db.commit()

--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -88,12 +88,17 @@ async def guarded_completion(
     conductai_workflow_id: str | None = None,
     hook_session_id: str | None = None,
     agent_identity_id: str | None = None,
+    is_trial: bool = False,
 ) -> StreamingResponse | JSONResponse:
     """Evaluate policy, dispatch to upstream if allowed, schedule audit.
 
     This is the ONE code path that must be true for every LLM call — HTTP
     proxy, Lens, per-tool guard_check. If a caller needs a variant, add a
     parameter here; do not fork the composition."""
+    import uuid as _uuid
+    from app.guard.receipts import build_receipt_url as _build_receipt_url
+    from app.guard.receipts import mint_share_token as _mint_share_token
+
     started = time.monotonic()
 
     # #1254 — composable policy engine (#1225). RulePolicySource inside
@@ -125,6 +130,12 @@ async def guarded_completion(
     )
 
     if decision.action == "BLOCK":
+        _receipt_id = str(_uuid.uuid4())
+        _share_token: str | None = None
+        _share_token_hash: str | None = None
+        if is_trial:
+            _share_token, _share_token_hash = _mint_share_token()
+        _receipt_url = _build_receipt_url(_receipt_id, _share_token)
         background.add_task(
             _record_audit,
             workspace_id, clerk_user_id, ai_tool, provider, model,
@@ -138,10 +149,14 @@ async def guarded_completion(
             hook_session_id=hook_session_id,
             evaluated_rules=decision.matched_rules,
             defense_score=decision.defense_score,
+            receipt_id=_receipt_id,
+            share_token_hash=_share_token_hash,
         )
         return _router.fail_closed(
             403,
-            f"Blocked by Guard rule {decision.rule_id}: {decision.message or 'policy violation'}",
+            f"Blocked by Guard rule {decision.rule_id}: {decision.message or 'policy violation'}"
+            f"\n→ Receipt: {_receipt_url}",
+            extra={"receipt_id": _receipt_id, "receipt_url": _receipt_url},
         )
 
     audit_args: tuple[Any, ...] = (
@@ -188,6 +203,8 @@ async def guarded_llm_call(
     vendor_key: str | None = None,
     extra_headers: dict | None = None,
     agent_identity_id: str | None = None,
+    hook_session_id: str | None = None,
+    is_trial: bool = False,
 ) -> dict:
     """In-process, non-streaming Lens sibling of `guarded_completion`.
 
@@ -226,6 +243,8 @@ async def guarded_llm_call(
         vendor_key=vendor_key,
         extra_headers=extra_headers,
         agent_identity_id=agent_identity_id,
+        hook_session_id=hook_session_id,
+        is_trial=is_trial,
     )
 
     # Drive the scheduled audit writes now — no request lifecycle to run them for us.
@@ -321,6 +340,7 @@ def guarded_client_call(
     agent_identity_id: str | None = None,
     prompt_summary: str = "",
     user_email: str | None = None,
+    hook_session_id: str | None = None,
 ):
     """Policy-checked LLMClient.create — same policy engine as guarded_completion.
 
@@ -362,6 +382,7 @@ def guarded_client_call(
                 int((_time.monotonic() - started) * 1000),
                 body=body, response_bytes=None,
                 prompt_summary=prompt_summary, user_email=user_email,
+                hook_session_id=hook_session_id,
             )
         except Exception as e:
             log.warning("guarded_client_call.audit_block_failed", err=str(e))
@@ -389,6 +410,7 @@ def guarded_client_call(
             int((_time.monotonic() - started) * 1000),
             body=body, response_bytes=synth,
             prompt_summary=prompt_summary, user_email=user_email,
+            hook_session_id=hook_session_id,
         )
     except Exception as e:
         log.warning("guarded_client_call.audit_allow_failed", err=str(e))
@@ -411,6 +433,7 @@ def guarded_client_stream(
     agent_identity_id: str | None = None,
     prompt_summary: str = "",
     user_email: str | None = None,
+    hook_session_id: str | None = None,
 ) -> str:
     """Policy-checked LLMClient.stream — text-only synthesis path.
 
@@ -449,6 +472,7 @@ def guarded_client_stream(
                 int((_time.monotonic() - started) * 1000),
                 body=body, response_bytes=None,
                 prompt_summary=prompt_summary, user_email=user_email,
+                hook_session_id=hook_session_id,
             )
         except Exception as e:
             log.warning("guarded_client_stream.audit_block_failed", err=str(e))
@@ -479,6 +503,7 @@ def guarded_client_stream(
             int((_time.monotonic() - started) * 1000),
             body=body, response_bytes=None,
             prompt_summary=prompt_summary, user_email=user_email,
+            hook_session_id=hook_session_id,
         )
     except Exception as e:
         log.warning("guarded_client_stream.audit_allow_failed", err=str(e))
@@ -501,6 +526,7 @@ def guarded_llm_stream(
     clerk_user_id: str = "system:lens",
     db=None,
     agent_identity_id: str | None = None,
+    hook_session_id: str | None = None,
 ) -> str:
     """Streaming, in-process sibling of `guarded_llm_call` for OpenAI-shape SSE.
 
@@ -554,6 +580,7 @@ def guarded_llm_stream(
                 prompt_summary=f"{ai_tool}.stream",
                 evaluated_rules=decision.matched_rules,
                 defense_score=decision.defense_score,
+                hook_session_id=hook_session_id,
             )
         except Exception:
             pass
@@ -604,6 +631,7 @@ def guarded_llm_stream(
             prompt_summary=f"{ai_tool}.stream",
             evaluated_rules=decision.matched_rules,
             defense_score=decision.defense_score,
+            hook_session_id=hook_session_id,
         )
     except Exception as e:
         log.warning("guarded_llm_stream.audit_failed", err=str(e))

--- a/apps/api/app/guard/receipts.py
+++ b/apps/api/app/guard/receipts.py
@@ -1,0 +1,40 @@
+"""Block receipt URL builder — the deep-link every block response carries.
+
+`build_receipt_url(receipt_id)` returns the workspace-authenticated URL
+(requires login). `build_receipt_url(receipt_id, share_token=...)` returns
+the anonymous public URL for trial signup users — the token is hashed with
+sha256 and the hash is stored on the audit row (see `guard.audit.record`).
+
+Reuses the same `CONDUCT_WEB_URL` env var pattern as `approval_url` in
+`app.modules.guard.approval` so trial + workspace + approval deep-links all
+resolve against the same host.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import secrets
+
+SHARE_TOKEN_PREFIX = "cond_bkr_"
+
+
+def _base_url() -> str:
+    return (os.environ.get("CONDUCT_WEB_URL") or "https://conductai.ai").rstrip("/")
+
+
+def mint_share_token() -> tuple[str, str]:
+    """Return (raw_token, sha256_hash). Store the hash on the audit row,
+    hand the raw back to the caller (embedded in the receipt URL)."""
+    raw = SHARE_TOKEN_PREFIX + secrets.token_urlsafe(24)
+    return raw, hashlib.sha256(raw.encode()).hexdigest()
+
+
+def hash_share_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode()).hexdigest()
+
+
+def build_receipt_url(receipt_id: str, share_token: str | None = None) -> str:
+    """Workspace URL requires login; public URL embeds the raw token in the path."""
+    if share_token:
+        return f"{_base_url()}/b/{receipt_id}/{share_token}"
+    return f"{_base_url()}/theguard/blocks/{receipt_id}"

--- a/apps/api/app/guard/router.py
+++ b/apps/api/app/guard/router.py
@@ -35,12 +35,21 @@ log = structlog.get_logger(__name__)
 
 # ─── Public helpers ───────────────────────────────────────────────────────────
 
-def fail_closed(status: int, message: str) -> JSONResponse:
-    """Security tool failing open is worse than no tool. Surface clear errors."""
-    return JSONResponse(
-        status_code=status,
-        content={"error": {"type": "conduct_guard_proxy", "message": message}},
-    )
+def fail_closed(
+    status: int,
+    message: str,
+    *,
+    extra: dict | None = None,
+) -> JSONResponse:
+    """Security tool failing open is worse than no tool. Surface clear errors.
+
+    `extra` merges into `error.metadata` so blocks can carry structured
+    fields (receipt_id, receipt_url) without breaking the canonical shape.
+    """
+    err: dict = {"type": "conduct_guard_proxy", "message": message}
+    if extra:
+        err["metadata"] = extra
+    return JSONResponse(status_code=status, content={"error": err})
 
 
 # ─── Private helpers ──────────────────────────────────────────────────────────

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -23,6 +23,7 @@ from app.modules.guard.routers import token_guardrails as guard_token_guardrails
 from app.modules.guard.routers import notifications as guard_notifications
 from app.modules.guard.routers import trial as guard_trial
 from app.modules.guard.routers import approvals as guard_approvals
+from app.modules.guard.routers import blocks as guard_blocks
 from app.modules.guard.routers import session_reports as guard_session_reports
 from app.modules.guard.routers import mcp as guard_mcp
 from app.modules.guard.routers import proxy as guard_proxy
@@ -161,6 +162,7 @@ app.include_router(guard_token_guardrails.router)
 app.include_router(guard_notifications.router)
 app.include_router(guard_trial.router)
 app.include_router(guard_approvals.router)
+app.include_router(guard_blocks.router)
 app.include_router(guard_session_reports.router)
 app.include_router(guard_mcp.router)
 app.include_router(guard_mcp.well_known_router)

--- a/apps/api/app/modules/glens/executor.py
+++ b/apps/api/app/modules/glens/executor.py
@@ -14,9 +14,20 @@ from sqlalchemy.orm import Session
 
 class Executor:
 
-    def __init__(self, db: Session, workspace_id: str, agent_identity_id: str | None = None):
+    def __init__(
+        self,
+        db: Session,
+        workspace_id: str,
+        agent_identity_id: str | None = None,
+        session_id: str | None = None,
+    ):
         self.db = db
         self.workspace_id = workspace_id
         # Set on chat endpoints so guarded_llm_call/stream can attribute egress
         # to the session-scoped AgentIdentity. None outside chat (tool registrations).
         self.agent_identity_id = agent_identity_id
+        # Lens chat session id — threaded into guarded_llm_call/stream as
+        # hook_session_id so audit rows link a block back to the Lens
+        # conversation that produced it (#1712 Track 1 quick win 3/3).
+        # None outside chat (tool registrations, headless callers).
+        self.session_id = session_id

--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -563,6 +563,7 @@ def _guarded_openai_completion(executor: Executor, provider: str, model: str,
             clerk_user_id="system:lens",
             agent_identity_id=executor.agent_identity_id,
             prompt_summary="lens.resolve_tools",
+            hook_session_id=executor.session_id,
         )
     except _Blocked as blk:
         raise Exception(f"Guard blocked Lens call: {blk.detail}") from blk
@@ -660,6 +661,7 @@ def _stream_synthesis(msgs: list[dict], system: str, executor: Executor, on_toke
         clerk_user_id="system:lens",
         agent_identity_id=executor.agent_identity_id,
         prompt_summary="lens.synthesis",
+        hook_session_id=executor.session_id,
     )
     return text or "Could not complete the analysis."
 
@@ -759,7 +761,11 @@ async def glens_chat_stream(
     session_messages = json.loads(session.messages)
     session_messages.append({"role": "user", "content": req.message})
     session_id_str = str(session.id)
-    executor = Executor(db, workspace_id, agent_identity_id=session.agent_identity_id)
+    executor = Executor(
+        db, workspace_id,
+        agent_identity_id=session.agent_identity_id,
+        session_id=session_id_str,
+    )
 
     _now = datetime.now(timezone.utc)
     today = _now.strftime("%Y-%m-%d")

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -220,6 +220,10 @@ class GuardAuditEvent(Base):
         ForeignKey("agent_identities.id", ondelete="SET NULL"),
         nullable=True,
     )
+    # Added by revision 0116 — sha256 of a short-lived share token, present
+    # only for trial-workspace blocks. Enables anonymous receipt lookup for
+    # signup users who don't yet have a login; workspace rows leave it NULL.
+    share_token_hash = Column(Text, nullable=True)
 
     __table_args__ = (
         Index("ix_guard_audit_events_source", "workspace_id", "source", "ts"),

--- a/apps/api/app/modules/guard/routers/_proxy_helpers.py
+++ b/apps/api/app/modules/guard/routers/_proxy_helpers.py
@@ -17,74 +17,100 @@ def render_block(
     decision, background, workspace_id, clerk_user_id, ai_tool, provider,
     model, body, prompt_summary, user_email, run_id, workflow,
     workflow_id, hook_session_id, started, record_audit_fn, fail_closed_fn,
+    *, is_trial: bool = False,
 ):
+    from app.guard.receipts import build_receipt_url, mint_share_token
+
     source = decision.source
     extras = decision.extras or {}
     duration_ms = int((time.monotonic() - started) * 1000)
 
-    if source == "rule":
-        background.add_task(
-            record_audit_fn, workspace_id, clerk_user_id, ai_tool, provider, model,
-            "blocked", decision.rule_id, duration_ms,
+    # Pre-mint the audit row id so the response can carry a link to it
+    # before the background audit write completes. Trial rows also get a
+    # short-lived share token so anonymous signup users can view their
+    # own receipt without logging in.
+    receipt_id = str(uuid.uuid4())
+    share_token: str | None = None
+    share_token_hash: str | None = None
+    if is_trial:
+        share_token, share_token_hash = mint_share_token()
+    receipt_url = build_receipt_url(receipt_id, share_token)
+
+    def _audit(decision_str: str, rule_id: str | None, *, with_verdict: bool):
+        kwargs = dict(
             body=body, response_bytes=None,
             prompt_summary=prompt_summary, user_email=user_email,
             conductai_run_id=run_id, conductai_workflow=workflow,
             conductai_workflow_id=workflow_id, hook_session_id=hook_session_id,
-            evaluated_rules=decision.matched_rules,
-            defense_score=decision.defense_score,
+            receipt_id=receipt_id,
+            share_token_hash=share_token_hash,
         )
+        if with_verdict:
+            kwargs["evaluated_rules"] = decision.matched_rules
+            kwargs["defense_score"] = decision.defense_score
+        background.add_task(
+            record_audit_fn, workspace_id, clerk_user_id, ai_tool, provider, model,
+            decision_str, rule_id, duration_ms, **kwargs,
+        )
+
+    # Embed the receipt URL in the message itself so every SDK that raises
+    # on `error.message` (Anthropic, OpenAI, LiteLLM, LangChain, raw curl)
+    # surfaces the link with zero per-integration wiring. Structured fields
+    # stay next to it for plugins that want machine-readable access.
+    def _with_receipt(msg: str | None) -> str:
+        base = msg or "Blocked by policy"
+        return f"{base}\n→ Receipt: {receipt_url}"
+
+    if source == "rule":
+        _audit("blocked", decision.rule_id, with_verdict=True)
         err = {
             "type": "guard_block",
-            "message": decision.reason,
+            "message": _with_receipt(decision.reason),
             "rule": decision.rule_id,
             "matched_rules": decision.matched_rules,
             "defense_score": decision.defense_score,
+            "receipt_id": receipt_id,
+            "receipt_url": receipt_url,
         }
         if decision.inject_guidance and decision.guidance:
             err["guidance"] = decision.guidance
         return JSONResponse(status_code=403, content={"error": err})
 
     if source == "spend_cap":
-        background.add_task(
-            record_audit_fn, workspace_id, clerk_user_id, ai_tool, provider, model,
-            "budget_exceeded", None, duration_ms,
-            body=body, response_bytes=None,
-            prompt_summary=prompt_summary, user_email=user_email,
-            conductai_run_id=run_id, conductai_workflow=workflow,
-            conductai_workflow_id=workflow_id, hook_session_id=hook_session_id,
-        )
+        _audit("budget_exceeded", None, with_verdict=False)
         return JSONResponse(
             status_code=429,
             content={"error": {
                 "type": "guard_budget_exceeded",
-                "message": decision.reason or "Monthly AI budget reached.",
+                "message": _with_receipt(decision.reason or "Monthly AI budget reached."),
                 "monthly_cost_usd": extras.get("monthly_cost_usd"),
                 "hard_limit_usd": extras.get("hard_limit_usd"),
+                "receipt_id": receipt_id,
+                "receipt_url": receipt_url,
             }},
         )
 
     if source == "throughput_cap":
-        background.add_task(
-            record_audit_fn, workspace_id, clerk_user_id, ai_tool, provider, model,
-            "rate_limited", None, duration_ms,
-            body=body, response_bytes=None,
-            prompt_summary=prompt_summary, user_email=user_email,
-            conductai_run_id=run_id, conductai_workflow=workflow,
-            conductai_workflow_id=workflow_id, hook_session_id=hook_session_id,
-        )
+        _audit("rate_limited", None, with_verdict=False)
         return JSONResponse(
             status_code=429,
             content={"error": {
                 "type": "guard_rate_limited",
-                "message": decision.reason,
+                "message": _with_receipt(decision.reason),
                 "metric": extras.get("metric"),
                 "limit": extras.get("limit"),
                 "current": extras.get("current"),
                 "scope": extras.get("scope"),
+                "receipt_id": receipt_id,
+                "receipt_url": receipt_url,
             }},
         )
 
-    return fail_closed_fn(403, decision.reason or "Blocked by policy")
+    return fail_closed_fn(
+        403,
+        _with_receipt(decision.reason or "Blocked by policy"),
+        extra={"receipt_id": receipt_id, "receipt_url": receipt_url},
+    )
 
 
 def render_approval(

--- a/apps/api/app/modules/guard/routers/blocks.py
+++ b/apps/api/app/modules/guard/routers/blocks.py
@@ -1,0 +1,107 @@
+"""Block receipt endpoints (#1712 Track 1 quick win 2/3).
+
+Every Guard block response carries `receipt_id` + `receipt_url` so an SDK
+error message can jump straight to a Lens receipt page. Two read paths:
+
+- ``GET /guard/blocks/{id}`` — workspace-authenticated. Any member with
+  ``guard.activity.view_own`` can read blocks in their own workspace.
+- ``GET /guard/blocks/public/{id}/{token}`` — no auth. The receipt row must
+  have a ``share_token_hash`` (populated only for trial workspaces) that
+  matches sha256(token), and the row's workspace must still be plan='trial'
+  at read time (so a converted paid workspace can't leak old trial receipts).
+
+Payload is a redacted subset of the audit row — enough to render the
+receipt card + seed a Lens chat about the block, without exposing raw
+prompts or PII to arbitrary link recipients.
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+
+import structlog
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.core.auth import get_workspace_id, require_permission
+from app.core.database import get_db
+from app.guard.receipts import hash_share_token
+
+log = structlog.get_logger(__name__)
+
+router = APIRouter(prefix="/guard/blocks", tags=["guard-blocks"])
+
+
+def _row_to_receipt(row) -> dict:
+    """Redacted receipt payload. Keeps rule + decision + provider context
+    but strips the raw prompt — the summary already lives in input_summary
+    which is bounded to 200 chars and pre-redacted upstream."""
+    return {
+        "receipt_id": str(row.id),
+        "ts": row.ts.isoformat() if row.ts else None,
+        "decision": row.decision,
+        "rule_id": row.rule_id,
+        "rule_message": row.rule_message,
+        "provider": row.provider,
+        "model": row.model,
+        "ai_tool": row.ai_tool,
+        "input_summary": row.input_summary,
+        "evaluated_rules": row.evaluated_rules,
+        "defense_score": row.defense_score,
+        "conductai_run_id": row.conductai_run_id,
+        "hook_session_id": row.hook_session_id,
+    }
+
+
+def _fetch_blocked(db: Session, receipt_id: _uuid.UUID):
+    return db.execute(
+        text("""
+            SELECT id, workspace_id, ts, decision, rule_id, rule_message,
+                   provider, model, ai_tool, input_summary,
+                   evaluated_rules, defense_score,
+                   conductai_run_id, hook_session_id,
+                   share_token_hash
+            FROM guard_audit_events
+            WHERE id = :id
+              AND decision IN ('blocked', 'budget_exceeded', 'rate_limited')
+            LIMIT 1
+        """),
+        {"id": str(receipt_id)},
+    ).fetchone()
+
+
+@router.get("/{receipt_id}")
+def get_receipt(
+    receipt_id: _uuid.UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+):
+    """Workspace-scoped receipt read. Cross-workspace requests get 404."""
+    row = _fetch_blocked(db, receipt_id)
+    if row is None or str(row.workspace_id) != str(workspace_id):
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+    return _row_to_receipt(row)
+
+
+@router.get("/public/{receipt_id}/{token}")
+def get_receipt_public(
+    receipt_id: _uuid.UUID,
+    token: str,
+    db: Session = Depends(get_db),
+):
+    """Anonymous receipt read for trial signup users. Hash-check the token
+    against the row and re-verify the workspace is still on the trial plan
+    — a converted paid workspace must not leak old trial receipts."""
+    row = _fetch_blocked(db, receipt_id)
+    if row is None or not row.share_token_hash:
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+    if row.share_token_hash != hash_share_token(token):
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+    plan = db.execute(
+        text("SELECT plan FROM workspaces WHERE id = :ws"),
+        {"ws": str(row.workspace_id)},
+    ).scalar()
+    if plan != "trial":
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+    return _row_to_receipt(row)

--- a/apps/api/app/modules/guard/routers/events.py
+++ b/apps/api/app/modules/guard/routers/events.py
@@ -80,6 +80,11 @@ class HookEvent(BaseModel):
     # #1150 phase 1 — layered verdict envelope; hooks may forward the same shape
     evaluated_rules: list[dict] | None = None
     defense_score: int | None = None
+    # #1712 Track 1 — hook-side pre-minted receipt id. When present the
+    # audit row's PK is set to this uuid so the URL the hook printed to
+    # stderr resolves to the row we just wrote. Optional; when absent the
+    # row gets its usual server-generated uuid and no receipt is emitted.
+    receipt_id: str | None = None
 
 
 class UsageUpdate(BaseModel):
@@ -580,7 +585,14 @@ def ingest_event(
     policy_hash = get_policy_hash(db, ws_uuid)
 
     # 2. Write the audit event
+    _event_id: uuid.UUID | None = None
+    if body.receipt_id:
+        try:
+            _event_id = uuid.UUID(body.receipt_id)
+        except ValueError:
+            _event_id = None
     event = GuardAuditEvent(
+        id=_event_id or uuid.uuid4(),
         workspace_id=ws_uuid,
         clerk_user_id=body.clerk_user_id,
         session_id=body.session_id,

--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -443,6 +443,21 @@ async def _proxy(
         _environment_id = request.headers.get("x-conductai-environment-id") or None
         _hook_session_id = request.headers.get("x-conduct-session-id") or None
 
+        # #1712 Track 1 quick win — trial-plan lookup before policy eval so a
+        # BLOCK response can carry an anonymous receipt URL (Priya use case:
+        # Cursor error → click → land in Lens receipt with no login). Cheap
+        # single-row read against an indexed PK; failure falls back to
+        # workspace-only receipt URL. Reused inside _render_block via kwarg.
+        _is_trial = False
+        try:
+            _plan = db.execute(
+                text("SELECT plan FROM workspaces WHERE id = :ws"),
+                {"ws": workspace_id},
+            ).scalar()
+            _is_trial = (_plan == "trial")
+        except Exception:
+            pass
+
         # 4c. Pre-call Guard policy evaluation — composed engine (#1225 Phase 4)
         prompt_summary = _flatten_prompt(body)[:200]
         from app.guard.policy import evaluate_composed as _eval_composed
@@ -477,6 +492,7 @@ async def _proxy(
                 _pd, background, workspace_id, clerk_user_id, ai_tool, provider,
                 model, body, prompt_summary, _user_email, _run_id, _workflow,
                 _workflow_id, _hook_session_id, started, _record_audit, _fail_closed,
+                is_trial=_is_trial,
             )
 
         if _pd.needs_approval:

--- a/apps/api/app/modules/guard/trial_teardown.py
+++ b/apps/api/app/modules/guard/trial_teardown.py
@@ -1,0 +1,122 @@
+"""Trial teardown on real-provider connect (epic #1587 Round C).
+
+When a workspace on `plan='free_trial'` saves a real LLM-provider credential
+via `POST /credentials`, the trial has done its job. Deactivate the trial
+identity, drop the workspace-default rate-limit + spend-budget rows minted
+by `trial_seed.seed_trial`, and flip the plan back to `free`. Idempotent:
+safe to call on a workspace that never had a trial or has already been torn
+down. Never raises — a teardown failure must not block the credential save.
+
+The provider set starts at just `anthropic` — the only provider funded by
+`GUARD_TRIAL_ANTHROPIC_KEY` today. When Round D adds funded upstreams for
+other providers (openai, groq, ...), add each to `TRIAL_TEARDOWN_PROVIDERS`
+so connecting them also ends the trial.
+"""
+from __future__ import annotations
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
+
+log = structlog.get_logger(__name__)
+
+# Services whose real-key connect signals "the trial has done its job".
+# Grows with Round D as funded upstreams land for more providers.
+TRIAL_TEARDOWN_PROVIDERS: set[str] = {"anthropic"}
+
+
+def teardown_trial(db: Session, workspace_id: str) -> bool:
+    """Deactivate any active trial artifacts on `workspace_id`. Idempotent.
+
+    Returns True if any row was actually changed, False if the workspace had
+    nothing to tear down (never on trial, or already torn down). Caller
+    commits. Never raises.
+    """
+    ws = str(workspace_id)
+    changed = False
+    try:
+        plan_res = db.execute(
+            text("UPDATE workspaces SET plan = 'free' WHERE id = :ws AND plan = :trial"),
+            {"ws": ws, "trial": TRIAL_PLAN},
+        )
+        if plan_res.rowcount:
+            changed = True
+
+        id_res = db.execute(
+            text("""
+                UPDATE agent_identities
+                SET lifecycle_state = 'expired'
+                WHERE workspace_id = :ws
+                  AND name = :name
+                  AND lifecycle_state = 'active'
+            """),
+            {"ws": ws, "name": TRIAL_IDENTITY_NAME},
+        )
+        if id_res.rowcount:
+            changed = True
+
+        rl_res = db.execute(
+            text("""
+                DELETE FROM guard_rate_limits
+                WHERE workspace_id = :ws AND agent_identity_id IS NULL
+            """),
+            {"ws": ws},
+        )
+        if rl_res.rowcount:
+            changed = True
+
+        sb_res = db.execute(
+            text("""
+                DELETE FROM guard_spend_budgets
+                WHERE workspace_id = :ws AND clerk_user_id IS NULL
+            """),
+            {"ws": ws},
+        )
+        if sb_res.rowcount:
+            changed = True
+
+        if changed:
+            log.info("guard.trial.torn_down", workspace_id=ws)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.trial.teardown_failed", workspace_id=ws, err=str(exc))
+        return False
+    return changed
+
+
+def sweep_expired_trials(db: Session) -> int:
+    """Tear down trials whose identity `expires_at` has passed. Idempotent.
+
+    Returns count of workspaces torn down. Called by the worker daemon on a
+    periodic interval. Never raises.
+    """
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    try:
+        rows = db.execute(
+            text(
+                """
+                SELECT DISTINCT workspace_id
+                FROM agent_identities
+                WHERE name = :name
+                  AND lifecycle_state = 'active'
+                  AND expires_at IS NOT NULL
+                  AND expires_at < :now
+                """
+            ),
+            {"name": TRIAL_IDENTITY_NAME, "now": now},
+        ).fetchall()
+    except Exception as exc:  # noqa: BLE001
+        log.warning("guard.trial.sweep_query_failed", err=str(exc))
+        return 0
+
+    torn = 0
+    for (ws_id,) in rows:
+        if teardown_trial(db, str(ws_id)):
+            torn += 1
+    if torn:
+        db.commit()
+        log.info("guard.trial.sweep_swept", count=torn)
+    return torn

--- a/apps/api/app/worker.py
+++ b/apps/api/app/worker.py
@@ -57,6 +57,7 @@ JUDGE_SAMPLE_RATE      = float(os.environ.get("ONLINE_EVAL_JUDGE_SAMPLE_RATE", "
 STALE_RUN_THRESHOLD_MINUTES        = int(os.environ.get("STALE_RUN_THRESHOLD_MINUTES", "20"))
 STALE_PENDING_THRESHOLD_MINUTES    = int(os.environ.get("STALE_PENDING_THRESHOLD_MINUTES", "10"))
 STALE_RUN_REAPER_INTERVAL          = int(os.environ.get("STALE_RUN_REAPER_INTERVAL", "120"))  # seconds
+TRIAL_TEARDOWN_INTERVAL            = int(os.environ.get("TRIAL_TEARDOWN_INTERVAL", "3600"))    # seconds
 AUTOMATION_PROJECT_RETENTION_DAYS  = int(os.environ.get("AUTOMATION_PROJECT_RETENTION_DAYS", "30"))
 
 
@@ -261,6 +262,24 @@ def _reaper_loop() -> None:
 
 # -- online eval scorer --------------------------------------------------------
 
+def _trial_teardown_loop() -> None:
+    """Daemon: periodically tear down trial workspaces whose identity has expired."""
+    from app.core.database import SessionLocal
+    from app.modules.guard.trial_teardown import sweep_expired_trials
+
+    log.info("trial_teardown.started", interval_seconds=TRIAL_TEARDOWN_INTERVAL)
+    while True:
+        time.sleep(TRIAL_TEARDOWN_INTERVAL)
+        try:
+            with SessionLocal() as db:
+                torn = sweep_expired_trials(db)
+            if torn:
+                log.info("trial_teardown.cycle", swept=torn)
+        except Exception:
+            log.exception("trial_teardown.loop_error")
+
+
+
 def _online_eval_loop() -> None:
     """Daemon thread: consume the online eval queue and score each completed run."""
     import random
@@ -384,6 +403,9 @@ def main() -> None:
 
     online_eval = threading.Thread(target=_online_eval_loop, daemon=True, name="online-eval")
     online_eval.start()
+
+    trial_teardown = threading.Thread(target=_trial_teardown_loop, daemon=True, name="trial-teardown")
+    trial_teardown.start()
 
     if CONCURRENCY == 1:
         _loop(0)

--- a/apps/api/scripts/check_auth_coverage.py
+++ b/apps/api/scripts/check_auth_coverage.py
@@ -74,6 +74,11 @@ ALLOWLIST = {
     "modules/guard/routers/events.py::ingest_event",
     "modules/guard/routers/events.py::update_usage",
     "modules/guard/routers/events.py::ingest_batch",
+    # Guard block receipt public read (#1712 — anonymous trial signup flow).
+    # Auth: sha256(share_token) in URL path must match share_token_hash on the
+    # audit row, AND the workspace must still be on the trial plan at read
+    # time. Never returns rows from paid workspaces.
+    "modules/guard/routers/blocks.py::get_receipt_public",
     # Guard budget check (workspace_id validated against guard_config — called pre-tool-use)
     "modules/guard/routers/spend.py::budget_check",
     # Telemetry ingest (auth via Authorization or X-Workspace-Id header — alternative auth)

--- a/apps/api/tests/guard/test_block_receipt.py
+++ b/apps/api/tests/guard/test_block_receipt.py
@@ -1,0 +1,367 @@
+"""#1712 Track 1 quick win 2/3 — block responses carry a receipt deep-link.
+
+Locks in these properties:
+  1. `_render_block` embeds `receipt_id` + `receipt_url` in the 403 payload
+  2. Trial callers get a `/b/{id}/{token}` URL; workspace callers get `/theguard/blocks/{id}`
+  3. `guarded_completion` BLOCK branch mirrors the same shape via fail_closed(extra=)
+  4. `hash_share_token` round-trips (mint → hash → verify)
+  5. The receipt URL builder honors CONDUCT_WEB_URL when set
+  6. `error.message` embeds the receipt URL for zero-integration SDK surfacing
+  7. `guarded_client_call` threads hook_session_id into the audit row
+  8. HTTP endpoints — workspace read, cross-workspace 404, public trial read, bad token 404
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import uuid as _uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi import BackgroundTasks
+from fastapi.responses import JSONResponse
+
+
+def _fake_rule_decision():
+    return SimpleNamespace(
+        source="rule",
+        rule_id="R-pii-leak",
+        reason="Blocked by test rule",
+        matched_rules=[{"id": "R-pii-leak", "severity": "block"}],
+        defense_score=99,
+        inject_guidance=False,
+        guidance=None,
+        extras={},
+    )
+
+
+def _payload(resp: JSONResponse) -> dict:
+    return json.loads(resp.body.decode())
+
+
+def test_render_block_returns_receipt_id_and_url_workspace_path():
+    from app.modules.guard.routers._proxy_helpers import render_block
+
+    bt = BackgroundTasks()
+    resp = render_block(
+        _fake_rule_decision(), bt,
+        workspace_id="00000000-0000-0000-0000-000000000001",
+        clerk_user_id="user_test", ai_tool="cursor",
+        provider="anthropic", model="claude-sonnet-4-5",
+        body={"messages": [{"role": "user", "content": "hi"}]},
+        prompt_summary="hi", user_email=None,
+        run_id=None, workflow=None, workflow_id=None, hook_session_id=None,
+        started=0.0, record_audit_fn=lambda *a, **kw: None,
+        fail_closed_fn=lambda s, m, **kw: JSONResponse(status_code=s, content={"error": {"message": m}}),
+        is_trial=False,
+    )
+
+    body = _payload(resp)
+    err = body["error"]
+    assert err["type"] == "guard_block"
+    assert "receipt_id" in err and err["receipt_id"]
+    # Workspace URL never contains the share-token segment
+    assert err["receipt_url"].endswith(f"/theguard/blocks/{err['receipt_id']}")
+    # Audit was scheduled with pre-minted receipt_id, no share_token_hash for non-trial
+    assert bt.tasks, "background audit task must be scheduled"
+    audit_kwargs = bt.tasks[0].kwargs
+    assert audit_kwargs["receipt_id"] == err["receipt_id"]
+    assert audit_kwargs["share_token_hash"] is None
+
+
+def test_render_block_trial_path_returns_public_receipt_url_and_share_hash():
+    from app.modules.guard.routers._proxy_helpers import render_block
+
+    bt = BackgroundTasks()
+    resp = render_block(
+        _fake_rule_decision(), bt,
+        workspace_id="00000000-0000-0000-0000-000000000002",
+        clerk_user_id="user_trial", ai_tool="cursor",
+        provider="anthropic", model="claude-sonnet-4-5",
+        body={"messages": []},
+        prompt_summary="hi", user_email=None,
+        run_id=None, workflow=None, workflow_id=None, hook_session_id=None,
+        started=0.0, record_audit_fn=lambda *a, **kw: None,
+        fail_closed_fn=lambda s, m, **kw: JSONResponse(status_code=s, content={}),
+        is_trial=True,
+    )
+
+    err = _payload(resp)["error"]
+    # Trial URL shape: /b/{id}/{token}
+    parts = err["receipt_url"].rsplit("/", 3)
+    assert parts[-3] == "b"
+    assert parts[-2] == err["receipt_id"]
+    raw_token = parts[-1]
+    assert raw_token.startswith("cond_bkr_")
+
+    # Hash on the audit row matches sha256(raw_token) — anonymous public
+    # endpoint uses this to authorize the reader.
+    from app.guard.receipts import hash_share_token
+    assert bt.tasks, "background audit task must be scheduled"
+    assert bt.tasks[0].kwargs["share_token_hash"] == hash_share_token(raw_token)
+
+
+def test_guarded_completion_block_carries_receipt_metadata():
+    from app.guard.gateway import guarded_completion
+    from app.guard.policy_types import PolicyAction
+
+    decision = SimpleNamespace(
+        action=PolicyAction.BLOCK,
+        rule_id="R-block-lens",
+        reason="lens block",
+        matched_rules=[{"id": "R-block-lens"}],
+        defense_score=88,
+        inject_guidance=False,
+        guidance=None,
+    )
+
+    with patch("app.guard.gateway._evaluate_composed", return_value=decision), \
+         patch("app.guard.router.upstream") as upstream_mock:
+        resp = asyncio.run(guarded_completion(
+            workspace_id="00000000-0000-0000-0000-000000000003",
+            clerk_user_id="", ai_tool="lens",
+            provider="anthropic", model="claude-sonnet-4-5",
+            body={"messages": []},
+            upstream_url="https://api.anthropic.com",
+            upstream_path="/v1/messages",
+            real_key="sk-test",
+            auth_header_out="x-api-key",
+            bearer=False, is_stream=False,
+            background=BackgroundTasks(),
+            is_trial=True,
+        ))
+
+    upstream_mock.assert_not_called()
+    body = _payload(resp)
+    meta = body["error"]["metadata"]
+    assert meta["receipt_id"]
+    # Trial URL from the gateway path
+    assert "/b/" in meta["receipt_url"] and meta["receipt_id"] in meta["receipt_url"]
+
+
+def test_share_token_hash_round_trip():
+    from app.guard.receipts import mint_share_token, hash_share_token
+
+    raw, digest = mint_share_token()
+    assert raw.startswith("cond_bkr_")
+    assert digest == hash_share_token(raw)
+    # Different mint = different digest
+    raw2, digest2 = mint_share_token()
+    assert digest != digest2
+
+
+def test_render_block_embeds_receipt_url_in_error_message():
+    """#1712 PR 4 — every SDK that raises on `error.message` should
+    surface the receipt URL without per-integration wiring."""
+    from app.modules.guard.routers._proxy_helpers import render_block
+
+    resp = render_block(
+        _fake_rule_decision(), BackgroundTasks(),
+        workspace_id="00000000-0000-0000-0000-000000000005",
+        clerk_user_id="user", ai_tool="cursor",
+        provider="anthropic", model="claude-sonnet-4-5",
+        body={"messages": []}, prompt_summary="hi", user_email=None,
+        run_id=None, workflow=None, workflow_id=None, hook_session_id=None,
+        started=0.0, record_audit_fn=lambda *a, **kw: None,
+        fail_closed_fn=lambda s, m, **kw: JSONResponse(status_code=s, content={}),
+        is_trial=False,
+    )
+    err = _payload(resp)["error"]
+    assert "→ Receipt:" in err["message"]
+    assert err["receipt_url"] in err["message"]
+
+
+def test_guarded_client_call_forwards_hook_session_id_to_audit(monkeypatch):
+    """#1712 Track 1 quick win 3/3 — Lens-in-process LLM calls now carry
+    the Lens chat session id into the audit row so a receipt links back to
+    the exact conversation that produced it. Previously the block was
+    orphaned (hook_session_id NULL) because guarded_client_call didn't
+    accept the field."""
+    from app.guard import gateway
+
+    recorded: dict = {}
+    def _fake_record(*args, **kwargs):
+        recorded["kwargs"] = kwargs
+
+    monkeypatch.setattr(gateway, "_record_audit", _fake_record)
+
+    # Compose a BLOCK decision so record() fires on the block path.
+    # guarded_client_call imports evaluate_composed locally, so patch the
+    # source module — not the alias inside gateway.
+    from app.guard import policy as _policy
+    from app.guard.policy_types import PolicyAction
+    fake = SimpleNamespace(
+        action=PolicyAction.BLOCK,
+        rule_id="R-lens-test",
+        reason="lens block",
+        matched_rules=[{"id": "R-lens-test"}],
+        defense_score=42,
+    )
+    monkeypatch.setattr(_policy, "evaluate_composed", lambda ctx: fake)
+
+    try:
+        gateway.guarded_client_call(
+            client=SimpleNamespace(),
+            workspace_id="00000000-0000-0000-0000-000000000004",
+            provider="anthropic",
+            model="claude-sonnet-4-5",
+            messages=[{"role": "user", "content": "hi"}],
+            system="",
+            hook_session_id="ses_abc123",
+        )
+    except gateway.GuardedLLMBlocked:
+        pass
+
+    assert recorded["kwargs"]["hook_session_id"] == "ses_abc123"
+
+
+def test_receipt_url_honors_conduct_web_url():
+    from app.guard.receipts import build_receipt_url
+
+    orig = os.environ.get("CONDUCT_WEB_URL")
+    try:
+        os.environ["CONDUCT_WEB_URL"] = "https://example.test"
+        assert build_receipt_url("abc").startswith("https://example.test/theguard/blocks/")
+        url = build_receipt_url("abc", "cond_bkr_xyz")
+        assert url == "https://example.test/b/abc/cond_bkr_xyz"
+    finally:
+        if orig is None:
+            del os.environ["CONDUCT_WEB_URL"]
+        else:
+            os.environ["CONDUCT_WEB_URL"] = orig
+
+
+# ─── HTTP endpoint tests ──────────────────────────────────────────────────────
+# TestClient smoke tests for GET /guard/blocks/{id} and the public path.
+# DB is mocked so we can drive different rows into a single test without
+# needing a real Postgres.
+
+def _make_audit_row(workspace_id: str, share_token_hash: str | None = None):
+    return SimpleNamespace(
+        id=_uuid.uuid4(),
+        workspace_id=_uuid.UUID(workspace_id),
+        ts=datetime.now(timezone.utc),
+        decision="blocked",
+        rule_id="R-test",
+        rule_message="Test block",
+        provider="anthropic",
+        model="claude-sonnet-4-5",
+        ai_tool="cursor",
+        input_summary="test input",
+        evaluated_rules=[{"id": "R-test"}],
+        defense_score=42,
+        conductai_run_id=None,
+        hook_session_id=None,
+        share_token_hash=share_token_hash,
+    )
+
+
+def _client_with_db(db, *, workspace_id: str):
+    from fastapi.testclient import TestClient
+    from app.main import app
+    from app.core.database import get_db
+    from app.core.auth import get_workspace_id, get_user_id
+
+    app.dependency_overrides[get_db] = lambda: db
+    app.dependency_overrides[get_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[get_user_id] = lambda: "user_test"
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _clear_overrides():
+    from app.main import app
+    from app.core.database import get_db
+    from app.core.auth import get_workspace_id, get_user_id
+    for dep in (get_db, get_workspace_id, get_user_id):
+        app.dependency_overrides.pop(dep, None)
+
+
+def test_endpoint_workspace_receipt_returns_row_for_own_workspace():
+    ws = "00000000-0000-0000-0000-000000000010"
+    row = _make_audit_row(ws)
+    db = MagicMock()
+    exec_result = MagicMock()
+    exec_result.fetchone.return_value = row
+    db.execute.return_value = exec_result
+
+    client = _client_with_db(db, workspace_id=ws)
+    try:
+        resp = client.get(f"/guard/blocks/{row.id}")
+        assert resp.status_code == 200
+        payload = resp.json()
+        assert payload["receipt_id"] == str(row.id)
+        assert payload["rule_id"] == "R-test"
+    finally:
+        _clear_overrides()
+
+
+def test_endpoint_workspace_receipt_404s_across_workspaces():
+    row_ws = "00000000-0000-0000-0000-000000000011"
+    caller_ws = "00000000-0000-0000-0000-000000000012"
+    row = _make_audit_row(row_ws)
+    db = MagicMock()
+    exec_result = MagicMock()
+    exec_result.fetchone.return_value = row
+    db.execute.return_value = exec_result
+
+    client = _client_with_db(db, workspace_id=caller_ws)
+    try:
+        resp = client.get(f"/guard/blocks/{row.id}")
+        assert resp.status_code == 404
+    finally:
+        _clear_overrides()
+
+
+def test_endpoint_public_receipt_returns_row_with_valid_token_on_trial_workspace():
+    from app.guard.receipts import mint_share_token
+    ws = "00000000-0000-0000-0000-000000000013"
+    raw_token, share_hash = mint_share_token()
+    row = _make_audit_row(ws, share_token_hash=share_hash)
+
+    # Two calls: fetchone for the audit row, scalar for the workspace plan.
+    db = MagicMock()
+    fetch = MagicMock(); fetch.fetchone.return_value = row
+    scalar = MagicMock(); scalar.scalar.return_value = "trial"
+    db.execute.side_effect = [fetch, scalar]
+
+    client = _client_with_db(db, workspace_id="does-not-matter-public-route")
+    try:
+        resp = client.get(f"/guard/blocks/public/{row.id}/{raw_token}")
+        assert resp.status_code == 200
+        assert resp.json()["receipt_id"] == str(row.id)
+    finally:
+        _clear_overrides()
+
+
+def test_endpoint_public_receipt_404s_on_bad_token_and_non_trial_plan():
+    from app.guard.receipts import mint_share_token
+    ws = "00000000-0000-0000-0000-000000000014"
+    _, share_hash = mint_share_token()
+    row = _make_audit_row(ws, share_token_hash=share_hash)
+
+    # Bad token — first call returns the row, we never reach the plan call
+    db_bad = MagicMock()
+    fetch_bad = MagicMock(); fetch_bad.fetchone.return_value = row
+    db_bad.execute.return_value = fetch_bad
+    client = _client_with_db(db_bad, workspace_id="x")
+    try:
+        resp = client.get(f"/guard/blocks/public/{row.id}/cond_bkr_WRONG")
+        assert resp.status_code == 404
+    finally:
+        _clear_overrides()
+
+    # Correct token but workspace has converted to paid — plan gate blocks.
+    raw_token, share_hash2 = mint_share_token()
+    row2 = _make_audit_row(ws, share_token_hash=share_hash2)
+    db_paid = MagicMock()
+    fetch2 = MagicMock(); fetch2.fetchone.return_value = row2
+    scalar2 = MagicMock(); scalar2.scalar.return_value = "pro"
+    db_paid.execute.side_effect = [fetch2, scalar2]
+    client = _client_with_db(db_paid, workspace_id="x")
+    try:
+        resp = client.get(f"/guard/blocks/public/{row2.id}/{raw_token}")
+        assert resp.status_code == 404
+    finally:
+        _clear_overrides()

--- a/apps/api/tests/test_trial_teardown.py
+++ b/apps/api/tests/test_trial_teardown.py
@@ -115,12 +115,23 @@ from app.modules.guard.trial_teardown import sweep_expired_trials  # noqa: E402
 
 
 def test_sweep_tears_down_only_expired_trials(ws):
+    """Workspace-scoped assertions — the sweeper is global, but other tests may
+    have left unrelated trial rows in this shared test DB, so we can't assert
+    the sweep count. What matters: this workspace's fresh trial is untouched
+    before its expires_at, and torn down after."""
     ws_id, db = ws
     seed_trial(db, ws_id)
     db.commit()
 
-    # Nothing has expired yet — sweep is a no-op.
-    assert sweep_expired_trials(db) == 0
+    # Fresh trial has expires_at 7d out — this workspace should survive a sweep.
+    sweep_expired_trials(db)
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free_trial"
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "active"
 
     # Force this trial's identity into the past.
     db.execute(
@@ -136,16 +147,12 @@ def test_sweep_tears_down_only_expired_trials(ws):
     )
     db.commit()
 
-    assert sweep_expired_trials(db) == 1
-
+    # Now sweep — this workspace should be torn down.
+    sweep_expired_trials(db)
     plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
     assert plan == "free"
-
     lifecycle = db.execute(
         text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
         {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
     ).scalar()
     assert lifecycle == "expired"
-
-    # Second sweep finds nothing left to tear down.
-    assert sweep_expired_trials(db) == 0

--- a/apps/api/tests/test_trial_teardown.py
+++ b/apps/api/tests/test_trial_teardown.py
@@ -1,0 +1,151 @@
+"""Trial teardown self-check (epic #1587 Round C).
+
+Mirrors the fixture pattern in test_trial_seed.py — skip module when
+Postgres is unreachable, workspace cascade-deletes seeded rows on teardown.
+"""
+from __future__ import annotations
+
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+HERE = Path(__file__).resolve()
+APPS_API = HERE.parent.parent
+if str(APPS_API) not in sys.path:
+    sys.path.insert(0, str(APPS_API))
+
+
+def _db_is_reachable() -> bool:
+    try:
+        import sqlalchemy
+        from app.core.config import settings
+        engine = sqlalchemy.create_engine(
+            settings.sqlalchemy_database_url,
+            connect_args={"connect_timeout": 3},
+        )
+        with engine.connect():
+            pass
+        return True
+    except Exception:
+        return False
+
+
+if not _db_is_reachable():
+    pytest.skip("Postgres unreachable", allow_module_level=True)
+
+
+from sqlalchemy import text  # noqa: E402
+from app.core.database import SessionLocal  # noqa: E402
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial  # noqa: E402
+from app.modules.guard.trial_teardown import teardown_trial  # noqa: E402
+
+
+@pytest.fixture()
+def ws():
+    db = SessionLocal()
+    ws_id = str(uuid.uuid4())
+    now = datetime.now(timezone.utc)
+    db.execute(
+        text(
+            "INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at) "
+            "VALUES (:id, :name, :owner, 'free', true, :now, :now)"
+        ),
+        {"id": ws_id, "name": f"trial-tear-{ws_id[:8]}", "owner": f"test-{ws_id[:8]}", "now": now},
+    )
+    db.commit()
+    try:
+        yield ws_id, db
+    finally:
+        db.execute(text("DELETE FROM workspaces WHERE id = :id"), {"id": ws_id})
+        db.commit()
+        db.close()
+
+
+def _count(db, sql: str, params: dict) -> int:
+    return db.execute(text(sql), params).scalar() or 0
+
+
+def test_teardown_removes_all_trial_artifacts(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    changed = teardown_trial(db, ws_id)
+    db.commit()
+    assert changed is True
+
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free"
+
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "expired"
+
+    assert _count(db, "SELECT COUNT(*) FROM guard_rate_limits WHERE workspace_id = :ws AND agent_identity_id IS NULL", {"ws": ws_id}) == 0
+    assert _count(db, "SELECT COUNT(*) FROM guard_spend_budgets WHERE workspace_id = :ws AND clerk_user_id IS NULL", {"ws": ws_id}) == 0
+
+
+def test_teardown_is_idempotent(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    assert teardown_trial(db, ws_id) is True
+    db.commit()
+    assert teardown_trial(db, ws_id) is False
+    db.commit()
+
+
+def test_teardown_noop_when_no_trial(ws):
+    """Workspace never had a trial — teardown returns False, nothing changes."""
+    ws_id, db = ws
+    plan_before = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert teardown_trial(db, ws_id) is False
+    db.commit()
+    plan_after = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan_before == plan_after == "free"
+
+
+from app.modules.guard.trial_teardown import sweep_expired_trials  # noqa: E402
+
+
+def test_sweep_tears_down_only_expired_trials(ws):
+    ws_id, db = ws
+    seed_trial(db, ws_id)
+    db.commit()
+
+    # Nothing has expired yet — sweep is a no-op.
+    assert sweep_expired_trials(db) == 0
+
+    # Force this trial's identity into the past.
+    db.execute(
+        text(
+            "UPDATE agent_identities SET expires_at = :past "
+            "WHERE workspace_id = :ws AND name = :name"
+        ),
+        {
+            "past": datetime.now(timezone.utc) - timedelta(minutes=1),
+            "ws": ws_id,
+            "name": TRIAL_IDENTITY_NAME,
+        },
+    )
+    db.commit()
+
+    assert sweep_expired_trials(db) == 1
+
+    plan = db.execute(text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id}).scalar()
+    assert plan == "free"
+
+    lifecycle = db.execute(
+        text("SELECT lifecycle_state FROM agent_identities WHERE workspace_id = :ws AND name = :name"),
+        {"ws": ws_id, "name": TRIAL_IDENTITY_NAME},
+    ).scalar()
+    assert lifecycle == "expired"
+
+    # Second sweep finds nothing left to tear down.
+    assert sweep_expired_trials(db) == 0

--- a/apps/web/src/app/(app)/theguard/blocks/[id]/page.tsx
+++ b/apps/web/src/app/(app)/theguard/blocks/[id]/page.tsx
@@ -1,0 +1,46 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+
+import AppShell from "@/components/AppShell"
+import { BlockReceiptCard } from "@/components/guard/BlockReceiptCard"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { blocks, type BlockReceipt } from "@/lib/api/guard"
+
+/**
+ * Workspace block-receipt page (#1712 Track 1 quick win 2/3).
+ *
+ * URL emitted in every Guard block response (`error.receipt_url`). Users
+ * signed into their workspace land here to see the receipt + jump into a
+ * Lens conversation seeded with a receipt-scoped question.
+ */
+export default function BlockReceiptPage() {
+  const params = useParams()
+  const id = typeof params.id === "string" ? params.id : ""
+  const { authFetch, workspaceId } = useAuthFetch()
+
+  const [receipt, setReceipt] = useState<BlockReceipt | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id || !workspaceId) return
+    let cancelled = false
+    blocks
+      .get(authFetch, id)
+      .then((r) => { if (!cancelled) setReceipt(r) })
+      .catch((e: Error) => { if (!cancelled) setErr(e.message) })
+    return () => { cancelled = true }
+  }, [id, workspaceId, authFetch])
+
+  return (
+    <AppShell>
+      {err && (
+        <div style={{ maxWidth: 640, margin: "48px auto", padding: 16, color: "var(--muted)" }}>
+          Receipt not found. It may have been purged or belongs to another workspace.
+        </div>
+      )}
+      {!err && receipt && <BlockReceiptCard receipt={receipt} />}
+    </AppShell>
+  )
+}

--- a/apps/web/src/app/(marketing)/b/[id]/[token]/page.tsx
+++ b/apps/web/src/app/(marketing)/b/[id]/[token]/page.tsx
@@ -1,0 +1,55 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useParams } from "next/navigation"
+import Link from "next/link"
+
+import { BlockReceiptCard } from "@/components/guard/BlockReceiptCard"
+import { blocks, type BlockReceipt } from "@/lib/api/guard"
+
+/**
+ * Anonymous trial receipt page (#1712 Track 1 quick win 2/3).
+ *
+ * Short public URL — the token in the path is checked server-side against
+ * a sha256 hash stored on the audit row, and the workspace must still be
+ * on the trial plan (see apps/api/app/modules/guard/routers/blocks.py).
+ *
+ * This is the Priya-story moment: Cursor error → click → receipt + Lens
+ * prompts without logging in. The Lens CTAs route through /sign-up?next=
+ * so activation converts to a real workspace.
+ */
+export default function PublicBlockReceiptPage() {
+  const params = useParams()
+  const id = typeof params.id === "string" ? params.id : ""
+  const token = typeof params.token === "string" ? params.token : ""
+
+  const [receipt, setReceipt] = useState<BlockReceipt | null>(null)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!id || !token) return
+    let cancelled = false
+    blocks
+      .getPublic(id, token)
+      .then((r) => { if (!cancelled) setReceipt(r) })
+      .catch((e: Error) => { if (!cancelled) setErr(e.message) })
+    return () => { cancelled = true }
+  }, [id, token])
+
+  return (
+    <main style={{ minHeight: "100vh", padding: "48px 0", background: "var(--bg)" }}>
+      <div style={{ maxWidth: 760, margin: "0 auto 24px", padding: "0 16px" }}>
+        <Link href="/" style={{ fontSize: 12, color: "var(--muted)", textDecoration: "none" }}>
+          ← conduct.ai
+        </Link>
+      </div>
+      {err && (
+        <div style={{ maxWidth: 640, margin: "48px auto", padding: 16, color: "var(--muted)" }}>
+          This receipt link is expired or invalid. Trial receipts are
+          preserved for the life of the trial workspace.
+        </div>
+      )}
+      {!err && receipt && <BlockReceiptCard receipt={receipt} mode="public" />}
+    </main>
+  )
+}

--- a/apps/web/src/components/guard/BlockReceiptCard.tsx
+++ b/apps/web/src/components/guard/BlockReceiptCard.tsx
@@ -1,0 +1,173 @@
+"use client"
+
+import Link from "next/link"
+import type { BlockReceipt } from "@/lib/api/guard"
+import { DecisionBadge } from "./DecisionBadge"
+
+/**
+ * Receipt card for a single Guard block (#1712 Track 1 quick win 2/3).
+ *
+ * Renders the audit-row fields the SDK error message linked to, plus four
+ * pre-canned prompts that seed a Lens conversation via ?q= — the user
+ * clicks, lands in Lens with the question already typed, presses enter.
+ *
+ * `mode="public"` swaps the "Ask Lens →" CTAs for a sign-up funnel so
+ * anonymous trial signup users (Cursor / one-liner install) end up
+ * activated instead of hitting a login wall.
+ */
+export function BlockReceiptCard({
+  receipt,
+  mode = "workspace",
+}: {
+  receipt: BlockReceipt
+  mode?: "workspace" | "public"
+}) {
+  const ts = receipt.ts ? new Date(receipt.ts) : null
+  const promptsForReceipt: Array<{ label: string; q: string }> = [
+    {
+      label: "Why did this block?",
+      q: `Explain why the rule ${receipt.rule_id ?? "(unknown)"} blocked this prompt (block ${receipt.receipt_id}).`,
+    },
+    {
+      label: "Show me the rule",
+      q: `Show me the full policy for rule ${receipt.rule_id ?? "(unknown)"} — matcher, message, and current enforcement level.`,
+    },
+    {
+      label: "What would have allowed it?",
+      q: `What change to the prompt or the policy would have allowed block ${receipt.receipt_id}? Suggest both a caller-side fix and a policy exception.`,
+    },
+    {
+      label: "Draft an exception",
+      q: `Draft a scoped exception for rule ${receipt.rule_id ?? "(unknown)"} that covers block ${receipt.receipt_id} only — YAML I can paste.`,
+    },
+  ]
+
+  return (
+    <div style={{ maxWidth: 760, margin: "0 auto", padding: "24px 16px" }}>
+      <div
+        style={{
+          background: "var(--card)",
+          border: "1px solid var(--border)",
+          borderRadius: 12,
+          padding: 20,
+        }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, marginBottom: 8 }}>
+          <DecisionBadge decision={receipt.decision} />
+          <span style={{ fontFamily: "var(--mono, monospace)", fontSize: 12, color: "var(--muted)" }}>
+            {receipt.receipt_id}
+          </span>
+          {ts && (
+            <span style={{ marginLeft: "auto", fontSize: 12, color: "var(--muted)" }}>
+              {ts.toLocaleString()}
+            </span>
+          )}
+        </div>
+
+        <h1 style={{ fontSize: 20, margin: "8px 0 4px", lineHeight: 1.3 }}>
+          {receipt.rule_message || receipt.rule_id || "Guard block"}
+        </h1>
+        {receipt.rule_id && (
+          <div style={{ fontFamily: "var(--mono, monospace)", fontSize: 12, color: "var(--muted)", marginBottom: 12 }}>
+            rule · {receipt.rule_id}
+          </div>
+        )}
+
+        <dl style={{ display: "grid", gridTemplateColumns: "auto 1fr", gap: "6px 12px", fontSize: 13, margin: "16px 0" }}>
+          {receipt.provider && (<>
+            <dt style={{ color: "var(--muted)" }}>Provider</dt>
+            <dd style={{ margin: 0 }}>{receipt.provider}</dd>
+          </>)}
+          {receipt.model && (<>
+            <dt style={{ color: "var(--muted)" }}>Model</dt>
+            <dd style={{ margin: 0, fontFamily: "var(--mono, monospace)" }}>{receipt.model}</dd>
+          </>)}
+          {receipt.ai_tool && (<>
+            <dt style={{ color: "var(--muted)" }}>Caller</dt>
+            <dd style={{ margin: 0 }}>{receipt.ai_tool}</dd>
+          </>)}
+          {typeof receipt.defense_score === "number" && (<>
+            <dt style={{ color: "var(--muted)" }}>Defense score</dt>
+            <dd style={{ margin: 0 }}>{receipt.defense_score}</dd>
+          </>)}
+        </dl>
+
+        {receipt.input_summary && (
+          <div style={{ marginBottom: 16 }}>
+            <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.6, color: "var(--muted)", marginBottom: 4 }}>
+              Prompt summary
+            </div>
+            <pre
+              style={{
+                margin: 0, padding: 12, borderRadius: 8,
+                background: "var(--input-bg, #0b0c10)",
+                fontSize: 12, whiteSpace: "pre-wrap", wordBreak: "break-word",
+              }}
+            >
+              {receipt.input_summary}
+            </pre>
+          </div>
+        )}
+
+        {receipt.evaluated_rules && receipt.evaluated_rules.length > 1 && (
+          <details style={{ fontSize: 13, marginBottom: 12 }}>
+            <summary style={{ cursor: "pointer", color: "var(--muted)" }}>
+              {receipt.evaluated_rules.length} rules evaluated
+            </summary>
+            <ul style={{ margin: "8px 0 0 18px" }}>
+              {receipt.evaluated_rules.map((r, i) => (
+                <li key={i} style={{ fontFamily: "var(--mono, monospace)", fontSize: 12 }}>
+                  {String((r as { id?: string; rule_id?: string }).id ?? (r as { rule_id?: string }).rule_id ?? JSON.stringify(r))}
+                </li>
+              ))}
+            </ul>
+          </details>
+        )}
+      </div>
+
+      <div style={{ marginTop: 20 }}>
+        <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.6, color: "var(--muted)", marginBottom: 8 }}>
+          Ask Lens about this block
+        </div>
+        <div style={{ display: "grid", gap: 8 }}>
+          {promptsForReceipt.map((p) => (
+            <ReceiptCta key={p.label} label={p.label} q={p.q} mode={mode} />
+          ))}
+        </div>
+      </div>
+
+      {receipt.conductai_run_id && mode === "workspace" && (
+        <div style={{ marginTop: 16, fontSize: 12 }}>
+          <Link href={`/runs/${receipt.conductai_run_id}`} style={{ color: "var(--accent-text)" }}>
+            View run trace →
+          </Link>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ReceiptCta({ label, q, mode }: { label: string; q: string; mode: "workspace" | "public" }) {
+  const encoded = encodeURIComponent(q)
+  const href =
+    mode === "workspace"
+      ? `/lens?q=${encoded}`
+      : `/sign-up?next=${encodeURIComponent(`/lens?q=${encoded}`)}`
+  return (
+    <Link
+      href={href}
+      style={{
+        display: "block",
+        padding: "10px 12px",
+        borderRadius: 8,
+        border: "1px solid var(--border)",
+        background: "var(--card)",
+        color: "inherit",
+        textDecoration: "none",
+        fontSize: 14,
+      }}
+    >
+      {label} →
+    </Link>
+  )
+}

--- a/apps/web/src/components/guard/__tests__/BlockReceiptCard.test.tsx
+++ b/apps/web/src/components/guard/__tests__/BlockReceiptCard.test.tsx
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest"
+import { render } from "@testing-library/react"
+import { screen } from "@testing-library/dom"
+
+import { BlockReceiptCard } from "../BlockReceiptCard"
+import type { BlockReceipt } from "@/lib/api/guard"
+
+const receipt: BlockReceipt = {
+  receipt_id: "01JAX00000000000000000000",
+  ts: "2026-09-07T21:00:00Z",
+  decision: "blocked",
+  rule_id: "pii.customer_email_in_prompt",
+  rule_message: "Customer email detected in prompt",
+  provider: "anthropic",
+  model: "claude-sonnet-4-5",
+  ai_tool: "cursor",
+  input_summary: "please normalize alice@example.com",
+  evaluated_rules: [{ id: "pii.customer_email_in_prompt" }],
+  defense_score: 90,
+  conductai_run_id: null,
+  hook_session_id: null,
+}
+
+describe("BlockReceiptCard", () => {
+  it("renders rule + prompt summary + 4 CTAs", () => {
+    render(<BlockReceiptCard receipt={receipt} />)
+    expect(screen.getByText("Customer email detected in prompt")).toBeTruthy()
+    expect(screen.getByText(/please normalize/)).toBeTruthy()
+    // 4 pre-canned prompts
+    expect(screen.getByText("Why did this block? →")).toBeTruthy()
+    expect(screen.getByText("Show me the rule →")).toBeTruthy()
+    expect(screen.getByText("What would have allowed it? →")).toBeTruthy()
+    expect(screen.getByText("Draft an exception →")).toBeTruthy()
+  })
+
+  it("workspace mode links CTA straight to /lens?q=...", () => {
+    render(<BlockReceiptCard receipt={receipt} mode="workspace" />)
+    const link = screen.getByText("Why did this block? →").closest("a") as HTMLAnchorElement
+    expect(link).toBeTruthy()
+    expect(link.getAttribute("href")).toMatch(/^\/lens\?q=/)
+    // Question includes the rule id so Lens has enough to answer
+    expect(decodeURIComponent(link.getAttribute("href") ?? "")).toContain("pii.customer_email_in_prompt")
+    expect(decodeURIComponent(link.getAttribute("href") ?? "")).toContain(receipt.receipt_id)
+  })
+
+  it("public mode routes CTA through /sign-up?next=/lens?q=... for anonymous trial users", () => {
+    render(<BlockReceiptCard receipt={receipt} mode="public" />)
+    const link = screen.getByText("Why did this block? →").closest("a") as HTMLAnchorElement
+    expect(link.getAttribute("href")).toMatch(/^\/sign-up\?next=/)
+    const href = decodeURIComponent(link.getAttribute("href") ?? "")
+    expect(href).toContain("/lens?q=")
+    expect(href).toContain("pii.customer_email_in_prompt")
+  })
+})

--- a/apps/web/src/lib/api/guard.ts
+++ b/apps/web/src/lib/api/guard.ts
@@ -341,3 +341,35 @@ export const glens = {
   session: (f: AuthFetch, sessionId: string) =>
     json<any>(f, `${API}/glens/sessions/${sessionId}`),
 }
+
+// Block receipts (#1712 Track 1) — every Guard block response carries a
+// receipt_id + receipt_url. Workspace users read via authFetch; anonymous
+// trial signup users hit the public path with a share token embedded in
+// the URL (never persisted anywhere else).
+export interface BlockReceipt {
+  receipt_id: string
+  ts: string | null
+  decision: string
+  rule_id: string | null
+  rule_message: string | null
+  provider: string | null
+  model: string | null
+  ai_tool: string
+  input_summary: string | null
+  evaluated_rules: Array<Record<string, unknown>> | null
+  defense_score: number | null
+  conductai_run_id: string | null
+  hook_session_id: string | null
+}
+
+export const blocks = {
+  get: (f: AuthFetch, id: string) =>
+    json<BlockReceipt>(f, `${base()}/blocks/${encodeURIComponent(id)}`),
+  getPublic: async (id: string, token: string): Promise<BlockReceipt> => {
+    const res = await fetch(
+      `${base()}/blocks/public/${encodeURIComponent(id)}/${encodeURIComponent(token)}`,
+    )
+    if (!res.ok) throw new Error(`receipt fetch ${res.status}`)
+    return res.json()
+  },
+}

--- a/packages/conduct-cli/src/conduct_cli/hooks/base.py
+++ b/packages/conduct-cli/src/conduct_cli/hooks/base.py
@@ -334,10 +334,13 @@ def post_event(
     *,
     drain_via: Optional[Path] = None,
     blast_radius: "dict | None" = None,
+    receipt_id: Optional[str] = None,
 ) -> None:
     """Post one guard event via the journal/drain pattern.  Never raises.
 
     drain_via — path of the calling hook file passed to ensure_drain_daemon().
+    receipt_id — pre-minted UUID (see hooks/pretooluse.py) so the row we
+    write here matches the receipt URL the hook already printed to stderr.
     """
     cfg = load_config()
     workspace_id = cfg.get("workspace_id")
@@ -365,7 +368,65 @@ def post_event(
         "blast_radius":    blast_radius,
         "goal_id":         _gcfg.get("current_goal_id") or None,
         "goal_name":       _gcfg.get("current_goal_name") or None,
+        "receipt_id":      receipt_id,
     })
     api_url = cfg.get("api_url", "https://api.conductai.ai").rstrip("/")
     journal_append(payload, api_url)
     ensure_drain_daemon(drain_via)
+
+
+def web_url_from_api(api_url: str) -> str:
+    """Derive the web-app URL from api_url.
+
+    `https://api.conductai.ai` → `https://conductai.ai`. Self-hosted setups
+    can override by setting `web_url` in ~/.conduct/config.json — see
+    hook_receipt_url() below."""
+    stripped = api_url.rstrip("/")
+    # Only replace when the host actually starts with "api." — avoids
+    # eating a legitimate hostname like "myapi.example.com".
+    for scheme in ("https://", "http://"):
+        if stripped.startswith(scheme + "api."):
+            return scheme + stripped[len(scheme) + 4:]
+    return stripped
+
+
+def hook_receipt_url(receipt_id: str) -> Optional[str]:
+    """Build the receipt URL for a hook-side pre-minted block.
+
+    Returns None if no workspace/config is set. Uses `web_url` from config
+    when present (self-host), otherwise derives from `api_url`."""
+    cfg = load_config()
+    if not cfg.get("workspace_id"):
+        return None
+    web_url = cfg.get("web_url") or web_url_from_api(
+        cfg.get("api_url", "https://api.conductai.ai")
+    )
+    return f"{web_url.rstrip('/')}/theguard/blocks/{receipt_id}"
+
+
+def boxed_stderr(message: str, receipt_url: Optional[str] = None) -> str:
+    """Format a block message + optional receipt URL as a bordered stderr
+    callout so `[ConductGuard]` prints stand out from Claude Code chatter.
+
+    Kept as a plain string builder — the print itself happens at the call
+    site so tests can assert on the shape without patching stderr.
+
+    Uses unicode box-drawing chars on utf-8 stderr; falls back to plain
+    ASCII (`+---+`) on cp1252/etc. so Windows terminals never crash the
+    hook with UnicodeEncodeError."""
+    import sys as _sys
+    _enc = (getattr(_sys.stderr, "encoding", None) or "").lower()
+    _utf8 = _enc.startswith("utf")
+    tl, tr, bl, br = ("┌", "┐", "└", "┘") if _utf8 else ("+", "+", "+", "+")
+    h, v = ("─", "│") if _utf8 else ("-", "|")
+    arrow = "→" if _utf8 else "->"
+
+    body = message.rstrip()
+    if receipt_url:
+        body = f"{body}\n{arrow} Receipt: {receipt_url}"
+    lines = body.splitlines()
+    # Grow the box to fit the longest line (URLs can be > 80 chars).
+    width = max(80, max(len(line) for line in lines) + 2)
+    bar = h * width
+    inner = "\n".join(f"{v} {line.ljust(width - 2)}{v}" for line in lines)
+    return f"{tl}{bar}{tr}\n{inner}\n{bl}{bar}{br}"

--- a/packages/conduct-cli/src/conduct_cli/hooks/pretooluse.py
+++ b/packages/conduct-cli/src/conduct_cli/hooks/pretooluse.py
@@ -856,12 +856,28 @@ def main() -> None:
         sys.exit(0)
     if action == "warn" and session_id and rule_id:
         _record_session_warn(session_id, rule_id)
-    post_event(tool_name, tool_input, decision, rule_id, message, session_id, drain_via=_this_file)
+
+    # Pre-mint the audit-row id ONLY on block. That way the receipt URL
+    # we print to stderr resolves to the row we're about to write via
+    # /guard/events. Non-block decisions don't need a receipt.
+    receipt_id = None
+    receipt_url = None
+    if action == "block":
+        import uuid as _uuid
+        from .base import hook_receipt_url, boxed_stderr  # local import — hooks avoid heavy top-level imports
+        receipt_id = str(_uuid.uuid4())
+        receipt_url = hook_receipt_url(receipt_id)
+
+    post_event(
+        tool_name, tool_input, decision, rule_id, message, session_id,
+        drain_via=_this_file, receipt_id=receipt_id,
+    )
 
     if action == "block":
+        from .base import boxed_stderr as _boxed
         msg = f"[ConductGuard] {message}"
         print(msg)
-        print(msg, file=sys.stderr)
+        print(_boxed(msg, receipt_url), file=sys.stderr)
         sys.exit(2)
     if action == "warn":
         print(f"[ConductGuard] {message}")

--- a/packages/conduct-cli/tests/test_hook_receipt.py
+++ b/packages/conduct-cli/tests/test_hook_receipt.py
@@ -1,0 +1,38 @@
+"""#1712 PR 4 — hook-side receipt URL helpers.
+
+The Claude Code hook mints a receipt id client-side and prints the URL in
+a boxed callout. Backend `POST /guard/events` accepts the pre-minted id
+so the audit row PK matches what the user saw on stderr.
+"""
+from __future__ import annotations
+
+from conduct_cli.hooks.base import boxed_stderr, web_url_from_api
+
+
+def test_web_url_from_api_strips_api_subdomain():
+    assert web_url_from_api("https://api.conductai.ai") == "https://conductai.ai"
+    assert web_url_from_api("https://api.conductai.ai/") == "https://conductai.ai"
+    assert web_url_from_api("http://api.example.test") == "http://example.test"
+
+
+def test_web_url_from_api_leaves_non_api_hosts_alone():
+    # "myapi.example.com" is not an api-subdomain — must not be mangled
+    assert web_url_from_api("https://myapi.example.com") == "https://myapi.example.com"
+    assert web_url_from_api("https://conduct.internal") == "https://conduct.internal"
+
+
+def test_boxed_stderr_wraps_message_and_receipt_url():
+    box = boxed_stderr("[ConductGuard] Prompt contains PII", receipt_url="https://x/theguard/blocks/abc")
+    lines = box.splitlines()
+    # top + at least the message line + the receipt line + bottom
+    assert lines[0].startswith("┌") and lines[0].endswith("┐")
+    assert lines[-1].startswith("└") and lines[-1].endswith("┘")
+    assert any("Prompt contains PII" in line for line in lines)
+    assert any("→ Receipt: https://x/theguard/blocks/abc" in line for line in lines)
+
+
+def test_boxed_stderr_without_receipt_still_boxes_message():
+    box = boxed_stderr("[ConductGuard] budget hard cap reached")
+    assert "→ Receipt:" not in box
+    assert "budget hard cap reached" in box
+    assert box.splitlines()[0].startswith("┌")


### PR DESCRIPTION
## Summary

- Every Guard block response now carries `receipt_id` + `receipt_url` — universal receipt surfacing at the SDK error-message layer, no per-integration wiring
- New workspace + anonymous public receipt pages seed Lens with four pre-canned prompts scoped to the block (Priya's use case: Cursor error → click → Lens receipt without login)
- Claude Code hook mints the receipt id client-side and prints it in a boxed callout to stderr; ASCII fallback on cp1252 terminals

Delivers all 4 "Track 1 quick win" sub-PRs from #1712:
1. **PR 1** — write path + API contract (`share_token_hash` column + Alembic 0116, `fail_closed(extra=)`, `GET /api/guard/blocks/{id}` + `/public/{id}/{token}`)
2. **PR 2** — FE receipt page + Lens seed (via existing `?q=` prefill in `GLensChatPage`)
3. **PR 3** — Lens forwards `hook_session_id` so Lens-origin blocks link back to the source chat
4. **PR 4** — universal `error.message` embed + Claude Code hook boxed printer

## Test plan

- [x] Backend `pytest tests/guard/ tests/glens/`: **1547 passed, 20 skipped**
  - 11 receipt-specific tests: message embed, trial vs workspace URLs, guarded_completion + guarded_client_call receipt/session threading, HMAC round-trip, HTTP endpoints (own-workspace 200, cross-workspace 404, public trial 200, bad token 404, non-trial 404)
- [x] Frontend `vitest`: **3/3** for `BlockReceiptCard` (rule + summary + CTAs, workspace URL, public sign-up funnel)
- [x] Frontend `tsc --noEmit`: clean
- [x] CLI `pytest`: **438 passed, 18 skipped** including 4 new tests for `web_url_from_api` + `boxed_stderr`
- [x] Alembic drift: paired migration 0116; drift check runs on CI

## Deploy order

1. **Merge + deploy backend first.** New `HookEvent.receipt_id` field must be live before CLI 0.11.0 users start sending it.
2. **Then bump `conduct-cli` 0.10.0 → 0.11.0** and publish to PyPI. Existing 0.10.0 users auto-upgrade via the pre-existing `_check_and_upgrade_packages()` at the top of `conduct guard sync`. The installed hook is a thin launcher, so new pretooluse runs on the next Claude Code invocation with no re-sync.

## Non-goals

- LiteLLM native `guardrail: conduct` plugin — universally covered by `error.message` embed
- CLI printer for `conduct` command errors — same reason
- Cursor recipe wiring — same reason
- Rich chat seeding with receipt as system context — `?q=` prefill covers 80% of value

## References

- Epic: #1712 (Track 1 = signup → first block visible in Lens under 5 min)