### PR TITLE
feat(mcp): conduct_current_workspace tool — active workspace + role

### DIFF
--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -76,6 +76,21 @@ def guard_status_impl(ctx: GuardCtx, **arguments) -> str:
 
     rules = _get_rules(db, ws_uuid)
     _ws_out = workspace_id or (str(ws_uuid) if ws_uuid else None)
+
+    # Include workspace_name so LLMs surface the team name (e.g. "ConductGuard
+    # is active on 'Acme Engineering'") without a second tool call. Non-fatal
+    # if the lookup fails.
+    _ws_name = None
+    try:
+        _row = db.execute(
+            _sql("SELECT name FROM workspaces WHERE id = :ws LIMIT 1"),
+            {"ws": str(ws_uuid)},
+        ).fetchone()
+        if _row:
+            _ws_name = _row.name
+    except Exception:
+        pass
+
     _pv = None
     _pv_at = None
     try:
@@ -88,6 +103,7 @@ def guard_status_impl(ctx: GuardCtx, **arguments) -> str:
         pass  # never fail guard_status over policy-version lookup
     return json.dumps({
         "workspace_id":       _ws_out,
+        "workspace_name":     _ws_name,
         "email":              user_email,
         "rules_active":       len(rules),
         "policy_version":     _pv,

--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -615,8 +615,51 @@ def conduct_get_run_impl(ctx: GuardCtx, **arguments) -> str:
 
 
 
+def conduct_current_workspace_impl(ctx: GuardCtx, **arguments) -> str:
+    """Return the caller's active workspace: id, name, and their role.
+
+    LLMs use this to remind themselves which workspace context they're in —
+    useful when a user is a member of multiple workspaces and has multiple
+    Conduct MCP connectors installed (see issue #1747 for the alternative
+    in-chat workspace-switching design).
+
+    Returns JSON: {workspace_id, workspace_name, role, member_email}. If the
+    workspace or membership can't be resolved, returns an {error} envelope.
+    """
+    db = ctx.db
+    ws_uuid = ctx.ws_uuid
+    clerk_user_id = ctx.clerk_user_id
+    user_email = ctx.user_email
+
+    try:
+        row = db.execute(
+            _sql("""
+                SELECT w.id AS workspace_id, w.name AS workspace_name, wu.role AS role
+                FROM workspaces w
+                LEFT JOIN workspace_users wu
+                       ON wu.workspace_id = w.id AND wu.clerk_user_id = :uid
+                WHERE w.id = :ws
+                LIMIT 1
+            """),
+            {"ws": str(ws_uuid), "uid": clerk_user_id or ""},
+        ).fetchone()
+    except Exception as e:
+        return json.dumps({"error": f"lookup_failed: {e}"})
+
+    if row is None:
+        return json.dumps({"error": "workspace_not_found"})
+
+    return json.dumps({
+        "workspace_id":   str(row.workspace_id),
+        "workspace_name": row.workspace_name,
+        "role":           row.role or "unknown",
+        "member_email":   user_email,
+    }, indent=2)
+
+
 _GUARD_TOOL_IMPLS: dict[str, Any] = {
     'guard_status': guard_status_impl,
+    'conduct_current_workspace': conduct_current_workspace_impl,
     'guard_check': guard_check_impl,
     'guard_sync': guard_sync_impl,
     'guard_enable': guard_enable_impl,

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -45,8 +45,9 @@ _TOOLS = [
     {
         "name": "guard_status",
         "description": (
-            "Returns current ConductGuard policy status: team name, your email, "
-            "number of active rules, and the policy version timestamp."
+            "Returns current ConductGuard policy status: workspace_id, "
+            "workspace_name, your email, number of active rules, and the "
+            "policy version timestamp."
         ),
         "inputSchema": {"type": "object", "properties": {}, "required": []},
     },

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -51,6 +51,17 @@ _TOOLS = [
         "inputSchema": {"type": "object", "properties": {}, "required": []},
     },
     {
+        "name": "conduct_current_workspace",
+        "description": (
+            "Return the active workspace this MCP session is scoped to: "
+            "workspace_id, workspace_name, and the caller's role in that workspace. "
+            "Use when the user asks 'which workspace am I in' or when you (the model) "
+            "need to confirm the workspace context before running side-effectful tools. "
+            "Read-only; no side effects."
+        ),
+        "inputSchema": {"type": "object", "properties": {}, "required": []},
+    },
+    {
         "name": "guard_check",
         "description": (
             "Check the intent about to be executed against team policy. "

--- a/apps/api/app/tools/registrations/guard.py
+++ b/apps/api/app/tools/registrations/guard.py
@@ -37,8 +37,9 @@ _GUARD_TAGS = ("guard",)
 # don't; guard_check + trigger_fix + post_finding + guard_discover_register
 # + conduct_run_workflow are open_world (they mutate DB / enqueue runs).
 _ANNOTATIONS: dict[str, ToolAnnotations] = {
-    "guard_status":            ToolAnnotations(read_only=True),
-    "guard_check":             ToolAnnotations(open_world=True),
+    "guard_status":              ToolAnnotations(read_only=True),
+    "conduct_current_workspace": ToolAnnotations(read_only=True, idempotent=True),
+    "guard_check":               ToolAnnotations(open_world=True),
     "guard_sync":              ToolAnnotations(read_only=True),
     "guard_enable":            ToolAnnotations(read_only=True),
     "guard_spend":             ToolAnnotations(read_only=True),

--- a/apps/api/tests/test_conduct_current_workspace.py
+++ b/apps/api/tests/test_conduct_current_workspace.py
@@ -1,0 +1,113 @@
+"""Unit tests for conduct_current_workspace MCP tool.
+
+The impl reads ctx (workspace_id, clerk_user_id, user_email) and does one
+DB query joining `workspaces` with `workspace_users` to return the caller's
+active workspace + role. Tests exercise all three response envelopes:
+- happy path (workspace exists, user is a member) → JSON with id/name/role
+- workspace missing → {"error": "workspace_not_found"}
+- DB failure → {"error": "lookup_failed: ..."}
+"""
+from __future__ import annotations
+
+import json
+import uuid
+from types import SimpleNamespace
+
+from app.modules.guard.mcp_impls import conduct_current_workspace_impl
+
+
+def _ctx(ws_uuid=None, clerk_user_id="user_x", user_email="x@example.com"):
+    """Minimal GuardCtx-shaped stub — impl only reads these fields."""
+    return SimpleNamespace(
+        db=None,
+        ws_uuid=ws_uuid or uuid.uuid4(),
+        workspace_id=None,
+        resolved_token="",
+        clerk_user_id=clerk_user_id,
+        user_email=user_email,
+        ai_tool="http",
+        session_id="",
+    )
+
+
+def _stub_db(row):
+    """DB stub: db.execute(sql, params).fetchone() → row."""
+    class _Result:
+        def __init__(self, row):
+            self._row = row
+
+        def fetchone(self):
+            return self._row
+
+    class _Db:
+        def execute(self, _sql, _params):
+            return _Result(row)
+
+    return _Db()
+
+
+def test_happy_path_returns_workspace_and_role():
+    ws_uuid = uuid.uuid4()
+    ctx = _ctx(ws_uuid=ws_uuid, clerk_user_id="user_1", user_email="alice@acme.com")
+    ctx.db = _stub_db(SimpleNamespace(
+        workspace_id=ws_uuid,
+        workspace_name="Acme Engineering",
+        role="admin",
+    ))
+
+    result = json.loads(conduct_current_workspace_impl(ctx))
+    assert result["workspace_id"] == str(ws_uuid)
+    assert result["workspace_name"] == "Acme Engineering"
+    assert result["role"] == "admin"
+    assert result["member_email"] == "alice@acme.com"
+
+
+def test_missing_membership_returns_unknown_role():
+    """User is on a workspace but has no workspace_users row (edge — legacy
+    owner without membership). Row still returns, but role is NULL → 'unknown'."""
+    ctx = _ctx()
+    ctx.db = _stub_db(SimpleNamespace(
+        workspace_id=ctx.ws_uuid,
+        workspace_name="Legacy Workspace",
+        role=None,
+    ))
+
+    result = json.loads(conduct_current_workspace_impl(ctx))
+    assert result["role"] == "unknown"
+    assert result["workspace_name"] == "Legacy Workspace"
+
+
+def test_workspace_not_found_returns_error_envelope():
+    ctx = _ctx()
+    ctx.db = _stub_db(None)  # fetchone returns None
+
+    result = json.loads(conduct_current_workspace_impl(ctx))
+    assert result == {"error": "workspace_not_found"}
+
+
+def test_db_exception_returns_error_envelope():
+    class _BoomDb:
+        def execute(self, *_a, **_k):
+            raise RuntimeError("connection reset")
+
+    ctx = _ctx()
+    ctx.db = _BoomDb()
+
+    result = json.loads(conduct_current_workspace_impl(ctx))
+    assert result["error"].startswith("lookup_failed:")
+    assert "connection reset" in result["error"]
+
+
+def test_tool_registered_via_default_registry():
+    """Integration: prove the tool is in default_registry with correct annotations.
+    This is what /mcp tools/list projects onto the wire."""
+    from app.tools.registry import default_registry
+    import app.tools.registrations  # noqa: F401  — side-effect: populate registry
+
+    tools = {t["name"]: t for t in default_registry.as_mcp_tools_list()}
+    assert "conduct_current_workspace" in tools
+    t = tools["conduct_current_workspace"]
+    # Spec-mandated Hint suffix (Claude.ai's strict parser rejects the no-suffix form).
+    assert t["annotations"]["readOnlyHint"] is True
+    assert t["annotations"]["idempotentHint"] is True
+    assert t["annotations"]["destructiveHint"] is False

--- a/apps/api/tests/test_conduct_current_workspace.py
+++ b/apps/api/tests/test_conduct_current_workspace.py
@@ -98,6 +98,47 @@ def test_db_exception_returns_error_envelope():
     assert "connection reset" in result["error"]
 
 
+def test_guard_status_includes_workspace_name():
+    """guard_status now returns workspace_name alongside workspace_id so LLMs
+    can surface the team name ('ConductGuard is active on Acme Engineering')
+    without a second tool call. Non-fatal if the name lookup fails."""
+    from unittest.mock import MagicMock, patch
+    from app.modules.guard.mcp_impls import guard_status_impl
+
+    ws_uuid = uuid.uuid4()
+    ctx = _ctx(ws_uuid=ws_uuid)
+
+    # Fake DB — first execute() returns workspace row, second is for policy cache
+    ws_row = SimpleNamespace(name="Acme Engineering")
+    ctx.db = MagicMock()
+    ctx.db.execute.return_value.fetchone.return_value = ws_row
+    ctx.db.get.return_value = None  # no policy cache
+
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=[]):
+        result = json.loads(guard_status_impl(ctx))
+
+    assert result["workspace_name"] == "Acme Engineering"
+    assert result["workspace_id"] == str(ws_uuid)
+
+
+def test_guard_status_survives_workspace_name_lookup_failure():
+    """Workspace-name lookup is best-effort. If it raises, guard_status still
+    returns the rest of the payload with workspace_name=None."""
+    from unittest.mock import MagicMock, patch
+    from app.modules.guard.mcp_impls import guard_status_impl
+
+    ctx = _ctx()
+    ctx.db = MagicMock()
+    ctx.db.execute.side_effect = RuntimeError("boom")
+    ctx.db.get.return_value = None
+
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=[]):
+        result = json.loads(guard_status_impl(ctx))
+
+    assert result["workspace_name"] is None
+    assert result["workspace_id"] is not None
+
+
 def test_tool_registered_via_default_registry():
     """Integration: prove the tool is in default_registry with correct annotations.
     This is what /mcp tools/list projects onto the wire."""


### PR DESCRIPTION
## What
One new read-only MCP tool: \`conduct_current_workspace\`. Returns \`{workspace_id, workspace_name, role, member_email}\` for the workspace the caller's token is scoped to.

## Why
Users often have multiple Conduct MCP connectors installed in Claude.ai / Cursor — one per workspace (Option B from #1747). LLMs currently guess which connector they're talking to based on the connector's display name in the client. This tool gives ground truth: call \`conduct_current_workspace\` and get the actual active workspace + your role.

Also useful before running side-effectful tools (\`guard_check\`, \`conduct_run_workflow\`) so the LLM can confirm-then-act.

## Shape
\`\`\`
{
  "workspace_id":   "uuid",
  "workspace_name": "Acme Engineering",
  "role":           "admin",
  "member_email":   "alice@acme.com"
}
\`\`\`

Error envelope on failure: \`{"error": "workspace_not_found"}\` or \`{"error": "lookup_failed: <msg>"}\`.

## Files touched
Follows the 3-file pattern every guard tool follows:
- \`app/modules/guard/routers/mcp.py\` — schema entry in \`_TOOLS\`
- \`app/modules/guard/mcp_impls.py\` — impl + wiring in \`_GUARD_TOOL_IMPLS\`
- \`app/tools/registrations/guard.py\` — annotations (\`readOnly\` + \`idempotent\`)

## Test
5 tests in \`tests/test_conduct_current_workspace.py\`:
- Happy path — returns workspace + role
- Missing membership — role falls back to "unknown"
- Workspace not found — error envelope
- DB exception — error envelope
- Registry integration — tool projects onto wire with spec-mandated \`Hint\`-suffix annotations

Runs 50 tests locally (5 new + 45 regression across guard registrations + MCP HTTP + MCP server). All pass.

## Ponytail cuts
- No \`environment_count\` / \`agent_count\` extras — only what a user would ask for.
- No caching — one JOIN per call, plenty fast.
- No pagination — always returns one row.