### PR TITLE
fix(docker): fresh-clone bootstrap works end-to-end (#1723)

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -6,7 +6,9 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM base AS dev
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000", "--reload"]
+# Run migrations on boot so `docker compose up` gives a working API without a
+# manual step; prod (below) already does the same.
+CMD ["sh", "-c", "alembic upgrade head && uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload"]
 
 FROM base AS prod
 COPY . .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   postgres:
-    image: postgres:16-alpine
+    # pgvector image required — 0001_baseline + 0077_session_reports_embedding
+    # both run CREATE EXTENSION vector. Kept in step with .github/workflows/ci.yml.
+    image: pgvector/pgvector:pg16
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-marshal}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-marshal}
@@ -62,7 +64,10 @@ services:
 
   web:
     build:
-      context: ./apps/web
+      # Context is repo root because apps/web/Dockerfile does `COPY docs/`
+      # (marketing pages read docs/reference/*.md at build time).
+      context: .
+      dockerfile: apps/web/Dockerfile
       target: dev
     ports:
       - "3000:3000"


### PR DESCRIPTION
Closes #1723. Reported by @yassergb26 while bootstrapping for #1715.

## Summary
- postgres image → \`pgvector/pgvector:pg16\` in \`docker-compose.yml\`. Two migrations (\`0001_baseline\`, \`0077_session_reports_embedding\`) run \`CREATE EXTENSION vector\`; the alpine image doesn't carry it. \`ci.yml\` already uses pgvector.
- api dev CMD prepends \`alembic upgrade head\` so \`docker compose up\` produces a migrated API on first boot. Prod already does the same; dev was the outlier.
- web build context → repo root with explicit \`dockerfile: apps/web/Dockerfile\`. The Dockerfile does \`COPY docs/\` for marketing-page content, which an \`apps/web\` context can't see.

Three-line change (plus comments explaining each). Nothing behavioural in the app — the API boots the same way it did after a manual bootstrap.

## Test plan
- [ ] Fresh clone: \`docker compose up\` — postgres, redis, api all come up healthy, no \`extension "vector" is not available\`, no \`relation "guard_config" does not exist\`.
- [ ] \`docker compose build web\` completes without \`"/docs": not found\`.
- [ ] Existing volumes still work (image swap is compatible — pgvector image is postgres 16 + extension).