### PR TITLE
perf(mcp): bound __aexit__ cleanup to 1s so hanging SSE close doesn't cost 30s

### DIFF
--- a/apps/api/app/runtime/integrations/mcp_client.py
+++ b/apps/api/app/runtime/integrations/mcp_client.py
@@ -5,7 +5,18 @@ Supports HTTP (Streamable) and SSE transports with auto-fallback.
 from __future__ import annotations
 import asyncio
 import json
-from typing import Any
+from contextlib import AsyncExitStack
+from typing import Any, Awaitable, Callable
+
+
+# ponytail: cleanup ceiling for bounded __aexit__ (issue #1728). Some MCP
+# servers (including our own /guard/mcp SSE endpoint) hold the connection
+# open with keepalive pings and never respond to client-side close. Without
+# this ceiling every RPC pays the outer 30s _run timeout on teardown even
+# though the tool call itself succeeded in milliseconds. Real fix is
+# server-side session lifecycle; this ceiling is the seatbelt for
+# third-party MCP servers we don't control.
+_CLEANUP_TIMEOUT_SECONDS = 1.0
 
 
 def _unwrap_exc(exc: BaseException) -> BaseException:
@@ -42,26 +53,77 @@ def _run(coro, timeout: float = 30.0):
         return asyncio.run(_bounded())
 
 
-async def _list_tools_http(server_url: str, token: str | None) -> list[dict]:
+async def _run_session(
+    transport_factory: Callable[[], Any],
+    op: Callable[[Any], Awaitable[Any]],
+) -> Any:
+    """Enter transport + ClientSession, run ``op(session)``, tear down safely.
+
+    Cleanup is bounded to ``_CLEANUP_TIMEOUT_SECONDS`` — see issue #1728. If
+    ``op`` succeeds and cleanup hangs (typical against keepalive-forever SSE
+    servers), we still return the result. If cleanup succeeds normally, we
+    exit in microseconds.
+
+    ``transport_factory`` returns the transport context manager (called with
+    no args). Each transport yields a tuple whose first two elements are
+    ``(read, write)``.
+    """
     from mcp.client.session import ClientSession
+
+    stack = AsyncExitStack()
+    try:
+        transport = await stack.enter_async_context(transport_factory())
+        read, write = transport[0], transport[1]
+        session = await stack.enter_async_context(ClientSession(read, write))
+        await session.initialize()
+        return await op(session)
+    finally:
+        try:
+            await asyncio.wait_for(stack.aclose(), timeout=_CLEANUP_TIMEOUT_SECONDS)
+        except Exception:
+            # ponytail: cleanup hangs are the whole reason this helper exists (#1728).
+            # Losing the RPC result over a slow teardown is the bug we're fixing.
+            pass
+
+
+def _tools_to_dicts(tools) -> list[dict]:
+    return [
+        {
+            "name": t.name,
+            "description": t.description or "",
+            "inputSchema": t.inputSchema if isinstance(t.inputSchema, dict) else {},
+        }
+        for t in tools
+    ]
+
+
+def _call_result_to_value(result) -> Any:
+    parts = [c.text for c in result.content if hasattr(c, "text")]
+    combined = "\n".join(parts)
+    try:
+        return json.loads(combined)
+    except Exception:
+        return combined
+
+
+async def _list_tools_http(server_url: str, token: str | None) -> list[dict]:
     from mcp.client.streamable_http import streamablehttp_client
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    async with streamablehttp_client(server_url, headers=headers) as (read, write, _):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.list_tools()
-            return [{"name": t.name, "description": t.description or "", "inputSchema": t.inputSchema if isinstance(t.inputSchema, dict) else {}} for t in result.tools]
+    result = await _run_session(
+        lambda: streamablehttp_client(server_url, headers=headers),
+        lambda session: session.list_tools(),
+    )
+    return _tools_to_dicts(result.tools)
 
 
 async def _list_tools_sse(server_url: str, token: str | None) -> list[dict]:
-    from mcp.client.session import ClientSession
     from mcp.client.sse import sse_client
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    async with sse_client(server_url, headers=headers) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.list_tools()
-            return [{"name": t.name, "description": t.description or "", "inputSchema": t.inputSchema if isinstance(t.inputSchema, dict) else {}} for t in result.tools]
+    result = await _run_session(
+        lambda: sse_client(server_url, headers=headers),
+        lambda session: session.list_tools(),
+    )
+    return _tools_to_dicts(result.tools)
 
 
 def list_tools(server_url: str, token: str | None = None, transport: str = "auto") -> tuple[list[dict], str]:
