### PR TITLE
fix(mcp): surface real error from /test-connection instead of empty string

### DIFF
--- a/apps/api/app/routers/mcp_servers.py
+++ b/apps/api/app/routers/mcp_servers.py
@@ -202,7 +202,14 @@ def test_mcp_connection(
     try:
         tools, transport_used = list_tools(body.url, token, body.transport)
     except Exception as e:
-        return McpTestOut(ok=False, error=str(e)[:300])
+        # ponytail: str(e) is empty for CancelledError, bare Exception(), or
+        # anyio ExceptionGroup with a naked inner — the UI then shows
+        # "Connection failed" with no cause. Always include the type name
+        # + a hint about whether we even had a token so the failure is
+        # actionable instead of opaque.
+        msg = str(e).strip() or repr(e) or type(e).__name__
+        token_hint = "" if token else " (no token was available — check auth_token / server_id / credential_key)"
+        return McpTestOut(ok=False, error=f"{type(e).__name__}: {msg}{token_hint}"[:300])
 
     sample = [t.get("name", "") for t in tools[:5] if t.get("name")]
     return McpTestOut(


### PR DESCRIPTION
## Symptom

User hit \"Connection failed\" in \`/integrations\` Test Connection after PR #1727 + #1729 merged. Response body was:

\`\`\`json
{\"ok\": false, \"error\": \"\", \"tool_count\": 0, \"transport_used\": \"\"}
\`\`\`

Empty \`error\` field, no actionable information.

## Root cause

\`test_mcp_connection\` at \`apps/api/app/routers/mcp_servers.py:205\` was:

\`\`\`python
return McpTestOut(ok=False, error=str(e)[:300])
\`\`\`

Some exception types have empty \`str()\`:
- \`asyncio.CancelledError\` — stringifies to \`\"\"\`
- \`Exception()\` with no args
- \`anyio.ExceptionGroup\` where the naked inner has no message

The UI faithfully renders \`error: \"\"\` as \"Connection failed\" — no clue why.

## Fix

Include the exception type name, fall back to \`repr()\`, and add a hint if we had no token at all (the most common silent failure — \`server_id\` lookup missed or \`credential_key\` resolution failed with no info):

\`\`\`python
msg = str(e).strip() or repr(e) or type(e).__name__
token_hint = \"\" if token else \" (no token was available — check auth_token / server_id / credential_key)\"
return McpTestOut(ok=False, error=f\"{type(e).__name__}: {msg}{token_hint}\"[:300])
\`\`\`

## Why this is worth a PR

Not a functional fix. But every time this happens in the future, we get an actionable message instead of \"Connection failed\" — dropping the mean-time-to-diagnose for these bugs from \"paste the response body and hope\" to \"read the error string.\"

## Test plan

- [ ] CI passes
- [ ] After deploy: retest against the failing workspace — response should now include the type name (e.g. \`\"anyio.ExceptionGroup: ...\"\` or \`\"TimeoutError: ... (no token was available)\"\`)
- [ ] Feed that new error back into diagnosis for the actual saved-token-not-being-used bug we're still hunting

## Related

- #1727 — the auth resolution chain that was supposed to make Test Connection work post-Save
- #1729 — the cleanup timeout that was supposed to make it fast
- Both merged, both live, but Test Connection still fails silently — this PR gets us the info to figure out why