### PR TITLE
fix(mcp): runtime resolves canvas server_id (not stale provider key)

### DIFF
--- a/apps/api/app/runtime/blocks/mcp_block.py
+++ b/apps/api/app/runtime/blocks/mcp_block.py
@@ -15,9 +15,14 @@ def _execute_mcp(block: dict, state: dict, cred_store: object, workspace_id: str
     """Execute an MCP tool call.
 
     Config may specify the server via either:
-    - ``server_name``: playbook path — logical name matched against mcp_servers.name for the workspace.
-    - ``provider``: canvas path — UUID from the mcp_servers table.
-    - ``credential_key``: legacy path — credential vault lookup for server_url + token.
+    - ``server_id`` / ``provider``: canvas path — UUID from the mcp_servers
+      table. The canvas MCP block writes to ``server_id``; ``provider`` is
+      the legacy key kept for backward compat with older block configs.
+    - ``server_name``: playbook path — logical name matched against
+      mcp_servers.name for the workspace. Used when a workflow is
+      instantiated from a YAML pack that can't hardcode a workspace UUID.
+    - ``credential_key``: legacy path — credential vault lookup for
+      server_url + token.
     """
     from app.runtime.integrations.mcp_client import call_tool
     from app.runtime.tool_engine import _resolve_refs
@@ -26,7 +31,13 @@ def _execute_mcp(block: dict, state: dict, cred_store: object, workspace_id: str
     config = data.get("config", {}) or {}
 
     credential_key = config.get("credential_key", "")
-    server_id      = config.get("provider", "")  # UUID stored by canvas MCP block
+    # ponytail: the canvas MCP block writes UUID to config.server_id — see
+    # apps/web/src/components/canvas/BlockEditor.tsx handleServerChange. The
+    # legacy comment claimed ``provider`` was the field but that's a different
+    # UI (sandbox provider select). Reading ``provider`` first left UUID
+    # resolution silently broken for every canvas-authored MCP block since
+    # the field was renamed — verified live 2026-09-08 during PR #1731 demo.
+    server_id      = config.get("server_id", "") or config.get("provider", "")
     server_name    = config.get("server_name", "")  # logical name used in playbooks
     tool_name      = config.get("tool_name", "")
     transport      = config.get("transport", "auto")

--- a/apps/api/app/runtime/mcp_credentials.py
+++ b/apps/api/app/runtime/mcp_credentials.py
@@ -35,18 +35,21 @@ def resolve_mcp_server(
     from sqlalchemy import text as _text
     from app.core.crypto import decrypt as _decrypt
 
+    # ponytail: try UUID first (canvas path), then fall back to name lookup
+    # if the UUID either wasn't set or points at a stale/deleted row. Old
+    # ``if server_id: ... elif server_name: ...`` meant a wrong UUID
+    # short-circuited without trying the name — masked stale block configs.
+    row = None
     if server_id:
         row = db.execute(
             _text("SELECT url, transport, encrypted_auth, name, environment_id FROM mcp_servers WHERE id = :id AND workspace_id = :ws"),
             {"id": server_id, "ws": workspace_id},
         ).fetchone()
-    elif server_name:
+    if not row and server_name:
         row = db.execute(
             _text("SELECT url, transport, encrypted_auth, name, environment_id FROM mcp_servers WHERE name = :name AND workspace_id = :ws"),
             {"name": server_name, "ws": workspace_id},
         ).fetchone()
-    else:
-        return None
 
     if not row:
         return None

--- a/apps/api/tests/test_mcp_block_server_resolution.py
+++ b/apps/api/tests/test_mcp_block_server_resolution.py
@@ -1,0 +1,146 @@
+"""MCP block server-resolution regression coverage.
+
+Two bugs fixed in one PR:
+
+1. ``mcp_block._execute_mcp`` read the UUID from ``config.provider`` but the
+   canvas MCP block editor writes it to ``config.server_id``. Field-name
+   mismatch meant UUID resolution was silently broken for every
+   canvas-authored MCP block since the field was renamed. Verified live
+   2026-09-08 during the NeMo guardrails demo — a workflow with a valid
+   server_id in its config still fell through to name lookup, and failed
+   with "MCP server 'X' not registered" when the workspace row had a
+   different display name.
+
+2. ``resolve_mcp_server`` had ``if server_id: ... elif server_name: ...`` —
+   a wrong or stale UUID short-circuited without trying the name lookup.
+   Now falls through to name if UUID misses.
+
+Both regressions land in one test file so they can't slip apart later.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.runtime.blocks.mcp_block import _execute_mcp
+from app.runtime.mcp_credentials import resolve_mcp_server
+
+
+# ── resolve_mcp_server: id → name fallback ────────────────────────────────────
+
+
+def _fake_db_with_rows(rows_by_query: dict) -> MagicMock:
+    """Build a fake db that returns different rows based on the SQL text.
+
+    ``rows_by_query`` keys are substrings of the SQL; the first key that
+    substring-matches wins. Values are the row object (or None).
+    """
+    db = MagicMock()
+
+    def _execute(query, params=None):
+        result = MagicMock()
+        sql = str(query)
+        row = None
+        for needle, r in rows_by_query.items():
+            if needle in sql:
+                # Also honour param matching so we can differentiate id vs name
+                # calls that both target mcp_servers.
+                if params and "id" in params and "id = :id" in sql:
+                    row = r if r and r.id == params["id"] else None
+                elif params and "name" in params and "name = :name" in sql:
+                    row = r if r and r.name == params["name"] else None
+                else:
+                    row = r
+                break
+        result.fetchone.return_value = row
+        return result
+
+    db.execute.side_effect = _execute
+    return db
+
+
+def _mock_row(row_id: str, name: str, url: str = "https://example.com/mcp") -> MagicMock:
+    r = MagicMock()
+    r.id = row_id
+    r.name = name
+    r.url = url
+    r.transport = "http"
+    r.encrypted_auth = None
+    r.environment_id = None
+    return r
+
+
+def test_resolve_prefers_server_id_when_it_matches():
+    row = _mock_row("uuid-A", "Conduct AI")
+    db = _fake_db_with_rows({"WHERE id = :id": row})
+    out = resolve_mcp_server(server_id="uuid-A", server_name="ignored", workspace_id="ws-1", db=db)
+    assert out is not None
+    assert out[0] == "https://example.com/mcp"
+
+
+def test_resolve_falls_through_to_name_when_id_misses():
+    """The bug — stale/wrong UUID must not short-circuit the name lookup."""
+    row = _mock_row("uuid-A", "Conduct AI Guard")
+    db = _fake_db_with_rows({
+        "WHERE id = :id": None,          # UUID doesn't match anything
+        "WHERE name = :name": row,        # but the name does
+    })
+    out = resolve_mcp_server(server_id="stale-uuid", server_name="Conduct AI Guard", workspace_id="ws-1", db=db)
+    assert out is not None, "should have fallen through to name lookup"
+    assert out[0] == "https://example.com/mcp"
+
+
+def test_resolve_returns_none_when_neither_matches():
+    db = _fake_db_with_rows({
+        "WHERE id = :id": None,
+        "WHERE name = :name": None,
+    })
+    out = resolve_mcp_server(server_id="stale", server_name="nope", workspace_id="ws-1", db=db)
+    assert out is None
+
+
+# ── mcp_block: reads server_id from the RIGHT config key ──────────────────────
+
+
+def _run_mcp_block(config: dict) -> dict:
+    """Execute _execute_mcp with the given config, mocking DB + call_tool."""
+    block = {"data": {"config": {**config, "tool_name": "some_tool"}}}
+    state = {}
+
+    with patch("app.runtime.blocks.mcp_block.call_tool") as mock_call, \
+         patch("app.core.database.get_db") as mock_get_db, \
+         patch("app.runtime.mcp_credentials.resolve_mcp_server") as mock_resolve:
+        mock_get_db.return_value = iter([MagicMock()])
+        mock_resolve.return_value = ("https://example.com/mcp", "http", "tok-xxx")
+        mock_call.return_value = {"verdict": "allowed"}
+        result = _execute_mcp(block, state, cred_store=None, workspace_id="ws-1")
+        return {"result": result, "resolve_call": mock_resolve.call_args}
+
+
+def test_mcp_block_reads_server_id_from_config_server_id():
+    """Canvas writes config.server_id — runtime must read from that key."""
+    out = _run_mcp_block({"server_id": "canvas-uuid", "server_name": "Whatever"})
+    _, kwargs = out["resolve_call"]
+    assert kwargs["server_id"] == "canvas-uuid", (
+        "runtime should have picked up the UUID from config.server_id — the "
+        "field the canvas MCP block editor actually writes"
+    )
+
+
+def test_mcp_block_falls_back_to_provider_key_for_legacy_configs():
+    """Older configs used 'provider' as the UUID key. Keep it working."""
+    out = _run_mcp_block({"provider": "legacy-uuid", "server_name": "Whatever"})
+    _, kwargs = out["resolve_call"]
+    assert kwargs["server_id"] == "legacy-uuid"
+
+
+def test_mcp_block_prefers_server_id_over_provider_if_both_set():
+    """If both keys exist, server_id (new) wins over provider (legacy)."""
+    out = _run_mcp_block({
+        "server_id": "new-uuid",
+        "provider":  "old-uuid",
+        "server_name": "Whatever",
+    })
+    _, kwargs = out["resolve_call"]
+    assert kwargs["server_id"] == "new-uuid"


### PR DESCRIPTION
Path B from tonight's demo triage — the real fix so canvas-picked MCP servers actually resolve by UUID at runtime.

## Bug 1 — runtime read the WRONG config key

**Canvas** (\`apps/web/src/components/canvas/BlockEditor.tsx:1083\`):
\`\`\`js
onChange(\"config.server_id\", srv.id)   // writes UUID here
\`\`\`

**Runtime** (\`apps/api/app/runtime/blocks/mcp_block.py:29\` — pre-fix):
\`\`\`python
server_id = config.get(\"provider\", \"\")   # reads a different key — always empty
\`\`\`

\`provider\` is the field name used by the **sandbox provider** select, a completely different piece of UI. The MCP block editor never writes it. So the runtime's UUID lookup path has been silently unused for every canvas-authored MCP block since the field was renamed.

**Consequence:** even when the user picked a server from the canvas dropdown, the workflow fell through to name-based lookup. If the block's \`server_name\` (usually inherited from the source YAML pack) didn't match the workspace row's display name exactly, the run errored with \`\"MCP server 'X' not registered\"\` — even though X was clearly registered.

**Fix:** \`server_id = config.get(\"server_id\", \"\") or config.get(\"provider\", \"\")\`. Reads the correct new key, keeps legacy fallback so no old configs break.

## Bug 2 — stale UUID short-circuited name fallback

\`apps/api/app/runtime/mcp_credentials.py:38-46\` had:

\`\`\`python
if server_id:
    row = ...  # by ID
elif server_name:
    row = ...  # by name
\`\`\`

If a canvas-stored UUID went stale (workspace re-seed, row deleted, workspace switch), the block's server_id would point at nothing. The \`elif\` prevented the fallback name lookup from running.

**Fix:** run both, name is used if id misses.

\`\`\`python
row = None
if server_id: row = query_by_id
if not row and server_name: row = query_by_name
\`\`\`

## Combined behavior

| Config shape | Path | Works? |
|---|---|---|
| Canvas-authored (server_id set) | UUID one-hop | ✓ (was silently broken) |
| YAML-installed (server_name only) | name lookup | ✓ (unchanged) |
| Stale UUID + valid name | id miss → name fallback | ✓ (new self-heal) |
| Neither set | returns None | ✓ (unchanged) |

## Tests

\`apps/api/tests/test_mcp_block_server_resolution.py\` — 6 cases:

- **resolve_mcp_server**: prefers id when it matches, falls through to name when id misses, returns None when both miss
- **_execute_mcp**: reads server_id from canvas key, falls back to legacy provider key, prefers new key when both set

Uses monkeypatch on \`get_db\` + \`resolve_mcp_server\` so tests run unit-mode with no DB.

## Post-deploy for existing broken workflows

After deploy, users can either:

- **Rename their MCP server row** to match the playbook's \`server_name\` string (immediate, no re-open needed)
- **Open the workflow in canvas, re-pick the server from the dropdown, save** — writes \`server_id\`, resolves by UUID going forward

New workflows created from YAML packs still resolve by name until the user touches the block. A future PR should auto-populate \`server_id\` on canvas load when a matching row is found — filing as follow-up.

## Related

- #1731 — plain httpx MCP client. Made the transport fast.
- **This PR** — makes the lookup layer correct.
- Together: NeMo Guardrails × Conduct demo playbook runs end-to-end.

## Test plan

- [ ] CI passes
- [ ] Live: open a canvas MCP block, pick server from dropdown, save, run — resolves by UUID
- [ ] Live: install a YAML playbook with a matching-name MCP block (no dropdown touch), run — resolves by name
- [ ] Live: canvas block with a stale UUID + valid name — self-heals via name fallback