@@ -79,35 +141,23 @@ def list_tools(server_url: str, token: str | None = None, transport: str = "auto
 
 
 async def _call_tool_http(server_url: str, token: str | None, tool_name: str, tool_input: dict) -> Any:
-    from mcp.client.session import ClientSession
     from mcp.client.streamable_http import streamablehttp_client
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    async with streamablehttp_client(server_url, headers=headers) as (read, write, _):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.call_tool(tool_name, arguments=tool_input)
-            parts = [c.text for c in result.content if hasattr(c, "text")]
-            combined = "\n".join(parts)
-            try:
-                return json.loads(combined)
-            except Exception:
-                return combined
+    result = await _run_session(
+        lambda: streamablehttp_client(server_url, headers=headers),
+        lambda session: session.call_tool(tool_name, arguments=tool_input),
+    )
+    return _call_result_to_value(result)
 
 
 async def _call_tool_sse(server_url: str, token: str | None, tool_name: str, tool_input: dict) -> Any:
-    from mcp.client.session import ClientSession
     from mcp.client.sse import sse_client
     headers = {"Authorization": f"Bearer {token}"} if token else {}
-    async with sse_client(server_url, headers=headers) as (read, write):
-        async with ClientSession(read, write) as session:
-            await session.initialize()
-            result = await session.call_tool(tool_name, arguments=tool_input)
-            parts = [c.text for c in result.content if hasattr(c, "text")]
-            combined = "\n".join(parts)
-            try:
-                return json.loads(combined)
-            except Exception:
-                return combined
+    result = await _run_session(
+        lambda: sse_client(server_url, headers=headers),
+        lambda session: session.call_tool(tool_name, arguments=tool_input),
+    )
+    return _call_result_to_value(result)
 
 
 def call_tool(server_url: str, token: str | None, tool_name: str, tool_input: dict, transport: str = "auto") -> Any:

--- a/apps/api/tests/test_mcp_client_bounded_cleanup.py
+++ b/apps/api/tests/test_mcp_client_bounded_cleanup.py
@@ -1,0 +1,134 @@
+"""Bounded cleanup for the MCP client — regression coverage for #1728.
+
+Some MCP servers (including our own /guard/mcp SSE endpoint) hold the
+connection open with keepalive pings and never respond to client-side
+close. Before this fix every RPC paid the outer 30s _run timeout on
+teardown even though the tool call itself succeeded in milliseconds.
+
+These tests use bare async context managers — no MCP SDK, no network —
+to prove that _run_session enforces the cleanup ceiling and preserves
+the RPC result even when __aexit__ hangs.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from app.runtime.integrations import mcp_client
+
+
+class _HangingTransport:
+    """Async context manager whose __aexit__ hangs forever.
+
+    Mirrors the shape of streamablehttp_client / sse_client — yields a tuple
+    whose first two elements are (read, write). The hang on exit is the
+    bug we're guarding against.
+    """
+
+    def __init__(self, hang_seconds: float = 300.0):
+        self.hang_seconds = hang_seconds
+        self.exit_started = False
+
+    async def __aenter__(self):
+        return ("read-stub", "write-stub", "extras-stub")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exit_started = True
+        await asyncio.sleep(self.hang_seconds)
+
+
+class _FastTransport:
+    """Async context manager that exits cleanly. Baseline sanity."""
+
+    def __init__(self):
+        self.exited = False
+
+    async def __aenter__(self):
+        return ("read-stub", "write-stub", "extras-stub")
+
+    async def __aexit__(self, exc_type, exc, tb):
+        self.exited = True
+
+
+class _FakeSession:
+    """Stand-in for mcp.client.session.ClientSession — no real transport work."""
+
+    def __init__(self, read, write):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        pass
+
+    async def initialize(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _patch_client_session(monkeypatch):
+    """_run_session imports ClientSession lazily — patch that import path."""
+    fake_module = MagicMock()
+    fake_module.ClientSession = _FakeSession
+    monkeypatch.setitem(
+        __import__("sys").modules,
+        "mcp.client.session",
+        fake_module,
+    )
+    yield
+
+
+def test_run_session_returns_result_when_cleanup_hangs():
+    """The bug fix: op succeeds, transport __aexit__ hangs — still return the result."""
+    hanging = _HangingTransport(hang_seconds=300.0)
+
+    async def op(session):
+        return "rpc-result"
+
+    started = time.monotonic()
+    result = asyncio.run(mcp_client._run_session(lambda: hanging, op))
+    elapsed = time.monotonic() - started
+
+    assert result == "rpc-result"
+    assert hanging.exit_started, "cleanup should have been attempted"
+    # cleanup ceiling is 1s — allow a little scheduler slack
+    assert elapsed < 3.0, f"took {elapsed:.2f}s — cleanup ceiling not enforced"
+
+
+def test_run_session_fast_transport_completes_in_microseconds():
+    """Baseline: clean transport should not pay the cleanup ceiling."""
+    fast = _FastTransport()
+
+    async def op(session):
+        return "quick"
+
+    started = time.monotonic()
+    result = asyncio.run(mcp_client._run_session(lambda: fast, op))
+    elapsed = time.monotonic() - started
+
+    assert result == "quick"
+    assert fast.exited is True
+    assert elapsed < 0.5, f"clean cleanup should be near-instant, took {elapsed:.2f}s"
+
+
+def test_run_session_propagates_op_exceptions_after_cleanup():
+    """If op raises, we still attempt cleanup, then re-raise the original error."""
+    hanging = _HangingTransport(hang_seconds=300.0)
+
+    class _RpcExplode(RuntimeError):
+        pass
+
+    async def op(session):
+        raise _RpcExplode("simulated rpc failure")
+
+    started = time.monotonic()
+    with pytest.raises(_RpcExplode, match="simulated rpc failure"):
+        asyncio.run(mcp_client._run_session(lambda: hanging, op))
+    elapsed = time.monotonic() - started
+
+    assert hanging.exit_started, "cleanup should still run on exception path"
+    assert elapsed < 3.0, "exception path also bounded by cleanup ceiling"


### PR DESCRIPTION
Partially closes #1728 (option B — client-side ceiling). Full fix is option C (server-side session lifecycle), tracked in #1728 for a separate PR.

## Symptom this fixes

Every MCP call was taking exactly ~30s to return, even when the RPC itself succeeded in milliseconds. Verified live in prod logs 2026-09-08 (#1727 conversation):

\`\`\`
test-connection duration_ms=31509   inner POST /guard/mcp returned 200 in <10ms
test-connection duration_ms=30027   inner POST /guard/mcp returned 200 in <10ms
\`\`\`

## Root cause

Two problems compounding — see #1728 for the full trace. The short version:

1. **Server-side:** \`/guard/mcp\` (and many third-party MCP servers) hold the SSE connection open with keepalive pings and never respond to client-side close.
2. **Client-side:** \`_run(coro, timeout=30.0)\` in \`mcp_client.py\` was the only thing that unwound the \`async with\` cleanup hang. Every call paid the ceiling.

## Fix

New helper \`_run_session(transport_factory, op)\` in \`apps/api/app/runtime/integrations/mcp_client.py\`:

- Manages the transport + \`ClientSession\` via \`AsyncExitStack\` so cleanup is a single \`stack.aclose()\` call we control.
- Wraps that cleanup in \`asyncio.wait_for(..., timeout=1.0)\` — the \`_CLEANUP_TIMEOUT_SECONDS\` constant, documented inline.
- **RPC result is captured before cleanup** so a hanging teardown never costs us the value the caller was waiting for.
- If cleanup completes cleanly we return in microseconds (baseline test proves this).

Also refactored the four transport-specific functions (\`_list_tools_http\`, \`_list_tools_sse\`, \`_call_tool_http\`, \`_call_tool_sse\`) to share this helper — they were four copies of the same nested \`async with\` pattern.

## Not the real fix

Option C in #1728 — server-side session lifecycle so we're a well-behaved MCP server that acknowledges client-side close. That's a ~2-day arc; this PR is ~1 hour so users stop paying the 30s penalty tomorrow.

**We keep the client-side ceiling even after C ships** — it's the seatbelt for third-party MCP servers we don't control.

## Tests

New file \`apps/api/tests/test_mcp_client_bounded_cleanup.py\` — three cases:

1. \`test_run_session_returns_result_when_cleanup_hangs\` — the actual bug fix. Transport \`__aexit__\` sleeps 300s; assert result returned in <3s.
2. \`test_run_session_fast_transport_completes_in_microseconds\` — baseline: clean transport should not pay the ceiling.
3. \`test_run_session_propagates_op_exceptions_after_cleanup\` — exception path also bounded; original error re-raised.

Uses bare async context managers (no MCP SDK, no network). Verified with Python 3.11 locally:

\`\`\`
result=ok elapsed=1.00s
PASS
\`\`\`

## Impact

- \`nemo-guardrails-demo\` playbook (#1631) — the 30s pause after each guard_check disappears
- Test Connection button in \`/integrations\` — returns in ~1s instead of 30s
- Every workflow that calls guard_check — silently 30s faster per call

## Test plan

- [ ] CI passes (new tests + pre-existing suite)
- [ ] Local: run \`nemo-guardrails-demo\` — beat 2 completes in ~2s not ~32s
- [ ] Local: Test Connection button in \`/integrations\` — returns in ~1-2s (also validates PR #1727)
- [ ] Prod deploy: correlate a few \`POST /mcp-servers/test-connection\` calls with logs — durations should drop from ~30s to <2s