### PR TITLE
fix(mcp): retire /guard/mcp URLs — Phase 5a URL migration (#1230)

### DIFF
--- a/apps/api/alembic/versions/0119_migrate_mcp_servers_url_to_mcp.py
+++ b/apps/api/alembic/versions/0119_migrate_mcp_servers_url_to_mcp.py
@@ -1,0 +1,50 @@
+"""Retire /guard/mcp — migrate existing mcp_servers.url to /mcp (#1230 Phase 5).
+
+Every mcp_servers row pointing at .../guard/mcp[?workspace_id=...] is
+rewritten to .../mcp with the same query string preserved. Idempotent via
+LIKE guard — safe to re-run.
+
+New agent installs already use /mcp after the paired code changes to
+apps/api/app/routers/projects.py (line 352). This migration heals the DB
+so existing workspaces don't need to reinstall to migrate off the legacy
+URL. /guard/mcp router remains live to handle any external client that
+hasn't upgraded yet; deletion happens in a follow-up PR once traffic
+drops to zero.
+
+Revision ID: 0119
+Revises: 0118
+Create Date: 2026-09-09
+"""
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "0119"
+down_revision = "0118"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        UPDATE mcp_servers
+        SET url = REPLACE(url, '/guard/mcp', '/mcp')
+        WHERE url LIKE '%/guard/mcp%'
+        """
+    )
+
+
+def downgrade() -> None:
+    # Reversible: swap /mcp → /guard/mcp for rows that currently end in /mcp
+    # via the same endpoint host. We can't distinguish rows that were always
+    # /mcp from rows that were migrated by this revision, so this downgrade
+    # is best-effort against the conductai.ai host only.
+    op.execute(
+        """
+        UPDATE mcp_servers
+        SET url = REPLACE(url, 'conductai.ai/mcp', 'conductai.ai/guard/mcp')
+        WHERE url LIKE '%conductai.ai/mcp%'
+        """
+    )

--- a/apps/api/app/routers/projects.py
+++ b/apps/api/app/routers/projects.py
@@ -349,7 +349,7 @@ def list_projects(
         db.execute(text("""
             INSERT INTO mcp_servers (id, workspace_id, environment_id, name, url, transport, encrypted_auth, created_at)
             VALUES (gen_random_uuid(), :ws, NULL, 'Conduct AI Guard',
-                    'https://api.conductai.ai/guard/mcp',
+                    'https://api.conductai.ai/mcp',
                     'http', :auth, :now)
             ON CONFLICT DO NOTHING
         """), {"ws": str(project_id), "auth": _enc_bearer, "now": now})

--- a/packages/conduct-cli/src/conduct_cli/guard.py
+++ b/packages/conduct-cli/src/conduct_cli/guard.py
@@ -498,7 +498,7 @@ def _patch_copilot_mcp(agent_token: str, api_url: str) -> None:
     import shutil
     sse_entry = {
         "type": "http",
-        "url": f"{api_url}/guard/mcp",
+        "url": f"{api_url}/mcp",
         "headers": {"Authorization": f"Bearer {agent_token}"},
     }
     booster_entry = {"command": "booster", "args": ["serve"]} if shutil.which("booster") else None
@@ -1618,7 +1618,7 @@ def cmd_guard_sync(args):
     # Print remote MCP URL for any MCP-compatible client
     agent_token = cfg.get("agent_token", "")
     if workspace_id and agent_token:
-        mcp_url = "https://api.conductai.ai/guard/mcp"
+        mcp_url = "https://api.conductai.ai/mcp"
         masked = agent_token[:13] + "•" * 20
         print(f"\n{BOLD}MCP server{RESET} (Claude.ai, Copilot, Cursor, Windsurf, any MCP client):")
         print(f"  URL:    {CYAN}{mcp_url}{RESET}")

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
@@ -79,7 +79,7 @@ class GuardCheckClient:
             headers["X-Conduct-Session-Id"] = session_id
 
         response = await self._client.post(
-            f"{self._base}/guard/mcp",
+            f"{self._base}/mcp",
             json=payload,
             headers=headers,
         )

--- a/packages/conduct-nemo-guard/src/conduct_nemo_guard/_client.py
+++ b/packages/conduct-nemo-guard/src/conduct_nemo_guard/_client.py
@@ -81,7 +81,7 @@ class GuardCheckClient:
             headers["X-Conduct-Session-Id"] = session_id
 
         response = await self._client.post(
-            f"{self._base}/guard/mcp",
+            f"{self._base}/mcp",
             json=payload,
             headers=headers,
         )


### PR DESCRIPTION
## Summary
Phase 5a of retiring /guard/mcp per #1230. All Conduct-owned code now points at \`/mcp\` (the OAuth 2.1-native URL). Existing user data is healed by an idempotent Alembic migration.

**Deliberately scope-cut:** the \`/guard/mcp\` router itself stays live for external clients still hardcoded to it. Handler deletion + 308 redirect ships in Phase 5b once analytics show sustained zero traffic.

## Files changed
| File | Change |
|---|---|
| \`apps/api/app/routers/projects.py:352\` | Pre-seed URL on new project → \`/mcp\` |
| \`packages/conduct-cli/src/conduct_cli/guard.py:501\` | \`conduct mcp install\` writes \`/mcp\` |
| \`packages/conduct-cli/src/conduct_cli/guard.py:1621\` | \`conduct login\` prints \`/mcp\` |
| \`packages/conduct-nemo-guard/_client.py:84\` | SDK POST URL |
| \`packages/conduct-litellm-guard/_client.py:82\` | SDK POST URL |
| \`apps/api/alembic/versions/0119_migrate_mcp_servers_url_to_mcp.py\` | \`REPLACE(url, '/guard/mcp', '/mcp')\` on existing rows |

## Migration safety
- Idempotent via \`WHERE url LIKE '%/guard/mcp%'\`
- Zero-downtime: no schema changes, just data rewrite
- \`downgrade()\` reversible on the conductai.ai host only (limited but sufficient for rollback)

## Test plan
- [x] Local: \`app.main\` imports cleanly; migration heads valid (0116 → 0117 → 0118 → 0119)
- [ ] Post-deploy: verify existing user's \`mcp_servers\` rows show \`/mcp\` URL
- [ ] Post-deploy: run \`conduct login\` on a fresh install → prints \`/mcp\` URL

## Phase 5b (follow-up, ~30 days)
- Add 308 Permanent Redirect on \`/guard/mcp\` GET/POST/DELETE → \`/mcp\`
- Delete handler code, update ~10 tests currently calling \`mcp_endpoint()\` directly
- Delete the legacy well-known metadata endpoint
- Reference: \`packages/conduct-cli/CHANGELOG.md:68\`