### PR TITLE
fix(mcp): tools/list — spec Hint suffix on annotations + drop non-spec extras

### DIFF
--- a/apps/api/app/mcp/server.py
+++ b/apps/api/app/mcp/server.py
@@ -144,13 +144,13 @@ def _handle_initialize(msg_id: Any, params: dict[str, Any]) -> dict[str, Any]:
 
 
 def _handle_tools_list(msg_id: Any, registry: ToolRegistry) -> dict[str, Any]:
-    """Project the registry onto the MCP tools/list response shape."""
-    return _ok(msg_id, {
-        "tools": registry.as_mcp_tools_list(),
-        # 2026-07-28 spec — cacheable list result
-        "ttlMs": 60_000,
-        "cacheScope": "workspace",
-    })
+    """Project the registry onto the MCP tools/list response shape.
+
+    Spec-strict: only `tools` (and optional `nextCursor` for pagination) at
+    the top level. Extra fields like ttlMs/cacheScope trip strict clients
+    (Claude.ai) into rejecting the whole response.
+    """
+    return _ok(msg_id, {"tools": registry.as_mcp_tools_list()})
 
 
 def _handle_tools_call(

--- a/apps/api/app/tools/registry.py
+++ b/apps/api/app/tools/registry.py
@@ -86,12 +86,15 @@ class ToolRegistry:
             }
             if t.output_schema is not None:
                 entry["outputSchema"] = t.output_schema
-            # MCP 2026-07-28 tool annotations
+            # MCP tool annotations — the spec-mandated field names carry the
+            # `Hint` suffix. Emitting `readOnly` (no suffix) caused Claude.ai
+            # to reject the entire tools/list response, surfacing in the UI as
+            # "This connector has no tools available".
             entry["annotations"] = {
-                "readOnly": t.annotations.read_only,
-                "idempotent": t.annotations.idempotent,
-                "destructive": t.annotations.destructive,
-                "openWorld": t.annotations.open_world,
+                "readOnlyHint": t.annotations.read_only,
+                "idempotentHint": t.annotations.idempotent,
+                "destructiveHint": t.annotations.destructive,
+                "openWorldHint": t.annotations.open_world,
             }
             out.append(entry)
         return out

--- a/apps/api/tests/mcp/test_server.py
+++ b/apps/api/tests/mcp/test_server.py
@@ -115,11 +115,12 @@ def test_tools_list_projects_registry():
     assert {t["name"] for t in tools} == {"a", "b"}
 
 
-def test_tools_list_includes_cacheable_metadata():
+def test_tools_list_result_body_is_spec_only():
+    # Spec-strict: only `tools` (and optional `nextCursor`) at the top level.
+    # The old ttlMs/cacheScope extras caused Claude.ai to reject the response.
     request = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
     response = dispatch(request, _ctx(), ToolRegistry())
-    assert response["result"]["ttlMs"] == 60_000
-    assert response["result"]["cacheScope"] == "workspace"
+    assert set(response["result"].keys()) <= {"tools", "nextCursor"}
 
 
 def test_tools_list_includes_annotations():
