### PR TITLE
feat(guard): single-evaluator mandate + LLM proxy egress + Policies UI (#1737 #1733)

### DIFF
--- a/apps/api/alembic/versions/0117_workspace_skill_packs_precedence.py
+++ b/apps/api/alembic/versions/0117_workspace_skill_packs_precedence.py
@@ -1,0 +1,36 @@
+"""Add precedence column to workspace_skill_packs (#1737 PR 1).
+
+Pack-level precedence resolves tie-breaks when rules from different packs match
+with the same action severity. Higher value wins. Default 100 lets admins push
+individual packs up or down without renumbering the whole set.
+
+Revision ID: 0117
+Revises: 0116
+Create Date: 2026-09-09
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "0117"
+down_revision = "0116"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workspace_skill_packs",
+        sa.Column(
+            "precedence",
+            sa.Integer(),
+            nullable=False,
+            server_default="100",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workspace_skill_packs", "precedence")

--- a/apps/api/alembic/versions/0120_workspace_skill_packs_precedence.py
+++ b/apps/api/alembic/versions/0120_workspace_skill_packs_precedence.py
@@ -4,8 +4,8 @@ Pack-level precedence resolves tie-breaks when rules from different packs match
 with the same action severity. Higher value wins. Default 100 lets admins push
 individual packs up or down without renumbering the whole set.
 
-Revision ID: 0117
-Revises: 0116
+Revision ID: 0120
+Revises: 0119
 Create Date: 2026-09-09
 """
 from __future__ import annotations
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from alembic import op
 
 
-revision = "0117"
-down_revision = "0116"
+revision = "0120"
+down_revision = "0119"
 branch_labels = None
 depends_on = None
 

--- a/apps/api/app/guard/gateway.py
+++ b/apps/api/app/guard/gateway.py
@@ -116,6 +116,7 @@ async def guarded_completion(
         body=body,
         input_tokens=0,
         db=None,
+        gate="prompt",  # #1733: outbound LLM proxy egress
     )
     _composed = _evaluate_composed(_ctx)
     decision = Decision(
@@ -371,6 +372,7 @@ def guarded_client_call(
         body=body,
         input_tokens=0,
         db=None,
+        gate="prompt",  # #1733: outbound LLM proxy egress
     )
     composed = _eval_composed(ctx)
 
@@ -461,6 +463,7 @@ def guarded_client_stream(
         body=body,
         input_tokens=0,
         db=None,
+        gate="prompt",  # #1733: outbound LLM proxy egress
     )
     composed = _eval_composed(ctx)
 
@@ -568,6 +571,7 @@ def guarded_llm_stream(
         body=payload,
         input_tokens=0,
         db=db,
+        gate="prompt",  # #1733: outbound LLM proxy egress
     )
     decision = _eval_composed(ctx)
 

--- a/apps/api/app/guard/policy.py
+++ b/apps/api/app/guard/policy.py
@@ -62,6 +62,40 @@ def flatten_prompt(body: dict) -> str:
     return "\n".join(out)
 
 
+def flatten_response(body: dict) -> str:
+    """#1733 PR 4: extract model reply text for response-gate matching.
+
+    Handles Anthropic (``content: [{type:'text', text:...}]``) and OpenAI
+    (``choices: [{message:{content:...}}]``) shapes. Silent on unknown
+    shapes — returns "" so the matcher sees an empty response and no rule
+    fires accidentally.
+    """
+    out: list[str] = []
+    # Anthropic Messages API
+    content = body.get("content")
+    if isinstance(content, list):
+        for part in content:
+            if isinstance(part, dict) and part.get("type") in (None, "text"):
+                text = part.get("text")
+                if text:
+                    out.append(text)
+    elif isinstance(content, str):
+        out.append(content)
+    # OpenAI-compatible chat completions
+    for choice in body.get("choices") or []:
+        msg = choice.get("message") or {}
+        c = msg.get("content")
+        if isinstance(c, str):
+            out.append(c)
+        elif isinstance(c, list):
+            for part in c:
+                if isinstance(part, dict) and part.get("type") in (None, "text"):
+                    text = part.get("text")
+                    if text:
+                        out.append(text)
+    return "\n".join(out)
+
+
 # ─── Rule matching helpers ────────────────────────────────────────────────────
 
 def _is_proxy_rule(rule: dict) -> bool:
@@ -73,7 +107,16 @@ def _is_proxy_rule(rule: dict) -> bool:
     return "match_pattern" in rule and "match_tool" not in rule
 
 
-def _rule_matches(rule: dict, provider: str, model: str, prompt_text: str) -> bool:
+def _rule_matches(
+    rule: dict, provider: str, model: str, prompt_text: str, gate: str = "prompt"
+) -> bool:
+    """Proxy-side rule matcher. ``gate`` filters by declared rule gates —
+    default ``"prompt"`` because every existing proxy caller today evaluates
+    outbound prompts (pre-#1733 baseline)."""
+    from app.modules.guard.enforcement import rule_matches_gate
+
+    if not rule_matches_gate(rule, gate):
+        return False
     p = rule.get("match_provider")
     if p is not None and p != provider:
         return False
@@ -94,7 +137,13 @@ def _rule_matches(rule: dict, provider: str, model: str, prompt_text: str) -> bo
 
 # ─── Evaluate (public API) ────────────────────────────────────────────────────
 
-def evaluate(workspace_id: str, provider: str, model: str, body: dict) -> dict:
+def evaluate(
+    workspace_id: str,
+    provider: str,
+    model: str,
+    body: dict,
+    gate: str = "prompt",
+) -> dict:
     """Pre-call Guard policy evaluation.
 
     Loads the workspace's compiled policy snapshot (from skill_packs via the
@@ -138,14 +187,16 @@ def evaluate(workspace_id: str, provider: str, model: str, body: dict) -> dict:
                 return {"action": "BLOCK", "rule_id": "guard.engine_error", "message": "Policy engine error — request blocked (fail-closed). Check Guard settings to change this behavior."}
             return {"action": "ALLOW", "rule_id": "guard.engine_error", "message": None}
 
-        prompt_text = flatten_prompt(body)
+        # #1733: response-gate feeds the model reply into the same matcher.
+        # For prompt gate (default), same behavior as before.
+        prompt_text = flatten_response(body) if gate == "response" else flatten_prompt(body)
         matched: list[dict] = []
         winner_full: dict | None = None
         winner_rank = -1
         for r in rules:
             if not _is_proxy_rule(r):
                 continue
-            if not _rule_matches(r, provider, model, prompt_text):
+            if not _rule_matches(r, provider, model, prompt_text, gate=gate):
                 continue
             rule_id = r.get("rule_id") or r.get("id")
             action = (r.get("action") or "warn").lower()

--- a/apps/api/app/guard/policy.py
+++ b/apps/api/app/guard/policy.py
@@ -108,14 +108,16 @@ def _is_proxy_rule(rule: dict) -> bool:
 
 
 def _rule_matches(
-    rule: dict, provider: str, model: str, prompt_text: str, gate: str = "prompt"
+    rule: dict, provider: str, model: str, prompt_text: str, gate: str | None = "prompt"
 ) -> bool:
     """Proxy-side rule matcher. ``gate`` filters by declared rule gates —
     default ``"prompt"`` because every existing proxy caller today evaluates
-    outbound prompts (pre-#1733 baseline)."""
+    outbound prompts (pre-#1733 baseline). Pass ``gate=None`` to skip gate
+    filtering — used by pack-authoring tests that assert rule matcher shape
+    without gate semantics."""
     from app.modules.guard.enforcement import rule_matches_gate
 
-    if not rule_matches_gate(rule, gate):
+    if gate is not None and not rule_matches_gate(rule, gate):
         return False
     p = rule.get("match_provider")
     if p is not None and p != provider:

--- a/apps/api/app/guard/policy_types.py
+++ b/apps/api/app/guard/policy_types.py
@@ -38,6 +38,11 @@ class PolicyContext:
     input_tokens: int = 0
     db: "Session | None" = None
     extras: dict[str, Any] = field(default_factory=dict)
+    # #1733: which enforcement gate this context represents. Locked enum
+    # ("action", "prompt", "response") per Guard architecture doc §3.
+    # "prompt" = outbound LLM proxy egress; "response" = inbound LLM proxy
+    # ingress; "action" = tool call. Default "action" for pre-#1733 callers.
+    gate: str = "action"
 
 
 @dataclass

--- a/apps/api/app/guard/sources.py
+++ b/apps/api/app/guard/sources.py
@@ -33,7 +33,7 @@ class RulePolicySource:
 
     def evaluate(self, ctx: PolicyContext) -> PolicyDecision:
         evaluator = self._evaluator or self._default_evaluator()
-        raw = evaluator(ctx.workspace_id, ctx.provider, ctx.model, ctx.body)
+        raw = evaluator(ctx.workspace_id, ctx.provider, ctx.model, ctx.body, gate=ctx.gate)
         action_str = (raw.get("action") or "ALLOW").upper()
         try:
             action = PolicyAction(action_str)

--- a/apps/api/app/modules/guard/enforcement.py
+++ b/apps/api/app/modules/guard/enforcement.py
@@ -44,6 +44,44 @@ def rule_personas(rule: dict[str, Any]) -> set[str]:
     return set()
 
 
+# #1733 / #1750 Phase A — locked enum, three gates, from day one. New signal
+# shapes route through obligations, not new gates. See docs/guard/architecture.md
+# Property 5.
+GATES = ("action", "prompt", "response")
+
+
+def derive_gates(rule: dict[str, Any]) -> list[str]:
+    """Return the enforcement gates a rule fires at.
+
+    Precedence:
+      1. Rule explicitly declares ``gates: [...]`` — use it (dropping unknown values).
+      2. Otherwise derive from persona: agent→action, proxy→prompt, both→both.
+      3. Fallback: ``['action']`` (the safest default — matches existing MCP behavior).
+
+    Preserves order: action first, then prompt, then response.
+    """
+    declared = rule.get("gates")
+    if isinstance(declared, list) and declared:
+        keep = [g for g in GATES if g in declared]
+        if keep:
+            return keep
+    personas = rule_personas(rule)
+    gates: list[str] = []
+    if "agent" in personas:
+        gates.append("action")
+    if "proxy" in personas:
+        gates.append("prompt")
+    return gates or ["action"]
+
+
+def rule_matches_gate(rule: dict[str, Any], gate: str) -> bool:
+    """Whether ``rule`` fires at the given enforcement gate. Rules loaded
+    through ``_build_rules`` already carry a ``gates`` list; for rules that
+    arrived by other paths (e.g. inline test fixtures) we derive lazily."""
+    gates = rule.get("gates") or derive_gates(rule)
+    return gate in gates
+
+
 def validate_enforcement_metadata(rule: dict[str, Any]) -> None:
     """Validate one rule's strict rule-level enforcement contract."""
     rule_id = rule.get("id") or rule.get("rule_id") or "(unknown)"

--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -38,12 +38,18 @@ _PACK_ARG_DEPRECATION_SUFFIX = (
 
 
 def _shadow_log_pack_divergence(
-    db, ws_uuid, pack: str, tool_name: str, tool_input: dict, pack_rules: list[dict]
+    db, ws_uuid, pack: str, tool_name: str, tool_input: dict, pack_rules: list[dict],
+    *, log_fn=None,
 ) -> None:
     """#1737 PR 4: run the unified path in shadow when pack: is used and
     log any divergence in match result. Never raises — shadow eval failure
     must not affect the primary decision. All logged payloads route through
-    redact_secrets (reviewer edit 3) — raw tool_input never persists."""
+    redact_secrets (reviewer edit 3) — raw tool_input never persists.
+
+    ``log_fn`` is a dependency-injection hook: pass a callable(msg, *args)
+    to receive the log call directly (e.g. for tests). Defaults to
+    ``LOG.warning`` so production callers don't need to know it exists."""
+    warn = log_fn if log_fn is not None else LOG.warning
     try:
         unified_rules = _get_rules(db, ws_uuid)
         pack_match = _match_policy(tool_name, tool_input, pack_rules)
@@ -54,7 +60,7 @@ def _shadow_log_pack_divergence(
             return
         from app.core.pii import redact_secrets
         redacted_input, _found = redact_secrets(json.dumps(tool_input, default=str))
-        LOG.warning(
+        warn(
             "guard_check shadow divergence (#1737) "
             "pack=%s tool=%s pack_rule=%s unified_rule=%s input=%s",
             pack, tool_name, pack_rid, unified_rid, redacted_input,

--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -48,7 +48,11 @@ def _build_divergence_log_line(
     if pack_rid == unified_rid:
         return None
     from app.core.pii import redact_secrets
-    redacted_input, _found = redact_secrets(json.dumps(tool_input, default=str))
+    # Defensive unpack: contract is tuple[str, list[str]], but some tests
+    # stub redact_secrets as a str→str lambda. Trust nothing — take element 0
+    # if the result is a tuple, else treat it as the string directly.
+    _res = redact_secrets(json.dumps(tool_input, default=str))
+    redacted_input = _res[0] if isinstance(_res, tuple) and _res else str(_res)
     return (
         "guard_check shadow divergence (#1737) "
         "pack=%s tool=%s pack_rule=%s unified_rule=%s input=%s",

--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -17,12 +17,50 @@ Contract:
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy import text as _sql
+
+LOG = logging.getLogger("guard.mcp_impls")
+
+# #1737 PR 3: deprecation window on guard_check `pack:` arg. Suffix appended
+# to non-"ok"/non-PENDING responses so callers see the notice; server-side
+# LOG.warning gives telemetry for who still passes it. Removed in Phase D
+# once telemetry shows zero callers.
+_PACK_ARG_DEPRECATION_SUFFIX = (
+    "\n\n[deprecation: guard_check(pack=...) is deprecated (#1737). "
+    "Use guard_test for pack-scoped isolation. This arg will be removed.]"
+)
+
+
+def _shadow_log_pack_divergence(
+    db, ws_uuid, pack: str, tool_name: str, tool_input: dict, pack_rules: list[dict]
+) -> None:
+    """#1737 PR 4: run the unified path in shadow when pack: is used and
+    log any divergence in match result. Never raises — shadow eval failure
+    must not affect the primary decision. All logged payloads route through
+    redact_secrets (reviewer edit 3) — raw tool_input never persists."""
+    try:
+        unified_rules = _get_rules(db, ws_uuid)
+        pack_match = _match_policy(tool_name, tool_input, pack_rules)
+        unified_match = _match_policy(tool_name, tool_input, unified_rules)
+        pack_rid = (pack_match or {}).get("rule_id")
+        unified_rid = (unified_match or {}).get("rule_id")
+        if pack_rid == unified_rid:
+            return
+        from app.core.pii import redact_secrets
+        redacted_input, _found = redact_secrets(json.dumps(tool_input, default=str))
+        LOG.warning(
+            "guard_check shadow divergence (#1737) "
+            "pack=%s tool=%s pack_rule=%s unified_rule=%s input=%s",
+            pack, tool_name, pack_rid, unified_rid, redacted_input,
+        )
+    except Exception as _shadow_err:
+        LOG.debug("shadow eval failed (#1737): %s", _shadow_err)
 from sqlalchemy.orm import Session
 
 from app.modules.guard import approval as _approval
@@ -30,6 +68,7 @@ from app.modules.guard.models import (
     GuardApprovalRequest,
     GuardAuditEvent,
     GuardConfig,
+    WorkspaceSkillPack,
 )
 from app.models.workspace import Workspace
 
@@ -44,6 +83,7 @@ from app.modules.guard.routers.mcp import (  # noqa: E402
     _list_playbooks,
     _list_projects,
     _match_policy,
+    _project_rule,
     _record_event,
     _run_workflow,
     _get_run_status,
@@ -127,20 +167,32 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
     _workflow = arguments.get("conduct_workflow") or None
     _pack = arguments.get("pack") or None
     _prompt = arguments.get("prompt") or None
+    _dep = _PACK_ARG_DEPRECATION_SUFFIX if _pack else ""
+    if _pack:
+        LOG.warning(
+            "guard_check pack: arg is deprecated (#1737); ai_tool=%s user=%s pack=%s",
+            ai_tool, user_email, _pack,
+        )
     try:
         if _pack:
             rules_or_err = _get_rules_for_pack(db, ws_uuid, _pack)
             if isinstance(rules_or_err, str):
-                return rules_or_err
+                return rules_or_err + _dep
             rules = rules_or_err
         else:
             rules = _get_rules(db, ws_uuid)
     except Exception as _eval_err:
         _cfg = db.query(GuardConfig).filter(GuardConfig.workspace_id == ws_uuid).first()
         if _cfg and not _cfg.deny_on_error:
-            return f"advisory: policy eval error (fail-open): {_eval_err}"
+            return f"advisory: policy eval error (fail-open): {_eval_err}{_dep}"
         _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", "policy_eval_error", ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
-        return f"BLOCKED — policy evaluation failed. Request denied by fail-closed default."
+        return f"BLOCKED — policy evaluation failed. Request denied by fail-closed default.{_dep}"
+
+    # #1737 PR 4: shadow eval — when pack: is used, also compute the unified
+    # path and log divergences. Builds confidence before removing the pack
+    # arg in Phase D. Redacted through pii.redact_secrets (reviewer edit 3).
+    if _pack:
+        _shadow_log_pack_divergence(db, ws_uuid, _pack, inner_tool, inner_input, rules)
 
     _cfg = db.query(GuardConfig).filter(GuardConfig.workspace_id == ws_uuid).first()
     _advisory = _cfg.advisory_mode if _cfg else False
@@ -161,11 +213,11 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
 
     if _advisory:
         _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
-        return f"advisory: {message} [rule: {rule_id}]{_guidance_suffix}"
+        return f"advisory: {message} [rule: {rule_id}]{_guidance_suffix}{_dep}"
 
     if action == "block":
         _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
-        return f"BLOCKED — {message}  [rule: {rule_id}]{_guidance_suffix}"
+        return f"BLOCKED — {message}  [rule: {rule_id}]{_guidance_suffix}{_dep}"
 
     if action == "warn":
         already_warned = db.query(GuardAuditEvent).filter(
@@ -177,7 +229,7 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
         if already_warned:
             return "ok"
         _record_event(db, ws_uuid, inner_tool, inner_input, "warned", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
-        return f"WARNING — {message}  [rule: {rule_id}]{_guidance_suffix}"
+        return f"WARNING — {message}  [rule: {rule_id}]{_guidance_suffix}{_dep}"
 
     if action == "approval":
         prior = None
@@ -201,7 +253,7 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
             return "ok"
         if verdict == "block":
             _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
-            return f"BLOCKED — {block_reason}  [rule: {rule_id}]{_guidance_suffix}"
+            return f"BLOCKED — {block_reason}  [rule: {rule_id}]{_guidance_suffix}{_dep}"
         if verdict == "wait":
             return _approval.pending_marker(prior)
         # verdict == "create"
@@ -223,6 +275,64 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
     _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
     return "ok"
 
+
+def guard_test_impl(ctx: GuardCtx, **arguments) -> str:
+    """#1737 PR 5: pack-scoped dry-run for pack authors + CI.
+
+    Semantics: evaluate `tool_name`/`tool_input` against `conduct-base` +
+    the named pack ONLY. Workspace custom rules, overrides, and other
+    installed packs are excluded — you see exactly what the pack ships.
+
+    Returns 'WOULD-<VERDICT> — <message> [rule: X]' or 'OK — no rule fired'.
+    Never writes to the audit chain — this is a dry-run verb.
+    """
+    from app.modules.guard.policy_engine import _build_rules
+
+    db = ctx.db
+    ws_uuid = ctx.ws_uuid
+
+    pack = arguments.get("pack") or ""
+    tool_name = arguments.get("tool_name") or ""
+    tool_input = arguments.get("tool_input") or {}
+
+    if not pack:
+        return "ERROR — 'pack' argument is required (e.g. 'conduct-hipaa')."
+    if pack == "conduct-base":
+        return 'ERROR — "conduct-base" is always enforced and cannot be tested in isolation. Pass a compliance pack (e.g. "conduct-eu-ai-act").'
+    if not tool_name:
+        return "ERROR — 'tool_name' argument is required."
+
+    installed = (
+        db.query(WorkspaceSkillPack)
+        .filter(
+            WorkspaceSkillPack.workspace_id == ws_uuid,
+            WorkspaceSkillPack.pack_slug == pack,
+        )
+        .first()
+    )
+    if not installed:
+        others = [
+            r.pack_slug for r in
+            db.query(WorkspaceSkillPack)
+            .filter(
+                WorkspaceSkillPack.workspace_id == ws_uuid,
+                WorkspaceSkillPack.pack_slug != "conduct-base",
+            )
+            .all()
+        ]
+        available = ", ".join(sorted(others)) or "none"
+        return f'ERROR — pack "{pack}" is not installed for this workspace. Installed packs: {available}.'
+
+    raw = _build_rules(db, ws_uuid, "agent", restrict_to_pack=pack)
+    rules = [_project_rule(r) for r in raw]
+    match = _match_policy(tool_name, tool_input, rules)
+    if match is None:
+        return f"OK — no rule fired in pack '{pack}'."
+
+    action = (match.get("action") or "audit").upper()
+    rule_id = match.get("rule_id", "unknown")
+    message = match.get("message") or f"Policy violation ({rule_id})"
+    return f"WOULD-{action} — {message}  [rule: {rule_id}]  [pack: {pack}]"
 
 
 def guard_sync_impl(ctx: GuardCtx, **arguments) -> str:
@@ -677,6 +787,7 @@ _GUARD_TOOL_IMPLS: dict[str, Any] = {
     'guard_status': guard_status_impl,
     'conduct_current_workspace': conduct_current_workspace_impl,
     'guard_check': guard_check_impl,
+    'guard_test': guard_test_impl,
     'guard_sync': guard_sync_impl,
     'guard_enable': guard_enable_impl,
     'guard_spend': guard_spend_impl,

--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -37,34 +37,44 @@ _PACK_ARG_DEPRECATION_SUFFIX = (
 )
 
 
+def _build_divergence_log_line(
+    pack: str, tool_name: str, tool_input: dict,
+    pack_rid: str | None, unified_rid: str | None,
+) -> tuple[str, tuple] | None:
+    """Pure helper: return (fmt_msg, args) for LOG.warning, or None if the
+    two paths agree. Split out from _shadow_log_pack_divergence so tests
+    can exercise the divergence-message shape + redaction without any
+    patching (was CI-flaky when we patched module-level names)."""
+    if pack_rid == unified_rid:
+        return None
+    from app.core.pii import redact_secrets
+    redacted_input, _found = redact_secrets(json.dumps(tool_input, default=str))
+    return (
+        "guard_check shadow divergence (#1737) "
+        "pack=%s tool=%s pack_rule=%s unified_rule=%s input=%s",
+        (pack, tool_name, pack_rid, unified_rid, redacted_input),
+    )
+
+
 def _shadow_log_pack_divergence(
     db, ws_uuid, pack: str, tool_name: str, tool_input: dict, pack_rules: list[dict],
-    *, log_fn=None,
 ) -> None:
     """#1737 PR 4: run the unified path in shadow when pack: is used and
     log any divergence in match result. Never raises — shadow eval failure
-    must not affect the primary decision. All logged payloads route through
-    redact_secrets (reviewer edit 3) — raw tool_input never persists.
-
-    ``log_fn`` is a dependency-injection hook: pass a callable(msg, *args)
-    to receive the log call directly (e.g. for tests). Defaults to
-    ``LOG.warning`` so production callers don't need to know it exists."""
-    warn = log_fn if log_fn is not None else LOG.warning
+    must not affect the primary decision. Redaction lives in the pure
+    helper `_build_divergence_log_line` so test coverage doesn't depend on
+    patching module-level names (reviewer edit 3)."""
     try:
         unified_rules = _get_rules(db, ws_uuid)
         pack_match = _match_policy(tool_name, tool_input, pack_rules)
         unified_match = _match_policy(tool_name, tool_input, unified_rules)
         pack_rid = (pack_match or {}).get("rule_id")
         unified_rid = (unified_match or {}).get("rule_id")
-        if pack_rid == unified_rid:
+        line = _build_divergence_log_line(pack, tool_name, tool_input, pack_rid, unified_rid)
+        if line is None:
             return
-        from app.core.pii import redact_secrets
-        redacted_input, _found = redact_secrets(json.dumps(tool_input, default=str))
-        warn(
-            "guard_check shadow divergence (#1737) "
-            "pack=%s tool=%s pack_rule=%s unified_rule=%s input=%s",
-            pack, tool_name, pack_rid, unified_rid, redacted_input,
-        )
+        fmt, args = line
+        LOG.warning(fmt, *args)
     except Exception as _shadow_err:
         LOG.debug("shadow eval failed (#1737): %s", _shadow_err)
 from sqlalchemy.orm import Session

--- a/apps/api/app/modules/guard/models.py
+++ b/apps/api/app/modules/guard/models.py
@@ -407,6 +407,7 @@ class WorkspaceSkillPack(Base):
     pinned_version  = Column(Text, nullable=True)   # null = always latest
     installed_by    = Column(Text, nullable=True)   # clerk_user_id
     installed_at    = Column(DateTime(timezone=True), nullable=False, default=lambda: datetime.now(timezone.utc))
+    precedence      = Column(Integer, nullable=False, server_default="100")  # higher wins on same-severity ties (#1737)
 
     __table_args__ = (
         Index("ix_workspace_skill_packs_workspace", "workspace_id"),

--- a/apps/api/app/modules/guard/policy_engine.py
+++ b/apps/api/app/modules/guard/policy_engine.py
@@ -30,7 +30,7 @@ from app.modules.guard.models import (
     WorkspaceCustomRule,
     WorkspaceSkillPack,
 )
-from app.modules.guard.enforcement import rule_personas
+from app.modules.guard.enforcement import derive_gates, rule_personas
 
 PERSONAS = ["agent", "proxy"]
 
@@ -174,6 +174,9 @@ def _build_rules(
             # #1048: stamp source_pack so downstream (sync response, audit,
             # debugging) can trace 'which pack put this rule into my cache'.
             body["source_pack"] = wp.pack_slug
+            # #1733/#1750-A: gates are locked to [action, prompt, response].
+            # Derived from persona for legacy rules; explicit on new rules.
+            body["gates"] = derive_gates(body)
             rules[rule["id"]] = body
 
     # 1b. merge workspace custom rules on top (workspace-defined wins on rule_id collision)
@@ -194,6 +197,7 @@ def _build_rules(
         affinity = body.get("persona_affinity", PERSONAS)
         if persona not in affinity:
             continue
+        body["gates"] = derive_gates(body)  # #1733/#1750-A
         rules[c.rule_id] = body
 
     # 2. apply workspace overrides (skipped in restrict_to_pack mode)

--- a/apps/api/app/modules/guard/policy_engine.py
+++ b/apps/api/app/modules/guard/policy_engine.py
@@ -138,14 +138,29 @@ def invalidate_policy_cache(db: Session, workspace_id: uuid.UUID) -> None:
 
 # ── Internal ──────────────────────────────────────────────────────────────────
 
-def _build_rules(db: Session, workspace_id: uuid.UUID, persona: str) -> list[dict]:
-    # 1. collect rules from installed packs, filtered by persona
-    installed = (
-        db.query(WorkspaceSkillPack)
-        .filter(WorkspaceSkillPack.workspace_id == workspace_id)
-        .order_by(WorkspaceSkillPack.installed_at)
-        .all()
-    )
+def _build_rules(
+    db: Session,
+    workspace_id: uuid.UUID,
+    persona: str,
+    restrict_to_pack: str | None = None,
+) -> list[dict]:
+    """Build the effective ruleset for a workspace + persona.
+
+    When ``restrict_to_pack`` is set (#1737 guard_test PR 5), the merge scope
+    narrows to ``conduct-base`` + the named pack, workspace custom rules and
+    overrides are skipped. The result is 'what this pack ships, in isolation'
+    — for pack authors and CI, not production traffic.
+    """
+    # 1. collect rules from installed packs, filtered by persona.
+    # Order: precedence ASC then installed_at ASC → higher-precedence packs
+    # process later and win on rule_id collision (last-write-wins). Default
+    # precedence 100 preserves pre-#1737 install-order semantics.
+    q = db.query(WorkspaceSkillPack).filter(WorkspaceSkillPack.workspace_id == workspace_id)
+    if restrict_to_pack:
+        q = q.filter(WorkspaceSkillPack.pack_slug.in_(["conduct-base", restrict_to_pack]))
+    installed = q.order_by(
+        WorkspaceSkillPack.precedence.asc(), WorkspaceSkillPack.installed_at.asc()
+    ).all()
 
     rules: dict[str, dict] = {}
     for wp in installed:
@@ -162,6 +177,8 @@ def _build_rules(db: Session, workspace_id: uuid.UUID, persona: str) -> list[dic
             rules[rule["id"]] = body
 
     # 1b. merge workspace custom rules on top (workspace-defined wins on rule_id collision)
+    # Skipped in restrict_to_pack mode — guard_test wants 'what the pack ships,'
+    # not the workspace's full effective policy.
     customs = (
         db.query(WorkspaceCustomRule)
         .filter(
@@ -170,7 +187,7 @@ def _build_rules(db: Session, workspace_id: uuid.UUID, persona: str) -> list[dic
             (WorkspaceCustomRule.persona == persona) | (WorkspaceCustomRule.persona.is_(None)),
         )
         .all()
-    )
+    ) if not restrict_to_pack else []
     for c in customs:
         body = dict(c.body or {})
         body.setdefault("id", c.rule_id)
@@ -179,12 +196,12 @@ def _build_rules(db: Session, workspace_id: uuid.UUID, persona: str) -> list[dic
             continue
         rules[c.rule_id] = body
 
-    # 2. apply workspace overrides
+    # 2. apply workspace overrides (skipped in restrict_to_pack mode)
     overrides = (
         db.query(GuardRuleOverride)
         .filter(GuardRuleOverride.workspace_id == workspace_id)
         .all()
-    )
+    ) if not restrict_to_pack else []
     now = datetime.now(timezone.utc)
     for o in overrides:
         if o.rule_id not in rules:

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -377,13 +377,14 @@ _ACTION_PRIORITY = {"block": 0, "approval": 1, "warn": 2, "audit": 3}
 
 
 def _match_policy(
-    tool_name: str, tool_input: dict, rules: list, gate: str = "action"
+    tool_name: str, tool_input: dict, rules: list, gate: str | None = "action"
 ) -> dict | None:
     """Return the most restrictive matching rule (block > approval > warn > audit).
 
     ``gate`` filters which rules are considered — only rules whose ``gates``
     list includes the given gate fire. Default ``"action"`` preserves
-    pre-#1733 MCP behavior for every existing caller.
+    pre-#1733 MCP behavior for every existing caller. Pass ``gate=None`` to
+    skip gate filtering — used by pack-authoring tests.
     """
     from app.modules.guard.enforcement import rule_matches_gate
 
@@ -395,7 +396,7 @@ def _match_policy(
     best_priority = 999
 
     for rule in rules:
-        if not rule_matches_gate(rule, gate):
+        if gate is not None and not rule_matches_gate(rule, gate):
             continue
         match_tool = (rule.get("match_tool") or "*").lower()
         if match_tool != "*":

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -376,8 +376,17 @@ def _detect_surface(client_info: dict) -> str:
 _ACTION_PRIORITY = {"block": 0, "approval": 1, "warn": 2, "audit": 3}
 
 
-def _match_policy(tool_name: str, tool_input: dict, rules: list) -> dict | None:
-    """Return the most restrictive matching rule (block > approval > warn > audit)."""
+def _match_policy(
+    tool_name: str, tool_input: dict, rules: list, gate: str = "action"
+) -> dict | None:
+    """Return the most restrictive matching rule (block > approval > warn > audit).
+
+    ``gate`` filters which rules are considered — only rules whose ``gates``
+    list includes the given gate fire. Default ``"action"`` preserves
+    pre-#1733 MCP behavior for every existing caller.
+    """
+    from app.modules.guard.enforcement import rule_matches_gate
+
     inp_text  = json.dumps(tool_input)
     path_keys = ["file_path", "path", "command"]
     path_text = " ".join(str(tool_input.get(k, "")) for k in path_keys)
@@ -386,6 +395,8 @@ def _match_policy(tool_name: str, tool_input: dict, rules: list) -> dict | None:
     best_priority = 999
 
     for rule in rules:
+        if not rule_matches_gate(rule, gate):
+            continue
         match_tool = (rule.get("match_tool") or "*").lower()
         if match_tool != "*":
             allowed = expand_match_tool(match_tool)
@@ -435,6 +446,7 @@ def _project_rule(r: dict) -> dict:
         "action":            r.get("action"),
         "message":           r.get("message"),
         "pack":              r.get("pack") or r.get("pack_slug"),
+        "gates":             r.get("gates") or ["action"],  # #1733: expose gate list to consumers
         "enforcement":       r.get("enforcement") or {},
     }
     for k in _APPROVAL_FIELDS:

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -89,6 +89,26 @@ _TOOLS = [
         },
     },
     {
+        "name": "guard_test",
+        "description": (
+            "Dry-run a single pack against a candidate tool call. "
+            "Evaluates only conduct-base + the named pack — workspace custom rules, "
+            "overrides, and other installed packs are excluded. Never writes to the "
+            "audit chain. Returns 'WOULD-<VERDICT> — <message>' or 'OK — no rule fired'. "
+            "Use for pack authoring, CI, and demos. Replaces guard_check(pack=...) which "
+            "is deprecated (#1737)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "pack":      {"type": "string", "description": "Compliance pack slug to test (e.g. 'conduct-eu-ai-act'). Must be installed for this workspace. 'conduct-base' is rejected — always enforced anyway."},
+                "tool_name": {"type": "string", "description": "The action to test (e.g. bash, write_file, curl)."},
+                "tool_input": {"type": "object", "description": "Parameters for that action, matching the shape guard_check would receive."},
+            },
+            "required": ["pack", "tool_name"],
+        },
+    },
+    {
         "name": "guard_sync",
         "description": "Returns current active ruleset (no-op for remote MCP — policy is always live).",
         "inputSchema": {"type": "object", "properties": {}, "required": []},
@@ -409,6 +429,7 @@ def _project_rule(r: dict) -> dict:
     out = {
         "rule_id":           r.get("id") or r.get("rule_id"),
         "match_tool":        r.get("match_tool"),
+        "match_ai_tool":     r.get("match_ai_tool"),  # #1752: was dropped by projector
         "match_pattern":     r.get("match_pattern"),
         "match_path_pattern": r.get("match_path_pattern"),
         "action":            r.get("action"),

--- a/apps/api/app/modules/guard/routers/policies.py
+++ b/apps/api/app/modules/guard/routers/policies.py
@@ -48,7 +48,7 @@ from app.modules.guard.policy_engine import (
     is_exception_active,
 )
 from app.modules.guard.coverage import workspace_coverage_matrix
-from app.modules.guard.enforcement import is_hook_applicable_rule
+from app.modules.guard.enforcement import derive_gates, is_hook_applicable_rule
 
 router = APIRouter(prefix="/guard/policies", tags=["guard-policies"])
 
@@ -106,6 +106,10 @@ class PolicyOut(BaseModel):
     severity: str = "medium"
     iso_control: Optional[str] = None
     tag: Optional[str] = None
+    gates: list[str] = []  # #1733/#1750 Phase B — locked enum [action, prompt, response]
+    # #1750 reviewer edit 4 — retained hand-authored prose (NOT deleted in Phase D).
+    guarantee: Optional[str] = None
+    known_limitations: list[str] = []
     exception_reason: Optional[str] = None
     exception_expires_at: Optional[datetime] = None
     exception_active: bool = False
@@ -227,6 +231,10 @@ def _org_ws_subquery(db: Session, workspace_id: str):
 
 def _custom_to_out(row: WorkspaceCustomRule) -> PolicyOut:
     body = row.body or {}
+    # #1733: derive_gates needs a persona hint. Custom rules store persona
+    # on the ORM row, not the body dict — inject a shallow copy so the
+    # helper sees it without mutating the underlying JSONB.
+    body_for_gates = {**body, "persona": body.get("persona") or row.persona or "agent"}
     return PolicyOut(
         id=row.rule_id,
         workspace_id=str(row.workspace_id),
@@ -247,6 +255,9 @@ def _custom_to_out(row: WorkspaceCustomRule) -> PolicyOut:
         frameworks=body.get("frameworks") or [],
         severity=body.get("severity") or "medium",
         iso_control=body.get("iso_control"),
+        gates=derive_gates(body_for_gates),
+        guarantee=(body.get("enforcement") or {}).get("guarantee"),
+        known_limitations=(body.get("enforcement") or {}).get("known_limitations") or [],
         created_at=row.created_at,
         updated_at=row.updated_at,
     )
@@ -300,6 +311,9 @@ def _pack_rule_to_out(
         severity=rule.get("severity") or "medium",
         iso_control=rule.get("iso_control"),
         tag=rule.get("tag"),
+        gates=derive_gates(rule),
+        guarantee=(rule.get("enforcement") or {}).get("guarantee"),
+        known_limitations=(rule.get("enforcement") or {}).get("known_limitations") or [],
         exception_reason=override.reason if override and relaxing else None,
         exception_expires_at=override.expires_at if override and relaxing else None,
         exception_active=active,

--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -478,6 +478,7 @@ async def _proxy(
             body=body,
             input_tokens=_estimate_input_tokens(body),
             db=db,
+            gate="prompt",  # #1733: outbound LLM proxy egress
         )
         _pd = _eval_composed(_ctx)
         decision = _pd.extras.get("raw") or {
@@ -593,7 +594,7 @@ async def _proxy(
         k.lower(): v for k, v in request.headers.items()
         if k.lower() not in _skip and not k.lower().startswith("x-conduct")
     }
-    return await _forward(
+    _response = await _forward(
         upstream=upstream,
         path=upstream_path,
         body=body,
@@ -608,9 +609,201 @@ async def _proxy(
         vendor_key=_vault_key_val,
         provider=provider,
     )
+    # #1733 PR 4: response gate (non-streaming).
+    if not is_stream and isinstance(_response, JSONResponse) and _response.status_code < 400:
+        _response = _apply_response_gate(
+            _response, workspace_id=workspace_id, provider=provider, model=model,
+            clerk_user_id=clerk_user_id, agent_identity_id=_agent_identity_id,
+        )
+    # #1733 PR 5: response gate (streaming, buffered end-of-stream scan).
+    elif is_stream and isinstance(_response, StreamingResponse) and _response.status_code < 400:
+        _response = _wrap_streaming_response(
+            _response, workspace_id=workspace_id, provider=provider, model=model,
+            clerk_user_id=clerk_user_id, agent_identity_id=_agent_identity_id,
+        )
+    return _response
 
 
 # ─── Helpers ───────────────────────────────────────────────────────────────
+
+def _evaluate_response_body(
+    resp_body: dict,
+    *,
+    workspace_id: str,
+    provider: str,
+    model: str,
+    clerk_user_id: str | None,
+    agent_identity_id: str | None,
+):
+    """#1733 PRs 4+5 — shared response-gate evaluator. Called by both the
+    non-streaming path (post-upstream, pre-return) and the streaming path
+    (end-of-stream, post-yield). Returns a ``PolicyDecision`` or ``None`` on
+    engine error. Never raises."""
+    try:
+        from app.guard.policy import evaluate_composed as _eval_composed
+        from app.guard.policy_types import PolicyContext as _PC
+
+        _ctx = _PC(
+            workspace_id=workspace_id,
+            clerk_user_id=clerk_user_id or None,
+            agent_identity_id=str(agent_identity_id) if agent_identity_id else None,
+            provider=provider,
+            model=model,
+            body=resp_body,
+            input_tokens=0,
+            db=None,
+            gate="response",  # #1733: inbound model reply
+        )
+        return _eval_composed(_ctx)
+    except Exception as _e:
+        log.warning("guard.proxy.response_gate_error", err=str(_e))
+        return None
+
+
+def _apply_response_gate(
+    response: JSONResponse,
+    *,
+    workspace_id: str,
+    provider: str,
+    model: str,
+    clerk_user_id: str | None,
+    agent_identity_id: str | None,
+) -> JSONResponse:
+    """#1733 PR 4 — evaluate the response body against gate='response' rules.
+
+    If a response-gate rule fires BLOCK, replace the upstream body with a
+    Guard-blocked envelope; otherwise return the original response.
+
+    Never raises — response-gate failures log at WARN and pass the response
+    through, so the response path never breaks on a policy engine hiccup.
+    """
+    try:
+        import json as _json
+        from app.guard.policy_types import PolicyAction as _PA
+
+        resp_body = _json.loads(response.body or b"{}")
+        decision = _evaluate_response_body(
+            resp_body,
+            workspace_id=workspace_id, provider=provider, model=model,
+            clerk_user_id=clerk_user_id, agent_identity_id=agent_identity_id,
+        )
+        if decision is None or decision.action != _PA.BLOCK:
+            return response
+        log.warning(
+            "guard.proxy.response_blocked",
+            workspace_id=workspace_id, provider=provider, model=model,
+            rule_id=decision.rule_id, reason=decision.reason,
+        )
+        return JSONResponse(
+            status_code=451,
+            content={
+                "error": {
+                    "type": "conduct_guard_response_block",
+                    "message": decision.reason or "Response blocked by ConductGuard response-gate policy.",
+                    "rule_id": decision.rule_id,
+                    "gate": "response",
+                }
+            },
+        )
+    except Exception as _e:
+        log.warning("guard.proxy.response_gate_error", err=str(_e))
+        return response
+
+
+_STREAM_TEXT_RE = None  # lazy compiled — see _extract_stream_text below
+
+
+def _extract_stream_text(collected: bytes) -> str:
+    """Best-effort text extraction from an SSE-formatted upstream stream.
+
+    Matches ``"text":"..."`` (Anthropic ``content_block_delta``/``text_delta``)
+    and ``"content":"..."`` (OpenAI streaming ``choices[].delta.content``) via
+    a single regex. Handles escaped quotes and backslashes.
+
+    ponytail: full-body regex sweep, not an SSE-aware parser. Upgrade path is
+    a proper event-frame decoder if false positives (e.g. matching input
+    echoes in trace metadata) become a real signal. Chunk-scan (per-chunk
+    eval with mid-stream halt) is the true long-term shape.
+    """
+    global _STREAM_TEXT_RE
+    import re as _re
+
+    if _STREAM_TEXT_RE is None:
+        _STREAM_TEXT_RE = _re.compile(r'"(?:text|content)":\s*"((?:[^"\\]|\\.)*)"')
+    try:
+        text = collected.decode("utf-8", errors="replace")
+    except Exception:
+        return ""
+    parts = [
+        m.encode("utf-8").decode("unicode_escape", errors="replace")
+        for m in _STREAM_TEXT_RE.findall(text)
+    ]
+    return "\n".join(parts)
+
+
+def _wrap_streaming_response(
+    response: StreamingResponse,
+    *,
+    workspace_id: str,
+    provider: str,
+    model: str,
+    clerk_user_id: str | None,
+    agent_identity_id: str | None,
+) -> StreamingResponse:
+    """#1733 PR 5 — buffered end-of-stream response gate.
+
+    Wraps the upstream StreamingResponse: yields each chunk to the client
+    unchanged, accumulates the full body in memory, then at end-of-stream
+    evaluates gate='response' rules and logs a WARN if any rule fires BLOCK.
+
+    ponytail: buffered scan. Client has already received the offending
+    tokens by the time we decide — we only get telemetry + audit-trail
+    coverage. Upgrade path: chunk-scan (per-chunk eval + mid-stream halt)
+    so a live rule fire terminates the stream before further leak.
+    """
+    original_iterator = response.body_iterator
+
+    async def _wrapped():
+        collected = bytearray()
+        async for chunk in original_iterator:
+            if isinstance(chunk, str):
+                chunk_bytes = chunk.encode("utf-8")
+            else:
+                chunk_bytes = chunk
+            collected.extend(chunk_bytes)
+            yield chunk_bytes
+        # End-of-stream response-gate scan. Wrapped in a broad try/except
+        # so a downstream failure NEVER truncates the stream after yield.
+        try:
+            text = _extract_stream_text(bytes(collected))
+            if not text:
+                return
+            synthetic = {"content": [{"type": "text", "text": text}]}
+            decision = _evaluate_response_body(
+                synthetic,
+                workspace_id=workspace_id, provider=provider, model=model,
+                clerk_user_id=clerk_user_id, agent_identity_id=agent_identity_id,
+            )
+            if decision is None:
+                return
+            from app.guard.policy_types import PolicyAction as _PA
+            if decision.action == _PA.BLOCK:
+                log.warning(
+                    "guard.proxy.response_stream_blocked_post_hoc",
+                    workspace_id=workspace_id, provider=provider, model=model,
+                    rule_id=decision.rule_id, reason=decision.reason,
+                    note="ponytail: buffered scan — client saw response; upgrade to chunk-scan",
+                )
+        except Exception as _e:
+            log.warning("guard.proxy.response_stream_gate_error", err=str(_e))
+
+    return StreamingResponse(
+        _wrapped(),
+        media_type=response.media_type,
+        headers=dict(response.headers),
+        status_code=response.status_code,
+    )
+
 
 def _extract_member_token(raw: str, *, bearer: bool) -> str | None:
     """Extract guard-mt- or cond_agt_ token from header value."""

--- a/apps/api/app/tools/registrations/guard.py
+++ b/apps/api/app/tools/registrations/guard.py
@@ -40,6 +40,7 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "guard_status":              ToolAnnotations(read_only=True),
     "conduct_current_workspace": ToolAnnotations(read_only=True, idempotent=True),
     "guard_check":               ToolAnnotations(open_world=True),
+    "guard_test":                ToolAnnotations(read_only=True),
     "guard_sync":              ToolAnnotations(read_only=True),
     "guard_enable":            ToolAnnotations(read_only=True),
     "guard_spend":             ToolAnnotations(read_only=True),

--- a/apps/api/tests/guard/test_derive_gates.py
+++ b/apps/api/tests/guard/test_derive_gates.py
@@ -1,0 +1,53 @@
+"""#1733 / #1750 Phase A — derive_gates() from rule spec.
+
+Locked enum: `[action, prompt, response]`. Legacy rules derive from persona;
+explicit `gates` in the rule spec wins. Fallback is `[action]` — the safest
+default because it matches pre-#1733 MCP behavior.
+"""
+from __future__ import annotations
+
+from app.modules.guard.enforcement import GATES, derive_gates
+
+
+def test_gates_enum_is_locked_to_three_values():
+    assert GATES == ("action", "prompt", "response")
+
+
+def test_derive_gates_defaults_to_action_and_prompt_when_persona_missing():
+    """Empty rule inherits both personas (rule_personas returns {agent, proxy}
+    when neither field is set), so it fires at both action + prompt."""
+    assert derive_gates({}) == ["action", "prompt"]
+
+
+def test_derive_gates_agent_persona_maps_to_action():
+    assert derive_gates({"persona": "agent"}) == ["action"]
+
+
+def test_derive_gates_proxy_persona_maps_to_prompt():
+    assert derive_gates({"persona": "proxy"}) == ["prompt"]
+
+
+def test_derive_gates_dual_persona_yields_both():
+    assert derive_gates({"persona_affinity": ["agent", "proxy"]}) == ["action", "prompt"]
+
+
+def test_explicit_gates_field_wins_over_persona():
+    rule = {"persona": "agent", "gates": ["response"]}
+    assert derive_gates(rule) == ["response"]
+
+
+def test_explicit_gates_drops_unknown_values():
+    """Reviewer edit 2: gates enum is locked. Unknown values are silently
+    dropped rather than raising — legacy interop safety."""
+    rule = {"gates": ["prompt", "hallucination-check", "response"]}
+    assert derive_gates(rule) == ["prompt", "response"]
+
+
+def test_explicit_gates_all_unknown_falls_back_to_persona():
+    rule = {"gates": ["hallucination-check"], "persona": "proxy"}
+    assert derive_gates(rule) == ["prompt"]
+
+
+def test_derive_gates_preserves_action_prompt_response_order():
+    rule = {"gates": ["response", "action", "prompt"]}
+    assert derive_gates(rule) == ["action", "prompt", "response"]

--- a/apps/api/tests/guard/test_gate_filter.py
+++ b/apps/api/tests/guard/test_gate_filter.py
@@ -1,0 +1,150 @@
+"""#1733 PR 2 — gate-based rule filtering.
+
+Locked enum: `[action, prompt, response]`. Every matcher (MCP + proxy)
+consults `rule_matches_gate` before considering a rule. Default gate is
+'action' for MCP callers, 'prompt' for proxy callers — chosen to match the
+pre-#1733 evaluation semantics of each surface.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.modules.guard.enforcement import rule_matches_gate
+from app.modules.guard.routers.mcp import _match_policy
+
+
+def test_rule_matches_gate_uses_explicit_gates_field():
+    rule = {"gates": ["prompt"]}
+    assert rule_matches_gate(rule, "prompt") is True
+    assert rule_matches_gate(rule, "action") is False
+    assert rule_matches_gate(rule, "response") is False
+
+
+def test_rule_matches_gate_derives_from_persona_when_gates_missing():
+    """Legacy rule with only persona still resolves to a gate."""
+    agent_rule = {"persona": "agent"}
+    proxy_rule = {"persona": "proxy"}
+    assert rule_matches_gate(agent_rule, "action") is True
+    assert rule_matches_gate(agent_rule, "prompt") is False
+    assert rule_matches_gate(proxy_rule, "prompt") is True
+    assert rule_matches_gate(proxy_rule, "response") is False
+
+
+def test_match_policy_default_gate_is_action():
+    """Existing callers that don't pass a gate keep the MCP baseline."""
+    action_rule = {
+        "rule_id": "a",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["action"],
+    }
+    prompt_rule = {
+        "rule_id": "p",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["prompt"],
+    }
+    hit = _match_policy("bash", {"command": "ls"}, [action_rule, prompt_rule])
+    assert hit is not None
+    assert hit["rule_id"] == "a"
+
+
+def test_match_policy_prompt_gate_skips_action_rules():
+    """When the caller says gate='prompt', pure action-gate rules must be filtered out."""
+    action_rule = {
+        "rule_id": "a",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["action"],
+    }
+    prompt_rule = {
+        "rule_id": "p",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["prompt"],
+    }
+    hit = _match_policy(
+        "bash", {"command": "ls"}, [action_rule, prompt_rule], gate="prompt"
+    )
+    assert hit is not None
+    assert hit["rule_id"] == "p"
+
+
+def test_match_policy_response_gate_returns_none_when_no_response_rules():
+    action_rule = {
+        "rule_id": "a",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["action"],
+    }
+    assert _match_policy("bash", {}, [action_rule], gate="response") is None
+
+
+def test_match_policy_rule_with_multiple_gates_matches_any():
+    dual_rule = {
+        "rule_id": "d",
+        "match_tool": "bash",
+        "action": "block",
+        "gates": ["action", "prompt"],
+    }
+    assert _match_policy("bash", {}, [dual_rule], gate="action")["rule_id"] == "d"
+    assert _match_policy("bash", {}, [dual_rule], gate="prompt")["rule_id"] == "d"
+    assert _match_policy("bash", {}, [dual_rule], gate="response") is None
+
+
+def test_policy_context_default_gate_is_action():
+    """PolicyContext defaults to gate='action' for callers that don't opt in."""
+    from app.guard.policy_types import PolicyContext
+
+    ctx = PolicyContext(workspace_id="ws", provider="anthropic", model="m", body={})
+    assert ctx.gate == "action"
+
+
+def test_policy_context_gate_can_be_set_to_prompt_or_response():
+    from app.guard.policy_types import PolicyContext
+
+    ctx = PolicyContext(
+        workspace_id="ws", provider="anthropic", model="m", body={}, gate="response"
+    )
+    assert ctx.gate == "response"
+
+
+def test_rule_policy_source_threads_ctx_gate_to_evaluator():
+    """Composable engine → evaluate() must receive ctx.gate."""
+    from app.guard.policy_types import PolicyContext
+    from app.guard.sources import RulePolicySource
+
+    seen = {}
+
+    def _fake_evaluate(workspace_id, provider, model, body, gate="prompt"):
+        seen["gate"] = gate
+        return {"action": "ALLOW", "rule_id": None, "message": None}
+
+    src = RulePolicySource(evaluator=_fake_evaluate)
+    ctx = PolicyContext(
+        workspace_id="ws", provider="anthropic", model="m", body={}, gate="response"
+    )
+    src.evaluate(ctx)
+    assert seen["gate"] == "response"
+
+
+def test_every_guarded_completion_call_site_labels_prompt_gate():
+    """#1733 PR 3 — proxy egress call sites must label PolicyContext with
+    gate='prompt' (or 'response' post-PR-4/5). Regression guard: every
+    `_PolicyContext(` opening in the proxy files must be matched by a
+    `gate=` line in the same file."""
+    from pathlib import Path
+
+    proxy_files = [
+        Path(__file__).resolve().parents[2] / "app/guard/gateway.py",
+        Path(__file__).resolve().parents[2] / "app/modules/guard/routers/proxy.py",
+    ]
+    for path in proxy_files:
+        text = path.read_text()
+        opens = text.count("_PolicyContext(")
+        labels = text.count('gate="prompt"') + text.count('gate="response"')
+        assert opens <= labels, (
+            f"{path.name}: {opens} PolicyContext build sites, only {labels} "
+            "gate labels. Every proxy-side _PolicyContext must set gate="
+            "'prompt' or 'response' (#1733)."
+        )

--- a/apps/api/tests/guard/test_guard_test_verb.py
+++ b/apps/api/tests/guard/test_guard_test_verb.py
@@ -1,0 +1,120 @@
+"""#1737 PR 5 — guard_test verb: pack-scoped dry-run.
+
+Verifies:
+- Missing/invalid pack args return ERROR strings
+- Uninstalled pack returns ERROR listing what IS installed
+- Matched rule returns WOULD-<VERDICT> string
+- No rule match returns 'OK — no rule fired'
+- Never writes to audit chain (no _record_event call)
+- _build_rules is invoked with restrict_to_pack (proves isolation, no drift)
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from app.modules.guard.mcp_impls import GuardCtx, guard_test_impl
+
+
+def _ctx() -> GuardCtx:
+    return GuardCtx(
+        db=MagicMock(),
+        ws_uuid=uuid.uuid4(),
+        workspace_id="ws-abc",
+        clerk_user_id="user_test",
+        user_email="test@example.com",
+        ai_tool="claude-code",
+        session_id="sess-1",
+        resolved_token="cond_tok_test",
+    )
+
+
+def test_guard_test_requires_pack():
+    result = guard_test_impl(_ctx(), tool_name="bash", tool_input={"command": "ls"})
+    assert result.startswith("ERROR")
+    assert "'pack' argument is required" in result
+
+
+def test_guard_test_rejects_conduct_base():
+    result = guard_test_impl(
+        _ctx(), pack="conduct-base", tool_name="bash", tool_input={"cmd": "x"}
+    )
+    assert result.startswith("ERROR")
+    assert "conduct-base" in result
+
+
+def test_guard_test_requires_tool_name():
+    ctx = _ctx()
+    # Pretend the pack IS installed so we get past the install check.
+    ctx.db.query.return_value.filter.return_value.first.return_value = MagicMock()
+    result = guard_test_impl(ctx, pack="conduct-hipaa")
+    assert result.startswith("ERROR")
+    assert "tool_name" in result
+
+
+def test_guard_test_returns_error_when_pack_not_installed():
+    ctx = _ctx()
+
+    # First query (single pack lookup) → None; second query (list others) → [].
+    filter1 = MagicMock()
+    filter1.first.return_value = None
+    filter2 = MagicMock()
+    filter2.all.return_value = []
+    ctx.db.query.return_value.filter.side_effect = [filter1, filter2]
+
+    result = guard_test_impl(
+        ctx, pack="conduct-fake", tool_name="bash", tool_input={"c": "x"}
+    )
+    assert result.startswith("ERROR")
+    assert "not installed" in result
+    assert "conduct-fake" in result
+
+
+def test_guard_test_returns_would_verdict_when_rule_matches():
+    ctx = _ctx()
+    # Pack is installed.
+    ctx.db.query.return_value.filter.return_value.first.return_value = MagicMock()
+
+    with patch(
+        "app.modules.guard.policy_engine._build_rules",
+        return_value=[{"id": "hipaa-x", "action": "block", "message": "PHI leak"}],
+    ) as bm, \
+         patch(
+             "app.modules.guard.mcp_impls._project_rule",
+             side_effect=lambda r: {"rule_id": r["id"], "action": r["action"], "message": r["message"]},
+         ), \
+         patch(
+             "app.modules.guard.mcp_impls._match_policy",
+             return_value={"rule_id": "hipaa-x", "action": "block", "message": "PHI leak"},
+         ), \
+         patch("app.modules.guard.mcp_impls._record_event") as rec:
+        result = guard_test_impl(
+            ctx, pack="conduct-hipaa", tool_name="bash", tool_input={"cmd": "cat /db"},
+        )
+
+    assert result.startswith("WOULD-BLOCK")
+    assert "hipaa-x" in result
+    assert "PHI leak" in result
+    assert "conduct-hipaa" in result
+    # Prove isolation: _build_rules called with restrict_to_pack
+    _, kwargs = bm.call_args
+    assert kwargs.get("restrict_to_pack") == "conduct-hipaa"
+    # Prove dry-run: audit chain never touched
+    rec.assert_not_called()
+
+
+def test_guard_test_returns_ok_when_no_rule_fires():
+    ctx = _ctx()
+    ctx.db.query.return_value.filter.return_value.first.return_value = MagicMock()
+
+    with patch(
+        "app.modules.guard.policy_engine._build_rules", return_value=[]
+    ), patch(
+        "app.modules.guard.mcp_impls._match_policy", return_value=None
+    ), patch("app.modules.guard.mcp_impls._record_event") as rec:
+        result = guard_test_impl(
+            ctx, pack="conduct-hipaa", tool_name="bash", tool_input={"cmd": "ls"},
+        )
+    assert result.startswith("OK")
+    assert "conduct-hipaa" in result
+    rec.assert_not_called()

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -1,0 +1,119 @@
+"""#1737 PRs 3+4 — guard_check `pack:` arg deprecation + shadow divergence log.
+
+Verifies:
+- Deprecation suffix appears on responses when a caller passes `pack:` (PR 3)
+- Server-side warning is logged for the deprecated call (PR 3)
+- Shadow log fires only when pack-scoped vs unified match diverges (PR 4)
+- Shadow log routes tool_input through redact_secrets (reviewer edit 3)
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from app.modules.guard.mcp_impls import (
+    _PACK_ARG_DEPRECATION_SUFFIX,
+    GuardCtx,
+    _shadow_log_pack_divergence,
+    guard_check_impl,
+)
+
+
+def _ctx() -> GuardCtx:
+    return GuardCtx(
+        db=MagicMock(),
+        ws_uuid=uuid.uuid4(),
+        workspace_id="ws-abc",
+        clerk_user_id="user_test",
+        user_email="test@example.com",
+        ai_tool="claude-code",
+        session_id="sess-1",
+        resolved_token="cond_tok_test",
+    )
+
+
+def test_pack_arg_returns_deprecation_suffix_on_error_path(caplog):
+    """`_get_rules_for_pack` returns a string when the pack isn't installed;
+    the suffix must be appended so the caller sees the deprecation notice."""
+    ctx = _ctx()
+    with patch(
+        "app.modules.guard.mcp_impls._get_rules_for_pack",
+        return_value="ERROR — pack 'conduct-fake' is not installed",
+    ):
+        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
+            result = guard_check_impl(
+                ctx,
+                tool_name="bash",
+                tool_input={"command": "ls"},
+                pack="conduct-fake",
+            )
+
+    assert result.startswith("ERROR — pack 'conduct-fake' is not installed")
+    assert result.endswith(_PACK_ARG_DEPRECATION_SUFFIX)
+    assert any("pack: arg is deprecated" in r.message for r in caplog.records)
+
+
+def test_shadow_log_fires_on_divergent_match(caplog):
+    """When pack-scoped and unified paths produce different rule matches,
+    the shadow log emits a warning with redacted input."""
+    pack_rules = [{"id": "pack-rule", "action": "warn"}]
+    unified_rules = [{"id": "unified-rule", "action": "block"}]
+    db = MagicMock()
+    ws_uuid = uuid.uuid4()
+
+    def match_side(_tool, _input, rules):
+        return {"rule_id": rules[0]["id"]} if rules else None
+
+    # Fake-format secret matching pii._SECRET_PATTERNS `sk-<20+>` regex.
+    # Built by concat so this fixture doesn't itself trip secret scanners.
+    secret = "sk" + "-" + ("X" * 30)
+
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=unified_rules), \
+         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side):
+        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
+            _shadow_log_pack_divergence(
+                db, ws_uuid, "conduct-fake", "bash",
+                {"command": "ls", "token": secret},
+                pack_rules,
+            )
+
+    msgs = [r.getMessage() for r in caplog.records]
+    assert any("shadow divergence" in m for m in msgs)
+    assert any("pack_rule=pack-rule" in m for m in msgs)
+    assert any("unified_rule=unified-rule" in m for m in msgs)
+    assert not any(secret in m for m in msgs), (
+        "raw secret leaked into shadow log — redact_secrets did not run"
+    )
+
+
+def test_shadow_log_silent_on_matching_result(caplog):
+    """When pack-scoped and unified paths agree, no divergence log."""
+    rules = [{"id": "same-rule", "action": "warn"}]
+    db = MagicMock()
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=rules), \
+         patch(
+             "app.modules.guard.mcp_impls._match_policy",
+             return_value={"rule_id": "same-rule"},
+         ):
+        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
+            _shadow_log_pack_divergence(
+                db, uuid.uuid4(), "conduct-fake", "bash", {"cmd": "ls"}, rules,
+            )
+    assert not any("shadow divergence" in r.getMessage() for r in caplog.records)
+
+
+def test_no_pack_arg_no_deprecation_suffix():
+    """Absent `pack:`, no suffix and no warning."""
+    ctx = _ctx()
+    # No rules → returns "ok"
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=[]):
+        # _record_event and GuardConfig lookup happen inside; keep DB permissive.
+        ctx.db.query.return_value.filter.return_value.first.return_value = None
+        with patch("app.modules.guard.mcp_impls._record_event"):
+            result = guard_check_impl(
+                ctx,
+                tool_name="bash",
+                tool_input={"command": "ls"},
+            )
+    assert result == "ok"
+    assert _PACK_ARG_DEPRECATION_SUFFIX not in result

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -14,7 +14,7 @@ from unittest.mock import MagicMock, patch
 from app.modules.guard.mcp_impls import (
     _PACK_ARG_DEPRECATION_SUFFIX,
     GuardCtx,
-    _shadow_log_pack_divergence,
+    _build_divergence_log_line,
     guard_check_impl,
 )
 
@@ -58,63 +58,52 @@ def test_pack_arg_returns_deprecation_suffix_on_error_path():
     assert any("pack: arg is deprecated" in m for m in logged)
 
 
-def test_shadow_log_fires_on_divergent_match():
-    """When pack-scoped and unified paths produce different rule matches,
-    the shadow log emits a warning with redacted input. Uses the log_fn DI
-    hook — no global patching, no logger reset ordering issues."""
-    pack_rules = [{"id": "pack-rule", "action": "warn"}]
-    unified_rules = [{"id": "unified-rule", "action": "block"}]
-    db = MagicMock()
-    ws_uuid = uuid.uuid4()
-
-    def match_side(_tool, _input, rules, gate=None):
-        return {"rule_id": rules[0]["id"]} if rules else None
-
+def test_divergence_log_line_fires_on_different_rule_ids():
+    """Pure-function coverage of the divergence-message builder — no
+    patching, no logger, no test-order coupling."""
     # Fake-format secret matching pii._SECRET_PATTERNS `sk-<20+>` regex.
     # Built by concat so this fixture doesn't itself trip secret scanners.
     secret = "sk" + "-" + ("X" * 30)
-
-    logged: list[str] = []
-
-    def _capture(msg, *args, **_kw):
-        logged.append(msg % args if args else msg)
-
-    with patch("app.modules.guard.mcp_impls._get_rules", return_value=unified_rules), \
-         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side):
-        _shadow_log_pack_divergence(
-            db, ws_uuid, "conduct-fake", "bash",
-            {"command": "ls", "token": secret},
-            pack_rules,
-            log_fn=_capture,
-        )
-
-    assert any("shadow divergence" in m for m in logged)
-    assert any("pack_rule=pack-rule" in m for m in logged)
-    assert any("unified_rule=unified-rule" in m for m in logged)
-    assert not any(secret in m for m in logged), (
+    line = _build_divergence_log_line(
+        pack="conduct-fake",
+        tool_name="bash",
+        tool_input={"command": "ls", "token": secret},
+        pack_rid="pack-rule",
+        unified_rid="unified-rule",
+    )
+    assert line is not None
+    fmt, args = line
+    assert "shadow divergence" in fmt
+    rendered = fmt % args
+    assert "pack_rule=pack-rule" in rendered
+    assert "unified_rule=unified-rule" in rendered
+    assert secret not in rendered, (
         "raw secret leaked into shadow log — redact_secrets did not run"
     )
 
 
-def test_shadow_log_silent_on_matching_result():
-    """When pack-scoped and unified paths agree, no divergence log."""
-    rules = [{"id": "same-rule", "action": "warn"}]
-    db = MagicMock()
-    logged: list[str] = []
+def test_divergence_log_line_silent_on_same_rule_ids():
+    """When both paths agree, builder returns None (no log)."""
+    line = _build_divergence_log_line(
+        pack="conduct-fake",
+        tool_name="bash",
+        tool_input={"cmd": "ls"},
+        pack_rid="same-rule",
+        unified_rid="same-rule",
+    )
+    assert line is None
 
-    def _capture(msg, *args, **_kw):
-        logged.append(msg % args if args else msg)
 
-    with patch("app.modules.guard.mcp_impls._get_rules", return_value=rules), \
-         patch(
-             "app.modules.guard.mcp_impls._match_policy",
-             return_value={"rule_id": "same-rule"},
-         ):
-        _shadow_log_pack_divergence(
-            db, uuid.uuid4(), "conduct-fake", "bash", {"cmd": "ls"}, rules,
-            log_fn=_capture,
-        )
-    assert not any("shadow divergence" in m for m in logged)
+def test_divergence_log_line_silent_when_both_paths_null():
+    """No rule matched on either side → no divergence."""
+    line = _build_divergence_log_line(
+        pack="conduct-fake",
+        tool_name="bash",
+        tool_input={},
+        pack_rid=None,
+        unified_rid=None,
+    )
+    assert line is None
 
 
 def test_no_pack_arg_no_deprecation_suffix():

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -32,30 +32,36 @@ def _ctx() -> GuardCtx:
     )
 
 
-def test_pack_arg_returns_deprecation_suffix_on_error_path(caplog):
+def test_pack_arg_returns_deprecation_suffix_on_error_path():
     """`_get_rules_for_pack` returns a string when the pack isn't installed;
-    the suffix must be appended so the caller sees the deprecation notice."""
+    the suffix must be appended so the caller sees the deprecation notice.
+    Direct-patch LOG.warning — caplog is flaky across CI/local logging configs."""
     ctx = _ctx()
+    logged: list[str] = []
+
+    def _capture(msg, *args, **_kw):
+        logged.append(msg % args if args else msg)
+
     with patch(
         "app.modules.guard.mcp_impls._get_rules_for_pack",
         return_value="ERROR — pack 'conduct-fake' is not installed",
-    ):
-        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
-            result = guard_check_impl(
-                ctx,
-                tool_name="bash",
-                tool_input={"command": "ls"},
-                pack="conduct-fake",
-            )
+    ), patch("app.modules.guard.mcp_impls.LOG.warning", side_effect=_capture):
+        result = guard_check_impl(
+            ctx,
+            tool_name="bash",
+            tool_input={"command": "ls"},
+            pack="conduct-fake",
+        )
 
     assert result.startswith("ERROR — pack 'conduct-fake' is not installed")
     assert result.endswith(_PACK_ARG_DEPRECATION_SUFFIX)
-    assert any("pack: arg is deprecated" in r.message for r in caplog.records)
+    assert any("pack: arg is deprecated" in m for m in logged)
 
 
-def test_shadow_log_fires_on_divergent_match(caplog):
+def test_shadow_log_fires_on_divergent_match():
     """When pack-scoped and unified paths produce different rule matches,
-    the shadow log emits a warning with redacted input."""
+    the shadow log emits a warning with redacted input. Patch LOG.warning
+    directly — caplog capture is flaky across CI/local logging configs."""
     pack_rules = [{"id": "pack-rule", "action": "warn"}]
     unified_rules = [{"id": "unified-rule", "action": "block"}]
     db = MagicMock()
@@ -68,38 +74,46 @@ def test_shadow_log_fires_on_divergent_match(caplog):
     # Built by concat so this fixture doesn't itself trip secret scanners.
     secret = "sk" + "-" + ("X" * 30)
 
-    with patch("app.modules.guard.mcp_impls._get_rules", return_value=unified_rules), \
-         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side):
-        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
-            _shadow_log_pack_divergence(
-                db, ws_uuid, "conduct-fake", "bash",
-                {"command": "ls", "token": secret},
-                pack_rules,
-            )
+    logged: list[str] = []
 
-    msgs = [r.getMessage() for r in caplog.records]
-    assert any("shadow divergence" in m for m in msgs)
-    assert any("pack_rule=pack-rule" in m for m in msgs)
-    assert any("unified_rule=unified-rule" in m for m in msgs)
-    assert not any(secret in m for m in msgs), (
+    def _capture(msg, *args, **_kw):
+        logged.append(msg % args if args else msg)
+
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=unified_rules), \
+         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side), \
+         patch("app.modules.guard.mcp_impls.LOG.warning", side_effect=_capture):
+        _shadow_log_pack_divergence(
+            db, ws_uuid, "conduct-fake", "bash",
+            {"command": "ls", "token": secret},
+            pack_rules,
+        )
+
+    assert any("shadow divergence" in m for m in logged)
+    assert any("pack_rule=pack-rule" in m for m in logged)
+    assert any("unified_rule=unified-rule" in m for m in logged)
+    assert not any(secret in m for m in logged), (
         "raw secret leaked into shadow log — redact_secrets did not run"
     )
 
 
-def test_shadow_log_silent_on_matching_result(caplog):
+def test_shadow_log_silent_on_matching_result():
     """When pack-scoped and unified paths agree, no divergence log."""
     rules = [{"id": "same-rule", "action": "warn"}]
     db = MagicMock()
+    logged: list[str] = []
+
+    def _capture(msg, *args, **_kw):
+        logged.append(msg % args if args else msg)
+
     with patch("app.modules.guard.mcp_impls._get_rules", return_value=rules), \
          patch(
              "app.modules.guard.mcp_impls._match_policy",
              return_value={"rule_id": "same-rule"},
-         ):
-        with caplog.at_level("WARNING", logger="guard.mcp_impls"):
-            _shadow_log_pack_divergence(
-                db, uuid.uuid4(), "conduct-fake", "bash", {"cmd": "ls"}, rules,
-            )
-    assert not any("shadow divergence" in r.getMessage() for r in caplog.records)
+         ), patch("app.modules.guard.mcp_impls.LOG.warning", side_effect=_capture):
+        _shadow_log_pack_divergence(
+            db, uuid.uuid4(), "conduct-fake", "bash", {"cmd": "ls"}, rules,
+        )
+    assert not any("shadow divergence" in m for m in logged)
 
 
 def test_no_pack_arg_no_deprecation_suffix():

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -60,14 +60,14 @@ def test_pack_arg_returns_deprecation_suffix_on_error_path():
 
 def test_shadow_log_fires_on_divergent_match():
     """When pack-scoped and unified paths produce different rule matches,
-    the shadow log emits a warning with redacted input. Patch LOG.warning
-    directly — caplog capture is flaky across CI/local logging configs."""
+    the shadow log emits a warning with redacted input. Uses the log_fn DI
+    hook — no global patching, no logger reset ordering issues."""
     pack_rules = [{"id": "pack-rule", "action": "warn"}]
     unified_rules = [{"id": "unified-rule", "action": "block"}]
     db = MagicMock()
     ws_uuid = uuid.uuid4()
 
-    def match_side(_tool, _input, rules):
+    def match_side(_tool, _input, rules, gate=None):
         return {"rule_id": rules[0]["id"]} if rules else None
 
     # Fake-format secret matching pii._SECRET_PATTERNS `sk-<20+>` regex.
@@ -80,12 +80,12 @@ def test_shadow_log_fires_on_divergent_match():
         logged.append(msg % args if args else msg)
 
     with patch("app.modules.guard.mcp_impls._get_rules", return_value=unified_rules), \
-         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side), \
-         patch("app.modules.guard.mcp_impls.LOG.warning", side_effect=_capture):
+         patch("app.modules.guard.mcp_impls._match_policy", side_effect=match_side):
         _shadow_log_pack_divergence(
             db, ws_uuid, "conduct-fake", "bash",
             {"command": "ls", "token": secret},
             pack_rules,
+            log_fn=_capture,
         )
 
     assert any("shadow divergence" in m for m in logged)
@@ -109,9 +109,10 @@ def test_shadow_log_silent_on_matching_result():
          patch(
              "app.modules.guard.mcp_impls._match_policy",
              return_value={"rule_id": "same-rule"},
-         ), patch("app.modules.guard.mcp_impls.LOG.warning", side_effect=_capture):
+         ):
         _shadow_log_pack_divergence(
             db, uuid.uuid4(), "conduct-fake", "bash", {"cmd": "ls"}, rules,
+            log_fn=_capture,
         )
     assert not any("shadow divergence" in m for m in logged)
 

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -59,36 +59,37 @@ def test_pack_arg_returns_deprecation_suffix_on_error_path():
 
 
 def test_divergence_log_line_fires_on_different_rule_ids():
-    """Pure-function coverage of the divergence-message builder — no
-    patching, no logger, no test-order coupling.
+    """Pure-function coverage of the divergence-message builder shape.
+    Injects a spy redactor so the assertion doesn't depend on which
+    version of app.core.pii is loaded in sys.modules — pre-existing
+    approval tests stub the module and the ratchet at #1075 forbids
+    poking sys.modules from new test files."""
+    spy_calls: list[str] = []
 
-    Pre-existing tests (test_guard_approval*.py) stub app.core.pii module
-    with a MagicMock at import time and never restore. Force-reload the
-    real module before this test runs so redaction actually executes."""
-    import sys, importlib
-    # Pre-existing tests stubbed sys.modules["app.core.pii"] = MagicMock().
-    # Drop the stub, force a fresh import of the real module.
-    sys.modules.pop("app.core.pii", None)
-    importlib.import_module("app.core.pii")
+    def _spy_redact(text: str):
+        spy_calls.append(text)
+        return ("[REDACTED]", ["secret_key"])
 
-    # Fake-format secret matching pii._SECRET_PATTERNS `sk-<20+>` regex.
-    # Built by concat so this fixture doesn't itself trip secret scanners.
-    secret = "sk" + "-" + ("X" * 30)
-    line = _build_divergence_log_line(
-        pack="conduct-fake",
-        tool_name="bash",
-        tool_input={"command": "ls", "token": secret},
-        pack_rid="pack-rule",
-        unified_rid="unified-rule",
-    )
+    with patch("app.core.pii.redact_secrets", side_effect=_spy_redact):
+        line = _build_divergence_log_line(
+            pack="conduct-fake",
+            tool_name="bash",
+            tool_input={"command": "ls", "token": "sk" + "-" + ("X" * 30)},
+            pack_rid="pack-rule",
+            unified_rid="unified-rule",
+        )
+
     assert line is not None
     fmt, args = line
     assert "shadow divergence" in fmt
     rendered = fmt % args
     assert "pack_rule=pack-rule" in rendered
     assert "unified_rule=unified-rule" in rendered
-    assert secret not in rendered, (
-        "raw secret leaked into shadow log — redact_secrets did not run"
+    # Property 9: builder MUST route the raw tool_input through
+    # redact_secrets before rendering it into the log message.
+    assert spy_calls, "redact_secrets was never called — Property 9 violated"
+    assert "[REDACTED]" in rendered, (
+        "redactor return value did not reach the rendered log line"
     )
 
 

--- a/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
+++ b/apps/api/tests/guard/test_mcp_impls_pack_deprecation.py
@@ -60,7 +60,17 @@ def test_pack_arg_returns_deprecation_suffix_on_error_path():
 
 def test_divergence_log_line_fires_on_different_rule_ids():
     """Pure-function coverage of the divergence-message builder — no
-    patching, no logger, no test-order coupling."""
+    patching, no logger, no test-order coupling.
+
+    Pre-existing tests (test_guard_approval*.py) stub app.core.pii module
+    with a MagicMock at import time and never restore. Force-reload the
+    real module before this test runs so redaction actually executes."""
+    import sys, importlib
+    # Pre-existing tests stubbed sys.modules["app.core.pii"] = MagicMock().
+    # Drop the stub, force a fresh import of the real module.
+    sys.modules.pop("app.core.pii", None)
+    importlib.import_module("app.core.pii")
+
     # Fake-format secret matching pii._SECRET_PATTERNS `sk-<20+>` regex.
     # Built by concat so this fixture doesn't itself trip secret scanners.
     secret = "sk" + "-" + ("X" * 30)

--- a/apps/api/tests/guard/test_policy_composed.py
+++ b/apps/api/tests/guard/test_policy_composed.py
@@ -153,7 +153,7 @@ def test_default_sources_used_when_none_passed(monkeypatch):
     # Stub the real rule source's underlying evaluator so no DB call is made.
     from app.guard import sources as _sources
 
-    def _stub(ws, provider, model, body):
+    def _stub(ws, provider, model, body, **_):  # **_ absorbs new gate kwarg (#1733)
         return {"action": "ALLOW", "rule_id": None, "matched_rules": [], "defense_score": 0}
 
     monkeypatch.setattr(

--- a/apps/api/tests/guard/test_policy_out_gates.py
+++ b/apps/api/tests/guard/test_policy_out_gates.py
@@ -1,0 +1,86 @@
+"""#1733 / #1750 Phase B — PolicyOut carries gates + retained prose.
+
+Verifies that the API surfaces the three fields the Policies UI needs:
+- ``gates`` (locked enum [action, prompt, response]) — derived on projection
+- ``guarantee`` (hand-authored trust prose, retained per reviewer edit 4)
+- ``known_limitations`` (hand-authored operational caveats, retained)
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+from app.modules.guard.routers.policies import (
+    PolicyOut,
+    _custom_to_out,
+    _pack_rule_to_out,
+)
+
+
+def test_pack_rule_to_out_stamps_gates_from_persona_default():
+    rule = {"id": "r-a", "action": "block", "persona": "agent"}
+    out = _pack_rule_to_out(rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert isinstance(out, PolicyOut)
+    assert out.gates == ["action"]
+
+
+def test_pack_rule_to_out_stamps_gates_from_proxy_persona():
+    rule = {"id": "r-p", "action": "warn", "persona": "proxy"}
+    out = _pack_rule_to_out(rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.gates == ["prompt"]
+
+
+def test_pack_rule_to_out_stamps_explicit_gates_over_persona():
+    """Rule authors that set gates explicitly (e.g. new response-gate rule)
+    have their choice honored — persona derivation only fills the gap."""
+    rule = {"id": "r-r", "action": "block", "persona": "proxy", "gates": ["response"]}
+    out = _pack_rule_to_out(rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.gates == ["response"]
+
+
+def test_pack_rule_to_out_exposes_guarantee_and_known_limitations():
+    rule = {
+        "id": "hipaa-ssn",
+        "action": "block",
+        "persona": "agent",
+        "enforcement": {
+            "guarantee": "Blocks SSN writes at the file boundary.",
+            "known_limitations": [
+                "MCP guard_check must be called by the agent",
+                "Zip-encoded uploads bypass the pattern",
+            ],
+        },
+    }
+    out = _pack_rule_to_out(rule, "conduct-hipaa", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.guarantee == "Blocks SSN writes at the file boundary."
+    assert len(out.known_limitations) == 2
+    assert "MCP guard_check must be called" in out.known_limitations[0]
+
+
+def test_pack_rule_to_out_defaults_prose_when_enforcement_missing():
+    rule = {"id": "r-x", "action": "audit"}
+    out = _pack_rule_to_out(rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.guarantee is None
+    assert out.known_limitations == []
+
+
+def test_custom_to_out_stamps_gates_and_prose():
+    row = MagicMock()
+    row.rule_id = "custom-a"
+    row.workspace_id = uuid.uuid4()
+    row.persona = "agent"
+    row.enabled = True
+    row.created_at = datetime.now(timezone.utc)
+    row.updated_at = datetime.now(timezone.utc)
+    row.body = {
+        "action": "warn",
+        "enforcement": {
+            "guarantee": "Warns on internal repo writes.",
+            "known_limitations": ["Case-insensitive path match only"],
+        },
+    }
+    out = _custom_to_out(row)
+    assert out.gates == ["action"]
+    assert out.guarantee == "Warns on internal repo writes."
+    assert out.known_limitations == ["Case-insensitive path match only"]

--- a/apps/api/tests/guard/test_policy_sources.py
+++ b/apps/api/tests/guard/test_policy_sources.py
@@ -30,7 +30,7 @@ def _ctx(**over):
 # ─── RulePolicySource ────────────────────────────────────────────────────────
 
 def test_rule_source_allow():
-    fake_evaluator = lambda ws, prov, model, body: {
+    fake_evaluator = lambda ws, prov, model, body, **_: {
         "action": "ALLOW", "rule_id": None, "matched_rules": [], "defense_score": 0,
     }
     d = RulePolicySource(evaluator=fake_evaluator).evaluate(_ctx())
@@ -39,7 +39,7 @@ def test_rule_source_allow():
 
 
 def test_rule_source_block():
-    fake_evaluator = lambda ws, prov, model, body: {
+    fake_evaluator = lambda ws, prov, model, body, **_: {
         "action": "BLOCK", "rule_id": "r-42", "message": "no secrets",
         "matched_rules": [{"rule_id": "r-42"}], "defense_score": 5,
     }
@@ -50,7 +50,7 @@ def test_rule_source_block():
 
 
 def test_rule_source_warn_with_guidance():
-    fake_evaluator = lambda ws, prov, model, body: {
+    fake_evaluator = lambda ws, prov, model, body, **_: {
         "action": "WARN", "rule_id": "r-1",
         "message": "be careful",
         "matched_rules": [{"rule_id": "r-1"}], "defense_score": 2,
@@ -63,7 +63,7 @@ def test_rule_source_warn_with_guidance():
 
 
 def test_rule_source_unknown_action_falls_back_to_allow():
-    fake_evaluator = lambda ws, prov, model, body: {"action": "MAYBE"}
+    fake_evaluator = lambda ws, prov, model, body, **_: {"action": "MAYBE"}
     d = RulePolicySource(evaluator=fake_evaluator).evaluate(_ctx())
     assert d.action == PolicyAction.ALLOW
 

--- a/apps/api/tests/guard/test_project_rule.py
+++ b/apps/api/tests/guard/test_project_rule.py
@@ -1,0 +1,35 @@
+"""#1752 — _project_rule must not drop match_ai_tool.
+
+Regression test for the projection bug called out in reviewer edit 5 of
+#1740. The server evaluates match_ai_tool correctly; the bug is only in
+what the MCP surface projects back to callers. Downstream UI/Lens/CLI
+consumers rely on the projected shape.
+"""
+from __future__ import annotations
+
+from app.modules.guard.routers.mcp import _project_rule
+
+
+def test_project_rule_preserves_match_ai_tool():
+    rule = {
+        "id": "surface-chat-no-write",
+        "match_tool": "Write",
+        "match_ai_tool": ["Write", "Edit"],
+        "action": "block",
+        "message": "chat surface must not write files",
+        "pack": "conduct-surface",
+    }
+    out = _project_rule(rule)
+    assert out["match_ai_tool"] == ["Write", "Edit"]
+    assert out["rule_id"] == "surface-chat-no-write"
+    assert out["match_tool"] == "Write"
+    assert out["action"] == "block"
+
+
+def test_project_rule_match_ai_tool_absent_is_none():
+    """When the source rule has no match_ai_tool, projection returns None
+    (not KeyError). Existing callers checking `.get('match_ai_tool')` keep
+    working."""
+    rule = {"id": "generic", "match_tool": "bash", "action": "warn"}
+    out = _project_rule(rule)
+    assert out["match_ai_tool"] is None

--- a/apps/api/tests/guard/test_response_gate_nonstream.py
+++ b/apps/api/tests/guard/test_response_gate_nonstream.py
@@ -1,0 +1,109 @@
+"""#1733 PR 4 — response gate (non-streaming path).
+
+Verifies:
+- Response-gate rule that fires BLOCK swaps the upstream body for a
+  ConductGuard 451 envelope.
+- Response-gate rule that fires WARN passes the original body through.
+- ``flatten_response`` extracts text from Anthropic + OpenAI shapes.
+- The response gate short-circuits on error (fail-open) so a policy hiccup
+  never breaks the response path.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from fastapi.responses import JSONResponse
+
+from app.guard.policy import flatten_prompt, flatten_response
+from app.guard.policy_types import PolicyAction, PolicyDecision
+from app.modules.guard.routers.proxy import _apply_response_gate
+
+
+def _resp(body: dict, status: int = 200) -> JSONResponse:
+    return JSONResponse(status_code=status, content=body)
+
+
+def test_flatten_response_anthropic_shape():
+    body = {"content": [{"type": "text", "text": "hello patient SSN 123-45-6789"}]}
+    assert "SSN 123-45-6789" in flatten_response(body)
+
+
+def test_flatten_response_openai_shape():
+    body = {"choices": [{"message": {"content": "hello patient"}}]}
+    assert flatten_response(body) == "hello patient"
+
+
+def test_flatten_response_unknown_shape_returns_empty():
+    assert flatten_response({"weird": True}) == ""
+
+
+def test_flatten_prompt_still_ignores_response_shape():
+    """Sanity: response-shape bodies must NOT flow through prompt extraction."""
+    body = {"content": [{"type": "text", "text": "assistant reply"}]}
+    assert flatten_prompt(body) == ""
+
+
+def test_apply_response_gate_passes_through_on_allow():
+    anthropic_response = _resp({"content": [{"type": "text", "text": "hi"}]})
+    with patch(
+        "app.guard.policy.evaluate_composed",
+        return_value=PolicyDecision(action=PolicyAction.ALLOW, source="rule"),
+    ):
+        out = _apply_response_gate(
+            anthropic_response, workspace_id="ws-a", provider="anthropic",
+            model="claude-3", clerk_user_id="u1", agent_identity_id=None,
+        )
+    assert out is anthropic_response  # unchanged, same object
+
+
+def test_apply_response_gate_replaces_body_on_block():
+    anthropic_response = _resp({"content": [{"type": "text", "text": "SSN leak"}]})
+    with patch(
+        "app.guard.policy.evaluate_composed",
+        return_value=PolicyDecision(
+            action=PolicyAction.BLOCK, source="rule",
+            reason="PHI detected in model reply", rule_id="hipaa-no-ssn-out",
+        ),
+    ):
+        out = _apply_response_gate(
+            anthropic_response, workspace_id="ws-a", provider="anthropic",
+            model="claude-3", clerk_user_id="u1", agent_identity_id=None,
+        )
+    assert out is not anthropic_response
+    assert out.status_code == 451
+    payload = json.loads(out.body)
+    assert payload["error"]["type"] == "conduct_guard_response_block"
+    assert payload["error"]["rule_id"] == "hipaa-no-ssn-out"
+    assert payload["error"]["gate"] == "response"
+
+
+def test_apply_response_gate_fails_open_on_error():
+    """A crash inside the response scan must not corrupt the response body."""
+    orig = _resp({"content": [{"type": "text", "text": "hi"}]})
+    with patch(
+        "app.guard.policy.evaluate_composed",
+        side_effect=RuntimeError("engine down"),
+    ):
+        out = _apply_response_gate(
+            orig, workspace_id="ws-a", provider="anthropic",
+            model="claude-3", clerk_user_id="u1", agent_identity_id=None,
+        )
+    assert out is orig
+
+
+def test_apply_response_gate_context_labels_response_gate():
+    """Regression: the ctx passed to evaluate_composed must have gate='response'."""
+    orig = _resp({"content": [{"type": "text", "text": "hi"}]})
+    seen = {}
+
+    def _spy(ctx):
+        seen["gate"] = ctx.gate
+        return PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+
+    with patch("app.guard.policy.evaluate_composed", side_effect=_spy):
+        _apply_response_gate(
+            orig, workspace_id="ws-a", provider="anthropic",
+            model="claude-3", clerk_user_id="u1", agent_identity_id=None,
+        )
+    assert seen["gate"] == "response"

--- a/apps/api/tests/guard/test_response_gate_streaming.py
+++ b/apps/api/tests/guard/test_response_gate_streaming.py
@@ -3,13 +3,16 @@
 ponytail: buffered — client already saw chunks by the time we decide. This
 suite proves telemetry (server-side WARN) fires on block. The chunk-scan
 upgrade path (mid-stream halt) is a follow-on.
+
+ponytail: async tests wrapped in asyncio.run() rather than marking with
+pytest.mark.asyncio so we don't add pytest-asyncio as a CI dep for four
+tests.
 """
 from __future__ import annotations
 
 import asyncio
 from unittest.mock import patch
 
-import pytest
 from fastapi.responses import StreamingResponse
 
 from app.guard.policy_types import PolicyAction, PolicyDecision
@@ -56,83 +59,86 @@ async def _drain(response: StreamingResponse) -> bytes:
     return bytes(out)
 
 
-@pytest.mark.asyncio
-async def test_wrap_streaming_response_passes_chunks_through_unchanged():
+def test_wrap_streaming_response_passes_chunks_through_unchanged():
     """Chunks reach the client verbatim — buffered scan happens at end only."""
-    async def _fake_stream():
-        yield b'data: {"delta":{"text":"hello"}}\n\n'
-        yield b'data: {"delta":{"text":" world"}}\n\n'
+    async def _body():
+        async def _fake_stream():
+            yield b'data: {"delta":{"text":"hello"}}\n\n'
+            yield b'data: {"delta":{"text":" world"}}\n\n'
 
-    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+        inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+        with patch(
+            "app.modules.guard.routers.proxy._evaluate_response_body",
+            return_value=PolicyDecision(action=PolicyAction.ALLOW, source="rule"),
+        ):
+            wrapped = _wrap_streaming_response(
+                inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+                clerk_user_id="u1", agent_identity_id=None,
+            )
+            return await _drain(wrapped)
 
-    with patch(
-        "app.modules.guard.routers.proxy._evaluate_response_body",
-        return_value=PolicyDecision(action=PolicyAction.ALLOW, source="rule"),
-    ):
-        wrapped = _wrap_streaming_response(
-            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
-            clerk_user_id="u1", agent_identity_id=None,
-        )
-        drained = await _drain(wrapped)
-
+    drained = asyncio.run(_body())
     assert b'"text":"hello"' in drained
     assert b'"text":" world"' in drained
 
 
-@pytest.mark.asyncio
-async def test_wrap_streaming_response_evaluates_synthetic_response_body():
+def test_wrap_streaming_response_evaluates_synthetic_response_body():
     """After the stream drains, the evaluator sees a body with text extracted
     from every text/content delta — Anthropic-shape synthetic envelope."""
-    async def _fake_stream():
-        yield b'data: {"delta":{"text":"leak-me-if-you-can"}}\n\n'
-
-    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
     seen = {}
 
-    def _spy(resp_body, **kwargs):
-        seen["body"] = resp_body
-        return PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+    async def _body():
+        async def _fake_stream():
+            yield b'data: {"delta":{"text":"leak-me-if-you-can"}}\n\n'
 
-    with patch(
-        "app.modules.guard.routers.proxy._evaluate_response_body",
-        side_effect=_spy,
-    ):
-        wrapped = _wrap_streaming_response(
-            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
-            clerk_user_id="u1", agent_identity_id=None,
-        )
-        await _drain(wrapped)
+        inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
 
+        def _spy(resp_body, **kwargs):
+            seen["body"] = resp_body
+            return PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+
+        with patch(
+            "app.modules.guard.routers.proxy._evaluate_response_body",
+            side_effect=_spy,
+        ):
+            wrapped = _wrap_streaming_response(
+                inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+                clerk_user_id="u1", agent_identity_id=None,
+            )
+            await _drain(wrapped)
+
+    asyncio.run(_body())
     assert seen["body"]["content"][0]["text"] == "leak-me-if-you-can"
 
 
-@pytest.mark.asyncio
-async def test_wrap_streaming_response_logs_when_block_fires_post_hoc():
+def test_wrap_streaming_response_logs_when_block_fires_post_hoc():
     """structlog doesn't route through stdlib caplog — patch log.warning
     directly to capture the response-gate telemetry payload."""
-    async def _fake_stream():
-        yield b'data: {"delta":{"text":"SSN 123-45-6789"}}\n\n'
-
-    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
-    block = PolicyDecision(
-        action=PolicyAction.BLOCK, source="rule",
-        reason="SSN leaked in stream", rule_id="hipaa-no-ssn-out",
-    )
     calls = []
 
-    with patch(
-        "app.modules.guard.routers.proxy._evaluate_response_body",
-        return_value=block,
-    ), patch(
-        "app.modules.guard.routers.proxy.log.warning",
-        side_effect=lambda event, **kw: calls.append((event, kw)),
-    ):
-        wrapped = _wrap_streaming_response(
-            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
-            clerk_user_id="u1", agent_identity_id=None,
-        )
-        await _drain(wrapped)
+    async def _body():
+        async def _fake_stream():
+            yield b'data: {"delta":{"text":"SSN 123-45-6789"}}\n\n'
 
+        inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+        block = PolicyDecision(
+            action=PolicyAction.BLOCK, source="rule",
+            reason="SSN leaked in stream", rule_id="hipaa-no-ssn-out",
+        )
+        with patch(
+            "app.modules.guard.routers.proxy._evaluate_response_body",
+            return_value=block,
+        ), patch(
+            "app.modules.guard.routers.proxy.log.warning",
+            side_effect=lambda event, **kw: calls.append((event, kw)),
+        ):
+            wrapped = _wrap_streaming_response(
+                inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+                clerk_user_id="u1", agent_identity_id=None,
+            )
+            await _drain(wrapped)
+
+    asyncio.run(_body())
     events = [c[0] for c in calls]
     assert "guard.proxy.response_stream_blocked_post_hoc" in events
     payload = next(kw for ev, kw in calls if ev == "guard.proxy.response_stream_blocked_post_hoc")
@@ -140,23 +146,22 @@ async def test_wrap_streaming_response_logs_when_block_fires_post_hoc():
     assert payload["workspace_id"] == "ws-a"
 
 
-@pytest.mark.asyncio
-async def test_wrap_streaming_response_swallows_evaluator_errors():
+def test_wrap_streaming_response_swallows_evaluator_errors():
     """Even a policy engine crash must not corrupt the response stream."""
-    async def _fake_stream():
-        yield b'data: {"delta":{"text":"hi"}}\n\n'
+    async def _body():
+        async def _fake_stream():
+            yield b'data: {"delta":{"text":"hi"}}\n\n'
 
-    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+        inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+        with patch(
+            "app.modules.guard.routers.proxy._evaluate_response_body",
+            side_effect=RuntimeError("engine down"),
+        ):
+            wrapped = _wrap_streaming_response(
+                inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+                clerk_user_id="u1", agent_identity_id=None,
+            )
+            return await _drain(wrapped)
 
-    with patch(
-        "app.modules.guard.routers.proxy._evaluate_response_body",
-        side_effect=RuntimeError("engine down"),
-    ):
-        wrapped = _wrap_streaming_response(
-            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
-            clerk_user_id="u1", agent_identity_id=None,
-        )
-        # If the wrapper propagates the exception, this raises.
-        drained = await _drain(wrapped)
-
+    drained = asyncio.run(_body())
     assert b'"text":"hi"' in drained

--- a/apps/api/tests/guard/test_response_gate_streaming.py
+++ b/apps/api/tests/guard/test_response_gate_streaming.py
@@ -1,0 +1,162 @@
+"""#1733 PR 5 — response gate on streaming path (buffered end-of-stream scan).
+
+ponytail: buffered — client already saw chunks by the time we decide. This
+suite proves telemetry (server-side WARN) fires on block. The chunk-scan
+upgrade path (mid-stream halt) is a follow-on.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+from fastapi.responses import StreamingResponse
+
+from app.guard.policy_types import PolicyAction, PolicyDecision
+from app.modules.guard.routers.proxy import (
+    _extract_stream_text,
+    _wrap_streaming_response,
+)
+
+
+def test_extract_stream_text_from_anthropic_deltas():
+    sse = (
+        b'event: content_block_delta\n'
+        b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"Hello "}}\n\n'
+        b'event: content_block_delta\n'
+        b'data: {"type":"content_block_delta","delta":{"type":"text_delta","text":"world"}}\n\n'
+    )
+    text = _extract_stream_text(sse)
+    assert "Hello " in text
+    assert "world" in text
+
+
+def test_extract_stream_text_from_openai_deltas():
+    sse = (
+        b'data: {"choices":[{"delta":{"content":"Hello "}}]}\n\n'
+        b'data: {"choices":[{"delta":{"content":"world"}}]}\n\n'
+        b'data: [DONE]\n\n'
+    )
+    text = _extract_stream_text(sse)
+    assert "Hello " in text
+    assert "world" in text
+
+
+def test_extract_stream_text_handles_escaped_quotes():
+    """Regex must handle escape sequences without truncating text."""
+    sse = b'data: {"delta":{"text":"quoted \\"foo\\" bar"}}\n\n'
+    text = _extract_stream_text(sse)
+    assert 'quoted "foo" bar' in text
+
+
+async def _drain(response: StreamingResponse) -> bytes:
+    out = bytearray()
+    async for chunk in response.body_iterator:
+        out.extend(chunk if isinstance(chunk, bytes) else chunk.encode("utf-8"))
+    return bytes(out)
+
+
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_passes_chunks_through_unchanged():
+    """Chunks reach the client verbatim — buffered scan happens at end only."""
+    async def _fake_stream():
+        yield b'data: {"delta":{"text":"hello"}}\n\n'
+        yield b'data: {"delta":{"text":" world"}}\n\n'
+
+    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+
+    with patch(
+        "app.modules.guard.routers.proxy._evaluate_response_body",
+        return_value=PolicyDecision(action=PolicyAction.ALLOW, source="rule"),
+    ):
+        wrapped = _wrap_streaming_response(
+            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+            clerk_user_id="u1", agent_identity_id=None,
+        )
+        drained = await _drain(wrapped)
+
+    assert b'"text":"hello"' in drained
+    assert b'"text":" world"' in drained
+
+
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_evaluates_synthetic_response_body():
+    """After the stream drains, the evaluator sees a body with text extracted
+    from every text/content delta — Anthropic-shape synthetic envelope."""
+    async def _fake_stream():
+        yield b'data: {"delta":{"text":"leak-me-if-you-can"}}\n\n'
+
+    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+    seen = {}
+
+    def _spy(resp_body, **kwargs):
+        seen["body"] = resp_body
+        return PolicyDecision(action=PolicyAction.ALLOW, source="rule")
+
+    with patch(
+        "app.modules.guard.routers.proxy._evaluate_response_body",
+        side_effect=_spy,
+    ):
+        wrapped = _wrap_streaming_response(
+            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+            clerk_user_id="u1", agent_identity_id=None,
+        )
+        await _drain(wrapped)
+
+    assert seen["body"]["content"][0]["text"] == "leak-me-if-you-can"
+
+
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_logs_when_block_fires_post_hoc():
+    """structlog doesn't route through stdlib caplog — patch log.warning
+    directly to capture the response-gate telemetry payload."""
+    async def _fake_stream():
+        yield b'data: {"delta":{"text":"SSN 123-45-6789"}}\n\n'
+
+    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+    block = PolicyDecision(
+        action=PolicyAction.BLOCK, source="rule",
+        reason="SSN leaked in stream", rule_id="hipaa-no-ssn-out",
+    )
+    calls = []
+
+    with patch(
+        "app.modules.guard.routers.proxy._evaluate_response_body",
+        return_value=block,
+    ), patch(
+        "app.modules.guard.routers.proxy.log.warning",
+        side_effect=lambda event, **kw: calls.append((event, kw)),
+    ):
+        wrapped = _wrap_streaming_response(
+            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+            clerk_user_id="u1", agent_identity_id=None,
+        )
+        await _drain(wrapped)
+
+    events = [c[0] for c in calls]
+    assert "guard.proxy.response_stream_blocked_post_hoc" in events
+    payload = next(kw for ev, kw in calls if ev == "guard.proxy.response_stream_blocked_post_hoc")
+    assert payload["rule_id"] == "hipaa-no-ssn-out"
+    assert payload["workspace_id"] == "ws-a"
+
+
+@pytest.mark.asyncio
+async def test_wrap_streaming_response_swallows_evaluator_errors():
+    """Even a policy engine crash must not corrupt the response stream."""
+    async def _fake_stream():
+        yield b'data: {"delta":{"text":"hi"}}\n\n'
+
+    inner = StreamingResponse(_fake_stream(), media_type="text/event-stream")
+
+    with patch(
+        "app.modules.guard.routers.proxy._evaluate_response_body",
+        side_effect=RuntimeError("engine down"),
+    ):
+        wrapped = _wrap_streaming_response(
+            inner, workspace_id="ws-a", provider="anthropic", model="claude-3",
+            clerk_user_id="u1", agent_identity_id=None,
+        )
+        # If the wrapper propagates the exception, this raises.
+        drained = await _drain(wrapped)
+
+    assert b'"text":"hi"' in drained

--- a/apps/api/tests/test_guard_approval.py
+++ b/apps/api/tests/test_guard_approval.py
@@ -30,8 +30,11 @@ for _m in _STUBS:
     sys.modules.setdefault(_m, MagicMock())
 # app.core.pii.redact_secrets must return its input (it is called by
 # create_approval_request); the MagicMock default returns a MagicMock.
+# Preserve the real signature: tuple[str, list[str]] — pre-#1737 stubs
+# used `lambda s: s` which poisoned tests loaded later in the session
+# that rely on the 2-tuple contract.
 import app.core.pii as _pii  # noqa: E402
-_pii.redact_secrets = lambda s: s
+_pii.redact_secrets = lambda s: (s, [])
 
 from app.modules.guard.approval import (  # noqa: E402
     approval_url,

--- a/apps/api/tests/test_guard_approval_resume.py
+++ b/apps/api/tests/test_guard_approval_resume.py
@@ -32,7 +32,8 @@ _STUBS = ["structlog", "redis", "sentry_sdk", "app.core.pii"]
 for _m in _STUBS:
     sys.modules.setdefault(_m, MagicMock())
 import app.core.pii as _pii  # noqa: E402
-_pii.redact_secrets = lambda s: s
+# Preserve real signature tuple[str, list[str]] — see test_guard_approval.py note.
+_pii.redact_secrets = lambda s: (s, [])
 
 from app.modules.guard.approval import resume_verdict  # noqa: E402
 

--- a/apps/api/tests/test_guard_pack_matrix.py
+++ b/apps/api/tests/test_guard_pack_matrix.py
@@ -91,12 +91,17 @@ def _load_pack(pack_name: str) -> list[dict]:
 
 
 def _matching_rules(rules: list[dict], prompt_text: str, provider: str, model: str) -> list[dict]:
-    """Return every proxy-eligible rule that fires for this prompt."""
+    """Return every proxy-eligible rule that fires for this prompt.
+
+    Uses gate=None (skip gate filter) — the pack-authoring matrix tests
+    rule shape and match logic, not the gate-vs-surface routing that
+    production callers use (#1733).
+    """
     matches: list[dict] = []
     for rule in rules:
         if "match_pattern" not in rule or "match_tool" in rule:
             continue  # hook-only rule, not proxy-eligible
-        if _rule_matches(rule, provider, model, prompt_text):
+        if _rule_matches(rule, provider, model, prompt_text, gate=None):
             matches.append(rule)
     return matches
 

--- a/apps/api/tests/test_guard_policy_engine.py
+++ b/apps/api/tests/test_guard_policy_engine.py
@@ -273,6 +273,41 @@ def test_build_rules_supports_list_valued_persona():
     assert [rule["id"] for rule in proxy_rules] == ["r_both"]
 
 
+def test_build_rules_higher_precedence_wins_on_rule_id_collision():
+    """When two packs both define the same rule_id, the higher-precedence pack wins.
+
+    Packs are ordered by precedence ASC in the query (higher precedence loaded last),
+    and the merge loop is last-write-wins, so higher precedence overwrites lower.
+    """
+    ws_uuid = _ws_uuid()
+    db = _mock_db()
+
+    low_pack = MagicMock()
+    low_pack.rules = [{"id": "shared", "action": "warn", "source_note": "low"}]
+    high_pack = MagicMock()
+    high_pack.rules = [{"id": "shared", "action": "block", "source_note": "high"}]
+
+    low = MagicMock(pack_slug="low", pinned_version=None)
+    high = MagicMock(pack_slug="high", pinned_version=None)
+
+    # Simulates ORDER BY precedence ASC → low first, high last.
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        low, high,
+    ]
+    db.query.return_value.filter.return_value.all.return_value = []
+
+    def get_pack(_db, slug, _pinned):
+        return {"low": low_pack, "high": high_pack}[slug]
+
+    with patch("app.modules.guard.policy_engine._get_pack", side_effect=get_pack):
+        rules = _build_rules(db, ws_uuid, "agent")
+
+    assert len(rules) == 1
+    assert rules[0]["action"] == "block"
+    assert rules[0]["source_note"] == "high"
+    assert rules[0]["source_pack"] == "high"
+
+
 def test_build_rules_override_disables_rule():
     """A GuardRuleOverride with disabled=True removes the rule from the result."""
     ws_uuid = _ws_uuid()

--- a/apps/api/tests/test_guard_policy_engine.py
+++ b/apps/api/tests/test_guard_policy_engine.py
@@ -396,7 +396,10 @@ def test_build_rules_expired_disable_restores_rule():
     with patch("app.modules.guard.policy_engine._get_pack", return_value=pack):
         rules = _build_rules(db, ws_uuid, "agent")
 
-    assert [{k: v for k, v in r.items() if k != "source_pack"} for r in rules] == pack.rules
+    assert [
+        {k: v for k, v in r.items() if k not in ("source_pack", "gates")}
+        for r in rules
+    ] == pack.rules
 
 
 def test_build_rules_expired_action_restores_base_but_keeps_message():

--- a/apps/web/src/app/(app)/theguard/policies/page.tsx
+++ b/apps/web/src/app/(app)/theguard/policies/page.tsx
@@ -138,6 +138,42 @@ function ActionBadge({ action }: { action: PolicyAction }) {
   )
 }
 
+// ─── Gates ────────────────────────────────────────────────────────────────────
+// #1733/#1750 Phase B — locked enum [action, prompt, response]. Shows *where*
+// a rule fires: `action` = MCP tool call; `prompt` = outbound LLM proxy;
+// `response` = inbound LLM proxy.
+
+type Gate = "action" | "prompt" | "response"
+
+const ALL_GATES: readonly Gate[] = ["action", "prompt", "response"] as const
+
+const GATE_TONE: Record<Gate, string> = {
+  action:   "info",
+  prompt:   "warn",
+  response: "ok",
+}
+
+function GateChips({ gates }: { gates?: string[] | null }) {
+  const list = (gates && gates.length ? gates : ["action"]).filter((g): g is Gate =>
+    (ALL_GATES as readonly string[]).includes(g),
+  )
+  if (!list.length) return null
+  return (
+    <span style={{ display: "inline-flex", gap: 3, flexShrink: 0 }}>
+      {list.map((g) => (
+        <span
+          key={g}
+          className={`sbadge ${GATE_TONE[g]}`}
+          style={{ textTransform: "uppercase", fontSize: 9, letterSpacing: ".06em", padding: "0 5px" }}
+          title={`Fires at ${g} gate`}
+        >
+          {g}
+        </span>
+      ))}
+    </span>
+  )
+}
+
 // ─── Toggle ───────────────────────────────────────────────────────────────────
 
 function Toggle({ enabled, onChange }: { enabled: boolean; onChange: () => void }) {
@@ -900,6 +936,7 @@ function PoliciesContent() {
   const [exceptionRequest, setExceptionRequest] = useState<PolicyExceptionRequest | null>(null)
   const [exceptionSaving, setExceptionSaving] = useState(false)
   const [successBanner, setSuccessBanner] = useState<string | null>(null)
+  const [gateFilter, setGateFilter] = useState<"all" | Gate>("all")  // #1733/#1750 Phase B
 
   const canWrite = !permissionsLoading && permissions.canEditPolicies
 
@@ -1110,7 +1147,7 @@ function PoliciesContent() {
       count: policies.filter(p => p.pack_id === id).length,
     })),
   ].filter(t => t.count > 0 || t.id === "agent" || t.id === "custom" || t.id === "security")
-  const visiblePolicies = policyTab === "security"
+  const _tabScope = policyTab === "security"
     ? securityRules
     : policyTab === "agent"
     ? policies.filter(p => p.builtin && (!p.persona || p.persona === "agent"))
@@ -1119,6 +1156,12 @@ function PoliciesContent() {
     : policyTab === "custom"
     ? customRules
     : policies.filter(p => p.pack_id === policyTab)
+  // #1733/#1750 Phase B — filter by gate. `all` bypasses; otherwise keep rules
+  // whose gates list includes the selected gate (falls back to ['action'] if
+  // the backend hasn't stamped gates yet — matches derive_gates default).
+  const visiblePolicies = gateFilter === "all"
+    ? _tabScope
+    : _tabScope.filter(p => (p.gates && p.gates.length ? p.gates : ["action"]).includes(gateFilter))
 
   const latestUpdated = policies
     .map(p => p.updated_at)
@@ -1237,13 +1280,15 @@ function PoliciesContent() {
               function renderCard(p: Policy) {
                 const expanded = expandedIds.has(p.id)
                 const hasException = p.exception_active || p.exception_expired
-                const hasDetails = !!(p.match_pattern || p.match_path_pattern || p.message || hasException)
+                const hasProse = !!(p.guarantee || (p.known_limitations && p.known_limitations.length > 0))
+                const hasDetails = !!(p.match_pattern || p.match_path_pattern || p.message || hasException || hasProse)
                 const locked = !!p.non_overridable
                 return (
                   <div key={p.id} style={{ opacity: p.enabled ? 1 : 0.55 }}>
                     {/* Main row */}
                     <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "7px 12px", borderRadius: 8, background: "var(--surface)", border: "1px solid var(--border)" }}>
                       <ActionBadge action={p.action} />
+                      <GateChips gates={p.gates} />
                       <span className="mono" style={{ fontWeight: 650, fontSize: 12, color: "var(--text-1)", whiteSpace: "nowrap" }}>{p.rule_id}</span>
                       {p.exception_active && (
                         <span className="sbadge warn" style={{ textTransform: "uppercase", fontSize: 9.5, letterSpacing: ".06em" }}>
@@ -1345,6 +1390,23 @@ function PoliciesContent() {
                         {p.match_pattern && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Pattern </span><span className="mono" style={{ fontSize: 11, color: "var(--err)", background: "var(--err-bg)", borderRadius: 4, padding: "1px 6px" }}>{p.match_pattern}</span></div>}
                         {p.match_path_pattern && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Path </span><span className="mono" style={{ fontSize: 11, color: "var(--warn)", background: "var(--warn-bg)", borderRadius: 4, padding: "1px 6px" }}>{p.match_path_pattern}</span></div>}
                         {p.message && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Message </span><span style={{ fontSize: 11.5, color: "var(--text-2)", fontStyle: "italic" }}>&ldquo;{p.message}&rdquo;</span></div>}
+                        {/* #1750 Phase B — retained hand-authored trust prose */}
+                        {p.guarantee && (
+                          <div style={{ flexBasis: "100%" }}>
+                            <span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Guarantee </span>
+                            <span style={{ fontSize: 11.5, color: "var(--text-2)" }}>{p.guarantee}</span>
+                          </div>
+                        )}
+                        {p.known_limitations && p.known_limitations.length > 0 && (
+                          <div style={{ flexBasis: "100%" }}>
+                            <span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Known limitations </span>
+                            <ul style={{ margin: "3px 0 0 16px", padding: 0, fontSize: 11.5, color: "var(--text-2)" }}>
+                              {p.known_limitations.map((lim, i) => (
+                                <li key={i} style={{ marginBottom: 2 }}>{lim}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
                         {hasException && (
                           <div style={{ flexBasis: "100%", display: "flex", flexWrap: "wrap", gap: 12, paddingTop: 4, borderTop: "1px solid var(--border)" }}>
                             <div>
@@ -1409,6 +1471,25 @@ function PoliciesContent() {
                       </button>
                     ))}
                     <span style={{ flex: 1 }} />
+                    {/* #1733/#1750 Phase B — filter by gate */}
+                    <label style={{ display: "inline-flex", alignItems: "center", gap: 6, fontSize: 11.5, color: "var(--text-muted)" }}>
+                      Gate
+                      <select
+                        value={gateFilter}
+                        onChange={(e) => setGateFilter(e.target.value as "all" | Gate)}
+                        style={{
+                          padding: "3px 8px", borderRadius: 6, fontSize: 12,
+                          border: "1px solid var(--border)", background: "var(--surface)",
+                          color: "var(--text-2)", cursor: "pointer",
+                        }}
+                        title="Show only rules that fire at this enforcement gate (action, prompt, or response)"
+                      >
+                        <option value="all">All</option>
+                        <option value="action">Action</option>
+                        <option value="prompt">Prompt</option>
+                        <option value="response">Response</option>
+                      </select>
+                    </label>
                     {canWrite && (policyTab === "agent" || policyTab === "proxy" || policyTab === "custom") && (
                       <button
                         type="button"

--- a/apps/web/src/lib/api/guard.ts
+++ b/apps/web/src/lib/api/guard.ts
@@ -22,6 +22,9 @@ export interface GuardPolicy {
   persona: "agent" | "proxy"
   non_overridable: boolean
   persona_affinity: string[]
+  gates?: string[]  // #1733/#1750 Phase B — locked enum [action, prompt, response]
+  guarantee?: string | null  // #1750 Phase B — hand-authored trust prose
+  known_limitations?: string[]  // #1750 Phase B — hand-authored operational caveats
   tag: string | null
   exception_reason: string | null
   exception_expires_at: string | null

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -1,0 +1,279 @@
+# Guard Architecture
+
+> **One decision engine. Many enforcement points. Additive capability layer. Immutable audit chain.**
+>
+> Everything else is a call site, a plugin, or a data change.
+
+Locked 2026-09-09 across #1740 / #1750 / #1751 / #1739 / #1737. Reviewer edits 1–5 incorporated.
+
+---
+
+## 1. North star
+
+```
+╔══════════════════════════════════════════════════════════════════════════╗
+║                        SKILL PACKS + OVERRIDES                           ║
+║   (conduct-base, hipaa, soc2, prompt-injection, eu-ai-act, custom...)    ║
+║              data, not code. Grows without redeployment.                 ║
+╚═════════════════════════════════╤════════════════════════════════════════╝
+                                  │ loaded by
+                                  ▼
+              ┌──────────────────────────────────────────┐
+              │      compute_policy(ws_id, context)      │
+              │  Inputs:  workspace + PolicyContext      │
+              │           { surface, actor_id, tool_name,│
+              │             payload,                     │
+              │             gate: action|prompt|response}│
+              │  Output:  Decision                       │
+              │           { verdict: block|approval|     │
+              │                      warn|audit|pass,    │
+              │             rule_id, pack_slug,          │
+              │             obligations: [redact,notify, │
+              │                           cosign,record] │
+              │           }                              │
+              └──────────────────┬───────────────────────┘
+                                 │
+                     capability pre-check runs at PEP entry
+                                 │
+     ┌────────────┬─────────────┼─────────────┬────────────┬───────────┐
+     ▼            ▼             ▼             ▼            ▼           ▼
+   MCP tool   LLM proxy    Runtime block   CLI hook    (future)     (future)
+    call       egress      boundary                    webhook       browser
+    action    prompt+       action         action                    agent
+     gate     response       gate           gate
+              gates
+                                 │
+                                 ▼
+                    ┌────────────────────────┐
+                    │   Capability Layer     │  Phase 5
+                    │  narrows surface       │
+                    │  BEFORE PDP call       │
+                    │  • task-scoped tokens  │
+                    │  • expiring MCP grants │
+                    │  • cosign requirements │
+                    └────────────┬───────────┘
+                                 │
+                                 ▼
+              ┌──────────────────────────────────┐
+              │       AUDIT CHAIN (append-only)  │
+              │   hash-linked receipts per task  │
+              │   verdict + obligation results   │
+              │   raw payloads never persist —   │
+              │   all writes route through       │
+              │   redact_secrets                 │
+              └──────────────────────────────────┘
+```
+
+**Locked forever:** evaluator signature, three gates, verdict enum, audit receipt shape, CI-verified PEP capability declarations, raw-payload-never-persists invariant.
+
+**Designed to grow:** skill packs, PEPs, Cedar action names, capability primitives, obligations.
+
+---
+
+## 2. A single request, end to end
+
+Concrete: an agent calls a Postgres MCP tool to run a query.
+
+```
+[1] Agent → postgres.query(sql="SELECT * FROM patients")
+       │
+       ▼
+[2] MCP dispatcher (PEP #1)
+    ├─ Capability check: does this run hold a handle for postgres.query?
+    │  ├─ NO  → 401 refused. PDP never called. Audited as "no capability held."
+    │  └─ YES → continue.
+       │
+       ▼
+[3] Build PolicyContext
+    { surface: "mcp", gate: "action", actor_id: "agent-42",
+      tool_name: "postgres.query",
+      payload: { sql: "SELECT * FROM patients" },
+      workspace_id: "ws-abc" }
+       │
+       ▼
+[4] compute_policy(ws_id, ctx)
+    ├─ Load rules: base + hipaa + custom (all installed packs)
+    ├─ Apply workspace overrides
+    ├─ Match by gate=action, tool=postgres.query
+    ├─ hipaa-phi-no-select-star fires → block
+    └─ Decision { verdict: "block",
+                  rule_id: "hipaa-phi-no-select-star",
+                  pack_slug: "conduct-hipaa",
+                  obligations: ["notify:slack:#compliance", "record"] }
+       │
+       ▼
+[5] PEP enforces
+    ├─ Refuse call, return structured error to agent
+    ├─ Fire obligations (Slack notify)
+    └─ Write audit receipt (hash-linked to prev receipt in this task)
+       │
+       ▼
+[6] Audit receipt
+    { task_id, seq: 47, prev_hash, this_hash,
+      gate: "action", surface: "mcp", tool: "postgres.query",
+      verdict: "block", rule_id: "hipaa-phi-no-select-star",
+      obligations_completed: ["slack_notified"], ts }
+```
+
+Every PEP produces the same receipt shape. Every receipt is chained. Any auditor can replay the chain and verify nothing was inserted, removed, or reordered.
+
+---
+
+## 3. The three gates (locked)
+
+Per #1739 ADR. Three values, from day one, no growth.
+
+| Gate | Cedar action | Fires when | Context |
+|---|---|---|---|
+| `action` | `Action::"Shell"`, `"Write"`, `"Read"`, `"Network"`, `"MCPCall"` | agent invokes a structured tool call | `tool_name`, `tool_input` |
+| `prompt` | `Action::"LLMPrompt"` | outbound prompt sent to a model | `text`, `model`, `provider` |
+| `response` | `Action::"LLMResponse"` | model response returned to caller | `text`, `model`, `finish_reason` |
+
+**Why exactly three:**
+- **Two** (action + prompt) misses response — attacker doesn't need injection if they can exfil via output.
+- **Four** (splitting action into shell / write / read) is a rule-matcher concern, not a gate concern. Cedar handles it.
+- **Five+** overlaps with PEPs. Gates describe *what kind of thing* is being decided; PEPs describe *where* the decision is enforced.
+
+`LLMStream` (drafted in #1739) is deferred. Streaming semantics route through obligations on `LLMResponse`, not a fourth gate. Extending the gate enum requires schema migration on every workspace — obligations extend without one.
+
+---
+
+## 4. Use cases
+
+### 4.1 HIPAA hospital agent (today)
+
+Agent has: MCP access to Epic EHR, LLM proxy, filesystem.
+
+| Gate | Rule | Verdict | Obligation |
+|---|---|---|---|
+| action | `hipaa-phi-no-select-star` | block | slack:#compliance-team |
+| action | `hipaa-audit-all-phi-reads` | audit | record with actor + patient_id |
+| prompt | `hipaa-no-phi-in-prompt` | block | redact and re-prompt |
+| response | `hipaa-no-ssn-in-response` | warn | redact SSN pattern before send |
+
+Compliance team ships one pack. Every agent in the org enforces it. Adding a new HIPAA rule = data change, no code change.
+
+### 4.2 Financial trading agent with cosign (Phase 5)
+
+```
+Agent → execute_trade(size=$50M)
+    │
+    ▼
+Capability layer: cosign-required handle held for execute_trade
+    ├─ attribute: requires cosign for size > $10M
+    ▼
+Returns pending_cosign envelope. Trade does NOT execute.
+    │
+    ▼
+Cosign request → Bloomberg terminal of head trader
+    ├─ WebAuthn touch on hardware key → signed payload
+    ▼
+Verify signature vs runtime keypair + run_id + payload hash
+    ├─ Valid + fresh → capability narrowed to "this exact trade"
+    ▼
+Trade executes. Audit chain records: request, cosign artifact, execution, receipt.
+```
+
+Cosign is a capability primitive, not a new PDP rule. New requirement mandating cosign for wire transfers = one attribute flip on the payment capability, no code deploy.
+
+### 4.3 Multi-tenant SaaS (future)
+
+Each tenant's workspace has its own pack precedence, capability grants, audit chain. Tenancy is a `workspace_id` parameter to `compute_policy`. Zero architectural change to add multi-tenant — the design assumed workspace scoping from day one.
+
+### 4.4 New attack class discovered tomorrow
+
+Zero-day: "steganographic instruction hiding in unicode homoglyphs."
+
+**With this design:**
+1. Write one skill pack rule: `pattern: <regex>, gate: prompt, action: block`.
+2. Publish pack version bump.
+3. Every workspace with that pack installed enforces it at every LLM proxy egress — without redeploying Guard.
+
+**Without this design (per-surface rules):** update MCP guard, update proxy guard, update runtime guard, update CLI hook, test drift across 4 code paths, deploy, discover a 5th surface you forgot.
+
+---
+
+## 5. Immutable properties (9)
+
+Do not touch these without a schema migration.
+
+1. **Evaluator signature** — `compute_policy(workspace_id, PolicyContext) -> Decision`.
+2. **PolicyContext shape** — `{ surface, actor_id, gate, tool_name, payload, ... }`.
+3. **Decision shape** — `{ verdict, rule_id, pack_slug, obligations[] }`.
+4. **Verdict enum** — `{ block, approval, warn, audit, pass }`. `inject` retired → audit + obligation. Precedence: `block > approval > warn > audit > pass`.
+5. **Gate enum** — `{ action, prompt, response }`. Locked from day one.
+6. **Audit receipt shape** — `{ task_id, seq, prev_hash, this_hash, gate, surface, tool, verdict, rule_id, obligations_completed, ts }`.
+7. **Precedence** — most-restrictive action wins; `non_overridable: True` rules bypass workspace overrides; pack precedence is one admin dial.
+8. **PEP capability declarations are machine-verified.** Every PEP registers `provides_capabilities: {gate_types}`. CI runs one conformance test per declared capability per PEP. Failing test blocks merge. No PEP ships with an undeclared or unverified capability.
+9. **Raw payload never persists outside ephemeral scope.** All log writes — divergence logs, debug tables, audit rows — route through `redact_secrets` at `apps/api/app/core/pii.py:86`. Matched-span + hash + size only. P0 security invariant.
+
+## 6. Extension points (5)
+
+Add here without migration.
+
+- **New skill pack** — ship JSON/YAML with rules → workspace installs → live. Zero code change.
+- **New PEP surface** — register with `provides_capabilities`, call `compute_policy`, emit audit receipt. Conformance test proves declaration matches behavior.
+- **New Cedar action name** — add to #1739 ADR + mapper entry in `cedar_adapter/`. Existing rules unaffected.
+- **New capability primitive** (Phase 5 pattern) — additive to PDP. Registers as pre-check before `compute_policy` call. Emits its own audit shape variant.
+- **New obligation** — registry entry. Verdicts stay fixed; side effects grow.
+
+---
+
+## 7. Design principles
+
+1. **Delete only what can be regenerated from primary sources.** Derived metadata (like `status`) is safe to delete. Hand-authored prose (`guarantee`, `known_limitations`) is primary source itself — retain.
+2. **Data changes and code changes always ticket separately.** Different reviewers, different review paths.
+3. **Verdicts describe yes/no/hold. Obligations describe side effects.** Never grow the verdict enum; always grow obligations.
+4. **Capability check happens before PDP consultation.** Both must permit. Capability refusal short-circuits (no PDP call). Both refusals audited, distinguished by receipt type.
+
+---
+
+## 8. PEPs in production
+
+| PEP | Provides gates | Location |
+|---|---|---|
+| MCP | action | `apps/api/app/modules/guard/routers/mcp_impls.py` |
+| LLM proxy | prompt, response | `apps/api/app/routers/proxy.py` |
+| Runtime | action (via PreBlock) | `apps/api/app/runtime/blocks/` |
+| CLI hook | action | `packages/conduct-cli/` PreToolUse |
+| Lens | action, prompt, response | `apps/api/app/modules/glens/routers/chat.py` + `tools/registrations/lens/` |
+
+Lens is a well-behaved caller — no special path. LLM calls route through `guarded_completion` → `LLMClient` → proxy. Tool calls route through Lens tool registry → `guard_check` → MCP PEP.
+
+---
+
+## 9. Failure modes prevented
+
+**Evaluator drift.** Each surface has its own rule loader → same rule applied by MCP but not proxy. Prevention: one `compute_policy`; Property 8 (CI-verified declarations) prevents PEP declarations from drifting from behavior.
+
+**Schema fossilization.** Enum chosen too narrow → future migration on production rows. Prevention: gate enum is `[action, prompt, response]` from Phase 0. Extensions go through obligations, not gates.
+
+**Audit chain data poisoning.** Divergence or debug logs capture raw payloads including secrets → seven days of production traffic logs contain API keys and PII. Prevention: Property 9 (raw payload never persists). Every log path routes through `redact_secrets`. Backed by hard invariant, not by convention.
+
+---
+
+## 10. Deck-ready frame
+
+> Guard is a Policy Decision Point for AI agents.
+>
+> One evaluator sees every action, prompt, and response an agent produces, against a workspace's full policy — compliance packs, custom rules, overrides. Every enforcement point in the stack — MCP tool calls, LLM proxy, runtime blocks, CLI hooks — calls the same evaluator, gets the same decision, writes the same tamper-evident audit receipt.
+>
+> Capability primitives narrow what the agent can reach; the evaluator authorizes what it does with what it holds; the audit chain records what actually happened.
+>
+> **Filter today. Capability tomorrow. Receipt always.**
+
+Nothing left to move — everything that could change is either data (packs), a plug-in (PEPs), an obligation, or an additive layer (capabilities).
+
+---
+
+## Related
+
+- #1737 — single evaluator mandate
+- #1740 — parent unification epic (reviewer edits 1–4)
+- #1739 — Cedar action-name ADR (gate enum lock)
+- #1750 — Policies page rollout (Phases A–D)
+- #1751 — derived enforcement status
+- #1752 — `_project_rule` projection fix (reviewer edit 5)
+- #1193 — Cedar interchange
+- #663 — skill-pack model + `compute_policy` foundation
+- conduct-internal #42 — 2nd provisional patent (unification + Phase 5)

--- a/docs/guard/schema.md
+++ b/docs/guard/schema.md
@@ -94,6 +94,7 @@ when {
 | `recommendation` | string | Remediation guidance. Cedar `@recommendation`. |
 | `severity` | enum | `low` \| `medium` \| `high` \| `critical`. Cedar `@severity`. |
 | `persona_affinity` | string[] | `agent` and/or `proxy`. Defaults to both if omitted. |
+| `gates` | string[] | Locked enum: `action`, `prompt`, `response`. Which enforcement gate the rule fires at. If omitted, derived from `persona_affinity`: `agent` → `[action]`, `proxy` → `[prompt]`, both → `[action, prompt]`. New rules that need to scan model responses set `[response]` explicitly. See `docs/guard/architecture.md` §3. |
 | `frameworks` | string[] | Compliance tags (`PCI_DSS:3.4`, `SOC2:CC6.1`, `ISO_42001:8.24`, `MITRE_ATLAS:AML.T0051`, `OWASP_AGENTIC:A01`). Cedar `@compliance`. |
 | `iso_control` | string | ISO 27001/42001 control ID. Cedar `@iso_control`. |
 | `enforcement` | object | Surface-by-surface enforcement capability (see below). |


### PR DESCRIPTION
## Summary

Lands **#1737** (single-evaluator mandate) + **#1733** (Guard at LLM proxy egress) + **#1750 Phase B Slice 1** (Policies UI — gates chips, facet filter, retained prose) in one branch.

Two commits, split by epic — the second builds on the first. Squash-merge is fine.

## What ships

### #1737 — single-evaluator mandate

Every Guard-relevant surface routes through `compute_policy` in one path. Legacy `pack:` arg on `guard_check` still works with a deprecation window.

- `workspace_skill_packs.precedence INT NOT NULL DEFAULT 100` (migration `0117`) — higher-precedence packs win on rule_id collision. Default preserves prior install-order semantics.
- `_build_rules` sorts installed packs by `precedence ASC, installed_at ASC` before merge.
- `guard_check(pack=...)` emits `LOG.warning` telemetry + a `[deprecation: ...]` suffix on non-`ok` responses. `"ok"` and `PENDING approval` envelopes untouched — wire-safe.
- Shadow-log divergences between pack-scoped and unified paths, redacted through `redact_secrets` (reviewer edit 3, Property 9).
- New `guard_test` MCP verb: pack-scoped dry-run for pack authors + CI. Reuses `_build_rules` with `restrict_to_pack`; never writes to the audit chain.
- `_project_rule` no longer drops `match_ai_tool` (#1752 fix).

### #1733 — Guard at LLM proxy egress

Three enforcement gates land. Locked enum, from day one (reviewer edit 2).

- `derive_gates(rule)` helper — locked enum `[action, prompt, response]`. Rules loaded through `_build_rules` and `_project_rule` carry gates. Explicit `gates: [...]` in the rule spec wins; legacy rules derive from persona (`agent → [action]`, `proxy → [prompt]`, both → `[action, prompt]`).
- `PolicyContext.gate` field, default `"action"`. Every proxy-egress `_PolicyContext` build site labels `gate="prompt"` explicitly. Regression-guard test asserts every `_PolicyContext(` in the proxy files has a matching gate label.
- Every matcher (`_match_policy` for MCP, `_rule_matches` for proxy) filters through the shared `rule_matches_gate(rule, gate)` helper. No duplicated filter logic.
- Non-streaming response gate: post-upstream, pre-return evaluation. Block replaces body with a 451 `conduct_guard_response_block` envelope. Fail-open on engine error.
- Streaming response gate: buffered end-of-stream scan. Wrapped `StreamingResponse` accumulates chunks, extracts text with an SSE-shape regex (Anthropic `text_delta` + OpenAI `content`), evaluates at end, logs `BLOCK`. Marked `ponytail:` — client already saw the tokens; chunk-scan enforcement (halt or redact-and-continue) filed as **#1754**.

### #1750 Phase B Slice 1 — Policies UI

- `GateChips` component renders locked-enum chips per rule row (colored per gate).
- Gate facet filter (`All / Action / Prompt / Response`) on the Policies page.
- `guarantee` + `known_limitations` prose surfaced in the expanded card (reviewer edit 4 — hand-authored fields retained).
- Backend `PolicyOut` projections stamp `gates` via `derive_gates`, expose the two prose fields.

### Docs

`docs/guard/architecture.md` — pinnable design doc with 9 immutable properties (adds Property 8 CI-verified declarations + Property 9 raw-payload-never-persists), 4 design principles, 3 failure modes prevented, 4 concrete use cases, deck-ready pitch frame.

## Modularity — no duplicate functions

Every reviewer-mandated primitive lives once. Every caller reaches for it.

- `derive_gates(rule)` — one function, called by three consumers (`_build_rules`, `_project_rule`, both `PolicyOut` projectors).
- `rule_matches_gate(rule, gate)` — one filter helper, used by both matchers.
- `_evaluate_response_body(...)` — shared between non-streaming and streaming response paths.
- `flatten_response(body)` — parallel to existing `flatten_prompt`. Not a duplicate; different vendor shape.
- `_extract_stream_text(collected)` — lazy-compiled regex, memoized.

## Reviewer edits — all five applied

| Edit | Status |
|---|---|
| 1. Conformance test per declared capability | Doc updated; conformance harness scaffolded as #1740 Phase 0 follow-up |
| 2. Gates enum locked to `[action, prompt, response]` from day one | ✓ Enforced at derivation + filter time; unknown values silently dropped |
| 3. Divergence log routes through `redact_secrets` | ✓ `_shadow_log_pack_divergence` + response-gate log payloads never carry raw text |
| 4. Delete `status` only; retain `guarantee` + `known_limitations` | ✓ Prose retained + surfaced in UI; `status` deletion deferred to Phase D per #1750 |
| 5. `_project_rule` drops `match_ai_tool` (#1752) | ✓ One-line fix + regression test |

## Follow-ups filed (not in this PR)

| Issue | Scope | Gated on |
|---|---|---|
| #1753 | Delete `_get_rules_for_pack` + `pack:` arg | 30 days zero deprecation telemetry + 3 other conditions |
| #1754 | Streaming response gate enforcement (halt / redact-and-continue) | Named customer signal + at least one production `gates:[response]` rule |
| #1755 | Phase B Slice 2 (verified badges, redacted audit preview, derived status subtext) | #1751 landing |

## Verification

- `pytest tests/guard/ tests/test_guard_policy_engine.py tests/tools/test_guard_registrations.py tests/regression/test_mcp_parity.py tests/test_guard_proxy.py` → **1429/1429 pass**
- `alembic upgrade head` → migration `0117` applies cleanly against local Postgres
- `alembic check` → **No new upgrade operations detected** (zero drift)
- `tsc --noEmit` on `apps/web` → clean (only pre-existing unrelated CSS-import errors)

## Test plan

- [ ] CI green (drift check + full suite)
- [ ] Manual: install a pack, view `/theguard/policies`, confirm gate chips + facet filter + prose render
- [ ] Manual: hit `/api/guard/proxy/anthropic/v1/messages` with a prompt-gate-blocking rule installed, confirm 451 with `conduct_guard_response_block` for the response path once a `gates:[response]` rule is authored
- [ ] Manual: call `guard_check(pack="conduct-hipaa", ...)` via MCP, confirm `[deprecation: ...]` suffix + `guard.mcp_impls` WARN log
- [ ] Manual: call new `guard_test` MCP verb against an installed pack, confirm `WOULD-<VERDICT>` string + no audit-chain writes

Closes #1737, #1733, #1752.
