### PR TITLE
feat(guard): derived enforcement status + pack coverage matrix + endpoint (#1751)

### DIFF
--- a/apps/api/app/modules/guard/coverage.py
+++ b/apps/api/app/modules/guard/coverage.py
@@ -5,10 +5,16 @@ import uuid
 from datetime import datetime, timezone
 from typing import Any
 
+import structlog
 from sqlalchemy.orm import Session
 
+log = structlog.get_logger(__name__)
+
 from app.modules.guard.enforcement import (
+    GATES,
     conservative_custom_enforcement,
+    derive_gates,
+    derive_surface_status,
     rule_personas,
     validate_enforcement_metadata,
 )
@@ -17,6 +23,7 @@ from app.modules.guard.models import (
     WorkspaceCustomRule,
     WorkspaceSkillPack,
 )
+from app.modules.guard.pep_registry import all_surfaces
 from app.modules.guard.policy_engine import (
     VALID_ACTIONS,
     _get_pack,
@@ -105,6 +112,27 @@ def workspace_coverage_matrix(db: Session, workspace_id: uuid.UUID) -> list[dict
         personas = sorted(rule_personas(rule))
         if not rule.get("_builtin") and rule.get("_custom_persona"):
             personas = [rule["_custom_persona"]]
+
+        # #1751 PR 4: log divergence between hand-authored enforcement.<surface>
+        # and derive_surface_status(rule, surface). Telemetry for #1750 Phase D
+        # cleanup — every 'not_supported' claim that's actually 'hard' (or vice
+        # versa) points at a rule whose hand-authored metadata is stale.
+        for _surface in ("proxy", "hook", "mcp", "runtime"):
+            _authored = metadata.get(_surface)
+            _derived = derive_surface_status(rule, _surface)
+            # 'conditional' and 'advisory' are deploy-caveat statuses derived
+            # doesn't model yet; only flag hard↔not_supported flips.
+            if _authored in ("hard", "not_supported") and _authored != _derived:
+                log.warning(
+                    "guard.coverage.status_divergence",
+                    rule_id=rule_id,
+                    pack=rule.get("_pack_slug"),
+                    surface=_surface,
+                    authored=_authored,
+                    derived=_derived,
+                    note="#1750 Phase D: authored value is stale; derived is authoritative",
+                )
+
         matrix.append({
             "rule_id": rule_id,
             "name": rule.get("name") or rule.get("description") or rule_id,
@@ -133,3 +161,64 @@ def workspace_coverage_matrix(db: Session, workspace_id: uuid.UUID) -> list[dict
         matrix,
         key=lambda item: (item["pack"] or "~custom", item["pack_version"] or "", item["rule_id"]),
     )
+
+
+def pack_coverage_matrix(db: Session, pack_slug: str) -> dict[str, Any]:
+    """#1751 PR 3 — return per-surface × per-gate rule counts for a pack.
+
+    Answers the Policies UI question "does this pack cover response-gate
+    leakage on the proxy?" in one call.
+
+    Shape::
+        {
+            "pack": "conduct-hipaa",
+            "version": "1.4.2",
+            "total_rules": 42,
+            "by_surface": {
+                "mcp":     {"hard": 27, "not_supported": 15},
+                "proxy":   {"hard": 12, "not_supported": 30},
+                "runtime": {"hard": 27, "not_supported": 15},
+                "hook":    {"hard": 27, "not_supported": 15},
+            },
+            "by_gate": {"action": 30, "prompt": 10, "response": 2},
+        }
+
+    Missing pack → ``{"pack": pack_slug, "version": None, "total_rules": 0,
+    "by_surface": {surface: {"hard": 0, "not_supported": 0} ...},
+    "by_gate": {gate: 0 ...}}`` so UI callers can render an empty state
+    without a null check.
+    """
+    surfaces = all_surfaces()
+    empty_by_surface = {s: {"hard": 0, "not_supported": 0} for s in surfaces}
+    empty_by_gate = {g: 0 for g in GATES}
+
+    pack = _get_pack(db, pack_slug, pinned_version=None)
+    if pack is None:
+        return {
+            "pack": pack_slug,
+            "version": None,
+            "total_rules": 0,
+            "by_surface": empty_by_surface,
+            "by_gate": empty_by_gate,
+        }
+
+    by_surface = {s: {"hard": 0, "not_supported": 0} for s in surfaces}
+    by_gate = {g: 0 for g in GATES}
+    total = 0
+    for rule in pack.rules or []:
+        total += 1
+        for gate in derive_gates(rule):
+            if gate in by_gate:
+                by_gate[gate] += 1
+        for surface in surfaces:
+            status = derive_surface_status(rule, surface)
+            key = status if status in by_surface[surface] else "not_supported"
+            by_surface[surface][key] += 1
+
+    return {
+        "pack": pack_slug,
+        "version": pack.version,
+        "total_rules": total,
+        "by_surface": by_surface,
+        "by_gate": by_gate,
+    }

--- a/apps/api/app/modules/guard/enforcement.py
+++ b/apps/api/app/modules/guard/enforcement.py
@@ -82,6 +82,33 @@ def rule_matches_gate(rule: dict[str, Any], gate: str) -> bool:
     return gate in gates
 
 
+def derive_surface_status(rule: dict[str, Any], surface: str) -> str:
+    """#1751 PR 2 — return whether a PEP surface can enforce a given rule.
+
+    Reads:
+      - rule.gates (derived on load — see derive_gates)
+      - pep_registry.PEP_CAPABILITIES[surface]
+
+    Returns:
+      - ``"hard"``           — intersection non-empty; PEP declares it can
+                                evaluate at least one gate the rule fires at.
+      - ``"not_supported"``  — no overlap OR unknown surface.
+
+    ``"conditional"`` and ``"advisory"`` are deploy-caveat concepts (a PEP
+    can technically evaluate but only under certain conditions, e.g. the
+    agent must voluntarily call guard_check). Those stay as hand-authored
+    fields on ``rule.enforcement`` until Phase D retires them; this helper
+    only reports the capability-declaration status.
+    """
+    from app.modules.guard.pep_registry import pep_provides
+
+    pep_gates = pep_provides(surface)
+    if not pep_gates:
+        return "not_supported"
+    rule_gates = set(rule.get("gates") or derive_gates(rule))
+    return "hard" if pep_gates & rule_gates else "not_supported"
+
+
 def validate_enforcement_metadata(rule: dict[str, Any]) -> None:
     """Validate one rule's strict rule-level enforcement contract."""
     rule_id = rule.get("id") or rule.get("rule_id") or "(unknown)"

--- a/apps/api/app/modules/guard/pep_registry.py
+++ b/apps/api/app/modules/guard/pep_registry.py
@@ -1,0 +1,55 @@
+"""PEP capability registry (#1751 PR 1).
+
+Each Policy Enforcement Point (MCP tool call, LLM proxy egress, runtime
+block boundary, CLI hook) declares which enforcement gates it can evaluate.
+This registry is the source of truth Property 8 (of the pinnable Guard
+architecture doc, §5) refers to as "PEP `provides_capabilities` declarations
+machine-verified in CI."
+
+The drift test in tests/guard/test_pep_registry.py locks the shape against
+the architecture doc — a PEP silently changing what it enforces will fail
+the test until either the code or the doc is updated deliberately.
+
+Downstream consumers:
+    derive_surface_status(rule, surface)     — #1751 PR 2
+    pack_coverage_matrix(pack_slug)          — #1751 PR 3
+    Policies UI verified badges              — #1750 Phase B Slice 2 (#1755)
+"""
+from __future__ import annotations
+
+from app.modules.guard.enforcement import GATES
+
+# The four surfaces documented today in apps/api/app/modules/guard/routers/
+# and packages/conduct-cli/. Lens is a well-behaved caller through MCP + proxy
+# per docs/guard/architecture.md §8 — no separate row.
+Surface = str  # one of PEP_CAPABILITIES.keys()
+
+PEP_CAPABILITIES: dict[Surface, frozenset[str]] = {
+    "mcp":     frozenset({"action"}),
+    "proxy":   frozenset({"prompt", "response"}),
+    "runtime": frozenset({"action"}),
+    "hook":    frozenset({"action"}),  # CLI pre-tool-use hook
+}
+
+
+def pep_provides(surface: str) -> frozenset[str]:
+    """Return the gates a PEP declares it can evaluate. Unknown surfaces
+    return the empty set — treat as `not_supported`."""
+    return PEP_CAPABILITIES.get(surface, frozenset())
+
+
+def all_surfaces() -> tuple[str, ...]:
+    """Ordered surface list — stable projection order for coverage matrices."""
+    return ("mcp", "proxy", "runtime", "hook")
+
+
+# Every declared gate must be a member of the locked GATES enum. Ratchet
+# enforced at import: adding a new value to a PEP set that isn't in GATES
+# fails fast at process start, not at run time.
+for _surface, _gates in PEP_CAPABILITIES.items():
+    _unknown = _gates - set(GATES)
+    if _unknown:
+        raise ValueError(
+            f"PEP_CAPABILITIES['{_surface}'] declares unknown gates {sorted(_unknown)} "
+            f"outside the locked GATES enum {GATES}"
+        )

--- a/apps/api/app/modules/guard/routers/policies.py
+++ b/apps/api/app/modules/guard/routers/policies.py
@@ -184,6 +184,26 @@ class PolicyGenerateOut(BaseModel):
     message: str
 
 
+class PackSurfaceCounts(BaseModel):
+    """Rule count per {hard, not_supported} for one PEP surface (#1751 PR 3)."""
+    hard: int = 0
+    not_supported: int = 0
+
+
+class PackCoverageMatrixOut(BaseModel):
+    """Per-pack coverage summary: rules per surface × per gate.
+
+    Response of ``GET /guard/policies/packs/{slug}/coverage-matrix`` (#1751 PR 5).
+    Feeds the pack-detail coverage table in the Policies UI (#1750 Phase B
+    Slice 2 / #1755).
+    """
+    pack: str
+    version: Optional[str] = None
+    total_rules: int
+    by_surface: dict[str, PackSurfaceCounts]
+    by_gate: dict[str, int]
+
+
 class EnforcementCoverageOut(BaseModel):
     rule_id: str
     name: str
@@ -748,6 +768,27 @@ def get_enforcement_coverage(
 ):
     """Generated enforcement matrix for the workspace's resolved policy sources."""
     return workspace_coverage_matrix(db, _ws_uuid(workspace_id))
+
+
+@router.get("/packs/{pack_slug}/coverage-matrix", response_model=PackCoverageMatrixOut)
+def get_pack_coverage_matrix(
+    pack_slug: str,
+    db: Session = Depends(get_db),
+    _workspace_id: str = Depends(get_workspace_id),
+    _: str = Depends(require_permission("guard.policies.view")),
+) -> PackCoverageMatrixOut:
+    """#1751 PR 5 — per-pack surface × gate coverage summary.
+
+    Answers "does conduct-hipaa cover response-gate leakage on the proxy?"
+    without walking every rule client-side. Feeds the Policies UI pack
+    detail table.
+
+    Missing pack returns a zero-filled envelope so callers can render an
+    empty state without null checks.
+    """
+    from app.modules.guard.coverage import pack_coverage_matrix
+
+    return PackCoverageMatrixOut(**pack_coverage_matrix(db, pack_slug))
 
 
 @router.post("", response_model=PolicyOut, status_code=201)

--- a/apps/api/tests/guard/test_coverage_divergence_log.py
+++ b/apps/api/tests/guard/test_coverage_divergence_log.py
@@ -1,0 +1,162 @@
+"""#1751 PR 4 — workspace_coverage_matrix logs divergence between the
+hand-authored enforcement.<surface> string and derive_surface_status.
+
+Purpose: telemetry for the #1750 Phase D cleanup — every divergence points
+at a rule whose hand-authored metadata is stale. This test doesn't change
+the return schema (that's a follow-up); it only proves the warn-log fires.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+from app.modules.guard.coverage import workspace_coverage_matrix
+
+
+def _installed_pack(slug: str = "conduct-fake", version: str = "1.0.0"):
+    p = MagicMock()
+    p.pack_slug = slug
+    p.pinned_version = None
+    return p
+
+
+def _pack_object(rules, version="1.0.0", slug="conduct-fake"):
+    obj = MagicMock()
+    obj.slug = slug
+    obj.version = version
+    obj.rules = rules
+    return obj
+
+
+def _authored(surface_map: dict[str, str]) -> dict:
+    """Minimum enforcement metadata dict validate_enforcement_metadata accepts."""
+    base = {
+        "version": 1,
+        "proxy": "not_supported",
+        "hook": "not_supported",
+        "mcp": "not_supported",
+        "runtime": "not_supported",
+        "guarantee": "test",
+        "requires": [],
+        "known_limitations": [],
+    }
+    base.update(surface_map)
+    return base
+
+
+def _make_db(rules: list[dict]):
+    db = MagicMock()
+    # installed WorkspaceSkillPack query
+    db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+        _installed_pack(),
+    ]
+    # custom rules + overrides — return empty for both
+    db.query.return_value.filter.return_value.all.return_value = []
+    return db
+
+
+def test_no_divergence_no_warning():
+    """Agent-persona action-gate rule with hand-authored surface statuses
+    that match derived reality → no warning."""
+    rule = {
+        "id": "action-only",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        # Correct claims: proxy=not_supported (proxy doesn't do action gate),
+        # mcp/hook/runtime=hard (they all do action gate).
+        "enforcement": _authored({
+            "proxy": "not_supported",
+            "mcp": "hard",
+            "hook": "hard",
+            "runtime": "hard",
+        }),
+    }
+    db = _make_db([rule])
+    calls = []
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([rule]),
+    ), patch("app.modules.guard.coverage.validate_enforcement_metadata"), \
+       patch("app.modules.guard.coverage.log.warning",
+             side_effect=lambda event, **kw: calls.append((event, kw))):
+        workspace_coverage_matrix(db, uuid.uuid4())
+
+    assert not any(ev == "guard.coverage.status_divergence" for ev, _ in calls)
+
+
+def test_hard_authored_but_derived_not_supported_logs():
+    """Rule with `enforcement.proxy: 'hard'` but gates=['action'] can't
+    actually be enforced on proxy → warn."""
+    rule = {
+        "id": "stale-hard",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": _authored({"proxy": "hard"}),
+    }
+    db = _make_db([rule])
+    calls = []
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([rule]),
+    ), patch("app.modules.guard.coverage.validate_enforcement_metadata"), \
+       patch("app.modules.guard.coverage.log.warning",
+             side_effect=lambda event, **kw: calls.append((event, kw))):
+        workspace_coverage_matrix(db, uuid.uuid4())
+
+    divergences = [kw for ev, kw in calls if ev == "guard.coverage.status_divergence"]
+    proxy_divergence = next(d for d in divergences if d["surface"] == "proxy")
+    assert proxy_divergence["rule_id"] == "stale-hard"
+    assert proxy_divergence["authored"] == "hard"
+    assert proxy_divergence["derived"] == "not_supported"
+
+
+def test_conditional_authored_never_logs():
+    """'conditional' and 'advisory' are deploy-caveat statuses that
+    derive_surface_status doesn't model — skip them, don't warn."""
+    rule = {
+        "id": "conditional-rule",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": _authored({
+            "mcp": "conditional",   # deploy-caveat, should not trigger warn
+            "hook": "hard",
+            "runtime": "hard",
+            "requires": ["agent calls guard_check"],
+        }),
+    }
+    db = _make_db([rule])
+    calls = []
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([rule]),
+    ), patch("app.modules.guard.coverage.validate_enforcement_metadata"), \
+       patch("app.modules.guard.coverage.log.warning",
+             side_effect=lambda event, **kw: calls.append((event, kw))):
+        workspace_coverage_matrix(db, uuid.uuid4())
+
+    assert not any(ev == "guard.coverage.status_divergence" for ev, _ in calls)
+
+
+def test_return_shape_unchanged():
+    """Non-goal in this PR: change what the API returns. Verify the
+    existing keys still land."""
+    rule = {
+        "id": "shape-check",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": _authored({"mcp": "hard"}),
+    }
+    db = _make_db([rule])
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([rule]),
+    ), patch("app.modules.guard.coverage.validate_enforcement_metadata"):
+        matrix = workspace_coverage_matrix(db, uuid.uuid4())
+
+    row = matrix[0]
+    for key in ("proxy", "hook", "mcp", "runtime", "guarantee", "requires", "known_limitations"):
+        assert key in row, f"expected key {key} still present"

--- a/apps/api/tests/guard/test_derive_surface_status.py
+++ b/apps/api/tests/guard/test_derive_surface_status.py
@@ -1,0 +1,83 @@
+"""#1751 PR 2 — derive_surface_status.
+
+Reads rule.gates × PEP_CAPABILITIES[surface] and returns "hard" if there's
+an overlap, "not_supported" otherwise. Legacy hand-authored "conditional"
+and "advisory" statuses are OUT of scope — this helper reports only the
+declared-capability status per Property 8.
+"""
+from __future__ import annotations
+
+from app.modules.guard.enforcement import derive_surface_status
+
+
+# ── proxy surface — evaluates prompt + response gates ──────────────────
+
+def test_proxy_supports_prompt_gate_rule():
+    rule = {"gates": ["prompt"]}
+    assert derive_surface_status(rule, "proxy") == "hard"
+
+
+def test_proxy_supports_response_gate_rule():
+    rule = {"gates": ["response"]}
+    assert derive_surface_status(rule, "proxy") == "hard"
+
+
+def test_proxy_does_not_support_pure_action_gate_rule():
+    rule = {"gates": ["action"]}
+    assert derive_surface_status(rule, "proxy") == "not_supported"
+
+
+def test_proxy_supports_dual_gate_rule_on_any_overlap():
+    """[action, prompt] rule → proxy sees the prompt half."""
+    rule = {"gates": ["action", "prompt"]}
+    assert derive_surface_status(rule, "proxy") == "hard"
+
+
+# ── mcp / runtime / hook — evaluate action gate only ───────────────────
+
+def test_mcp_supports_action_gate():
+    rule = {"gates": ["action"]}
+    assert derive_surface_status(rule, "mcp") == "hard"
+
+
+def test_mcp_does_not_support_prompt_gate():
+    rule = {"gates": ["prompt"]}
+    assert derive_surface_status(rule, "mcp") == "not_supported"
+
+
+def test_runtime_supports_action_gate():
+    rule = {"gates": ["action"]}
+    assert derive_surface_status(rule, "runtime") == "hard"
+
+
+def test_hook_supports_action_gate():
+    rule = {"gates": ["action"]}
+    assert derive_surface_status(rule, "hook") == "hard"
+
+
+# ── unknown surfaces + missing gates ──────────────────────────────────
+
+def test_unknown_surface_is_not_supported():
+    rule = {"gates": ["action"]}
+    assert derive_surface_status(rule, "carrier-pigeon") == "not_supported"
+
+
+def test_legacy_rule_without_gates_derives_from_persona():
+    """When gates aren't stamped, derive_gates fills in from persona."""
+    agent_rule = {"persona": "agent"}
+    proxy_rule = {"persona": "proxy"}
+    assert derive_surface_status(agent_rule, "mcp") == "hard"
+    assert derive_surface_status(agent_rule, "proxy") == "not_supported"
+    assert derive_surface_status(proxy_rule, "proxy") == "hard"
+    assert derive_surface_status(proxy_rule, "mcp") == "not_supported"
+
+
+def test_no_conditional_or_advisory_returned():
+    """PR 2 scope: only 'hard' or 'not_supported'. Conditional and advisory
+    stay hand-authored on rule.enforcement until Phase D."""
+    for gates in (["action"], ["prompt"], ["response"], ["action", "prompt"], []):
+        for surface in ("mcp", "proxy", "runtime", "hook", "unknown"):
+            status = derive_surface_status({"gates": gates}, surface)
+            assert status in ("hard", "not_supported"), (
+                f"surface={surface} gates={gates} → {status}"
+            )

--- a/apps/api/tests/guard/test_pack_coverage_endpoint.py
+++ b/apps/api/tests/guard/test_pack_coverage_endpoint.py
@@ -1,0 +1,86 @@
+"""#1751 PR 5 — GET /guard/policies/packs/{slug}/coverage-matrix endpoint.
+
+Wires PackCoverageMatrixOut over the pack_coverage_matrix helper. Auth
+via require_permission("guard.policies.view") — conftest.py stubs the
+permission check to a noop, so we can hit the endpoint directly.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _client():
+    from app.main import app
+    from app.core.database import get_db
+    from app.core.auth import get_workspace_id, get_user_id
+
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+    app.dependency_overrides[get_workspace_id] = lambda: "ws-abc"
+    app.dependency_overrides[get_user_id] = lambda: "user_test"
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def _clear():
+    from app.main import app
+    app.dependency_overrides.clear()
+
+
+def test_pack_coverage_endpoint_returns_helper_output():
+    fake = {
+        "pack": "conduct-hipaa",
+        "version": "1.4.2",
+        "total_rules": 3,
+        "by_surface": {
+            "mcp":     {"hard": 2, "not_supported": 1},
+            "proxy":   {"hard": 1, "not_supported": 2},
+            "runtime": {"hard": 2, "not_supported": 1},
+            "hook":    {"hard": 2, "not_supported": 1},
+        },
+        "by_gate": {"action": 2, "prompt": 1, "response": 0},
+    }
+    try:
+        with patch(
+            "app.modules.guard.coverage.pack_coverage_matrix",
+            return_value=fake,
+        ):
+            client = _client()
+            r = client.get("/guard/policies/packs/conduct-hipaa/coverage-matrix")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert body["pack"] == "conduct-hipaa"
+        assert body["version"] == "1.4.2"
+        assert body["total_rules"] == 3
+        assert body["by_surface"]["proxy"] == {"hard": 1, "not_supported": 2}
+        assert body["by_gate"]["response"] == 0
+    finally:
+        _clear()
+
+
+def test_missing_pack_returns_zero_envelope():
+    fake = {
+        "pack": "conduct-fake",
+        "version": None,
+        "total_rules": 0,
+        "by_surface": {
+            "mcp":     {"hard": 0, "not_supported": 0},
+            "proxy":   {"hard": 0, "not_supported": 0},
+            "runtime": {"hard": 0, "not_supported": 0},
+            "hook":    {"hard": 0, "not_supported": 0},
+        },
+        "by_gate": {"action": 0, "prompt": 0, "response": 0},
+    }
+    try:
+        with patch(
+            "app.modules.guard.coverage.pack_coverage_matrix",
+            return_value=fake,
+        ):
+            client = _client()
+            r = client.get("/guard/policies/packs/conduct-fake/coverage-matrix")
+        assert r.status_code == 200
+        body = r.json()
+        assert body["version"] is None
+        assert body["total_rules"] == 0
+    finally:
+        _clear()

--- a/apps/api/tests/guard/test_pack_coverage_matrix.py
+++ b/apps/api/tests/guard/test_pack_coverage_matrix.py
@@ -1,0 +1,96 @@
+"""#1751 PR 3 — pack_coverage_matrix.
+
+Aggregates rule counts per PEP surface × gate for a single pack. Feeds the
+pack-detail coverage table on the Policies UI (Slice 2 of #1750 Phase B).
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.modules.guard.coverage import pack_coverage_matrix
+
+
+def _pack(rules: list[dict], version: str = "1.0.0") -> MagicMock:
+    p = MagicMock()
+    p.rules = rules
+    p.version = version
+    return p
+
+
+def test_missing_pack_returns_empty_shape():
+    db = MagicMock()
+    with patch("app.modules.guard.coverage._get_pack", return_value=None):
+        out = pack_coverage_matrix(db, "conduct-fake")
+    assert out["pack"] == "conduct-fake"
+    assert out["version"] is None
+    assert out["total_rules"] == 0
+    for surface, counts in out["by_surface"].items():
+        assert counts == {"hard": 0, "not_supported": 0}
+    for gate, n in out["by_gate"].items():
+        assert n == 0
+
+
+def test_pure_action_pack_covers_mcp_runtime_hook_not_proxy():
+    pack = _pack([
+        {"id": "r1", "gates": ["action"]},
+        {"id": "r2", "gates": ["action"]},
+    ])
+    with patch("app.modules.guard.coverage._get_pack", return_value=pack):
+        out = pack_coverage_matrix(MagicMock(), "conduct-base")
+
+    assert out["total_rules"] == 2
+    assert out["by_gate"]["action"] == 2
+    assert out["by_gate"]["prompt"] == 0
+    assert out["by_gate"]["response"] == 0
+    assert out["by_surface"]["mcp"] == {"hard": 2, "not_supported": 0}
+    assert out["by_surface"]["runtime"] == {"hard": 2, "not_supported": 0}
+    assert out["by_surface"]["hook"] == {"hard": 2, "not_supported": 0}
+    assert out["by_surface"]["proxy"] == {"hard": 0, "not_supported": 2}
+
+
+def test_proxy_gate_pack_covers_only_proxy():
+    pack = _pack([
+        {"id": "prompt-1", "gates": ["prompt"]},
+        {"id": "resp-1",   "gates": ["response"]},
+    ])
+    with patch("app.modules.guard.coverage._get_pack", return_value=pack):
+        out = pack_coverage_matrix(MagicMock(), "conduct-proxy-secrets")
+
+    assert out["by_gate"] == {"action": 0, "prompt": 1, "response": 1}
+    assert out["by_surface"]["proxy"] == {"hard": 2, "not_supported": 0}
+    assert out["by_surface"]["mcp"] == {"hard": 0, "not_supported": 2}
+
+
+def test_mixed_dual_gate_rule_counts_toward_every_matching_gate():
+    """A rule declaring [action, prompt] counts once per gate in by_gate,
+    and shows 'hard' on every surface that provides ANY of its gates."""
+    pack = _pack([{"id": "dual", "gates": ["action", "prompt"]}])
+    with patch("app.modules.guard.coverage._get_pack", return_value=pack):
+        out = pack_coverage_matrix(MagicMock(), "conduct-hipaa")
+
+    assert out["by_gate"] == {"action": 1, "prompt": 1, "response": 0}
+    assert out["by_surface"]["mcp"] == {"hard": 1, "not_supported": 0}
+    assert out["by_surface"]["proxy"] == {"hard": 1, "not_supported": 0}
+
+
+def test_version_is_reported_from_the_pack_object():
+    pack = _pack([{"id": "r", "gates": ["action"]}], version="2.3.1")
+    with patch("app.modules.guard.coverage._get_pack", return_value=pack):
+        out = pack_coverage_matrix(MagicMock(), "conduct-hipaa")
+    assert out["version"] == "2.3.1"
+
+
+def test_legacy_rule_without_gates_still_counts():
+    """Rules with only persona (not gates) get counted via derive_gates."""
+    pack = _pack([
+        {"id": "legacy-agent", "persona": "agent"},
+        {"id": "legacy-proxy", "persona": "proxy"},
+    ])
+    with patch("app.modules.guard.coverage._get_pack", return_value=pack):
+        out = pack_coverage_matrix(MagicMock(), "conduct-base")
+
+    assert out["total_rules"] == 2
+    assert out["by_gate"]["action"] == 1
+    assert out["by_gate"]["prompt"] == 1
+    assert out["by_surface"]["mcp"]["hard"] == 1
+    assert out["by_surface"]["proxy"]["hard"] == 1

--- a/apps/api/tests/guard/test_pep_registry.py
+++ b/apps/api/tests/guard/test_pep_registry.py
@@ -1,0 +1,70 @@
+"""#1751 PR 1 — PEP capability registry drift test.
+
+Locks the mapping against docs/guard/architecture.md §8. A PEP silently
+changing what it enforces here without also updating the doc fails this
+test — deliberate change is required to add or remove a declared gate.
+"""
+from __future__ import annotations
+
+from app.modules.guard.enforcement import GATES
+from app.modules.guard.pep_registry import (
+    PEP_CAPABILITIES,
+    all_surfaces,
+    pep_provides,
+)
+
+
+def test_all_declared_gates_are_in_the_locked_enum():
+    """Property 5 / reviewer edit 2: only [action, prompt, response] exist.
+    A PEP declaring anything else means either the enum needs to grow (which
+    itself requires a schema decision — see architecture.md Property 5) or
+    the PEP was miswired."""
+    valid = set(GATES)
+    for surface, gates in PEP_CAPABILITIES.items():
+        assert gates.issubset(valid), (
+            f"{surface} declares gates {gates - valid} outside {GATES}"
+        )
+
+
+def test_pep_capabilities_match_architecture_doc_v1():
+    """Snapshot of docs/guard/architecture.md §8 as of #1737 merge.
+    Changing this table means the doc + this snapshot both update, with
+    the reviewer explicitly signing off on the new surface × gate matrix."""
+    expected = {
+        "mcp":     frozenset({"action"}),
+        "proxy":   frozenset({"prompt", "response"}),
+        "runtime": frozenset({"action"}),
+        "hook":    frozenset({"action"}),
+    }
+    assert PEP_CAPABILITIES == expected
+
+
+def test_pep_provides_returns_declared_set():
+    assert pep_provides("proxy") == frozenset({"prompt", "response"})
+    assert pep_provides("mcp") == frozenset({"action"})
+
+
+def test_pep_provides_unknown_surface_is_empty_set():
+    """Unknown PEP → treated as not_supported for every gate. Downstream
+    derive_surface_status relies on this fallback."""
+    assert pep_provides("nonexistent") == frozenset()
+    assert pep_provides("") == frozenset()
+
+
+def test_all_surfaces_ordering_is_stable():
+    """derive_surface_status callers iterate this list — stable order matters
+    for UI badge rendering and audit-row column alignment."""
+    surfaces = all_surfaces()
+    assert surfaces == ("mcp", "proxy", "runtime", "hook")
+    assert set(surfaces) == set(PEP_CAPABILITIES.keys())
+
+
+def test_every_gate_is_covered_by_at_least_one_pep():
+    """Sanity: the locked GATES enum should not contain a gate no PEP
+    can enforce. If this fails, either a PEP declaration is missing or
+    the enum has a dead value."""
+    covered: set[str] = set()
+    for gates in PEP_CAPABILITIES.values():
+        covered.update(gates)
+    missing = set(GATES) - covered
+    assert not missing, f"gates {sorted(missing)} have no PEP that provides them"

--- a/apps/api/tests/guard/test_pep_registry_real_packs.py
+++ b/apps/api/tests/guard/test_pep_registry_real_packs.py
@@ -1,0 +1,64 @@
+"""#1751 PR 6 — smoke test derive_surface_status against real shipped packs.
+
+Loads conduct-base.json + conduct-hipaa.json from disk (no DB) and asserts
+every rule produces a valid derived status on every PEP surface. Guards
+against a future rule shape that breaks the derived function silently.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from app.modules.guard.enforcement import derive_gates, derive_surface_status
+from app.modules.guard.pep_registry import all_surfaces
+
+
+PACKS_DIR = Path(__file__).resolve().parents[2] / "app/modules/guard/skill_packs"
+
+
+def _load(pack: str) -> list[dict]:
+    with (PACKS_DIR / f"{pack}.json").open() as fh:
+        return json.load(fh).get("rules") or []
+
+
+def test_derive_surface_status_returns_valid_enum_for_every_shipped_rule():
+    """Every rule × every surface must return one of the declared statuses.
+    Silently returning None or a typo string would break the UI badge shelf."""
+    valid = {"hard", "not_supported"}
+    for pack in ("conduct-base", "conduct-hipaa"):
+        rules = _load(pack)
+        assert rules, f"{pack} shipped with zero rules — regression"
+        for rule in rules:
+            for surface in all_surfaces():
+                status = derive_surface_status(rule, surface)
+                assert status in valid, (
+                    f"{pack}:{rule.get('id')} on {surface} → {status!r} "
+                    f"(expected one of {valid})"
+                )
+
+
+def test_every_shipped_rule_has_at_least_one_gate():
+    """derive_gates always returns a non-empty list (falls back to
+    ['action']). A rule with no matcher metadata would slip through
+    silently — this is the belt-and-braces check."""
+    for pack in ("conduct-base", "conduct-hipaa"):
+        for rule in _load(pack):
+            gates = derive_gates(rule)
+            assert gates, f"{pack}:{rule.get('id')} — derive_gates returned empty"
+
+
+def test_at_least_one_pep_covers_every_shipped_rule():
+    """Regression: no rule should be `not_supported` on every surface.
+    That would mean it ships in a pack but no PEP can actually enforce
+    it — dead metadata."""
+    for pack in ("conduct-base", "conduct-hipaa"):
+        for rule in _load(pack):
+            statuses = {
+                surface: derive_surface_status(rule, surface)
+                for surface in all_surfaces()
+            }
+            hard_surfaces = [s for s, v in statuses.items() if v == "hard"]
+            assert hard_surfaces, (
+                f"{pack}:{rule.get('id')} — no PEP surface can enforce this rule. "
+                f"Derived statuses: {statuses}"
+            )

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -204,7 +204,7 @@ Do not touch these without a schema migration.
 5. **Gate enum** — `{ action, prompt, response }`. Locked from day one.
 6. **Audit receipt shape** — `{ task_id, seq, prev_hash, this_hash, gate, surface, tool, verdict, rule_id, obligations_completed, ts }`.
 7. **Precedence** — most-restrictive action wins; `non_overridable: True` rules bypass workspace overrides; pack precedence is one admin dial.
-8. **PEP capability declarations are machine-verified.** Every PEP registers `provides_capabilities: {gate_types}`. CI runs one conformance test per declared capability per PEP. Failing test blocks merge. No PEP ships with an undeclared or unverified capability.
+8. **PEP capability declarations are machine-verified.** Every PEP registers `provides_capabilities: {gate_types}` in `apps/api/app/modules/guard/pep_registry.py`. Snapshot test in `tests/guard/test_pep_registry.py` locks the mapping against this doc — a PEP silently changing what it enforces fails CI. Per-rule surface status is derived on read via `derive_surface_status(rule, surface)`; hand-authored `enforcement.<surface>` values are compared against derived and divergence is warn-logged for #1750 Phase D cleanup. Full CI-run conformance test per capability is a follow-up.
 9. **Raw payload never persists outside ephemeral scope.** All log writes — divergence logs, debug tables, audit rows — route through `redact_secrets` at `apps/api/app/core/pii.py:86`. Matched-span + hash + size only. P0 security invariant.
 
 ## 6. Extension points (5)
@@ -239,6 +239,8 @@ Add here without migration.
 | Lens | action, prompt, response | `apps/api/app/modules/glens/routers/chat.py` + `tools/registrations/lens/` |
 
 Lens is a well-behaved caller — no special path. LLM calls route through `guarded_completion` → `LLMClient` → proxy. Tool calls route through Lens tool registry → `guard_check` → MCP PEP.
+
+The four rows above (excluding Lens) are the source of truth for `PEP_CAPABILITIES` in `apps/api/app/modules/guard/pep_registry.py`. `derive_surface_status(rule, surface)` reads this table + the rule's `gates` to compute per-rule enforcement status. `pack_coverage_matrix(db, pack_slug)` aggregates across a pack; the Policies UI reads it via `GET /guard/policies/packs/{slug}/coverage-matrix`.
 
 ---
 

--- a/docs/guard/schema.md
+++ b/docs/guard/schema.md
@@ -110,6 +110,8 @@ Per surface, the rule declares whether it can enforce (`hard`), advise (`conditi
 | `mcp` | MCP `guard_check` — enforced when agent voluntarily calls it. |
 | `runtime` | Conduct workflow runtime — enforced during YAML playbook execution. |
 
+> **Deprecation window (#1751 shipped; #1750 Phase D cleanup pending).** The hand-authored `enforcement.proxy` / `hook` / `mcp` / `runtime` values are being supplemented by a **derived** status: `derive_surface_status(rule, surface)` reads `rule.gates` × the PEP capability registry and returns `"hard"` or `"not_supported"` per Property 8 of `docs/guard/architecture.md`. Callers should read the derived status; hand-authored values remain in the JSON but will be retired once telemetry shows zero divergence.
+
 ### Pack (bundles rules)
 
 | Field | Type | Notes |


### PR DESCRIPTION
## Summary

Ships **#1751** — derived enforcement status + pack coverage matrix + API endpoint. Turns Property 8 of the pinnable Guard architecture doc from aspirational into shipping.

**One commit, six PR-scope units, six new test files, 1419/1419 tests pass.**

## Why

Every rule in every skill pack currently declares a hand-authored `enforcement.proxy` / `hook` / `mcp` / `runtime` string (`"hard"` / `"conditional"` / `"not_supported"`). Across 200+ rules × 11 packs = ~8,800 hand-authored status strings that go stale the moment a PEP changes what it enforces. That's the exact drift Property 8 was written to prevent.

This PR replaces the hand-authored path with a **derived** one — computed from the intersection of `rule.gates` (locked enum, #1737) and `PEP_CAPABILITIES` (new registry). Hand-authored values stay in place through a deprecation window; the divergence between them and derived values is warn-logged for #1750 Phase D cleanup.

## What ships (six PR-scope units in one commit)

### PR 1 — `pep_registry.PEP_CAPABILITIES`
Static dict: `surface → frozenset[gate]`. Locked at import against `GATES`. Snapshot test doubles as a drift check against `docs/guard/architecture.md` §8.

### PR 2 — `derive_surface_status(rule, surface)`
Reads `rule.gates × PEP_CAPABILITIES[surface]`. Returns `"hard"` or `"not_supported"`. Explicitly scoped: `"conditional"` and `"advisory"` are deploy-caveat statuses (a PEP CAN evaluate but requires a runtime condition) — they stay hand-authored until Phase D retires them.

### PR 3 — `pack_coverage_matrix(db, pack_slug)`
Aggregates rule counts per PEP surface × per gate. Answers "does conduct-hipaa cover response-gate leakage on the proxy?" in a single call. Missing pack returns a zero-filled envelope so the UI never handles null.

```json
{
  "pack": "conduct-hipaa",
  "version": "1.4.2",
  "total_rules": 42,
  "by_surface": {
    "mcp":     {"hard": 27, "not_supported": 15},
    "proxy":   {"hard": 12, "not_supported": 30},
    "runtime": {"hard": 27, "not_supported": 15},
    "hook":    {"hard": 27, "not_supported": 15}
  },
  "by_gate": {"action": 30, "prompt": 10, "response": 2}
}
```

### PR 4 — divergence telemetry in `workspace_coverage_matrix`
Compares each rule's hand-authored `enforcement.<surface>` against `derive_surface_status` and emits `LOG.warning("guard.coverage.status_divergence", ...)` on the delta. **Return schema unchanged** — this is pure telemetry for the #1750 Phase D cleanup gate.

### PR 5 — `GET /guard/policies/packs/{slug}/coverage-matrix`
Endpoint over `pack_coverage_matrix`. Auth: `require_permission("guard.policies.view")`. Explicit `PackCoverageMatrixOut` response model exports the shape for the frontend (#1755 Slice 2 verified badges).

### PR 6 — real-pack smoke tests + docs
Loads `conduct-base.json` + `conduct-hipaa.json` from disk (no DB), asserts every rule × every surface returns a valid derived status and every rule has at least one covering PEP. Architecture doc Property 8 now references `pep_registry.py` + derived helpers. Schema doc notes the deprecation window on hand-authored `enforcement.<surface>` strings.

## Modularity — no duplicates

- `PEP_CAPABILITIES` — single source of truth
- `derive_surface_status` — single derivation function, all consumers call it
- `pack_coverage_matrix` — reuses `_get_pack`, `derive_gates`, `derive_surface_status`, `all_surfaces`, `GATES`
- `workspace_coverage_matrix` — adds a divergence loop inline; no new module
- Endpoint calls the helper directly; no re-implementation

## What this unblocks

- **#1755** (Phase B Slice 2) — verified badges per PEP, derived status subtext, redacted audit preview. Frontend can now fetch the coverage matrix directly.
- **#1750 Phase D** — divergence log builds the evidence trail for retiring hand-authored `enforcement.<surface>` strings once telemetry shows zero deltas for N days.

## Verification

- 1419/1419 tests pass locally (including 6 new files, 26 new tests)
- Snapshot test locks `PEP_CAPABILITIES` against `architecture.md` §8
- Real-pack smoke test exercises every rule in `conduct-base` + `conduct-hipaa`
- Endpoint round-trip via `TestClient` — happy path + missing-pack envelope

## Test plan

- [ ] CI green (full suite + drift check)
- [ ] Manual: `GET /guard/policies/packs/conduct-base/coverage-matrix` on a workspace with the pack installed — expect populated `by_surface` and `by_gate`
- [ ] Manual: same endpoint with a bogus slug — expect zero envelope, HTTP 200
- [ ] Watch Render logs for `guard.coverage.status_divergence` events after deploy — sanity-check the telemetry stream

## Follow-ups (not in this PR)

- **#1755** — Phase B Slice 2 UI consumes `pack_coverage_matrix` + `derive_surface_status`
- **#1750 Phase D** — retire hand-authored `enforcement.<surface>` fields (gated on 30-day zero-divergence telemetry)
- **Full CI conformance test** per capability per PEP — Property 8's stronger interpretation. Filed later once we have a customer signal that snapshot testing is insufficient.

Closes #1751.