@@ -128,8 +129,9 @@ def test_tools_list_includes_annotations():
     ])
     request = {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
     tools = dispatch(request, _ctx(), registry)["result"]["tools"]
-    assert tools[0]["annotations"]["readOnly"] is True
-    assert tools[0]["annotations"]["idempotent"] is True
+    # Spec-mandated `Hint` suffix — Claude.ai drops tools without it.
+    assert tools[0]["annotations"]["readOnlyHint"] is True
+    assert tools[0]["annotations"]["idempotentHint"] is True
 
 
 # ─── tools/call ──────────────────────────────────────────────────────────────

--- a/apps/api/tests/test_mcp_http_streamable.py
+++ b/apps/api/tests/test_mcp_http_streamable.py
@@ -115,6 +115,48 @@ def test_list_my_runs_declares_output_schema():
     assert "outputSchema" in tools["list_runs_in_session"]
 
 
+def test_tools_list_uses_spec_hint_suffix_on_annotations():
+    """Regression: MCP spec mandates readOnlyHint/idempotentHint/destructiveHint/
+    openWorldHint. Emitting readOnly (no suffix) caused Claude.ai to reject the
+    entire tools/list response, surfacing as 'no tools available' in the UI.
+    """
+    from app.tools.registry import ToolRegistry
+    from app.tools.types import ToolAnnotations, ToolDef
+
+    reg = ToolRegistry()
+    reg.register(
+        ToolDef(
+            name="probe",
+            description="d",
+            input_schema={"type": "object"},
+            impl=lambda ctx=None: "x",
+            annotations=ToolAnnotations(read_only=True, destructive=False),
+        )
+    )
+    entry = reg.as_mcp_tools_list()[0]
+    ann = entry["annotations"]
+    for key in ("readOnlyHint", "idempotentHint", "destructiveHint", "openWorldHint"):
+        assert key in ann, f"missing spec-mandated {key!r}"
+    # No-suffix legacy field names must not sneak back in.
+    for legacy in ("readOnly", "idempotent", "destructive", "openWorld"):
+        assert legacy not in ann, f"legacy no-suffix field {legacy!r} present"
+    assert ann["readOnlyHint"] is True
+    assert ann["destructiveHint"] is False
+
+
+def test_tools_list_response_has_no_non_spec_extras():
+    """Regression: `ttlMs` / `cacheScope` at the top level of tools/list result
+    tripped strict clients into rejecting the whole response.
+    """
+    from app.mcp.server import _handle_tools_list
+    from app.tools.registry import ToolRegistry
+
+    result = _handle_tools_list(msg_id=1, registry=ToolRegistry())
+    body = result["result"]
+    assert set(body.keys()) <= {"tools", "nextCursor"}, f"unexpected keys: {set(body.keys())}"
+    assert body["tools"] == []
+
+
 def test_get_route_is_registered(monkeypatch):
     # ponytail: SSE-open test hangs TestClient (infinite generator + full-body
     # drain). The 401 test above already proves the route exists and is auth-

--- a/apps/api/tests/tools/test_registry.py
+++ b/apps/api/tests/tools/test_registry.py
@@ -128,24 +128,24 @@ def test_as_mcp_tools_list_shape():
     assert entry["description"] == "A sample tool."
     assert entry["inputSchema"] == {"type": "object", "properties": {"q": {"type": "string"}}}
     assert entry["annotations"] == {
-        "readOnly": True,
-        "idempotent": True,
-        "destructive": False,
-        "openWorld": False,
+        "readOnlyHint": True,
+        "idempotentHint": True,
+        "destructiveHint": False,
+        "openWorldHint": False,
     }
 
 
 def test_as_mcp_tools_list_default_annotations():
     """Tools registered without explicit annotations get the safe default
-    (all False — treat as unknown)."""
+    (all False — treat as unknown). Uses the spec-mandated `Hint` suffix."""
     reg = ToolRegistry()
     reg.register(_tool("noannot"))
     entry = reg.as_mcp_tools_list()[0]
     assert entry["annotations"] == {
-        "readOnly": False,
-        "idempotent": False,
-        "destructive": False,
-        "openWorld": False,
+        "readOnlyHint": False,
+        "idempotentHint": False,
+        "destructiveHint": False,
+        "openWorldHint": False,
     }
 
 


### PR DESCRIPTION
## Problem

Claude.ai's connector UI showed **"This connector has no tools available"** for \`https://api.conductai.ai/mcp\` even though the server has 99 tools registered locally. OAuth flow completed successfully (Disconnect button shown) but no tools were exposed.

## Root cause

The tools/list response violated the MCP spec in two ways strict clients reject:

**1. Annotation field names missing spec-mandated \`Hint\` suffix.**

We were emitting:
\`\`\`json
"annotations": {
  "readOnly": true,
  "idempotent": false,
  "destructive": false,
  "openWorld": false
}
\`\`\`

Spec requires:
\`\`\`json
"annotations": {
  "readOnlyHint": true,
  "idempotentHint": false,
  "destructiveHint": false,
  "openWorldHint": false
}
\`\`\`

Claude.ai's strict validator drops unknown fields, sees no valid annotations, and treats the tool entry as invalid.

**2. Non-spec top-level extras in the result body.**

\`_handle_tools_list\` returned:
\`\`\`json
{"tools": [...], "ttlMs": 60000, "cacheScope": "workspace"}
\`\`\`

The \`ttlMs\`/\`cacheScope\` fields were nice-to-have caching hints, not in the spec. Strict clients reject unexpected fields in the tools/list result envelope.

## Fix

- \`app/tools/registry.py\` — emit \`readOnlyHint\` / \`idempotentHint\` / \`destructiveHint\` / \`openWorldHint\`.
- \`app/mcp/server.py\` — result body is now exactly \`{"tools": [...]}\`. \`nextCursor\` slot kept available for future pagination.

## Regression tests

Two new tests in \`tests/test_mcp_http_streamable.py\`:

- \`test_tools_list_uses_spec_hint_suffix_on_annotations\` — asserts all four \`*Hint\` names present, and that legacy no-suffix names never sneak back in.
- \`test_tools_list_response_has_no_non_spec_extras\` — asserts the result body has only spec-allowed keys (\`tools\` and optional \`nextCursor\`).

## Test plan

- [x] \`test_mcp_http_streamable.py\` — 10 tests all pass
- [ ] Deploy → refresh Claude.ai connector → confirm tools show up
- [ ] Ask Claude for \`guard_status\` in a chat → confirm the call goes through

## Post-deploy verification

\`\`\`
curl -sS https://api.conductai.ai/mcp \\
  -H "Authorization: Bearer <your cond_agt>" \\
  -H "Content-Type: application/json" \\
  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | jq '.result.tools[0].annotations'
\`\`\`

Expected: \`{"readOnlyHint": true, "idempotentHint": false, ...}\` (with the \`Hint\` suffix).