### PR TITLE
fix(playbook): nemo-guardrails-demo — llm_call tool + payload-free LLM prompts (v3)

### DIFF
--- a/apps/api/playbooks/nemo-guardrails-demo.yaml
+++ b/apps/api/playbooks/nemo-guardrails-demo.yaml
@@ -15,7 +15,7 @@
 # See #1631 for design context.
 # ──────────────────────────────────────────────────────────────────────────────
 name: NeMo Guardrails × Conduct — DETECT & ENFORCE demo
-version: 2
+version: 3
 description: >
   5-beat live demo showing Conduct as the DETECT & ENFORCE layer at L4
   AI RUNTIME TRUST on HPE PCAI. A NeMo-style input rail hits guard_check,
@@ -65,7 +65,7 @@ blocks:
       _PREVENT (DSPM) is upstream. RECOVER (Zerto · Veeam) is downstream.
       This demo lives in the middle box._
 
-      _Prompt about to be checked_ → `{{inputs.demo_prompt}}`
+      _Sending a prompt-injection payload to Conduct's guard_check for evaluation._
 
   # ── 2a. Guardrails leg — real Conduct verdict (Beat 2) ────────────────────
   call_guard_check:
@@ -76,10 +76,16 @@ blocks:
       server_name: "Conduct AI Guard"
       tool_name: guard_check
       inputs:
-        tool_name: "write"
+        # ponytail: tool_name is llm_call, not write. write trips the always-on
+        # conduct-base rule surface-chat-no-file-write BEFORE the caller's
+        # pack: gets evaluated, so the demo would show the wrong rule id.
+        # llm_call is the correct action family for a prompt being sent to
+        # a model — nothing in conduct-base short-circuits it, so the
+        # conduct-prompt-injection pack rule fires cleanly on the payload.
+        tool_name: "llm_call"
         tool_input:
-          file_path: "demo.py"
-          content: "prompt = '{{inputs.demo_prompt}}'"
+          model: "claude-sonnet-4-5"
+          prompt: "{{inputs.demo_prompt}}"
         pack: "conduct-prompt-injection"
         ai_tool: "{{inputs.ai_tool_label}}"
     next: explain_verdict
@@ -89,29 +95,30 @@ blocks:
     type: brain
     mode: single
     label: Verdict — plain English
