### PR TITLE
feat(guard): multi-provider trial upstream — OpenAI + Anthropic (#1712)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Built for engineering teams. Install in 10 minutes. Evidence for the CISO from 
 curl -fsSL conductai.ai/install | sh
 ```
 
-Prompts for email + company, provisions a 7-day trial workspace, drops `~/.conduct/env` with `ANTHROPIC_BASE_URL` + a trial token. Any Anthropic-SDK client on the machine (Cursor, Claude Code, LangChain, LiteLLM, raw SDK) now routes through the Guard proxy. A blocked call comes back with a `Receipt: https://conductai.ai/theguard/blocks/…` URL — click it to view the block, ask Lens follow-up questions, and log in to the dashboard via the magic-link the installer prints.
+Prompts for email + company, provisions a 7-day trial workspace, drops `~/.conduct/env` with `ANTHROPIC_BASE_URL` + `OPENAI_BASE_URL` + a trial token (200 requests/day shared across both providers). Any Anthropic- or OpenAI-SDK client on the machine (Cursor, Claude Code, LangChain, LiteLLM, raw SDK) now routes through the Guard proxy. A blocked call comes back with a `Receipt: https://conductai.ai/theguard/blocks/…` URL — click it to view the block, ask Lens follow-up questions, and log in to the dashboard via the magic-link the installer prints.
 
 ### Full install (for daily use)
 

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -273,7 +273,15 @@ class TrialProvisionIn(BaseModel):
 class TrialProvisionOut(BaseModel):
     workspace_id: str
     agent_token: str
+    # `gateway_url` — Anthropic-specific route (`.../proxy/anthropic`).
+    # The Anthropic SDK does `POST {base}/v1/messages`; other vendors
+    # follow the same pattern under their own `/proxy/<vendor>` prefix.
+    # Kept as-is for backwards compat with older install scripts.
     gateway_url: str
+    # `proxy_base_url` — vendor-agnostic root (`.../proxy`). Newer install
+    # scripts derive OpenAI / Perplexity URLs from this so we don't need
+    # a new response field per provider.
+    proxy_base_url: str
     workspace_url: str
     # Clerk one-time sign-in URL — click to land signed-in in dashboard.
     # Optional: null if Clerk isn't configured (local dev) or minting failed.
@@ -419,16 +427,18 @@ def provision_trial(
     # curl-install still works, user just goes to /sign-in manually.
     sign_in_url = _clerk_mint_sign_in_token(clerk_user_id)
 
-    # Anthropic SDK does `POST {base}/v1/messages`, so ANTHROPIC_BASE_URL
-    # must land on the vendor-specific route (`/proxy/anthropic`), not the
-    # bare `/proxy` root. Endpoint paths for other providers live under
-    # `/proxy/openai` and `/proxy/perplexity` — install.sh only wires
-    # Anthropic today; users who want OpenAI/Perplexity edit their env
-    # file directly.
+    # `gateway_url` is Anthropic-shaped because that's what the trial
+    # upstream key covers today. `proxy_base_url` is the vendor-agnostic
+    # root so newer install scripts can derive OpenAI / Perplexity URLs
+    # (`{proxy_base_url}/openai`, `.../perplexity`) without another API
+    # round-trip. Both routes accept the same trial token; Guard policy
+    # and hash-chained audit apply uniformly.
+    _proxy_base = settings.conduct_proxy_url.rstrip("/")
     return TrialProvisionOut(
         workspace_id=ws_id,
         agent_token=token,
-        gateway_url=f"{settings.conduct_proxy_url.rstrip('/')}/anthropic",
+        gateway_url=f"{_proxy_base}/anthropic",
+        proxy_base_url=_proxy_base,
         workspace_url=f"{_web_base_url()}/theguard",
         sign_in_url=sign_in_url,
     )

--- a/apps/api/app/modules/guard/trial_upstream.py
+++ b/apps/api/app/modules/guard/trial_upstream.py
@@ -36,6 +36,17 @@ from app.modules.guard.trial_seed import TRIAL_IDENTITY_NAME, TRIAL_PLAN
 log = structlog.get_logger(__name__)
 
 GUARD_TRIAL_ANTHROPIC_KEY_ENV = "GUARD_TRIAL_ANTHROPIC_KEY"
+GUARD_TRIAL_OPENAI_KEY_ENV = "GUARD_TRIAL_OPENAI_KEY"
+# Provider → env-var name for the platform-funded trial upstream key.
+# Adding a provider = one entry here + one Render env var, no code fork.
+# Cap semantics are SHARED across providers (see try_reserve_trial_slot):
+# a workspace gets TRIAL_DAILY_CAP total requests per day regardless of
+# which provider it hits — that matches the existing agent-identity
+# scope of the Redis counter.
+TRIAL_UPSTREAM_KEY_ENV_BY_PROVIDER = {
+    "anthropic": GUARD_TRIAL_ANTHROPIC_KEY_ENV,
+    "openai": GUARD_TRIAL_OPENAI_KEY_ENV,
+}
 TRIAL_DAILY_CAP = 200
 TRIAL_CAP_WINDOW_HOURS = 24
 TrialStatus = Literal["active", "expired", "exceeded", "ineligible"]
@@ -110,11 +121,18 @@ def resolve_trial_key(
     agent_identity_id: str | None,
 ) -> tuple[str | None, TrialStatus]:
     """Trial-only platform upstream key resolver. See module docstring."""
-    if provider != "anthropic":
+    env_var = TRIAL_UPSTREAM_KEY_ENV_BY_PROVIDER.get(provider)
+    if env_var is None:
+        # Provider outside the trial-funded set (Perplexity, Bedrock, etc.)
+        # — user brings their own vendor key via the workspace vault.
         return None, "ineligible"
 
-    env_key = os.environ.get(GUARD_TRIAL_ANTHROPIC_KEY_ENV) or ""
+    env_key = os.environ.get(env_var) or ""
     if not env_key:
+        # Trial-funded set includes this provider, but no key is
+        # configured on this deploy. Trial workspaces still authenticate
+        # to the proxy, but the upstream call has nowhere to go — same
+        # outcome as a truly-unsupported provider from the user's POV.
         return None, "ineligible"
 
     if not agent_identity_id:

--- a/apps/api/tests/test_trial_upstream.py
+++ b/apps/api/tests/test_trial_upstream.py
@@ -41,6 +41,7 @@ from app.modules.guard.trial_seed import (  # noqa: E402
 )
 from app.modules.guard.trial_upstream import (  # noqa: E402
     GUARD_TRIAL_ANTHROPIC_KEY_ENV,
+    GUARD_TRIAL_OPENAI_KEY_ENV,
     TRIAL_DAILY_CAP,
     resolve_trial_key,
 )
@@ -87,11 +88,37 @@ def test_returns_key_when_all_gates_pass(seeded_ws):
     assert key == _KEY
 
 
-def test_wrong_provider_is_ineligible(seeded_ws):
+def test_unsupported_provider_is_ineligible(seeded_ws):
+    """Perplexity + Bedrock aren't in the trial-funded set; user brings
+    their own vendor key via the workspace vault."""
     ws_id, trial_id, db = seeded_ws
+    for provider in ("perplexity", "bedrock", "cohere"):
+        key, status = resolve_trial_key(db, ws_id, provider, trial_id)
+        assert status == "ineligible", f"{provider} should be ineligible"
+        assert key is None
+
+
+def test_openai_is_ineligible_when_key_env_not_configured(seeded_ws, monkeypatch):
+    """OpenAI is IN the trial-funded set but the env key isn't
+    configured on every deploy — behavior should match unsupported
+    providers so the user path is uniform."""
+    ws_id, trial_id, db = seeded_ws
+    monkeypatch.delenv(GUARD_TRIAL_OPENAI_KEY_ENV, raising=False)
     key, status = resolve_trial_key(db, ws_id, "openai", trial_id)
     assert status == "ineligible"
     assert key is None
+
+
+def test_openai_is_active_when_env_key_configured(seeded_ws, monkeypatch):
+    """When Render (or local dev) has `GUARD_TRIAL_OPENAI_KEY` set, the
+    trial resolver returns that key for OpenAI proxy calls — same shape
+    as the Anthropic path."""
+    ws_id, trial_id, db = seeded_ws
+    _openai_key = "TRIAL-OPENAI-KEY-PLACEHOLDER-" + uuid.uuid4().hex
+    monkeypatch.setenv(GUARD_TRIAL_OPENAI_KEY_ENV, _openai_key)
+    key, status = resolve_trial_key(db, ws_id, "openai", trial_id)
+    assert status == "active"
+    assert key == _openai_key
 
 
 def test_missing_env_var_is_ineligible(seeded_ws, monkeypatch):

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -89,20 +89,35 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 1
 fi
 
-# One python invocation extracts every field — cheaper than four separate
+# One python invocation extracts every field — cheaper than five separate
 # json.load calls and gives us a single failure point if the shape changes.
+# `gateway_url` is the Anthropic-specific route (kept for backwards compat).
+# `proxy_base_url` is the vendor-agnostic root so we can derive OpenAI /
+# Perplexity URLs client-side without another API round-trip.
 _parsed=$(printf '%s' "$HTTP_BODY" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
 print(d["agent_token"])
 print(d["gateway_url"])
+print(d.get("proxy_base_url") or "")
 print(d["workspace_url"])
 print(d.get("sign_in_url") or "")
 ')
 AGENT_TOKEN=$(printf '%s\n' "$_parsed" | sed -n '1p')
 GATEWAY_URL=$(printf '%s\n' "$_parsed" | sed -n '2p')
-WORKSPACE_URL=$(printf '%s\n' "$_parsed" | sed -n '3p')
-SIGN_IN_URL=$(printf '%s\n' "$_parsed" | sed -n '4p')
+PROXY_BASE_URL=$(printf '%s\n' "$_parsed" | sed -n '3p')
+WORKSPACE_URL=$(printf '%s\n' "$_parsed" | sed -n '4p')
+SIGN_IN_URL=$(printf '%s\n' "$_parsed" | sed -n '5p')
+
+# Derive OpenAI base from proxy_base_url. Anthropic already lives on
+# GATEWAY_URL. Skipped if the backend hasn't started returning
+# proxy_base_url yet (older deploys) — user can still trip a block via
+# Anthropic; OpenAI just doesn't get wired.
+if [ -n "$PROXY_BASE_URL" ]; then
+    OPENAI_BASE_URL="${PROXY_BASE_URL}/openai"
+else
+    OPENAI_BASE_URL=""
+fi
 
 if [ -z "$AGENT_TOKEN" ]; then
     printf '%serror: could not extract agent_token from response.%s\n' "$YELLOW" "$RESET" >&2
@@ -117,13 +132,26 @@ mkdir -p "$(dirname "$ENV_FILE")"
 # explicit permission-modifying call, without invoking one.
 TMP_ENV=$(mktemp)
 cat > "$TMP_ENV" <<EOF
-# ConductGuard trial — 7 days, 200 requests/day
-# Point any Anthropic-SDK client at this base URL and the trial token
-# authenticates you. Same env var (ANTHROPIC_BASE_URL) works with Cursor,
-# Claude Code, LangChain, LiteLLM, and every SDK we've tested.
+# ConductGuard trial — 7 days, 200 Anthropic requests/day
+#
+# Anthropic (trial-funded):
+#   The trial token authenticates every Anthropic-SDK client on this
+#   machine — Cursor, Claude Code, LangChain, LiteLLM, raw SDK, curl.
 export ANTHROPIC_BASE_URL="$GATEWAY_URL"
 export ANTHROPIC_API_KEY="$AGENT_TOKEN"
 EOF
+
+if [ -n "$OPENAI_BASE_URL" ]; then
+    cat >> "$TMP_ENV" <<EOF
+
+# OpenAI (also trial-funded when Guard has GUARD_TRIAL_OPENAI_KEY):
+#   The same trial token authenticates OpenAI-SDK clients — LangChain,
+#   raw SDK, curl. Same 200 requests/day cap across all providers.
+export OPENAI_BASE_URL="$OPENAI_BASE_URL"
+export OPENAI_API_KEY="$AGENT_TOKEN"
+EOF
+fi
+
 mv "$TMP_ENV" "$ENV_FILE"
 
 printf '%s✓ Trial workspace provisioned.%s\n' "$GREEN" "$RESET"

--- a/apps/web/src/app/(marketing)/docs/page.tsx
+++ b/apps/web/src/app/(marketing)/docs/page.tsx
@@ -90,10 +90,11 @@ type TabId = typeof TABS[number]["id"]
 
 const TAB_NAV: Record<TabId, { href: string; label: string }[]> = {
   "overview": [
-    { href: "#how-it-works", label: "Architecture" },
-    { href: "#threat-model", label: "Security & threat model" },
-    { href: "#action-tools", label: "Gating agent actions" },
-    { href: "#cedar-import", label: "Cedar policy import" },
+    { href: "#try-in-60-seconds", label: "Try in 60 seconds" },
+    { href: "#how-it-works",      label: "Architecture" },
+    { href: "#threat-model",      label: "Security & threat model" },
+    { href: "#action-tools",      label: "Gating agent actions" },
+    { href: "#cedar-import",      label: "Cedar policy import" },
   ],
   "getting-started": [
     { href: "#overview",     label: "Overview" },
@@ -163,6 +164,21 @@ const TAB_NAV: Record<TabId, { href: string; label: string }[]> = {
 function TabOverview() {
   return (
     <div className="space-y-16">
+      <section id="try-in-60-seconds">
+        <div className="rounded-2xl border border-indigo-200 bg-indigo-50/60 px-6 py-5">
+          <p className="text-xs uppercase tracking-wide text-indigo-700 font-semibold mb-2">Try Conduct in 60 seconds</p>
+          <h2 className="text-lg font-bold text-stone-900 mb-3">Zero local install. Point any Anthropic SDK at the hosted Guard proxy.</h2>
+          <Pre>{`curl -fsSL conductai.ai/install | sh`}</Pre>
+          <p className="text-sm text-stone-600 mt-3">
+            Prompts for email + company, provisions a 7-day trial workspace, drops <Code>~/.conduct/env</Code> with a trial token for Anthropic + OpenAI, and prints a magic-link URL to sign into the dashboard.{" "}
+            <a href="/docs?tab=getting-started#quick-trial" className="text-indigo-600 hover:underline font-medium">Full walkthrough →</a>
+          </p>
+          <p className="text-xs text-stone-500 mt-2">
+            Trial cap: 200 requests/day shared across providers. Perplexity / Bedrock / others: same proxy, same policy — bring your own vendor key in Settings → Environments.
+          </p>
+        </div>
+      </section>
+
       <section id="how-it-works">
         <h1 className="text-3xl font-bold text-stone-900 mb-3">How Conduct works</h1>
         <p className="text-stone-600 leading-relaxed text-base mb-10">
@@ -375,12 +391,12 @@ function TabGettingStarted() {
         <Pre>{`curl -fsSL conductai.ai/install | sh`}</Pre>
         <p className="text-stone-500 text-sm mt-4 mb-2">What it does:</p>
         <ul className="list-disc list-inside space-y-1 text-sm text-stone-600 mb-4">
-          <li>Provisions a 7-day trial workspace (200 requests/day, no credit card)</li>
-          <li>Drops <Code>~/.conduct/env</Code> with <Code>ANTHROPIC_BASE_URL</Code> + a trial <Code>cond_agt_trial_*</Code> token</li>
+          <li>Provisions a 7-day trial workspace (200 requests/day shared across Anthropic + OpenAI, no credit card)</li>
+          <li>Drops <Code>~/.conduct/env</Code> with <Code>ANTHROPIC_BASE_URL</Code> + <Code>OPENAI_BASE_URL</Code> + a trial <Code>cond_agt_trial_*</Code> token</li>
           <li>Prints a magic-link URL — click to sign into your dashboard, no password</li>
           <li>Prints a copy-pasteable trip-a-block curl so you can see the receipt flow immediately</li>
         </ul>
-        <p className="text-stone-500 text-sm mb-2">Try it:</p>
+        <p className="text-stone-500 text-sm mb-2">Try it (Anthropic):</p>
         <Pre>{`source ~/.conduct/env
 curl -sS "$ANTHROPIC_BASE_URL/v1/messages" \\
   -H "x-api-key: $ANTHROPIC_API_KEY" \\
@@ -390,7 +406,23 @@ curl -sS "$ANTHROPIC_BASE_URL/v1/messages" \\
         <p className="text-stone-500 text-sm mt-3">
           Response is a 403 with <Code>→ Receipt: https://conductai.ai/theguard/blocks/…</Code> in the message. Click the URL to open the block receipt, ask Lens follow-up questions (<em>Why did this block? What would have allowed it? Draft an exception</em>), or share externally via <strong>Make shareable</strong>.
         </p>
-        <p className="text-stone-500 text-sm mt-3">
+
+        <SubHeading>OpenAI (also trial-funded)</SubHeading>
+        <p className="text-stone-500 text-sm mb-3">
+          The install script also wires <Code>OPENAI_BASE_URL</Code>. Same trial token authenticates you; same 200 requests/day cap is shared across Anthropic + OpenAI.
+        </p>
+        <Pre>{`source ~/.conduct/env
+curl -sS "$OPENAI_BASE_URL/v1/chat/completions" \\
+  -H "Authorization: Bearer $OPENAI_API_KEY" \\
+  -H 'content-type: application/json' \\
+  -d '{"model":"gpt-4o","messages":[{"role":"user","content":"Please redact my SSN 123-45-6789 for me."}]}'`}</Pre>
+
+        <SubHeading>Perplexity, Bedrock, others</SubHeading>
+        <p className="text-stone-500 text-sm mb-3">
+          Proxy routes exist under <Code>/proxy/perplexity</Code> and future providers. Guard policy + hash-chained audit apply uniformly. Trial upstream key isn't funded for these yet — bring your own vendor key in <strong>Settings → Environments</strong>. The proxy forwards to your vault key transparently.
+        </p>
+
+        <p className="text-stone-500 text-sm mt-4">
           Under the hood: same Clerk user, same workspace, same trial guarantees as browser signup. Sign in later via the magic link or at <a href="/sign-in" className="text-indigo-600 hover:underline">conductai.ai/sign-in</a>.
         </p>
       </section>


### PR DESCRIPTION
## Summary

Follow-up to #1720. The trial-funded upstream now covers OpenAI alongside Anthropic. Same proxy, same policy, same 200-requests/day cap (shared across providers per agent identity — no new counter dimension).

## Backend

- `trial_upstream.py`: replaced hardcoded `provider != "anthropic"` check with a `TRIAL_UPSTREAM_KEY_ENV_BY_PROVIDER` map. Adding a provider = one entry + one Render env var, no code fork.
  - `GUARD_TRIAL_ANTHROPIC_KEY` (existing) — Anthropic upstream
  - `GUARD_TRIAL_OPENAI_KEY` (new) — OpenAI upstream
  - Perplexity / Bedrock stay ineligible until we opt them in — user brings their own vendor key via workspace vault (same as before).
- `trial.py::provision_trial` returns `proxy_base_url` in addition to the Anthropic-specific `gateway_url`. Newer install scripts derive OpenAI / Perplexity URLs from the base without another round-trip.

## Install script

`apps/web/public/install.sh` writes both `ANTHROPIC_BASE_URL` and `OPENAI_BASE_URL` (derived from `proxy_base_url`). Same trial token authenticates both.

## Tests

- Renamed `test_wrong_provider_is_ineligible` → `test_unsupported_provider_is_ineligible` and expanded to cover Perplexity / Bedrock / Cohere.
- New `test_openai_is_ineligible_when_key_env_not_configured` — behavior should match unsupported providers when the env var is missing on a deploy.
- New `test_openai_is_active_when_env_key_configured` — happy path round-trip.

## Docs

Overview + Automations sections in `apps/web/(marketing)/docs`, plus `README.md`: reworded to reflect shared-cap multi-provider trial. Added a full OpenAI trip-a-block snippet next to the Anthropic one.

## Deploy dependency

Add `GUARD_TRIAL_OPENAI_KEY` to Render env vars alongside the existing `GUARD_TRIAL_ANTHROPIC_KEY`. When both are set, both providers work in the trial. Missing one = that provider gracefully falls through to `"ineligible"` (user sees the same "bring your own key" path they see for Perplexity today).

## Test plan

- [x] Backend `pytest tests/guard/ tests/glens/ tests/test_trial_upstream.py` under real Postgres: **1586 passed, 2 skipped**
- [x] 3 new trial-upstream tests (Anthropic unchanged, OpenAI without-key, OpenAI with-key, unsupported providers)
- [x] Frontend `tsc --noEmit`: clean
- [x] No regression on the existing browser signup / receipt flows

## References

- Epic: #1712 (Track 1)
- Prior: #1720 (initial curl | sh installer + unified onboarding)