### PR TITLE
fix(mcp): /test-connection uses saved token when form field empty

### DIFF
--- a/apps/api/app/routers/mcp_servers.py
+++ b/apps/api/app/routers/mcp_servers.py
@@ -142,6 +142,7 @@ class McpTestIn(BaseModel):
     transport: str = "auto"
     environment_id: Optional[str] = None
     credential_key: Optional[str] = None  # e.g. GITHUB_TOKEN — resolve from env if auth_token blank
+    server_id: Optional[str] = None  # when set, fall back to this server's saved token if auth_token blank
 
 
 class McpTestOut(BaseModel):
@@ -164,10 +165,31 @@ def test_mcp_connection(
     Returns ok=True with a tool sample on success, ok=False with the underlying
     error message on failure. Saves the user a 30-minute agent run that fails
     at the first tool call because the token was wrong.
+
+    Auth resolution chain (first hit wins):
+      1. ``body.auth_token`` — the token typed into the form. Lets the user
+         validate a NEW token before overwriting the saved one.
+      2. ``body.server_id`` — decrypts the saved token for that row (workspace-
+         scoped). Lets the user re-test an existing config without re-typing.
+      3. ``body.credential_key`` — resolves via workspace env-var table.
     """
     from app.runtime.integrations.mcp_client import list_tools
 
     token = body.auth_token or None
+    if not token and body.server_id:
+        # Workspace-scoped lookup — never leak another workspace's token.
+        row = db.execute(
+            text(
+                "SELECT encrypted_auth FROM mcp_servers "
+                "WHERE id = :id AND workspace_id = :ws"
+            ),
+            {"id": body.server_id, "ws": workspace_id},
+        ).fetchone()
+        if row and row.encrypted_auth:
+            try:
+                token = decrypt(row.encrypted_auth).get("token")
+            except Exception:
+                token = None
     if not token and body.credential_key:
         try:
             from app.runtime.mcp_credentials import resolve_mcp_token_by_credential_key

--- a/apps/api/tests/test_mcp_test_connection.py
+++ b/apps/api/tests/test_mcp_test_connection.py
@@ -1,0 +1,141 @@
+"""Auth-resolution chain for POST /mcp-servers/test-connection.
+
+The Test Connection button in /integrations must be usable after Save —
+i.e. re-testing an existing server should use the SAVED token, not require
+the user to re-paste. Regression coverage for the "re-test always 401s"
+bug where the endpoint only trusted body.auth_token.
+
+Resolution order:
+  1. body.auth_token       — typed value wins (lets user validate NEW tokens)
+  2. body.server_id        — falls back to saved (workspace-scoped decrypt)
+  3. body.credential_key   — env-var fallback
+
+Runs unit-mode (no DB, no network): patches list_tools and the DB session
+lookup so the tests exercise the resolver, not the transport.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.crypto import encrypt as _encrypt
+from app.main import app
+
+
+def _stub_deps(monkeypatch, *, workspace_id="ws-1", saved_token=None, saved_ws="ws-1"):
+    """Patch auth + DB dependencies so the endpoint runs without a real request.
+
+    Returns a MagicMock for list_tools so the caller can assert what token
+    the resolver produced.
+    """
+    from app.core import auth as _auth
+    from app.core import database as _db
+
+    app.dependency_overrides[_auth.get_workspace_id] = lambda: workspace_id
+    app.dependency_overrides[_auth.require_permission("platform.credentials.manage")] = lambda: "test-user"
+
+    fake_db = MagicMock()
+    if saved_token is not None and saved_ws == workspace_id:
+        fake_row = MagicMock()
+        fake_row.encrypted_auth = _encrypt({"token": saved_token})
+        fake_db.execute.return_value.fetchone.return_value = fake_row
+    else:
+        fake_db.execute.return_value.fetchone.return_value = None
+
+    app.dependency_overrides[_db.get_db] = lambda: fake_db
+
+    mock_list = MagicMock(return_value=([{"name": "tool_a"}], "http"))
+    monkeypatch.setattr(
+        "app.runtime.integrations.mcp_client.list_tools",
+        mock_list,
+    )
+    return mock_list
+
+
+@pytest.fixture(autouse=True)
+def _clear_overrides():
+    yield
+    app.dependency_overrides.clear()
+
+
+def test_typed_auth_token_wins_over_saved(monkeypatch):
+    """Rule 1: if the form field has a value, use it — even if a saved token exists."""
+    mock_list = _stub_deps(monkeypatch, saved_token="saved-token-xxx")
+
+    r = TestClient(app).post(
+        "/mcp-servers/test-connection",
+        json={
+            "url": "https://example.com/mcp",
+            "auth_token": "typed-token-yyy",
+            "server_id": "row-1",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    # list_tools called with the TYPED token, not the saved one
+    args, _ = mock_list.call_args
+    assert args[1] == "typed-token-yyy"
+
+
+def test_saved_token_used_when_field_empty(monkeypatch):
+    """Rule 2 — the actual bug fix: empty field + server_id → decrypt saved."""
+    mock_list = _stub_deps(monkeypatch, saved_token="saved-token-xxx")
+
+    r = TestClient(app).post(
+        "/mcp-servers/test-connection",
+        json={
+            "url": "https://example.com/mcp",
+            "auth_token": None,
+            "server_id": "row-1",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    args, _ = mock_list.call_args
+    assert args[1] == "saved-token-xxx"
+
+
+def test_saved_token_ignored_when_server_id_from_other_workspace(monkeypatch):
+    """Never leak another workspace's token. Row lookup is scoped by workspace_id."""
+    mock_list = _stub_deps(
+        monkeypatch,
+        workspace_id="ws-A",
+        saved_token="ws-B-secret",
+        saved_ws="ws-B",  # simulated: row belongs to a different workspace
+    )
+
+    r = TestClient(app).post(
+        "/mcp-servers/test-connection",
+        json={
+            "url": "https://example.com/mcp",
+            "auth_token": None,
+            "server_id": "row-from-ws-B",
+        },
+    )
+    assert r.status_code == 200
+    # list_tools was called with None (row lookup returned no match under ws-A)
+    args, _ = mock_list.call_args
+    assert args[1] is None
+
+
+def test_no_server_id_no_token_falls_through_to_credential_key(monkeypatch):
+    """Rule 3: nothing typed, no server_id → try credential_key env-var fallback."""
+    mock_list = _stub_deps(monkeypatch, saved_token=None)
+    monkeypatch.setattr(
+        "app.runtime.mcp_credentials.resolve_mcp_token_by_credential_key",
+        lambda key, ws, env, db: "env-fallback-token",
+    )
+
+    r = TestClient(app).post(
+        "/mcp-servers/test-connection",
+        json={
+            "url": "https://example.com/mcp",
+            "auth_token": None,
+            "credential_key": "GITHUB_TOKEN",
+        },
+    )
+    assert r.status_code == 200
+    args, _ = mock_list.call_args
+    assert args[1] == "env-fallback-token"

--- a/apps/web/src/app/(app)/integrations/page.tsx
+++ b/apps/web/src/app/(app)/integrations/page.tsx
@@ -93,16 +93,18 @@ function McpModal({
   isSystem,
   isConductManaged,
   hasExistingAuth,
+  serverId,
 }: {
   mode: "add" | "edit"
   initial: FormState
   environments: Environment[]
   onSave: (form: FormState) => Promise<void>
-  onTest: (body: { url: string; auth_token: string | null; transport: string; environment_id?: string; credential_key?: string }) => Promise<{ ok: boolean; msg: string }>
+  onTest: (body: { url: string; auth_token: string | null; transport: string; environment_id?: string; credential_key?: string; server_id?: string }) => Promise<{ ok: boolean; msg: string }>
   onClose: () => void
   isSystem?: boolean
   isConductManaged?: boolean
   hasExistingAuth?: boolean
+  serverId?: string
 }) {
   const [form, setForm] = useState<FormState>(initial)
   const [saving, setSaving] = useState(false)
@@ -124,6 +126,7 @@ function McpModal({
         transport: form.transport,
         environment_id: form.environment_id || undefined,
         credential_key: getProvider(form.provider)?.credentialKey || undefined,
+        server_id: serverId,
       })
       setTestResult(result)
     } catch (e: unknown) {
@@ -422,7 +425,7 @@ function IntegrationsPageInner({
     setEditTarget(null)
   }
 
-  async function handleTest(body: { url: string; auth_token: string | null; transport: string; environment_id?: string; credential_key?: string }): Promise<{ ok: boolean; msg: string }> {
+  async function handleTest(body: { url: string; auth_token: string | null; transport: string; environment_id?: string; credential_key?: string; server_id?: string }): Promise<{ ok: boolean; msg: string }> {
     const headers = await buildHeaders(true)
     const res = await authFetch(`${API}/mcp-servers/test-connection`, {
       method: "POST",
@@ -652,6 +655,7 @@ function IntegrationsPageInner({
           isSystem={!!editTarget?.is_system}
           isConductManaged={editTarget?.name === "Conduct AI Guard"}
           hasExistingAuth={!!editTarget?.has_auth}
+          serverId={editTarget?.id}
           initial={initialForm}
           environments={environments}
           onSave={handleSave}


### PR DESCRIPTION
## Bug

The **Test Connection** button in `/integrations` was broken after Save. If the auth-token field showed the masked placeholder (`•••••••• existing token preserved — type to replace`), the field was actually empty in JS state, so the frontend sent `auth_token: null` to the backend. The backend's resolver at \`apps/api/app/routers/mcp_servers.py:170\` only trusted the payload — no fallback to the row's \`encrypted_auth\`. Result: every re-test after Save returned 401 even when the saved token was valid and worked at runtime.

## Fix — proper resolution chain

\`test_mcp_connection\` now resolves the token in this order (first hit wins):

1. \`body.auth_token\` — typed value wins so users can validate a **new** token before overwriting the saved one.
2. \`body.server_id\` — decrypts the saved token for that row. **Workspace-scoped** (\`WHERE id = :id AND workspace_id = :ws\`) so no cross-tenant leak.
3. \`body.credential_key\` — existing env-var fallback (unchanged behavior).

Frontend passes \`server_id\` when the modal is in **edit** mode. Add-mode has no server_id so behavior is unchanged (still just uses typed value or credential-key fallback).

## Why not a frontend-only band-aid

Considered: prefill the auth field on modal open, or send a "use saved" sentinel. Both leak trust boundaries — the client would either hold the plaintext token in memory or have to know which mode to send. The backend is the only surface that legitimately holds the decrypted value, and it's the right place to do the resolution.

## Tests

New file \`apps/api/tests/test_mcp_test_connection.py\` — 4 cases, one per resolver branch plus a cross-workspace isolation proof:

1. \`test_typed_auth_token_wins_over_saved\` — rule 1
2. \`test_saved_token_used_when_field_empty\` — rule 2 (the actual bug fix)
3. \`test_saved_token_ignored_when_server_id_from_other_workspace\` — cross-tenant safety
4. \`test_no_server_id_no_token_falls_through_to_credential_key\` — rule 3 unchanged

Runs unit-mode with \`monkeypatch\` on \`list_tools\` + \`get_db\` — no real DB or network calls.

## Related bug not fixed here

\`/mcp-servers/test-connection\` blocks the UI for ~30 seconds on success because \`list_tools\` in \`mcp_client.py\` waits for the SSE stream to close after the JSON-RPC \`tools/list\` succeeds. Separate concern, separate PR — filing as a follow-up issue.

## Test plan

- [ ] CI passes (new tests + pre-existing suite)
- [ ] Local: open \`/integrations\`, edit an existing MCP server, click Test — succeeds without re-typing token
- [ ] Local: edit again, paste a new token, click Test — succeeds using typed value
- [ ] Local: add a new MCP server, click Test — succeeds with typed value (add-mode path unchanged)
- [ ] Confirm cross-workspace: user A cannot test connection with a \`server_id\` belonging to workspace B (returns without leaking B's token)