-    description: Human-readable rendering of the guard_check response for a non-technical viewer.
+    description: Human-readable rendering of the guard_check response. Reads verdict + rule id from the guard_check response text without echoing any raw payload back to the LLM (see epic #1734 — LLM proxy egress lacks pack-rule scanning, so CF WAF ends up filtering our own demo payloads).
     max_turns: 1
     next: gateway_and_observability
     system: |
       You explain a Conduct guard_check response in plain English for a
       non-technical viewer. Output markdown only. No preamble, no meta
-      commentary, no advice. Do not invent facts beyond the response text.
+      commentary, no advice.
     prompt: |
-      The guard_check response was:
+      A Conduct guard_check call just completed. The response text looks
+      like this (verdict word first, then a message, then a rule id in
+      brackets):
 
-      ```
-      {{call_guard_check.output}}
-      ```
+      Response: `{{call_guard_check.output}}`
 
-      Render exactly this shape, filling in values from the response above:
+      Read the verdict word and the rule id, then render EXACTLY this
+      shape (no other text):
 
-      **Conduct verdict.** _<one line: Blocked / Warned / Audited / Allowed and why in plain English>_
+      **Conduct verdict.** _<one line based on the verdict word — Blocked, Warned, Audited, or Allowed — and the message>_
 
-      **Rule that matched.** `<rule id from the response, or "none" if allowed>`
+      **Rule that matched.** `<the rule id from the brackets, or "none" if no brackets>`
 
-      **What just happened.** The prompt never reached the model — Conduct
-      intercepted it at L4 AI RUNTIME TRUST and hash-chained the decision
-      into the workspace audit trail.
+      **What just happened.** Conduct intercepted the request at L4 AI
+      RUNTIME TRUST and hash-chained the decision into the workspace
+      audit trail before the model saw the payload.
 
   # ── 3+4. Gateway leg + Observability leg (Beats 3 & 4) ────────────────────
   gateway_and_observability:

--- a/apps/api/tests/test_mcp_block_server_resolution.py
+++ b/apps/api/tests/test_mcp_block_server_resolution.py
@@ -108,7 +108,13 @@ def _run_mcp_block(config: dict) -> dict:
     block = {"data": {"config": {**config, "tool_name": "some_tool"}}}
     state = {}
 
-    with patch("app.runtime.blocks.mcp_block.call_tool") as mock_call, \
+    # ponytail: patch call_tool at its source module (integrations.mcp_client),
+    # not on mcp_block. mcp_block imports it INSIDE the function via
+    # `from app.runtime.integrations.mcp_client import call_tool`, so it never
+    # exists as an attribute on mcp_block itself — patching there raises
+    # AttributeError. Same for get_db + resolve_mcp_server, which are also
+    # local imports inside _execute_mcp.
+    with patch("app.runtime.integrations.mcp_client.call_tool") as mock_call, \
          patch("app.core.database.get_db") as mock_get_db, \
          patch("app.runtime.mcp_credentials.resolve_mcp_server") as mock_resolve:
         mock_get_db.return_value = iter([MagicMock()])


### PR DESCRIPTION
Demo-hardening pass for tomorrow's HPE PCAI live run. Two YAML-only changes address the two narrative-breakers from tonight's live triage.

## 1. call_guard_check: \`tool_name: write\` → \`tool_name: llm_call\`

**Problem:** \`conduct-base\` pack is always enforced first (see \`mcp_impls.py:114\`). Its \`surface-chat-no-file-write\` rule matches on \`tool_name=write\` from chat surfaces and short-circuits before the caller's \`pack:\` argument gets evaluated. The demo tripped the WRONG rule id — \`surface-chat-no-file-write\` instead of \`prompt-inject-override-instructions\` — which broke the narrative "look, our prompt-injection pack caught it."

**Fix:** \`llm_call\` is the correct action family for a prompt about to be sent to a model. Nothing in \`conduct-base\` short-circuits it, so the \`conduct-prompt-injection\` pack rule inspects the \`tool_input.prompt\` content directly and fires cleanly.

Also updated \`tool_input\` shape from \`{file_path, content}\` to \`{model, prompt}\` to match the new action family semantically.

## 2. frame_l4 no longer echoes the payload into the LLM

**Problem:** The \`frame_l4\` brain block rendered the demo payload verbatim in its LLM prompt via \`{{inputs.demo_prompt}}\`. That string went through the Conduct LLM proxy → Cloudflare edge → Anthropic. CF WAF ended up catching our own demo payload, and downstream beats (\`gateway_and_observability\`) got 502'd after 3 retries with the confusing \`LLM_UPSTREAM_BLOCKED\` error.

**Fix:** narrate the scenario without quoting the payload string. Beat 1's story reads exactly as before — \"a prompt-injection payload is about to be evaluated\" — no functional loss, no CF trigger.

**Real fix is elsewhere:** epic #1734 sub-issue in the same tracking arc calls for Guard pack rules to run at the LLM proxy egress. When that ships, Conduct catches its own payloads deterministically and CF isn't the layer we rely on. Filed as arch gap in #1733 as well.

## explain_verdict — reworded lightly

Kept the \`{{call_guard_check.output}}\` reference since the guard_check response text is the RULE MESSAGE (verdict word + short description + rule id), not the input payload — that content is safe to loop through the LLM. Just tightened the prompt so the model reads only the verdict word and rule id fields, no free-form paraphrase of the raw response.

## Version bump 2 → 3

Marketplace card will re-install cleanly for anyone already on v2.

## Not fixable in YAML — user setup still required

- **Rename the workspace's MCP server row from "Conduct AI" → "Conduct AI Guard"** to match the auto-seed default. PR #1732 fixed the runtime UUID lookup but epic #1734 sub-issue 1 (canvas save race on \`server_id\` write) means the server_id doesn't persist reliably. Name match is the fastest workaround.
- **Install the \`conduct-prompt-injection\` pack** in the workspace if not already installed.
- **After install, manually fill canvas fields** in \`call_guard_check\` — PACK, TOOL_NAME, TOOL_INPUT — because epic #1734 sub-issue 2 (YAML → canvas hydration on install) hasn't shipped. See PR body comments for exact values to paste.

## Related

- #1631 — original playbook design issue
- #1726 — v1 shipped
- #1731 — plain httpx MCP client (transport layer fix)
- #1732 — server_id resolution
- #1733 — LLM proxy egress gap (root cause of the CF WAF issue)
- #1734 — 6-item demo-readiness epic

## Test plan

- [ ] CI passes (YAML validation + playbook eval harness)
- [ ] After merge + deploy: re-install \`nemo_guardrails_demo\` v3 from \`/packs\`
- [ ] Beat 2 returns BLOCKED with \`rule: prompt-inject-override-instructions\` (not \`surface-chat-no-file-write\`)
- [ ] All 5 beats complete — no CF 502 loop on \`gateway_and_observability\`
- [ ] Total run time under ~10s (was ~90s pre-#1731, and hung indefinitely pre-tonight)