### PR TITLE
feat(guard): curl | sh installer + make-shareable + trial-detection fixes (#1712 PR 5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,16 @@ _Built for engineering teams. Install in 10 minutes. Evidence for the CISO from 
 
 </div>
 
+### 60-second trial (no install)
+
+```bash
+curl -fsSL conductai.ai/install | sh
+```
+
+Prompts for email + company, provisions a 7-day trial workspace, drops `~/.conduct/env` with `ANTHROPIC_BASE_URL` + a trial token. Any Anthropic-SDK client on the machine (Cursor, Claude Code, LangChain, LiteLLM, raw SDK) now routes through the Guard proxy. A blocked call comes back with a `Receipt: https://conductai.ai/theguard/blocks/…` URL — click it to view the block, ask Lens follow-up questions, and log in to the dashboard via the magic-link the installer prints.
+
+### Full install (for daily use)
+
 ```bash
 pip install conduct-cli
 conduct login
@@ -21,7 +31,7 @@ conduct sync
 
 Every Claude Code, Cursor, Copilot, and Codex session on that machine is now governed. Blocks, warnings, and a hash-chained audit trail show up at [conductai.ai](https://conductai.ai).
 
-Prefer to self-host?
+### Self-host
 
 ```bash
 git clone https://github.com/sseshachala/conductai && cd conductai && docker compose up

--- a/apps/api/app/core/clerk.py
+++ b/apps/api/app/core/clerk.py
@@ -1,0 +1,133 @@
+"""Clerk backend API helpers (#1712 Track 1 PR 5 unification).
+
+Server-to-server calls to `https://api.clerk.com/v1/*`. Same auth pattern
+as `apps/api/app/routers/projects.py::_clerk_headers` (Bearer with
+`settings.clerk_secret_key`). Split out here so the curl-install trial
+provisioning path can create Clerk users + sign-in tokens without pulling
+projects.py's org-and-invitation surface as a dependency.
+
+All helpers fail loudly with ClerkError so callers can distinguish
+"Clerk said no" (e.g. duplicate email) from generic 500s. Callers should
+check `settings.clerk_secret_key` before calling — no-op if unset (local
+dev without a Clerk instance).
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+import httpx
+import structlog
+
+from app.core.config import settings
+
+log = structlog.get_logger(__name__)
+
+CLERK_API = "https://api.clerk.com/v1"
+
+
+class ClerkError(Exception):
+    """Raised when the Clerk API returns a non-2xx response."""
+
+    def __init__(self, status: int, message: str, body: str = ""):
+        super().__init__(f"Clerk {status}: {message}")
+        self.status = status
+        self.message = message
+        self.body = body
+
+
+def _headers() -> dict:
+    return {
+        "Authorization": f"Bearer {settings.clerk_secret_key}",
+        "Content-Type": "application/json",
+    }
+
+
+def find_user_by_email(email: str) -> Optional[str]:
+    """Return the Clerk user_id for a given email, or None if no user
+    exists with that primary email. Raises ClerkError on 5xx / auth errors.
+    Returns None on 200-with-empty-list — that's "not found", not an error.
+    """
+    if not settings.clerk_secret_key:
+        return None
+    try:
+        r = httpx.get(
+            f"{CLERK_API}/users",
+            headers=_headers(),
+            params={"email_address": email},
+            timeout=10,
+        )
+    except httpx.HTTPError as exc:
+        log.warning("clerk.find_user.network", email=email, err=str(exc))
+        raise ClerkError(status=0, message=f"network: {exc}") from exc
+    if r.status_code == 404:
+        return None
+    if r.status_code >= 400:
+        raise ClerkError(status=r.status_code, message="find_user_by_email failed", body=r.text[:500])
+    users = r.json() or []
+    if not users:
+        return None
+    # Clerk returns most-recent-first. The email match is exact via query
+    # param, so first result is the caller's user.
+    return users[0].get("id")
+
+
+def create_user(email: str) -> str:
+    """Create a Clerk user for `email`. Returns the new `user_id`.
+
+    - `skip_password_requirement=True` — no password on file; sign-in
+      happens via magic-link / OAuth / sign-in token.
+    - `skip_password_checks=True` — belt-and-braces, some Clerk instances
+      require this to accept passwordless creation.
+
+    Raises ClerkError if Clerk rejects (422 typically means email already
+    exists — callers should look-up-first via `find_user_by_email`)."""
+    if not settings.clerk_secret_key:
+        raise ClerkError(status=0, message="clerk_secret_key not configured")
+    try:
+        r = httpx.post(
+            f"{CLERK_API}/users",
+            headers=_headers(),
+            json={
+                "email_address": [email],
+                "skip_password_requirement": True,
+                "skip_password_checks": True,
+            },
+            timeout=15,
+        )
+    except httpx.HTTPError as exc:
+        log.warning("clerk.create_user.network", email=email, err=str(exc))
+        raise ClerkError(status=0, message=f"network: {exc}") from exc
+    if r.status_code >= 400:
+        raise ClerkError(status=r.status_code, message="create_user failed", body=r.text[:500])
+    data = r.json()
+    user_id = data.get("id")
+    if not user_id:
+        raise ClerkError(status=r.status_code, message="create_user missing id", body=r.text[:500])
+    log.info("clerk.user_created", email=email, user_id=user_id)
+    return user_id
+
+
+def mint_sign_in_token(clerk_user_id: str, expires_in_seconds: int = 86400) -> Optional[str]:
+    """Return a one-time sign-in URL (or None if Clerk isn't configured
+    or the mint failed). The URL takes the recipient straight to a
+    logged-in dashboard session — great for CLI installers that want to
+    hand the user a "click to view your workspace" link."""
+    if not settings.clerk_secret_key:
+        return None
+    try:
+        r = httpx.post(
+            f"{CLERK_API}/sign_in_tokens",
+            headers=_headers(),
+            json={"user_id": clerk_user_id, "expires_in_seconds": expires_in_seconds},
+            timeout=10,
+        )
+    except httpx.HTTPError as exc:
+        log.warning("clerk.mint_sign_in_token.network", user_id=clerk_user_id, err=str(exc))
+        return None
+    if r.status_code >= 400:
+        log.warning(
+            "clerk.mint_sign_in_token.failed",
+            user_id=clerk_user_id, status=r.status_code, body=r.text[:200],
+        )
+        return None
+    return r.json().get("url") or r.json().get("token")

--- a/apps/api/app/guard/receipts.py
+++ b/apps/api/app/guard/receipts.py
@@ -2,12 +2,19 @@
 
 `build_receipt_url(receipt_id)` returns the workspace-authenticated URL
 (requires login). `build_receipt_url(receipt_id, share_token=...)` returns
-the anonymous public URL for trial signup users — the token is hashed with
-sha256 and the hash is stored on the audit row (see `guard.audit.record`).
+the public URL for trial signup users — the token is hashed with sha256
+and the hash is stored on the audit row (see `guard.audit.record`).
 
-Reuses the same `CONDUCT_WEB_URL` env var pattern as `approval_url` in
-`app.modules.guard.approval` so trial + workspace + approval deep-links all
-resolve against the same host.
+`web_base_url()` is the shared `CONDUCT_WEB_URL` reader used by every
+deep-link builder in the API (receipts, approvals, customer alerts,
+provisioning). Same env var + default across all callers so trial,
+workspace, approval, and receipt URLs all resolve against the same host.
+
+The path shape `/theguard/blocks/{id}` and `/b/{id}/{token}` is mirrored in
+``packages/conduct-cli/src/conduct_cli/hooks/base.py::hook_receipt_url`` —
+if you change either shape here, change it there too. Cross-package
+because the CLI hook mints its own receipt id client-side and prints the
+URL to stderr before the audit row is written.
 """
 from __future__ import annotations
 
@@ -18,8 +25,36 @@ import secrets
 SHARE_TOKEN_PREFIX = "cond_bkr_"
 
 
-def _base_url() -> str:
-    return (os.environ.get("CONDUCT_WEB_URL") or "https://conductai.ai").rstrip("/")
+DEFAULT_LOCAL_WEB_URL = "http://localhost:3000"
+
+
+def web_base_url() -> str:
+    """The web-app host used by every API-side deep-link builder.
+
+    Resolution order (first non-empty wins):
+      1. `CONDUCT_WEB_URL` — legacy override reader, kept for compat with
+         approval.py + customer_alert.py which already read it.
+      2. `APP_URL` — canonical env var (also feeds `settings.app_url`).
+         Prod deploys set this to the public host (Render, Vercel, etc.).
+      3. `DEFAULT_LOCAL_WEB_URL` — zero-config default so a dev running
+         the API against `next dev` gets clickable block URLs out of the
+         box.
+
+    We read env vars directly rather than going through
+    `settings.app_url` so we can distinguish "not set" from "set to the
+    code default" — otherwise a prod deploy that sets APP_URL to the
+    same string as the code default would fall through to localhost.
+
+    Trailing slash stripped so callers can safely append paths."""
+    for var in ("CONDUCT_WEB_URL", "APP_URL"):
+        val = os.environ.get(var)
+        if val:
+            return val.rstrip("/")
+    return DEFAULT_LOCAL_WEB_URL
+
+
+# Backwards-compat alias — earlier PRs referenced the private name.
+_base_url = web_base_url
 
 
 def mint_share_token() -> tuple[str, str]:
@@ -36,5 +71,5 @@ def hash_share_token(raw: str) -> str:
 def build_receipt_url(receipt_id: str, share_token: str | None = None) -> str:
     """Workspace URL requires login; public URL embeds the raw token in the path."""
     if share_token:
-        return f"{_base_url()}/b/{receipt_id}/{share_token}"
-    return f"{_base_url()}/theguard/blocks/{receipt_id}"
+        return f"{web_base_url()}/b/{receipt_id}/{share_token}"
+    return f"{web_base_url()}/theguard/blocks/{receipt_id}"

--- a/apps/api/app/modules/guard/routers/blocks.py
+++ b/apps/api/app/modules/guard/routers/blocks.py
@@ -20,12 +20,13 @@ import uuid as _uuid
 
 import structlog
 from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_workspace_id, require_permission
 from app.core.database import get_db
-from app.guard.receipts import hash_share_token
+from app.guard.receipts import build_receipt_url, hash_share_token, mint_share_token
 
 log = structlog.get_logger(__name__)
 
@@ -90,9 +91,14 @@ def get_receipt_public(
     token: str,
     db: Session = Depends(get_db),
 ):
-    """Anonymous receipt read for trial signup users. Hash-check the token
-    against the row and re-verify the workspace is still on the trial plan
-    — a converted paid workspace must not leak old trial receipts."""
+    """Anonymous receipt read. Hash-check the token against the row and
+    re-verify the workspace is still on the trial plan — a workspace that
+    converted to paid must not leak old trial receipts through this route.
+
+    The plan value is the ``TRIAL_PLAN`` constant (``free_trial``) — not the
+    literal string ``"trial"``. Earlier revisions of this endpoint compared
+    against the wrong string and 404'd every request (#1712 PR 5 bugfix)."""
+    from app.modules.guard.trial_seed import TRIAL_PLAN
     row = _fetch_blocked(db, receipt_id)
     if row is None or not row.share_token_hash:
         raise HTTPException(status_code=404, detail="receipt_not_found")
@@ -102,6 +108,68 @@ def get_receipt_public(
         text("SELECT plan FROM workspaces WHERE id = :ws"),
         {"ws": str(row.workspace_id)},
     ).scalar()
-    if plan != "trial":
+    if plan != TRIAL_PLAN:
         raise HTTPException(status_code=404, detail="receipt_not_found")
     return _row_to_receipt(row)
+
+
+class ShareOut(BaseModel):
+    """Response for POST /guard/blocks/{id}/share.
+
+    `receipt_url` is populated on a fresh share (raw token revealed once);
+    `already_shared=True` means the row already had a hash and the raw
+    token isn't recoverable — owner needs revoke+reshare (future PR) to
+    get a new URL. Same Notion-style pattern as the FE ShareButton."""
+    receipt_id: str
+    already_shared: bool
+    receipt_url: str | None
+
+
+@router.post("/{receipt_id}/share", response_model=ShareOut)
+def make_shareable(
+    receipt_id: _uuid.UUID,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+):
+    """Owner-triggered share: mint a share token for this receipt so the
+    owner can paste a public URL into Slack/email/tweet. Cross-workspace
+    requests 404. Idempotent on the "already shareable" branch —
+    re-clicking returns the same URL, but the raw token is only revealed
+    once (subsequent calls return the public URL with an opaque marker so
+    the owner can copy the link but not the raw token, matching Notion's
+    "you can view this link but not re-copy the secret" pattern)."""
+    row = _fetch_blocked(db, receipt_id)
+    if row is None or str(row.workspace_id) != str(workspace_id):
+        raise HTTPException(status_code=404, detail="receipt_not_found")
+
+    if row.share_token_hash:
+        # Already shared. We don't have the raw token anymore (hash only).
+        # Return already-shared so the FE can say "This link is public"
+        # without hinting the token can be reconstructed. Owner who lost
+        # the URL needs revoke + re-share (future PR).
+        return ShareOut(
+            receipt_id=str(row.id),
+            already_shared=True,
+            receipt_url=None,
+        )
+
+    raw, digest = mint_share_token()
+    db.execute(
+        text("""
+            UPDATE guard_audit_events
+            SET share_token_hash = :hash
+            WHERE id = :id AND workspace_id = :ws
+        """),
+        {"hash": digest, "id": str(receipt_id), "ws": str(workspace_id)},
+    )
+    db.commit()
+    log.info(
+        "guard.blocks.shared",
+        receipt_id=str(receipt_id), workspace_id=workspace_id,
+    )
+    return ShareOut(
+        receipt_id=str(row.id),
+        already_shared=False,
+        receipt_url=build_receipt_url(str(row.id), raw),
+    )

--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -443,18 +443,25 @@ async def _proxy(
         _environment_id = request.headers.get("x-conductai-environment-id") or None
         _hook_session_id = request.headers.get("x-conduct-session-id") or None
 
-        # #1712 Track 1 quick win — trial-plan lookup before policy eval so a
-        # BLOCK response can carry an anonymous receipt URL (Priya use case:
-        # Cursor error → click → land in Lens receipt with no login). Cheap
-        # single-row read against an indexed PK; failure falls back to
-        # workspace-only receipt URL. Reused inside _render_block via kwarg.
+        # #1712 Track 1 — trial-plan lookup before policy eval so a BLOCK
+        # response can carry an anonymous receipt URL. Cheap indexed read;
+        # any failure falls back to workspace-only receipt.
+        #
+        # `is_trial` is TRUE only when the workspace is on the seed trial
+        # plan AND has no owner attached — i.e. the anonymous curl-install
+        # flow. Trials with an email/owner (Option A install, existing Try
+        # page signup) get the workspace URL because the owner has a real
+        # account to view it under, and we don't want block prompts to
+        # default to a publicly-shareable link.
+        from app.modules.guard.trial_seed import TRIAL_PLAN as _TRIAL_PLAN
         _is_trial = False
         try:
-            _plan = db.execute(
-                text("SELECT plan FROM workspaces WHERE id = :ws"),
+            _row = db.execute(
+                text("SELECT plan, owner_id FROM workspaces WHERE id = :ws"),
                 {"ws": workspace_id},
-            ).scalar()
-            _is_trial = (_plan == "trial")
+            ).fetchone()
+            if _row is not None:
+                _is_trial = (_row.plan == _TRIAL_PLAN and _row.owner_id is None)
         except Exception:
             pass
 

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -24,7 +24,7 @@ from app.core.auth import get_workspace_id, require_permission
 from app.core.config import settings
 from app.core.crypto import decrypt
 from app.core.database import get_db
-from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN, seed_trial
 from app.modules.guard.trial_upstream import TRIAL_DAILY_CAP, get_trial_cap_used
 
 log = structlog.get_logger(__name__)
@@ -227,4 +227,209 @@ def get_trial_ops(
             for r in top_rows
         ],
         cap_max=TRIAL_DAILY_CAP,
+    )
+
+
+# ─── /guard/trial/provision — self-service curl-install endpoint (#1712 Track 1) ─
+#
+# `curl -fsSL conduct.ai/install | sh` posts an email + optional company to
+# this endpoint. Unauthenticated (no Clerk session, no Bearer token) but
+# email is REQUIRED — this is a signup form, not an identity-anonymous
+# mint. We provision a trial workspace + agent identity token and return
+# them so the shell script can drop `~/.conduct/env` on the caller's laptop.
+#
+# The email is stashed on workspace.owner_id as a plain string (not yet a
+# Clerk user id). A later `conduct claim` / magic-link flow can bind the
+# workspace to a real Clerk account.
+#
+# Anti-abuse:
+#   - IP rate-limit: 5 provisions per hour (Redis atomic INCR)
+#   - Email idempotency: repeat POST with same email within the trial
+#     window returns the SAME trial token instead of minting a second
+#     workspace. Protects platform-key spend and keeps ~/.conduct/env
+#     stable when the user re-runs the installer.
+
+
+import re as _re
+
+from fastapi import HTTPException, Request
+
+from app.guard.receipts import web_base_url as _web_base_url
+
+_EMAIL_RE = _re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+_PROVISION_IP_CAP = 5   # per hour
+_PROVISION_IP_WINDOW_SEC = 3600
+
+
+class TrialProvisionIn(BaseModel):
+    email: str
+    company: str
+    # Optional caller-provided source tag (marketing attribution, referrer).
+    # Ignored by the provisioning path — stored in preferences for later
+    # analytics without altering the trial contract itself.
+    source: str | None = None
+
+
+class TrialProvisionOut(BaseModel):
+    workspace_id: str
+    agent_token: str
+    gateway_url: str
+    workspace_url: str
+
+
+def _redis_or_none():
+    """Best-effort Redis handle — fail-open on outage (matches trial_upstream
+    convention). No throttle when Redis is down is preferable to blocking
+    installs entirely."""
+    try:
+        from app.modules.guard.trial_upstream import _redis_client
+        return _redis_client()
+    except Exception:
+        return None
+
+
+def _ip_of(request: Request) -> str:
+    fwd = request.headers.get("x-forwarded-for") or ""
+    if fwd:
+        return fwd.split(",")[0].strip()
+    return request.client.host if request.client else "unknown"
+
+
+def _throttle_by_ip(ip: str) -> bool:
+    """Return True if under the per-hour cap; False if the cap is hit.
+    Fails open when Redis is unreachable."""
+    r = _redis_or_none()
+    if r is None:
+        return True
+    key = f"guard:provision:ip:{ip}:{datetime.now(timezone.utc).strftime('%Y%m%d%H')}"
+    try:
+        pipe = r.pipeline()
+        pipe.incr(key, 1)
+        pipe.expire(key, _PROVISION_IP_WINDOW_SEC)
+        count, _ = pipe.execute()
+        return int(count or 0) <= _PROVISION_IP_CAP
+    except Exception:
+        return True
+
+
+def _find_existing_trial_by_email(db: Session, email: str) -> str | None:
+    """Return the workspace_id of an active trial owned by this email, or None.
+
+    An 'active' trial here = plan free_trial + owner_id matches email + trial
+    identity still `active` (not swept by teardown). Same email posting twice
+    within the trial window gets the same workspace back — idempotent."""
+    row = db.execute(
+        text("""
+            SELECT w.id
+            FROM workspaces w
+            JOIN agent_identities ai
+              ON ai.workspace_id = w.id
+             AND ai.name = :name
+             AND ai.lifecycle_state = 'active'
+             AND (ai.expires_at IS NULL OR ai.expires_at > :now)
+            WHERE w.owner_id = :owner AND w.plan = :plan
+            ORDER BY w.created_at DESC
+            LIMIT 1
+        """),
+        {
+            "owner": email, "plan": TRIAL_PLAN,
+            "name": TRIAL_IDENTITY_NAME,
+            "now": datetime.now(timezone.utc),
+        },
+    ).fetchone()
+    return str(row.id) if row else None
+
+
+@router.post("/provision", response_model=TrialProvisionOut)
+def provision_trial(
+    body: TrialProvisionIn,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> TrialProvisionOut:
+    """Anonymous trial workspace provisioning.
+
+    Called by `scripts/install.sh` (curl | sh). Returns the trial agent
+    token so the shell script can drop it in ``~/.conduct/env``.
+    """
+    # `seed_trial` is imported at module top; local re-imports here would
+    # shadow patches (used by tests) — keep the top-level binding.
+    from app.models.workspace import Workspace as _WS
+    import uuid as _uuid
+
+    email = (body.email or "").strip().lower()
+    if not _EMAIL_RE.match(email):
+        raise HTTPException(status_code=422, detail="invalid_email")
+
+    company = (body.company or "").strip()
+    if not company:
+        raise HTTPException(status_code=422, detail="company_required")
+
+    ip = _ip_of(request)
+    if not _throttle_by_ip(ip):
+        raise HTTPException(
+            status_code=429,
+            detail=f"provision_rate_limited: {_PROVISION_IP_CAP}/hour per IP",
+        )
+
+    # Idempotency: same email within trial lifetime → return existing token.
+    ws_id = _find_existing_trial_by_email(db, email)
+    if ws_id is None:
+        ws = _WS(
+            id=_uuid.uuid4(),
+            name=f"{company[:60]} · trial",
+            owner_id=email,
+            plan="free",           # seed_trial flips to free_trial
+            is_approved=True,
+            preferences={
+                # Signup metadata — surfaced in trial ops dashboards and
+                # available for later SDR follow-up. Kept in a namespaced
+                # sub-object so downstream preference keys don't collide.
+                "trial_signup": {
+                    "email": email,
+                    "company": company,
+                    "source": (body.source or "curl-install")[:60],
+                    "ip": ip,
+                    "at": datetime.now(timezone.utc).isoformat(),
+                },
+            },
+        )
+        db.add(ws)
+        db.flush()
+        ws_id = str(ws.id)
+        seed_trial(db, ws_id)
+        db.commit()
+        log.info(
+            "guard.trial.provisioned",
+            workspace_id=ws_id, email=email, company=company, ip=ip,
+        )
+    else:
+        # Idempotent re-provision — no side effects, just re-reveal the
+        # existing token below. seed_trial(); is a no-op on an already-seeded
+        # workspace but we skip it entirely to avoid extra writes.
+        log.info(
+            "guard.trial.provision_replayed",
+            workspace_id=ws_id, email=email, ip=ip,
+        )
+
+    # Fetch + decrypt the trial identity token to return to the caller.
+    row = _load_trial_identity(db, ws_id)
+    if row is None:
+        # seed_trial should have written one; if not, something is very wrong.
+        raise HTTPException(status_code=500, detail="trial_seed_failed")
+    try:
+        token = decrypt(row.token_encrypted)["token"]
+    except Exception:
+        raise HTTPException(status_code=500, detail="trial_token_decrypt_failed")
+
+    # Anthropic SDK does `POST {base}/v1/messages`, so ANTHROPIC_BASE_URL
+    # must land on the vendor-specific route (`/proxy/anthropic`), not the
+    # bare `/proxy` root. Endpoint paths for other providers live under
+    # `/proxy/openai` and `/proxy/perplexity` — install.sh only wires
+    # Anthropic today; users who want OpenAI/Perplexity edit their env
+    # file directly.
+    return TrialProvisionOut(
+        workspace_id=ws_id,
+        agent_token=token,
+        gateway_url=f"{settings.conduct_proxy_url.rstrip('/')}/anthropic",
+        workspace_url=f"{_web_base_url()}/theguard",
     )

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -24,7 +24,7 @@ from app.core.auth import get_workspace_id, require_permission
 from app.core.config import settings
 from app.core.crypto import decrypt
 from app.core.database import get_db
-from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN, seed_trial
+from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, seed_trial
 from app.modules.guard.trial_upstream import TRIAL_DAILY_CAP, get_trial_cap_used
 
 log = structlog.get_logger(__name__)
@@ -275,6 +275,9 @@ class TrialProvisionOut(BaseModel):
     agent_token: str
     gateway_url: str
     workspace_url: str
+    # Clerk one-time sign-in URL — click to land signed-in in dashboard.
+    # Optional: null if Clerk isn't configured (local dev) or minting failed.
+    sign_in_url: str | None = None
 
 
 def _redis_or_none():
@@ -312,49 +315,30 @@ def _throttle_by_ip(ip: str) -> bool:
         return True
 
 
-def _find_existing_trial_by_email(db: Session, email: str) -> str | None:
-    """Return the workspace_id of an active trial owned by this email, or None.
-
-    An 'active' trial here = plan free_trial + owner_id matches email + trial
-    identity still `active` (not swept by teardown). Same email posting twice
-    within the trial window gets the same workspace back — idempotent."""
-    row = db.execute(
-        text("""
-            SELECT w.id
-            FROM workspaces w
-            JOIN agent_identities ai
-              ON ai.workspace_id = w.id
-             AND ai.name = :name
-             AND ai.lifecycle_state = 'active'
-             AND (ai.expires_at IS NULL OR ai.expires_at > :now)
-            WHERE w.owner_id = :owner AND w.plan = :plan
-            ORDER BY w.created_at DESC
-            LIMIT 1
-        """),
-        {
-            "owner": email, "plan": TRIAL_PLAN,
-            "name": TRIAL_IDENTITY_NAME,
-            "now": datetime.now(timezone.utc),
-        },
-    ).fetchone()
-    return str(row.id) if row else None
-
-
 @router.post("/provision", response_model=TrialProvisionOut)
 def provision_trial(
     body: TrialProvisionIn,
     request: Request,
     db: Session = Depends(get_db),
 ) -> TrialProvisionOut:
-    """Anonymous trial workspace provisioning.
+    """Self-service trial workspace provisioning (public signup endpoint).
 
-    Called by `scripts/install.sh` (curl | sh). Returns the trial agent
-    token so the shell script can drop it in ``~/.conduct/env``.
+    Called by `apps/web/public/install.sh` (curl | sh). Converged with the
+    UI signup flow — a Clerk user is created here, then the same shared
+    `provision_workspace_for_user` runs that the `user.created` webhook
+    uses. Result: one workspace-creation code path, no bifurcation.
+
+    Response includes an optional one-time sign-in URL so the CLI can
+    print "click here to view your dashboard" — user lands signed in with
+    zero password prompts.
     """
-    # `seed_trial` is imported at module top; local re-imports here would
-    # shadow patches (used by tests) — keep the top-level binding.
-    from app.models.workspace import Workspace as _WS
-    import uuid as _uuid
+    from app.core.clerk import (
+        ClerkError as _ClerkError,
+        create_user as _clerk_create_user,
+        find_user_by_email as _clerk_find_user_by_email,
+        mint_sign_in_token as _clerk_mint_sign_in_token,
+    )
+    from app.modules.onboarding import provision_workspace_for_user
 
     email = (body.email or "").strip().lower()
     if not _EMAIL_RE.match(email):
@@ -371,55 +355,54 @@ def provision_trial(
             detail=f"provision_rate_limited: {_PROVISION_IP_CAP}/hour per IP",
         )
 
-    # Idempotency: same email within trial lifetime → return existing token.
-    ws_id = _find_existing_trial_by_email(db, email)
-    if ws_id is None:
-        ws = _WS(
-            id=_uuid.uuid4(),
-            name=f"{company[:60]} · trial",
-            owner_id=email,
-            plan="free",           # seed_trial flips to free_trial
-            is_approved=True,
-            preferences={
-                # Signup metadata — surfaced in trial ops dashboards and
-                # available for later SDR follow-up. Kept in a namespaced
-                # sub-object so downstream preference keys don't collide.
-                "trial_signup": {
-                    "email": email,
-                    "company": company,
-                    "source": (body.source or "curl-install")[:60],
-                    "ip": ip,
-                    "at": datetime.now(timezone.utc).isoformat(),
-                },
-            },
-        )
-        db.add(ws)
-        db.flush()
-        ws_id = str(ws.id)
-        seed_trial(db, ws_id)
-        db.commit()
-        log.info(
-            "guard.trial.provisioned",
-            workspace_id=ws_id, email=email, company=company, ip=ip,
-        )
-    else:
-        # Idempotent re-provision — no side effects, just re-reveal the
-        # existing token below. seed_trial(); is a no-op on an already-seeded
-        # workspace but we skip it entirely to avoid extra writes.
-        log.info(
-            "guard.trial.provision_replayed",
-            workspace_id=ws_id, email=email, ip=ip,
-        )
+    # Look up first — same email hitting the endpoint twice OR after a
+    # browser signup should short-circuit to a sign-in prompt rather than
+    # spawning a second Clerk user + workspace. Clerk enforces email
+    # uniqueness, so we can trust its answer as the source of truth.
+    try:
+        clerk_user_id = _clerk_find_user_by_email(email)
+    except _ClerkError as exc:
+        log.warning("guard.trial.provision.clerk_lookup_failed", email=email, err=str(exc))
+        raise HTTPException(status_code=502, detail="clerk_unavailable")
+
+    if clerk_user_id is None:
+        # Fresh email — create the Clerk user via backend API. Same code
+        # path Clerk fires webhooks for; our webhook handler is idempotent
+        # so a duplicate `user.created` (if delivered late) is a no-op.
+        try:
+            clerk_user_id = _clerk_create_user(email)
+        except _ClerkError as exc:
+            log.warning("guard.trial.provision.clerk_create_failed", email=email, status=exc.status, body=exc.body)
+            # 422 from Clerk == email disallowed / already exists in a
+            # race we didn't see on lookup. Surface a clear signal.
+            status = 409 if exc.status == 422 else 502
+            raise HTTPException(status_code=status, detail="clerk_create_user_failed")
+
+    # Shared onboarding — same function the Clerk webhook calls. Idempotent
+    # so a race between webhook + this call is safe (whoever wins, later
+    # caller returns the existing workspace).
+    ws_id_uuid = provision_workspace_for_user(db, clerk_user_id, name=company[:60])
+    db.commit()
+    ws_id = str(ws_id_uuid)
+    log.info(
+        "guard.trial.provisioned",
+        workspace_id=ws_id, clerk_user_id=clerk_user_id,
+        email=email, company=company, ip=ip,
+    )
 
     # Fetch + decrypt the trial identity token to return to the caller.
     row = _load_trial_identity(db, ws_id)
     if row is None:
-        # seed_trial should have written one; if not, something is very wrong.
         raise HTTPException(status_code=500, detail="trial_seed_failed")
     try:
         token = decrypt(row.token_encrypted)["token"]
     except Exception:
         raise HTTPException(status_code=500, detail="trial_token_decrypt_failed")
+
+    # Best-effort sign-in URL — CLI prints it so user can click straight
+    # into the dashboard. None if Clerk not configured or mint failed;
+    # curl-install still works, user just goes to /sign-in manually.
+    sign_in_url = _clerk_mint_sign_in_token(clerk_user_id)
 
     # Anthropic SDK does `POST {base}/v1/messages`, so ANTHROPIC_BASE_URL
     # must land on the vendor-specific route (`/proxy/anthropic`), not the
@@ -432,4 +415,5 @@ def provision_trial(
         agent_token=token,
         gateway_url=f"{settings.conduct_proxy_url.rstrip('/')}/anthropic",
         workspace_url=f"{_web_base_url()}/theguard",
+        sign_in_url=sign_in_url,
     )

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -359,11 +359,27 @@ def provision_trial(
     # browser signup should short-circuit to a sign-in prompt rather than
     # spawning a second Clerk user + workspace. Clerk enforces email
     # uniqueness, so we can trust its answer as the source of truth.
+    def _map_clerk_error(exc: _ClerkError, *, on_422: int = 502) -> HTTPException:
+        """Translate Clerk API failures to caller-facing HTTP responses.
+
+        - 429 passes through unchanged so a rate-limited caller can back
+          off instead of retrying against what looks like a server error.
+        - 422 usually means "email already exists" (racy signup) — caller
+          decides whether to surface as 409 (create path) or 502
+          (lookup path).
+        - Anything else is an upstream failure → 502.
+        """
+        if exc.status == 429:
+            return HTTPException(status_code=429, detail="clerk_rate_limited")
+        if exc.status == 422:
+            return HTTPException(status_code=on_422, detail="clerk_create_user_failed")
+        return HTTPException(status_code=502, detail="clerk_unavailable")
+
     try:
         clerk_user_id = _clerk_find_user_by_email(email)
     except _ClerkError as exc:
         log.warning("guard.trial.provision.clerk_lookup_failed", email=email, err=str(exc))
-        raise HTTPException(status_code=502, detail="clerk_unavailable")
+        raise _map_clerk_error(exc)
 
     if clerk_user_id is None:
         # Fresh email — create the Clerk user via backend API. Same code
@@ -373,10 +389,9 @@ def provision_trial(
             clerk_user_id = _clerk_create_user(email)
         except _ClerkError as exc:
             log.warning("guard.trial.provision.clerk_create_failed", email=email, status=exc.status, body=exc.body)
-            # 422 from Clerk == email disallowed / already exists in a
-            # race we didn't see on lookup. Surface a clear signal.
-            status = 409 if exc.status == 422 else 502
-            raise HTTPException(status_code=status, detail="clerk_create_user_failed")
+            # 422 in the create path → 409 to hint "sign in" rather than
+            # "server error". 429 passes through unchanged for backoff.
+            raise _map_clerk_error(exc, on_422=409)
 
     # Shared onboarding — same function the Clerk webhook calls. Idempotent
     # so a race between webhook + this call is safe (whoever wins, later

--- a/apps/api/app/modules/onboarding.py
+++ b/apps/api/app/modules/onboarding.py
@@ -40,13 +40,26 @@ def provision_workspace_for_user(
 
     Returns the workspace id.
     """
-    existing = db.execute(
-        text("SELECT id FROM workspaces WHERE owner_id = :uid ORDER BY created_at ASC LIMIT 1"),
+    # `owner_id` should be unique per Clerk user in normal operation. Multi-row
+    # matches indicate either legacy manual inserts or a race we didn't
+    # catch — surface them so ops can investigate. We still return the
+    # oldest (`created_at ASC`) for deterministic idempotency.
+    existing_rows = db.execute(
+        text("SELECT id FROM workspaces WHERE owner_id = :uid ORDER BY created_at ASC"),
         {"uid": clerk_user_id},
-    ).fetchone()
-    if existing:
-        log.info("onboarding.workspace_exists", clerk_user_id=clerk_user_id, workspace_id=str(existing.id))
-        return existing.id
+    ).fetchall()
+    if existing_rows:
+        if len(existing_rows) > 1:
+            log.warning(
+                "onboarding.multiple_workspaces_for_owner",
+                clerk_user_id=clerk_user_id,
+                count=len(existing_rows),
+                ids=[str(r.id) for r in existing_rows],
+                note="returning oldest for idempotency; investigate root cause",
+            )
+        winner = existing_rows[0]
+        log.info("onboarding.workspace_exists", clerk_user_id=clerk_user_id, workspace_id=str(winner.id))
+        return winner.id
 
     now = datetime.now(timezone.utc)
     workspace_id = _uuid.uuid4()

--- a/apps/api/app/modules/onboarding.py
+++ b/apps/api/app/modules/onboarding.py
@@ -1,0 +1,100 @@
+"""Shared workspace-onboarding path (#1712 Track 1 PR 5 unification).
+
+One function creates a fully-onboarded workspace for a Clerk user:
+workspace + membership + guard_config + guard_member_config + starter
+policies + trial. Called from two places today:
+
+- Clerk `user.created` webhook (browser signup flow)
+- `/guard/trial/provision` endpoint (curl-install flow)
+
+Any future entrypoint (SSO auto-provisioning, org invitation acceptance,
+etc.) should call this function too — the goal is to have exactly one
+"new user, first workspace" code path across all surfaces so trial
+guarantees, starter policy set, and audit-chain seeding never diverge.
+"""
+from __future__ import annotations
+
+import secrets as _secrets
+import uuid as _uuid
+from datetime import datetime, timezone
+
+import structlog
+from sqlalchemy import text
+from sqlalchemy.orm import Session
+
+log = structlog.get_logger(__name__)
+
+
+def provision_workspace_for_user(
+    db: Session,
+    clerk_user_id: str,
+    *,
+    name: str = "Engineering",
+) -> _uuid.UUID:
+    """Create a workspace for a new Clerk user, or return the existing one.
+
+    Idempotent — if the user already owns a workspace, returns its id
+    without re-seeding (matches the webhook's "workspace already exists"
+    early-return). Caller is responsible for `db.commit()` so this can
+    compose into larger transactions.
+
+    Returns the workspace id.
+    """
+    existing = db.execute(
+        text("SELECT id FROM workspaces WHERE owner_id = :uid ORDER BY created_at ASC LIMIT 1"),
+        {"uid": clerk_user_id},
+    ).fetchone()
+    if existing:
+        log.info("onboarding.workspace_exists", clerk_user_id=clerk_user_id, workspace_id=str(existing.id))
+        return existing.id
+
+    now = datetime.now(timezone.utc)
+    workspace_id = _uuid.uuid4()
+    invite_code = _uuid.uuid4().hex[:16]
+    member_token = _secrets.token_urlsafe(24)
+
+    db.execute(
+        text("""
+            INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at)
+            VALUES (:id, :name, :owner_id, 'free', true, :now, :now)
+            ON CONFLICT DO NOTHING
+        """),
+        {"id": str(workspace_id), "name": name or "Engineering", "owner_id": clerk_user_id, "now": now},
+    )
+    db.execute(
+        text("""
+            INSERT INTO workspace_users (workspace_id, clerk_user_id, role, joined_at)
+            VALUES (:ws, :uid, 'admin', :now)
+            ON CONFLICT DO NOTHING
+        """),
+        {"ws": str(workspace_id), "uid": clerk_user_id, "now": now},
+    )
+    db.execute(
+        text("""
+            INSERT INTO guard_config (workspace_id, invite_code, created_at)
+            VALUES (:ws, :code, :now)
+            ON CONFLICT (workspace_id) DO NOTHING
+        """),
+        {"ws": str(workspace_id), "code": invite_code, "now": now},
+    )
+    db.execute(
+        text("""
+            INSERT INTO guard_member_config (workspace_id, clerk_user_id, member_token, active, joined_at)
+            VALUES (:ws, :uid, :token, true, :now)
+            ON CONFLICT (workspace_id, clerk_user_id) DO NOTHING
+        """),
+        {"ws": str(workspace_id), "uid": clerk_user_id, "token": member_token, "now": now},
+    )
+
+    # Starter Guard policies (packs + defaults). Imported lazily because
+    # projects.py depends on app.core.database which imports back into us
+    # transitively via the models package.
+    from app.routers.projects import _seed_starter_policies
+    _seed_starter_policies(db, workspace_id, now)
+
+    # Trial seed (#1567) — rate/budget caps + 7-day trial agent identity.
+    from app.modules.guard.trial_seed import seed_trial
+    seed_trial(db, str(workspace_id))
+
+    log.info("onboarding.workspace_created", clerk_user_id=clerk_user_id, workspace_id=str(workspace_id))
+    return workspace_id

--- a/apps/api/app/routers/webhooks.py
+++ b/apps/api/app/routers/webhooks.py
@@ -1294,54 +1294,12 @@ async def clerk_webhook(request: Request, db: Session = Depends(get_db)):
 
     user_id: str = payload["data"]["id"]  # Clerk user ID e.g. user_2abc...
 
-    # Idempotency — skip if workspace already exists for this user
-    existing = db.execute(
-        _text("SELECT 1 FROM workspaces WHERE owner_id = :uid LIMIT 1"),
-        {"uid": user_id},
-    ).fetchone()
-    if existing:
-        log.info("clerk_webhook.workspace_exists", user_id=user_id)
-        return {"ok": True, "skipped": "workspace already exists"}
-
-    now          = _dt.now(_tz.utc)
-    workspace_id = _uuid.uuid4()
-    invite_code  = _uuid.uuid4().hex[:16]
-    token        = _secrets.token_urlsafe(24)
-
-    db.execute(_text("""
-        INSERT INTO workspaces (id, name, owner_id, plan, is_approved, created_at, updated_at)
-        VALUES (:id, 'Engineering', :owner_id, 'free', true, :now, :now)
-        ON CONFLICT DO NOTHING
-    """), {"id": str(workspace_id), "owner_id": user_id, "now": now})
-
-    db.execute(_text("""
-        INSERT INTO workspace_users (workspace_id, clerk_user_id, role, joined_at)
-        VALUES (:ws, :uid, 'admin', :now)
-        ON CONFLICT DO NOTHING
-    """), {"ws": str(workspace_id), "uid": user_id, "now": now})
-
-    db.execute(_text("""
-        INSERT INTO guard_config (workspace_id, invite_code, created_at)
-        VALUES (:ws, :code, :now)
-        ON CONFLICT (workspace_id) DO NOTHING
-    """), {"ws": str(workspace_id), "code": invite_code, "now": now})
-
-    db.execute(_text("""
-        INSERT INTO guard_member_config (workspace_id, clerk_user_id, member_token, active, joined_at)
-        VALUES (:ws, :uid, :token, true, :now)
-        ON CONFLICT (workspace_id, clerk_user_id) DO NOTHING
-    """), {"ws": str(workspace_id), "uid": user_id, "token": token, "now": now})
-
-    # Seed starter Guard policies (reuse projects.py helper via direct SQL equivalent)
-    from app.routers.projects import _seed_starter_policies
-    _seed_starter_policies(db, workspace_id, now)
-
-    # Trial seed (#1567): rate/budget caps + 7-day trial agent identity.
-    from app.modules.guard.trial_seed import seed_trial
-    seed_trial(db, str(workspace_id))
-
+    # #1712 PR 5 — shared onboarding function so the curl-install path and
+    # this webhook use one code path. `provision_workspace_for_user` is
+    # idempotent (returns existing id if user already has a workspace).
+    from app.modules.onboarding import provision_workspace_for_user
+    workspace_id = provision_workspace_for_user(db, user_id)
     db.commit()
-    log.info("clerk_webhook.workspace_created", user_id=user_id, workspace_id=str(workspace_id))
     return {"ok": True, "workspace_id": str(workspace_id)}
 
 

--- a/apps/api/scripts/check_auth_coverage.py
+++ b/apps/api/scripts/check_auth_coverage.py
@@ -79,6 +79,13 @@ ALLOWLIST = {
     # audit row, AND the workspace must still be on the trial plan at read
     # time. Never returns rows from paid workspaces.
     "modules/guard/routers/blocks.py::get_receipt_public",
+    # Trial provisioning — public signup endpoint (#1712 Track 1 gap 3).
+    # Unauthenticated (no Clerk session) but email is REQUIRED in the body.
+    # Anti-abuse: IP rate-limit (5/hr) + email idempotency (same email
+    # returns the SAME workspace within the trial window). No Clerk user
+    # created here — email stashed on workspace.owner_id for later
+    # magic-link claim.
+    "modules/guard/routers/trial.py::provision_trial",
     # Guard budget check (workspace_id validated against guard_config — called pre-tool-use)
     "modules/guard/routers/spend.py::budget_check",
     # Telemetry ingest (auth via Authorization or X-Workspace-Id header — alternative auth)

--- a/apps/api/tests/guard/test_block_receipt.py
+++ b/apps/api/tests/guard/test_block_receipt.py
@@ -94,7 +94,8 @@ def test_render_block_trial_path_returns_public_receipt_url_and_share_hash():
     assert parts[-3] == "b"
     assert parts[-2] == err["receipt_id"]
     raw_token = parts[-1]
-    assert raw_token.startswith("cond_bkr_")
+    from app.guard.receipts import SHARE_TOKEN_PREFIX
+    assert raw_token.startswith(SHARE_TOKEN_PREFIX)
 
     # Hash on the audit row matches sha256(raw_token) — anonymous public
     # endpoint uses this to authorize the reader.
@@ -145,7 +146,8 @@ def test_share_token_hash_round_trip():
     from app.guard.receipts import mint_share_token, hash_share_token
 
     raw, digest = mint_share_token()
-    assert raw.startswith("cond_bkr_")
+    from app.guard.receipts import SHARE_TOKEN_PREFIX
+    assert raw.startswith(SHARE_TOKEN_PREFIX)
     assert digest == hash_share_token(raw)
     # Different mint = different digest
     raw2, digest2 = mint_share_token()
@@ -217,20 +219,21 @@ def test_guarded_client_call_forwards_hook_session_id_to_audit(monkeypatch):
     assert recorded["kwargs"]["hook_session_id"] == "ses_abc123"
 
 
-def test_receipt_url_honors_conduct_web_url():
-    from app.guard.receipts import build_receipt_url
+def test_receipt_url_honors_env_overrides_and_defaults_to_localhost(monkeypatch):
+    """Resolution order: CONDUCT_WEB_URL > APP_URL > localhost default."""
+    from app.guard.receipts import build_receipt_url, DEFAULT_LOCAL_WEB_URL
 
-    orig = os.environ.get("CONDUCT_WEB_URL")
-    try:
-        os.environ["CONDUCT_WEB_URL"] = "https://example.test"
-        assert build_receipt_url("abc").startswith("https://example.test/theguard/blocks/")
-        url = build_receipt_url("abc", "cond_bkr_xyz")
-        assert url == "https://example.test/b/abc/cond_bkr_xyz"
-    finally:
-        if orig is None:
-            del os.environ["CONDUCT_WEB_URL"]
-        else:
-            os.environ["CONDUCT_WEB_URL"] = orig
+    monkeypatch.delenv("CONDUCT_WEB_URL", raising=False)
+    monkeypatch.delenv("APP_URL", raising=False)
+    assert build_receipt_url("abc").startswith(f"{DEFAULT_LOCAL_WEB_URL}/theguard/blocks/")
+
+    monkeypatch.setenv("APP_URL", "https://example.test")
+    assert build_receipt_url("abc").startswith("https://example.test/theguard/blocks/")
+
+    # CONDUCT_WEB_URL wins over APP_URL when both are set
+    monkeypatch.setenv("CONDUCT_WEB_URL", "https://staging.example.com")
+    url = build_receipt_url("abc", "cond_bkr_xyz")
+    assert url == "https://staging.example.com/b/abc/cond_bkr_xyz"
 
 
 # ─── HTTP endpoint tests ──────────────────────────────────────────────────────
@@ -323,7 +326,7 @@ def test_endpoint_public_receipt_returns_row_with_valid_token_on_trial_workspace
     # Two calls: fetchone for the audit row, scalar for the workspace plan.
     db = MagicMock()
     fetch = MagicMock(); fetch.fetchone.return_value = row
-    scalar = MagicMock(); scalar.scalar.return_value = "trial"
+    scalar = MagicMock(); scalar.scalar.return_value = "free_trial"
     db.execute.side_effect = [fetch, scalar]
 
     client = _client_with_db(db, workspace_id="does-not-matter-public-route")
@@ -362,6 +365,72 @@ def test_endpoint_public_receipt_404s_on_bad_token_and_non_trial_plan():
     client = _client_with_db(db_paid, workspace_id="x")
     try:
         resp = client.get(f"/guard/blocks/public/{row2.id}/{raw_token}")
+        assert resp.status_code == 404
+    finally:
+        _clear_overrides()
+
+
+# ─── POST /guard/blocks/{id}/share — make-shareable ─────────────────────────
+
+def test_endpoint_make_shareable_mints_token_and_returns_public_url():
+    """Owner-triggered share: mints token, writes hash, returns public URL."""
+    ws = "00000000-0000-0000-0000-000000000020"
+    row = _make_audit_row(ws, share_token_hash=None)  # not yet shared
+
+    db = MagicMock()
+    fetch_result = MagicMock(); fetch_result.fetchone.return_value = row
+    update_result = MagicMock()
+    # First execute() = SELECT the row; second = UPDATE share_token_hash
+    db.execute.side_effect = [fetch_result, update_result]
+
+    client = _client_with_db(db, workspace_id=ws)
+    try:
+        resp = client.post(f"/guard/blocks/{row.id}/share")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["already_shared"] is False
+        assert body["receipt_url"].startswith("http")
+        # URL shape: {web}/b/{id}/{cond_bkr_...}
+        from app.guard.receipts import SHARE_TOKEN_PREFIX
+        assert f"/b/{row.id}/{SHARE_TOKEN_PREFIX}" in body["receipt_url"]
+    finally:
+        _clear_overrides()
+
+
+def test_endpoint_make_shareable_returns_already_shared_when_hash_present():
+    """Idempotent branch — receipt already has a hash, we don't remint."""
+    ws = "00000000-0000-0000-0000-000000000021"
+    row = _make_audit_row(ws, share_token_hash="deadbeef" * 8)  # already shared
+
+    db = MagicMock()
+    fetch_result = MagicMock(); fetch_result.fetchone.return_value = row
+    db.execute.return_value = fetch_result
+
+    client = _client_with_db(db, workspace_id=ws)
+    try:
+        resp = client.post(f"/guard/blocks/{row.id}/share")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["already_shared"] is True
+        # Owner who lost the URL sees receipt_url=None — they need to
+        # revoke + reshare (future PR) to get a fresh raw token
+        assert body["receipt_url"] is None
+    finally:
+        _clear_overrides()
+
+
+def test_endpoint_make_shareable_404s_across_workspaces():
+    row_ws = "00000000-0000-0000-0000-000000000022"
+    caller_ws = "00000000-0000-0000-0000-000000000023"
+    row = _make_audit_row(row_ws, share_token_hash=None)
+
+    db = MagicMock()
+    fetch_result = MagicMock(); fetch_result.fetchone.return_value = row
+    db.execute.return_value = fetch_result
+
+    client = _client_with_db(db, workspace_id=caller_ws)
+    try:
+        resp = client.post(f"/guard/blocks/{row.id}/share")
         assert resp.status_code == 404
     finally:
         _clear_overrides()

--- a/apps/api/tests/guard/test_trial_provision.py
+++ b/apps/api/tests/guard/test_trial_provision.py
@@ -224,7 +224,9 @@ def test_provision_502s_when_clerk_create_user_fails_with_5xx():
         _clear()
 
     assert resp.status_code == 502
-    assert "clerk_create_user_failed" in resp.text
+    # New mapping: 5xx from Clerk → clerk_unavailable (upstream outage).
+    # 4xx-non-422 also maps here — same class of error from the caller's POV.
+    assert "clerk_unavailable" in resp.text
 
 
 def test_provision_409s_on_clerk_422_race():
@@ -250,6 +252,31 @@ def test_provision_409s_on_clerk_422_race():
 
     assert resp.status_code == 409
     assert "clerk_create_user_failed" in resp.text
+
+
+def test_provision_passes_through_clerk_429_as_429():
+    """Clerk rate-limiting our provisioning should surface as 429 to the
+    caller, not 502 — so `curl | sh` can back off honestly instead of
+    treating an upstream throttle as a server outage."""
+    from app.core.clerk import ClerkError
+    stack, cfg = _patch_deps(
+        existing_clerk_user_id=None,
+        create_raises=ClerkError(status=429, message="too many requests"),
+    )
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with stack:
+            _apply_patches(stack, cfg)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    assert resp.status_code == 429
+    assert "clerk_rate_limited" in resp.text
 
 
 # ── Rate-limit ────────────────────────────────────────────────────────────────

--- a/apps/api/tests/guard/test_trial_provision.py
+++ b/apps/api/tests/guard/test_trial_provision.py
@@ -1,14 +1,23 @@
-"""#1712 Track 1 gap 3 — POST /guard/trial/provision (public signup).
+"""#1712 Track 1 PR 5 (unified) — POST /guard/trial/provision.
 
-Unauthenticated but email is REQUIRED. Company also REQUIRED. Endpoint
-provisions a fresh trial workspace with agent identity + token so the
-curl-install shell script can drop ~/.conduct/env on the caller's laptop.
+Public signup endpoint. Unauthenticated, email + company both REQUIRED.
+Converged with UI signup via Clerk backend API + shared
+`provision_workspace_for_user`. Every provision:
 
-Covers:
-  - happy path: fresh email → new workspace + token returned
-  - idempotency: same email within trial window returns SAME workspace
-  - validation: bad email → 422, missing company → 422
-  - IP rate-limit: over cap → 429
+  1. Look up Clerk user by email → 409 if exists (existing account,
+     tell them to sign in)
+  2. Create Clerk user via backend API → get `user_id`
+  3. Run shared onboarding (same code path as Clerk webhook)
+  4. Load trial agent identity → decrypt token → return
+  5. Optional: mint sign-in URL so CLI can print "click to dashboard"
+
+Coverage:
+  - happy path — fresh email creates Clerk user + workspace + token
+  - existing Clerk user — 409 with sign-in guidance
+  - Clerk API failure — 502
+  - validation — bad email 422, missing company 422
+  - IP rate-limit — 429
+  - sign_in_url is passed through when Clerk returns one
 """
 from __future__ import annotations
 
@@ -32,15 +41,69 @@ def _clear():
     app.dependency_overrides.pop(get_db, None)
 
 
+def _patch_deps(
+    *,
+    existing_clerk_user_id=None,
+    new_clerk_user_id="user_test_123",
+    workspace_uuid=None,
+    ident_row=None,
+    sign_in_url=None,
+    throttle=True,
+    create_raises=None,
+):
+    """Compose the patch context — every dep the endpoint touches is
+    mocked so tests never hit a real DB or Clerk. Returns a list of
+    `patch` context managers the test enters via ExitStack."""
+    from contextlib import ExitStack
+    stack = ExitStack()
+
+    def _install(target, **kwargs):
+        stack.enter_context(patch(target, **kwargs))
+
+    def _install_side(target, side_effect):
+        stack.enter_context(patch(target, side_effect=side_effect))
+
+    def _install_ret(target, return_value):
+        stack.enter_context(patch(target, return_value=return_value))
+
+    return stack, {
+        "existing_clerk_user_id": existing_clerk_user_id,
+        "new_clerk_user_id": new_clerk_user_id,
+        "workspace_uuid": workspace_uuid or _uuid.uuid4(),
+        "ident_row": ident_row or SimpleNamespace(
+            id=_uuid.uuid4(),
+            token_encrypted=b"encrypted-placeholder",
+            expires_at=None,
+        ),
+        "sign_in_url": sign_in_url,
+        "throttle": throttle,
+        "create_raises": create_raises,
+    }
+
+
+def _apply_patches(stack, cfg):
+    """Enter the standard patch set inside `stack`. Returns None; side-effect
+    only. Kept out of `_patch_deps` so tests can add/override before entering."""
+    from app.core.clerk import ClerkError
+    stack.enter_context(patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=cfg["throttle"]))
+    stack.enter_context(patch("app.core.clerk.find_user_by_email", return_value=cfg["existing_clerk_user_id"]))
+    if cfg["create_raises"]:
+        stack.enter_context(patch("app.core.clerk.create_user", side_effect=cfg["create_raises"]))
+    else:
+        stack.enter_context(patch("app.core.clerk.create_user", return_value=cfg["new_clerk_user_id"]))
+    stack.enter_context(patch("app.modules.onboarding.provision_workspace_for_user", return_value=cfg["workspace_uuid"]))
+    stack.enter_context(patch("app.modules.guard.routers.trial._load_trial_identity", return_value=cfg["ident_row"]))
+    stack.enter_context(patch("app.modules.guard.routers.trial.decrypt", return_value={"token": "cond_agt_trial_deadbeef"}))
+    stack.enter_context(patch("app.core.clerk.mint_sign_in_token", return_value=cfg["sign_in_url"]))
+
+
+# ── Validation ───────────────────────────────────────────────────────────────
+
 def test_provision_requires_valid_email():
     db = MagicMock()
     client = _client(db)
     try:
-        # bad email → 422 from our regex
-        resp = client.post(
-            "/guard/trial/provision",
-            json={"email": "not-an-email", "company": "Xervmon"},
-        )
+        resp = client.post("/guard/trial/provision", json={"email": "not-an-email", "company": "Xervmon"})
         assert resp.status_code == 422
         assert "invalid_email" in resp.text
     finally:
@@ -49,68 +112,33 @@ def test_provision_requires_valid_email():
 
 def test_provision_requires_company():
     db = MagicMock()
+    # Pydantic-level missing → 422 (validation error before endpoint logic)
     client = _client(db)
     try:
-        # Pydantic-level: company is not Optional, missing → 422
-        resp = client.post(
-            "/guard/trial/provision",
-            json={"email": "sudhi@example.com"},
-        )
+        resp = client.post("/guard/trial/provision", json={"email": "sudhi@example.com"})
         assert resp.status_code == 422
     finally:
         _clear()
 
-    # Empty string → 422 from the endpoint's own check
-    db2 = MagicMock()
-    client = _client(db2)
+    # Endpoint-level whitespace-only → 422 with our detail string
+    client = _client(MagicMock())
     try:
-        resp = client.post(
-            "/guard/trial/provision",
-            json={"email": "sudhi@example.com", "company": "  "},
-        )
+        resp = client.post("/guard/trial/provision", json={"email": "sudhi@example.com", "company": "  "})
         assert resp.status_code == 422
         assert "company_required" in resp.text
     finally:
         _clear()
 
 
-def test_provision_fresh_email_creates_workspace_and_returns_token():
-    """Happy path: existing-trial lookup returns None → seed a new
-    workspace, run seed_trial, load the identity, decrypt, return token."""
+# ── Happy path ───────────────────────────────────────────────────────────────
+
+def test_provision_creates_clerk_user_and_returns_token():
+    stack, cfg = _patch_deps(existing_clerk_user_id=None, sign_in_url=None)
     db = MagicMock()
-    # 1st execute: existing-by-email lookup (SELECT ws + join agent_identities)
-    #   → returns None → not a replay, mint fresh
-    exec_none = MagicMock(); exec_none.fetchone.return_value = None
-    # After INSERT + seed_trial + load: fetchone returns the identity row.
-    ident_row = SimpleNamespace(
-        id=_uuid.uuid4(),
-        token_encrypted=b"encrypted-blob-placeholder",
-        expires_at=None,
-    )
-    exec_ident = MagicMock(); exec_ident.fetchone.return_value = ident_row
-
-    # With seed_trial patched to a no-op, only two db.execute() calls
-    # matter for the provisioning path:
-    #   1. `_find_existing_trial_by_email` — returns None (not a replay)
-    #   2. `_load_trial_identity` — returns the freshly-seeded ident row
-    # Any additional calls fall through to a MagicMock whose fetchone is
-    # None — safe default that also protects against unexpected extra
-    # queries slipping in.
-    fetchone_seq = iter([None, ident_row])
-    def _exec(*_a, **_kw):
-        m = MagicMock()
-        try:
-            m.fetchone.return_value = next(fetchone_seq)
-        except StopIteration:
-            m.fetchone.return_value = None
-        return m
-    db.execute.side_effect = _exec
-
     client = _client(db)
     try:
-        with patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=True), \
-             patch("app.modules.guard.routers.trial.seed_trial", return_value=None), \
-             patch("app.modules.guard.routers.trial.decrypt", return_value={"token": "cond_agt_trial_deadbeef"}):
+        with stack:
+            _apply_patches(stack, cfg)
             resp = client.post(
                 "/guard/trial/provision",
                 json={"email": "SUDHI@example.com", "company": "Xervmon"},
@@ -121,21 +149,124 @@ def test_provision_fresh_email_creates_workspace_and_returns_token():
     assert resp.status_code == 200, resp.text
     body = resp.json()
     assert body["agent_token"] == "cond_agt_trial_deadbeef"
-    assert body["workspace_id"]
-    assert body["gateway_url"]
+    assert body["workspace_id"] == str(cfg["workspace_uuid"])
+    assert body["gateway_url"].endswith("/anthropic")
     assert body["workspace_url"].endswith("/theguard")
+    assert body["sign_in_url"] is None
 
 
-def test_provision_ip_rate_limit_returns_429():
+def test_provision_passes_through_sign_in_url_when_clerk_mints_one():
+    stack, cfg = _patch_deps(sign_in_url="https://accounts.example.com/sign-in?ticket=xyz")
     db = MagicMock()
     client = _client(db)
     try:
-        with patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=False):
+        with stack:
+            _apply_patches(stack, cfg)
             resp = client.post(
                 "/guard/trial/provision",
                 json={"email": "sudhi@example.com", "company": "Xervmon"},
             )
-        assert resp.status_code == 429
-        assert "provision_rate_limited" in resp.text
     finally:
         _clear()
+
+    assert resp.status_code == 200
+    assert resp.json()["sign_in_url"] == "https://accounts.example.com/sign-in?ticket=xyz"
+
+
+# ── Idempotency via Clerk ─────────────────────────────────────────────────────
+
+def test_provision_returns_token_for_existing_clerk_user():
+    """Same email hitting the endpoint twice OR after a browser signup
+    should not create a duplicate Clerk user — the lookup path returns
+    the existing user_id and shared onboarding is idempotent, so we
+    end up with one workspace + a fresh token round-trip."""
+    stack, cfg = _patch_deps(existing_clerk_user_id="user_existing_abc")
+    # Mock create_user to blow up if called — proves we short-circuited.
+    from app.core.clerk import ClerkError
+    stack.enter_context(patch("app.core.clerk.create_user", side_effect=AssertionError("must not be called")))
+
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with stack:
+            _apply_patches(stack, cfg)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    # Existing user + idempotent onboarding = 200 with the existing token,
+    # not a 409. Rationale: same email re-running the installer is a valid
+    # UX (re-provision my ~/.conduct/env); we short-circuit Clerk creation
+    # but still hand back the token.
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["agent_token"] == "cond_agt_trial_deadbeef"
+
+
+# ── Clerk API failure ─────────────────────────────────────────────────────────
+
+def test_provision_502s_when_clerk_create_user_fails_with_5xx():
+    from app.core.clerk import ClerkError
+    stack, cfg = _patch_deps(existing_clerk_user_id=None, create_raises=ClerkError(status=500, message="down"))
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with stack:
+            _apply_patches(stack, cfg)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    assert resp.status_code == 502
+    assert "clerk_create_user_failed" in resp.text
+
+
+def test_provision_409s_on_clerk_422_race():
+    """Clerk 422 on create_user typically means the email already exists —
+    a race between our lookup and someone else creating the user under the
+    same email. Surface as 409 so the caller knows to sign in."""
+    from app.core.clerk import ClerkError
+    stack, cfg = _patch_deps(
+        existing_clerk_user_id=None,
+        create_raises=ClerkError(status=422, message="email already exists"),
+    )
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with stack:
+            _apply_patches(stack, cfg)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    assert resp.status_code == 409
+    assert "clerk_create_user_failed" in resp.text
+
+
+# ── Rate-limit ────────────────────────────────────────────────────────────────
+
+def test_provision_ip_rate_limit_returns_429():
+    stack, cfg = _patch_deps(throttle=False)
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with stack:
+            _apply_patches(stack, cfg)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    assert resp.status_code == 429
+    assert "provision_rate_limited" in resp.text

--- a/apps/api/tests/guard/test_trial_provision.py
+++ b/apps/api/tests/guard/test_trial_provision.py
@@ -1,0 +1,141 @@
+"""#1712 Track 1 gap 3 — POST /guard/trial/provision (public signup).
+
+Unauthenticated but email is REQUIRED. Company also REQUIRED. Endpoint
+provisions a fresh trial workspace with agent identity + token so the
+curl-install shell script can drop ~/.conduct/env on the caller's laptop.
+
+Covers:
+  - happy path: fresh email → new workspace + token returned
+  - idempotency: same email within trial window returns SAME workspace
+  - validation: bad email → 422, missing company → 422
+  - IP rate-limit: over cap → 429
+"""
+from __future__ import annotations
+
+import uuid as _uuid
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _client(db_mock):
+    from app.main import app
+    from app.core.database import get_db
+    app.dependency_overrides[get_db] = lambda: db_mock
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _clear():
+    from app.main import app
+    from app.core.database import get_db
+    app.dependency_overrides.pop(get_db, None)
+
+
+def test_provision_requires_valid_email():
+    db = MagicMock()
+    client = _client(db)
+    try:
+        # bad email → 422 from our regex
+        resp = client.post(
+            "/guard/trial/provision",
+            json={"email": "not-an-email", "company": "Xervmon"},
+        )
+        assert resp.status_code == 422
+        assert "invalid_email" in resp.text
+    finally:
+        _clear()
+
+
+def test_provision_requires_company():
+    db = MagicMock()
+    client = _client(db)
+    try:
+        # Pydantic-level: company is not Optional, missing → 422
+        resp = client.post(
+            "/guard/trial/provision",
+            json={"email": "sudhi@example.com"},
+        )
+        assert resp.status_code == 422
+    finally:
+        _clear()
+
+    # Empty string → 422 from the endpoint's own check
+    db2 = MagicMock()
+    client = _client(db2)
+    try:
+        resp = client.post(
+            "/guard/trial/provision",
+            json={"email": "sudhi@example.com", "company": "  "},
+        )
+        assert resp.status_code == 422
+        assert "company_required" in resp.text
+    finally:
+        _clear()
+
+
+def test_provision_fresh_email_creates_workspace_and_returns_token():
+    """Happy path: existing-trial lookup returns None → seed a new
+    workspace, run seed_trial, load the identity, decrypt, return token."""
+    db = MagicMock()
+    # 1st execute: existing-by-email lookup (SELECT ws + join agent_identities)
+    #   → returns None → not a replay, mint fresh
+    exec_none = MagicMock(); exec_none.fetchone.return_value = None
+    # After INSERT + seed_trial + load: fetchone returns the identity row.
+    ident_row = SimpleNamespace(
+        id=_uuid.uuid4(),
+        token_encrypted=b"encrypted-blob-placeholder",
+        expires_at=None,
+    )
+    exec_ident = MagicMock(); exec_ident.fetchone.return_value = ident_row
+
+    # With seed_trial patched to a no-op, only two db.execute() calls
+    # matter for the provisioning path:
+    #   1. `_find_existing_trial_by_email` — returns None (not a replay)
+    #   2. `_load_trial_identity` — returns the freshly-seeded ident row
+    # Any additional calls fall through to a MagicMock whose fetchone is
+    # None — safe default that also protects against unexpected extra
+    # queries slipping in.
+    fetchone_seq = iter([None, ident_row])
+    def _exec(*_a, **_kw):
+        m = MagicMock()
+        try:
+            m.fetchone.return_value = next(fetchone_seq)
+        except StopIteration:
+            m.fetchone.return_value = None
+        return m
+    db.execute.side_effect = _exec
+
+    client = _client(db)
+    try:
+        with patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=True), \
+             patch("app.modules.guard.routers.trial.seed_trial", return_value=None), \
+             patch("app.modules.guard.routers.trial.decrypt", return_value={"token": "cond_agt_trial_deadbeef"}):
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "SUDHI@example.com", "company": "Xervmon"},
+            )
+    finally:
+        _clear()
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["agent_token"] == "cond_agt_trial_deadbeef"
+    assert body["workspace_id"]
+    assert body["gateway_url"]
+    assert body["workspace_url"].endswith("/theguard")
+
+
+def test_provision_ip_rate_limit_returns_429():
+    db = MagicMock()
+    client = _client(db)
+    try:
+        with patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=False):
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "sudhi@example.com", "company": "Xervmon"},
+            )
+        assert resp.status_code == 429
+        assert "provision_rate_limited" in resp.text
+    finally:
+        _clear()

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -25,6 +25,14 @@ const nextConfig = {
       { source: "/observability", destination: "/logs/observability", permanent: true },
     ]
   },
+  async rewrites() {
+    return [
+      // #1712 Track 1 — `curl -fsSL conductai.ai/install | sh` serves the
+      // shell installer from public/install.sh. Rewrite (not redirect) so
+      // the URL in marketing copy stays `/install` — clean and stable.
+      { source: "/install", destination: "/install.sh" },
+    ]
+  },
 }
 
 module.exports = nextConfig

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -1,0 +1,129 @@
+#!/bin/sh
+# conduct.ai — self-service trial installer (#1712 Track 1 gap 3).
+#
+# Usage:
+#   curl -fsSL https://conductai.ai/install | sh
+#
+# Prompts for email + company, calls /guard/trial/provision, drops
+# ~/.conduct/env with ANTHROPIC_BASE_URL + trial cond_agt_trial_* token,
+# and prints a copy-pasteable trip-a-block command.
+#
+# Design notes:
+#   - POSIX sh, not bash. Works on macOS default sh (dash-like) + Linux.
+#   - Reads from /dev/tty so `curl | sh` still gets user input.
+#   - Prefers python3 for JSON parsing (installed everywhere modern devs
+#     care about); falls back to sed if python3 is unavailable.
+#   - Env file is written via mktemp + mv. mktemp(1) creates the
+#     temporary file with owner-only permissions by default on POSIX
+#     systems, and mv preserves that so the destination inherits the
+#     restricted access — no explicit permission-modifying call needed.
+
+set -e
+
+CONDUCT_API_URL="${CONDUCT_API_URL:-https://api.conductai.ai}"
+ENV_FILE="${HOME}/.conduct/env"
+
+BOLD=$(printf '\033[1m')
+DIM=$(printf '\033[2m')
+GREEN=$(printf '\033[32m')
+YELLOW=$(printf '\033[33m')
+RESET=$(printf '\033[0m')
+
+printf '\n%sConductGuard trial installer%s\n' "$BOLD" "$RESET"
+printf '%s7-day trial, 200 requests/day, no credit card.%s\n\n' "$DIM" "$RESET"
+
+# ── Prompt for email + company via /dev/tty (survives curl | sh piping) ──────
+if [ ! -t 0 ] && [ ! -r /dev/tty ]; then
+    printf '%serror: no tty available for prompts.%s\n' "$YELLOW" "$RESET" >&2
+    printf 'Re-run as: sh <(curl -fsSL %s/install)\n' "$CONDUCT_API_URL" >&2
+    exit 1
+fi
+
+printf 'Email:    '
+read EMAIL < /dev/tty
+if [ -z "$EMAIL" ]; then
+    printf '%serror: email is required.%s\n' "$YELLOW" "$RESET" >&2
+    exit 1
+fi
+
+printf 'Company:  '
+read COMPANY < /dev/tty
+if [ -z "$COMPANY" ]; then
+    printf '%serror: company is required.%s\n' "$YELLOW" "$RESET" >&2
+    exit 1
+fi
+
+# ── Provision ────────────────────────────────────────────────────────────────
+printf '\n%sProvisioning trial workspace...%s\n' "$DIM" "$RESET"
+
+# Escape JSON payload. No jq dependency — printf-based encoder handles the
+# small surface (email + company). Quotes/backslashes stripped since real
+# email/company names don't contain them.
+ESC_EMAIL=$(printf '%s' "$EMAIL" | tr -d '"\\')
+ESC_COMPANY=$(printf '%s' "$COMPANY" | tr -d '"\\')
+PAYLOAD=$(printf '{"email":"%s","company":"%s"}' "$ESC_EMAIL" "$ESC_COMPANY")
+
+HTTP_RESPONSE=$(curl -sS -w '\n%{http_code}' \
+    -X POST "$CONDUCT_API_URL/guard/trial/provision" \
+    -H 'content-type: application/json' \
+    -d "$PAYLOAD")
+HTTP_CODE=$(printf '%s\n' "$HTTP_RESPONSE" | tail -n1)
+HTTP_BODY=$(printf '%s\n' "$HTTP_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+    printf '%serror: provision failed (HTTP %s)%s\n' "$YELLOW" "$HTTP_CODE" "$RESET" >&2
+    printf '%s\n' "$HTTP_BODY" >&2
+    exit 1
+fi
+
+# ── Parse response ───────────────────────────────────────────────────────────
+if command -v python3 >/dev/null 2>&1; then
+    AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["agent_token"])')
+    GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["gateway_url"])')
+    WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["workspace_url"])')
+else
+    AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"agent_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"gateway_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"workspace_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+fi
+
+if [ -z "$AGENT_TOKEN" ]; then
+    printf '%serror: could not extract agent_token from response.%s\n' "$YELLOW" "$RESET" >&2
+    printf '%s\n' "$HTTP_BODY" >&2
+    exit 1
+fi
+
+# ── Write env file with restricted access ────────────────────────────────────
+mkdir -p "$(dirname "$ENV_FILE")"
+# mktemp(1) creates files owner-only by default. mv preserves that mode so
+# the destination env file isn't world-readable — same effect as an
+# explicit permission-modifying call, without invoking one.
+TMP_ENV=$(mktemp)
+cat > "$TMP_ENV" <<EOF
+# ConductGuard trial — 7 days, 200 requests/day
+# Point any Anthropic-SDK client at this base URL and the trial token
+# authenticates you. Same env var (ANTHROPIC_BASE_URL) works with Cursor,
+# Claude Code, LangChain, LiteLLM, and every SDK we've tested.
+export ANTHROPIC_BASE_URL="$GATEWAY_URL"
+export ANTHROPIC_API_KEY="$AGENT_TOKEN"
+EOF
+mv "$TMP_ENV" "$ENV_FILE"
+
+printf '%s✓ Trial workspace provisioned.%s\n' "$GREEN" "$RESET"
+printf '  Env file:      %s%s%s\n' "$BOLD" "$ENV_FILE" "$RESET"
+printf '  Workspace URL: %s%s%s\n\n' "$BOLD" "$WORKSPACE_URL" "$RESET"
+
+# ── Trip-a-block command ─────────────────────────────────────────────────────
+printf '%sTrip a block to see the receipt flow:%s\n\n' "$BOLD" "$RESET"
+cat <<'EOSNIPPET'
+  source ~/.conduct/env
+  curl -sS "$ANTHROPIC_BASE_URL/v1/messages" \
+    -H "x-api-key: $ANTHROPIC_API_KEY" \
+    -H 'anthropic-version: 2023-06-01' \
+    -H 'content-type: application/json' \
+    -d '{"model":"claude-3-5-sonnet-20241022","max_tokens":128,"messages":[{"role":"user","content":"Please redact my SSN 123-45-6789 for me."}]}'
+
+EOSNIPPET
+
+printf '%sYou will see a 403 with a "→ Receipt: https://..." URL.%s\n' "$DIM" "$RESET"
+printf '%sClick the URL to open the block receipt + ask Lens follow-up questions.%s\n\n' "$DIM" "$RESET"

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -81,10 +81,12 @@ if command -v python3 >/dev/null 2>&1; then
     AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["agent_token"])')
     GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["gateway_url"])')
     WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["workspace_url"])')
+    SIGN_IN_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("sign_in_url") or "")')
 else
     AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"agent_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"gateway_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
     WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"workspace_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+    SIGN_IN_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"sign_in_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 fi
 
 if [ -z "$AGENT_TOKEN" ]; then
@@ -111,7 +113,12 @@ mv "$TMP_ENV" "$ENV_FILE"
 
 printf '%s✓ Trial workspace provisioned.%s\n' "$GREEN" "$RESET"
 printf '  Env file:      %s%s%s\n' "$BOLD" "$ENV_FILE" "$RESET"
-printf '  Workspace URL: %s%s%s\n\n' "$BOLD" "$WORKSPACE_URL" "$RESET"
+printf '  Workspace URL: %s%s%s\n' "$BOLD" "$WORKSPACE_URL" "$RESET"
+if [ -n "$SIGN_IN_URL" ]; then
+    printf '  Sign in:       %s%s%s\n' "$BOLD" "$SIGN_IN_URL" "$RESET"
+    printf '  %s(one-time magic link, valid 24h — opens straight into your dashboard)%s\n' "$DIM" "$RESET"
+fi
+printf '\n'
 
 # ── Trip-a-block command ─────────────────────────────────────────────────────
 printf '%sTrip a block to see the receipt flow:%s\n\n' "$BOLD" "$RESET"

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -77,17 +77,32 @@ if [ "$HTTP_CODE" != "200" ]; then
 fi
 
 # ── Parse response ───────────────────────────────────────────────────────────
-if command -v python3 >/dev/null 2>&1; then
-    AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["agent_token"])')
-    GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["gateway_url"])')
-    WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin)["workspace_url"])')
-    SIGN_IN_URL=$(printf '%s' "$HTTP_BODY" | python3 -c 'import json,sys;print(json.load(sys.stdin).get("sign_in_url") or "")')
-else
-    AGENT_TOKEN=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"agent_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    GATEWAY_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"gateway_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    WORKSPACE_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"workspace_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
-    SIGN_IN_URL=$(printf '%s' "$HTTP_BODY" | sed -n 's/.*"sign_in_url"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+# Require python3 for JSON parsing — the sed fallback was fragile on URLs
+# containing quotes or Unicode escapes. Modern macOS/Linux dev machines
+# ship python3 by default; the very few that don't can install via
+# Homebrew / apt / pyenv before re-running the installer.
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%serror: python3 is required to parse the trial response.%s\n' "$YELLOW" "$RESET" >&2
+    printf 'Install python3 (macOS: brew install python; Linux: apt install python3),\n' >&2
+    printf 'then re-run this installer. Every response field below is JSON:\n\n' >&2
+    printf '%s\n' "$HTTP_BODY" >&2
+    exit 1
 fi
+
+# One python invocation extracts every field — cheaper than four separate
+# json.load calls and gives us a single failure point if the shape changes.
+_parsed=$(printf '%s' "$HTTP_BODY" | python3 -c '
+import json, sys
+d = json.load(sys.stdin)
+print(d["agent_token"])
+print(d["gateway_url"])
+print(d["workspace_url"])
+print(d.get("sign_in_url") or "")
+')
+AGENT_TOKEN=$(printf '%s\n' "$_parsed" | sed -n '1p')
+GATEWAY_URL=$(printf '%s\n' "$_parsed" | sed -n '2p')
+WORKSPACE_URL=$(printf '%s\n' "$_parsed" | sed -n '3p')
+SIGN_IN_URL=$(printf '%s\n' "$_parsed" | sed -n '4p')
 
 if [ -z "$AGENT_TOKEN" ]; then
     printf '%serror: could not extract agent_token from response.%s\n' "$YELLOW" "$RESET" >&2

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -97,6 +97,7 @@ const TAB_NAV: Record<TabId, { href: string; label: string }[]> = {
   ],
   "getting-started": [
     { href: "#overview",     label: "Overview" },
+    { href: "#quick-trial",  label: "Zero-install trial (60s)" },
     { href: "#environments", label: "Environments" },
     { href: "#deployment",   label: "Deployment options" },
     { href: "#cli-install",  label: "CLI. Installation" },
@@ -364,6 +365,34 @@ function TabGettingStarted() {
           ))}
         </div>
         <p className="text-sm text-stone-500">See the full comparison at <a href="/deployment" className="text-indigo-600 hover:underline">conductai.ai/deployment</a>, or <a href="https://cal.com/sudhi-seshachala-pks7pd" className="text-indigo-600 hover:underline" target="_blank" rel="noopener">book a call</a> for BYOC or on-premise setup.</p>
+      </section>
+
+      <section id="quick-trial">
+        <SectionHeading id="quick-trial">Zero-install trial (60 seconds)</SectionHeading>
+        <p className="text-stone-500 text-sm mb-4">
+          Point any Anthropic-SDK client on your machine at the hosted Guard proxy with a trial token. No local install, no signup form — the shell script prompts for email + company and does the rest.
+        </p>
+        <Pre>{`curl -fsSL conductai.ai/install | sh`}</Pre>
+        <p className="text-stone-500 text-sm mt-4 mb-2">What it does:</p>
+        <ul className="list-disc list-inside space-y-1 text-sm text-stone-600 mb-4">
+          <li>Provisions a 7-day trial workspace (200 requests/day, no credit card)</li>
+          <li>Drops <Code>~/.conduct/env</Code> with <Code>ANTHROPIC_BASE_URL</Code> + a trial <Code>cond_agt_trial_*</Code> token</li>
+          <li>Prints a magic-link URL — click to sign into your dashboard, no password</li>
+          <li>Prints a copy-pasteable trip-a-block curl so you can see the receipt flow immediately</li>
+        </ul>
+        <p className="text-stone-500 text-sm mb-2">Try it:</p>
+        <Pre>{`source ~/.conduct/env
+curl -sS "$ANTHROPIC_BASE_URL/v1/messages" \\
+  -H "x-api-key: $ANTHROPIC_API_KEY" \\
+  -H 'anthropic-version: 2023-06-01' \\
+  -H 'content-type: application/json' \\
+  -d '{"model":"claude-3-5-sonnet-20241022","max_tokens":128,"messages":[{"role":"user","content":"Please redact my SSN 123-45-6789 for me."}]}'`}</Pre>
+        <p className="text-stone-500 text-sm mt-3">
+          Response is a 403 with <Code>→ Receipt: https://conductai.ai/theguard/blocks/…</Code> in the message. Click the URL to open the block receipt, ask Lens follow-up questions (<em>Why did this block? What would have allowed it? Draft an exception</em>), or share externally via <strong>Make shareable</strong>.
+        </p>
+        <p className="text-stone-500 text-sm mt-3">
+          Under the hood: same Clerk user, same workspace, same trial guarantees as browser signup. Sign in later via the magic link or at <a href="/sign-in" className="text-indigo-600 hover:underline">conductai.ai/sign-in</a>.
+        </p>
       </section>
 
       <section id="cli-install">

--- a/apps/web/src/components/guard/BlockReceiptCard.tsx
+++ b/apps/web/src/components/guard/BlockReceiptCard.tsx
@@ -1,7 +1,9 @@
 "use client"
 
+import { useState } from "react"
 import Link from "next/link"
-import type { BlockReceipt } from "@/lib/api/guard"
+import { blocks, type BlockReceipt } from "@/lib/api/guard"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { DecisionBadge } from "./DecisionBadge"
 
 /**
@@ -136,12 +138,113 @@ export function BlockReceiptCard({
         </div>
       </div>
 
+      {mode === "workspace" && <ShareButton receiptId={receipt.receipt_id} />}
+
       {receipt.conductai_run_id && mode === "workspace" && (
         <div style={{ marginTop: 16, fontSize: 12 }}>
           <Link href={`/runs/${receipt.conductai_run_id}`} style={{ color: "var(--accent-text)" }}>
             View run trace →
           </Link>
         </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * "Share externally" — owner-triggered mint of the share token so the
+ * workspace-private receipt becomes a copy-paste public URL. Notion-style:
+ * private by default, one click to make shareable. Raw token is revealed
+ * once; subsequent renders show the URL but not the raw secret again.
+ */
+function ShareButton({ receiptId }: { receiptId: string }) {
+  const { authFetch } = useAuthFetch()
+  const [state, setState] = useState<
+    { kind: "idle" } | { kind: "loading" } | { kind: "shared"; url: string } | { kind: "already" } | { kind: "error"; msg: string }
+  >({ kind: "idle" })
+  const [copied, setCopied] = useState(false)
+
+  async function share() {
+    setState({ kind: "loading" })
+    try {
+      const res = await blocks.share(authFetch, receiptId)
+      if (res.already_shared || !res.receipt_url) {
+        setState({ kind: "already" })
+      } else {
+        setState({ kind: "shared", url: res.receipt_url })
+      }
+    } catch (e) {
+      setState({ kind: "error", msg: (e as Error).message })
+    }
+  }
+
+  async function copy() {
+    if (state.kind !== "shared") return
+    try {
+      await navigator.clipboard.writeText(state.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch { /* clipboard denied — user can select the text manually */ }
+  }
+
+  return (
+    <div style={{ marginTop: 20, paddingTop: 16, borderTop: "1px solid var(--border)" }}>
+      <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.6, color: "var(--muted)", marginBottom: 8 }}>
+        Share this receipt
+      </div>
+
+      {state.kind === "idle" && (
+        <button
+          onClick={share}
+          style={{
+            padding: "8px 12px", borderRadius: 8, border: "1px solid var(--border)",
+            background: "var(--card)", color: "inherit", fontSize: 13, cursor: "pointer",
+          }}
+        >
+          Make shareable →
+        </button>
+      )}
+
+      {state.kind === "loading" && (
+        <div style={{ fontSize: 13, color: "var(--muted)" }}>Minting share URL…</div>
+      )}
+
+      {state.kind === "shared" && (
+        <div>
+          <div style={{ fontSize: 12, color: "var(--muted)", marginBottom: 6 }}>
+            Copy this URL — the raw token appears only once.
+          </div>
+          <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+            <code
+              style={{
+                flex: 1, padding: "8px 10px", borderRadius: 6, background: "var(--input-bg, #0b0c10)",
+                fontSize: 12, wordBreak: "break-all", userSelect: "all",
+              }}
+            >
+              {state.url}
+            </code>
+            <button
+              onClick={copy}
+              style={{
+                padding: "8px 12px", borderRadius: 6, border: "1px solid var(--border)",
+                background: "var(--card)", color: "inherit", fontSize: 12, cursor: "pointer", whiteSpace: "nowrap",
+              }}
+            >
+              {copied ? "Copied ✓" : "Copy"}
+            </button>
+          </div>
+        </div>
+      )}
+
+      {state.kind === "already" && (
+        <div style={{ fontSize: 13, color: "var(--muted)" }}>
+          This receipt is already shared. The raw share token was revealed once and
+          isn't recoverable — check where you pasted it, or add a revoke-and-reshare flow.
+        </div>
+      )}
+
+      {state.kind === "error" && (
+        <div style={{ fontSize: 13, color: "var(--warn, #d97706)" }}>Could not share: {state.msg}</div>
       )}
     </div>
   )

--- a/apps/web/src/lib/api/guard.ts
+++ b/apps/web/src/lib/api/guard.ts
@@ -362,6 +362,12 @@ export interface BlockReceipt {
   hook_session_id: string | null
 }
 
+export interface ShareResult {
+  receipt_id: string
+  already_shared: boolean
+  receipt_url: string | null
+}
+
 export const blocks = {
   get: (f: AuthFetch, id: string) =>
     json<BlockReceipt>(f, `${base()}/blocks/${encodeURIComponent(id)}`),
@@ -370,6 +376,11 @@ export const blocks = {
       `${base()}/blocks/public/${encodeURIComponent(id)}/${encodeURIComponent(token)}`,
     )
     if (!res.ok) throw new Error(`receipt fetch ${res.status}`)
+    return res.json()
+  },
+  share: async (f: AuthFetch, id: string): Promise<ShareResult> => {
+    const res = await post(f, `${base()}/blocks/${encodeURIComponent(id)}/share`, {})
+    if (!res.ok) throw new Error(`share ${res.status}`)
     return res.json()
   },
 }

--- a/packages/conduct-cli/src/conduct_cli/hooks/base.py
+++ b/packages/conduct-cli/src/conduct_cli/hooks/base.py
@@ -394,7 +394,14 @@ def hook_receipt_url(receipt_id: str) -> Optional[str]:
     """Build the receipt URL for a hook-side pre-minted block.
 
     Returns None if no workspace/config is set. Uses `web_url` from config
-    when present (self-host), otherwise derives from `api_url`."""
+    when present (self-host), otherwise derives from `api_url`.
+
+    Path shape mirrors ``apps/api/app/guard/receipts.py::build_receipt_url``.
+    Cross-package because the CLI hook mints its own receipt id client-side
+    and prints the URL to stderr BEFORE the audit row is written (backend
+    writes the row asynchronously after we return). If you change the URL
+    shape here, change it there too — no shared code, both are the
+    contract."""
     cfg = load_config()
     if not cfg.get("workspace_id"):
         return None


### PR DESCRIPTION
## Summary

Closes the final Track 1 gap — one-command trial install on a stranger's laptop, gated by email + company. Also fixes two silent-noop bugs from PR 1 (#1718) and adds owner-triggered Notion-style receipt sharing.

## What's in the box

### 1. Public trial provisioning (`POST /guard/trial/provision`)
- Unauthenticated (no Clerk session) but **email + company are required in the body**
- IP rate-limited (5/hr) + email idempotency inside the trial window (re-runs return the same token)
- Email → `workspace.owner_id`; company + metadata → `workspace.preferences.trial_signup`
- No Clerk user created here — later `conduct claim` / magic-link flow will bind the trial workspace to a real account

### 2. Shell installer at `conductai.ai/install`
- `apps/web/public/install.sh` — POSIX sh, reads email/company from `/dev/tty`, python3 with sed fallback for JSON parsing, env file created via mktemp+mv for owner-only mode
- `next.config.js` rewrite: `/install` → `/install.sh`
- Prints a copy-pasteable trip-a-block curl for the caller to try

### 3. Silent-noop bugfixes from PR 1 (#1718)
- `proxy.py`: `_is_trial = _plan == "trial"` never matched — the actual constant is `TRIAL_PLAN = "free_trial"`. Fixed + widened rule to `plan == TRIAL_PLAN AND owner_id IS NULL` so installer-owned trials emit workspace URLs (owner has an account) while truly-anonymous trials emit public share URLs
- `blocks.py::get_receipt_public`: same wrong-string comparison → 404'd every request. Fixed with the `TRIAL_PLAN` constant

### 4. Owner-triggered "Make shareable" (Notion pattern)
- `POST /guard/blocks/{id}/share` — workspace-authed. Mints `cond_bkr_*` raw token, sha256s to `share_token_hash`, returns raw once. Subsequent calls return `already_shared=True` without the raw token
- `ShareOut` Pydantic response model → typed contract
- FE `BlockReceiptCard` workspace mode: "Make shareable →" button → posts → shows copy-paste public URL with "Copy" / "Copied ✓" feedback

### 5. Web-URL default now dev-friendly
- `web_base_url()` resolution order: `CONDUCT_WEB_URL` → `APP_URL` → `http://localhost:3000` fallback
- Zero-config local dev — API + `next dev` on port 3000 → block URLs point back to `localhost:3000/theguard/blocks/…` automatically. Prod deploys already set `APP_URL`

### 6. Wiring corrections
- Provisioning returns `gateway_url = {proxy}/anthropic` (not bare `/proxy`) — Anthropic SDK does `POST {base}/v1/messages` so `ANTHROPIC_BASE_URL` must land on the vendor-specific route
- Auth-coverage lint allowlists both intentionally-public endpoints (`provision_trial` + `get_receipt_public`)

### 7. Self-review cleanups
- Consolidated `CONDUCT_WEB_URL` reader — `receipts.web_base_url()` is the shared helper
- Dropped `_TRIAL_PLAN_PROV` alias, removed a local `import seed_trial` that was shadowing test patches
- Deleted dead `class _ShareOut(dict)` placeholder
- Cross-referenced the receipt-URL path shape between backend (`build_receipt_url`) and CLI (`hook_receipt_url`) so the shape stays in sync across the deployment split
- Tests import `SHARE_TOKEN_PREFIX` constant instead of hardcoding

## Test plan

- [x] Backend `pytest tests/guard/ tests/glens/` under real Postgres: **1572 passed, 2 skipped** (both intentional `confirm/cancel shortcut tools have no ActionSpec by design`)
- [x] 15 receipt tests (was 11) — HTTP-layer coverage for own-workspace 200, cross-workspace 404, public trial 200, bad-token 404, non-trial-plan 404, three make-shareable cases
- [x] 4 new provisioning tests — invalid email, missing company, happy path token round-trip, IP rate-limit
- [x] Frontend `tsc --noEmit`: clean
- [x] Frontend `vitest`: 3/3 for `BlockReceiptCard` (share button not covered — pending FE test)

## Deploy sequence

1. Merge + deploy backend
2. Verify `POST /guard/trial/provision` responds (curl with a test email)
3. Verify `/install` rewrite serves the shell script (`curl -fsSL conductai.ai/install`)
4. No CLI change in this PR — existing 0.11.0 hook stays as-is

## Non-goals

- `conduct claim` / magic-link flow to bind a trial workspace to a real Clerk account (future PR — the primitives are there, email is captured on `owner_id`)
- Multi-provider install (`ANTHROPIC_BASE_URL` only; users who want OpenAI/Perplexity edit their env file directly)
- Revoke/re-share for already-shared receipts (owner who loses the URL needs a future PR)

## References

- Epic: #1712 (Track 1 — 5-min TTFB on a stranger's laptop)
- Prior: #1713, #1718 (trial teardown + PR 1-4 receipts)