### PR TITLE
feat(guard): Phase B Slice 2 — verified badges + redacted firings + divergence UI (#1755)

### DIFF
--- a/apps/api/app/modules/guard/coverage.py
+++ b/apps/api/app/modules/guard/coverage.py
@@ -147,6 +147,11 @@ def workspace_coverage_matrix(db: Session, workspace_id: uuid.UUID) -> list[dict
             "hook": metadata["hook"],
             "mcp": metadata["mcp"],
             "runtime": metadata["runtime"],
+            # #1755 Slice 2 (real PR 5) — derived counterparts for divergence UI.
+            "derived_proxy": derive_surface_status(rule, "proxy"),
+            "derived_hook": derive_surface_status(rule, "hook"),
+            "derived_mcp": derive_surface_status(rule, "mcp"),
+            "derived_runtime": derive_surface_status(rule, "runtime"),
             "guarantee": metadata["guarantee"],
             "requires": list(metadata["requires"]),
             "known_limitations": list(metadata["known_limitations"]),

--- a/apps/api/app/modules/guard/routers/events.py
+++ b/apps/api/app/modules/guard/routers/events.py
@@ -17,8 +17,9 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_workspace_id, _clerk_enabled, _verify_clerk_token
+from app.core.auth import get_workspace_id, require_permission, _clerk_enabled, _verify_clerk_token
 from app.core.database import SessionLocal, get_db
+from app.core.pii import redact_secrets
 from app.models.workspace import Workspace
 from app.modules.guard.models import DiscoveredAgent, GuardAuditEvent, GuardConfig, GuardSession, GuardSpendBudget, chain_hash_for_insert, get_policy_hash
 
@@ -140,6 +141,26 @@ class EventOut(BaseModel):
     evaluated_rules: list[dict] | None = None
     defense_score: int | None = None
     routing_meta: dict | None = None
+
+
+class RuleFireOut(BaseModel):
+    """#1755 Slice 2 — safe projection of a rule firing for the Policies UI
+    'Recent Firings' panel. Property 9: raw input_summary NEVER surfaces —
+    the field is routed through ``redact_secrets`` before serialization
+    and augmented with a hash prefix + size hint so consumers can dedupe
+    without needing the raw content."""
+    id: str
+    ts: str
+    rule_id: str | None
+    decision: str
+    tool_call: str | None = None
+    source: str
+    ai_tool: str
+    # Redacted preview (matched-span shape, credentials + emails/SSNs masked).
+    input_summary_redacted: str | None = None
+    # sha256 of the raw input_summary, first 16 hex chars — dedupe without leaking payload.
+    input_hash_prefix: str | None = None
+    input_size_bytes: int = 0
 
 
 # ── Helpers ───────────────────────────────────────────────────────────────────
@@ -877,6 +898,59 @@ def list_events(
         .all()
     )
     return [EventOut(**_event_to_dict(e)) for e in rows]
+
+
+# ── GET /guard/events/rule/{rule_id}/fires — redacted preview (#1755 Slice 2) ─
+
+def _project_rule_fire(e: GuardAuditEvent) -> RuleFireOut:
+    """Property 9: redact input_summary via app.core.pii.redact_secrets
+    before it leaves the API. Emit only a hash prefix + size for dedupe."""
+    raw = e.input_summary or ""
+    redacted_text, _found = redact_secrets(raw) if raw else ("", [])
+    return RuleFireOut(
+        id=str(e.id),
+        ts=e.ts.isoformat() if e.ts else "",
+        rule_id=e.rule_id,
+        decision=e.decision,
+        tool_call=e.tool_call,
+        source=e.source or "hook",
+        ai_tool=e.ai_tool,
+        input_summary_redacted=redacted_text or None,
+        input_hash_prefix=(
+            hashlib.sha256(raw.encode("utf-8", errors="replace")).hexdigest()[:16]
+            if raw else None
+        ),
+        input_size_bytes=len(raw.encode("utf-8", errors="replace")),
+    )
+
+
+@router.get("/rule/{rule_id}/fires", response_model=list[RuleFireOut])
+def list_rule_fires(
+    rule_id: str,
+    db: Session = Depends(get_db),
+    workspace_id: str = Depends(get_workspace_id),
+    limit: int = Query(default=20, ge=1, le=100),
+    _: str = Depends(require_permission("guard.activity.view_own")),
+):
+    """#1755 Slice 2 — Recent Firings panel for a specific rule.
+
+    Returns the most recent N events that fired ``rule_id`` in this
+    workspace, projected through ``redact_secrets`` so raw input_summary
+    never leaves the API. Hash prefix + size ride along for dedupe /
+    volume signals without needing the payload.
+    """
+    org_ws = _org_ws_subquery(db, workspace_id)
+    rows = (
+        db.query(GuardAuditEvent)
+        .filter(
+            GuardAuditEvent.workspace_id.in_(org_ws),
+            GuardAuditEvent.rule_id == rule_id,
+        )
+        .order_by(GuardAuditEvent.ts.desc())
+        .limit(limit)
+        .all()
+    )
+    return [_project_rule_fire(e) for e in rows]
 
 
 # ── GET /guard/events/cost-trend ─────────────────────────────────────────────

--- a/apps/api/app/modules/guard/routers/policies.py
+++ b/apps/api/app/modules/guard/routers/policies.py
@@ -48,7 +48,11 @@ from app.modules.guard.policy_engine import (
     is_exception_active,
 )
 from app.modules.guard.coverage import workspace_coverage_matrix
-from app.modules.guard.enforcement import derive_gates, is_hook_applicable_rule
+from app.modules.guard.enforcement import (
+    derive_gates,
+    derive_surface_status,
+    is_hook_applicable_rule,
+)
 
 router = APIRouter(prefix="/guard/policies", tags=["guard-policies"])
 
@@ -107,6 +111,14 @@ class PolicyOut(BaseModel):
     iso_control: Optional[str] = None
     tag: Optional[str] = None
     gates: list[str] = []  # #1733/#1750 Phase B — locked enum [action, prompt, response]
+    # #1755 Slice 2 — derived per-PEP surface status. Reads pep_registry
+    # capabilities × rule.gates. UI renders these as verified badges on
+    # rule detail. Hand-authored `enforcement.<surface>` fields stay
+    # in the JSON but are being retired (#1750 Phase D).
+    derived_mcp: str = "not_supported"
+    derived_proxy: str = "not_supported"
+    derived_runtime: str = "not_supported"
+    derived_hook: str = "not_supported"
     # #1750 reviewer edit 4 — retained hand-authored prose (NOT deleted in Phase D).
     guarantee: Optional[str] = None
     known_limitations: list[str] = []
@@ -218,6 +230,16 @@ class EnforcementCoverageOut(BaseModel):
     hook: Literal["hard", "conditional", "advisory", "not_supported"]
     mcp: Literal["hard", "conditional", "advisory", "not_supported"]
     runtime: Literal["hard", "conditional", "advisory", "not_supported"]
+    # #1755 Slice 2 (real PR 5) — derived counterparts. Same values, but
+    # computed live from rule.gates × PEP_CAPABILITIES rather than
+    # hand-authored. UI renders both side-by-side so a compliance officer
+    # can see when the hand-authored value has gone stale (divergence).
+    # After #1750 Phase D retires the hand-authored fields above, these
+    # derived fields become the sole source of truth.
+    derived_proxy: str = "not_supported"
+    derived_hook: str = "not_supported"
+    derived_mcp: str = "not_supported"
+    derived_runtime: str = "not_supported"
     guarantee: str
     requires: list[str]
     known_limitations: list[str]
@@ -276,6 +298,10 @@ def _custom_to_out(row: WorkspaceCustomRule) -> PolicyOut:
         severity=body.get("severity") or "medium",
         iso_control=body.get("iso_control"),
         gates=derive_gates(body_for_gates),
+        derived_mcp=derive_surface_status(body_for_gates, "mcp"),
+        derived_proxy=derive_surface_status(body_for_gates, "proxy"),
+        derived_runtime=derive_surface_status(body_for_gates, "runtime"),
+        derived_hook=derive_surface_status(body_for_gates, "hook"),
         guarantee=(body.get("enforcement") or {}).get("guarantee"),
         known_limitations=(body.get("enforcement") or {}).get("known_limitations") or [],
         created_at=row.created_at,
@@ -332,6 +358,10 @@ def _pack_rule_to_out(
         iso_control=rule.get("iso_control"),
         tag=rule.get("tag"),
         gates=derive_gates(rule),
+        derived_mcp=derive_surface_status(rule, "mcp"),
+        derived_proxy=derive_surface_status(rule, "proxy"),
+        derived_runtime=derive_surface_status(rule, "runtime"),
+        derived_hook=derive_surface_status(rule, "hook"),
         guarantee=(rule.get("enforcement") or {}).get("guarantee"),
         known_limitations=(rule.get("enforcement") or {}).get("known_limitations") or [],
         exception_reason=override.reason if override and relaxing else None,

--- a/apps/api/tests/guard/test_coverage_divergence_log.py
+++ b/apps/api/tests/guard/test_coverage_divergence_log.py
@@ -160,3 +160,33 @@ def test_return_shape_unchanged():
     row = matrix[0]
     for key in ("proxy", "hook", "mcp", "runtime", "guarantee", "requires", "known_limitations"):
         assert key in row, f"expected key {key} still present"
+
+
+def test_derived_fields_land_on_coverage_row():
+    """#1755 Slice 2 (real PR 5) — coverage rows carry derived_<surface>
+    alongside hand-authored so the UI can render both + flag divergence."""
+    rule = {
+        "id": "derived-check",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": _authored({
+            "proxy": "not_supported",
+            "mcp": "hard",
+            "hook": "hard",
+            "runtime": "hard",
+        }),
+    }
+    db = _make_db([rule])
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([rule]),
+    ), patch("app.modules.guard.coverage.validate_enforcement_metadata"):
+        matrix = workspace_coverage_matrix(db, uuid.uuid4())
+
+    row = matrix[0]
+    # Action-gate rule → mcp/hook/runtime derive "hard", proxy derives "not_supported".
+    assert row["derived_mcp"] == "hard"
+    assert row["derived_hook"] == "hard"
+    assert row["derived_runtime"] == "hard"
+    assert row["derived_proxy"] == "not_supported"

--- a/apps/api/tests/guard/test_policy_out_gates.py
+++ b/apps/api/tests/guard/test_policy_out_gates.py
@@ -25,6 +25,23 @@ def test_pack_rule_to_out_stamps_gates_from_persona_default():
     assert out.gates == ["action"]
 
 
+def test_pack_rule_to_out_populates_derived_surface_status():
+    """#1755 Slice 2 — every PolicyOut carries derived_<surface> for all four PEPs."""
+    action_rule = {"id": "act", "action": "block", "gates": ["action"]}
+    out = _pack_rule_to_out(action_rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.derived_mcp == "hard"
+    assert out.derived_hook == "hard"
+    assert out.derived_runtime == "hard"
+    assert out.derived_proxy == "not_supported"
+
+
+def test_pack_rule_to_out_derived_proxy_hard_for_prompt_gate_rule():
+    prompt_rule = {"id": "prompt-x", "action": "block", "gates": ["prompt"]}
+    out = _pack_rule_to_out(prompt_rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)
+    assert out.derived_proxy == "hard"
+    assert out.derived_mcp == "not_supported"
+
+
 def test_pack_rule_to_out_stamps_gates_from_proxy_persona():
     rule = {"id": "r-p", "action": "warn", "persona": "proxy"}
     out = _pack_rule_to_out(rule, "conduct-base", datetime.now(timezone.utc), uuid.uuid4(), None)

--- a/apps/api/tests/guard/test_rule_fires_endpoint.py
+++ b/apps/api/tests/guard/test_rule_fires_endpoint.py
@@ -1,0 +1,130 @@
+"""#1755 Slice 2 — GET /guard/events/rule/{rule_id}/fires.
+
+Property 9: raw input_summary must never leave the API. The redacted
+projection replaces secrets in-place and adds hash + size fields for
+dedupe/volume signals without exposing payload.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+
+def _client():
+    from app.main import app
+    from app.core.database import get_db
+    from app.core.auth import get_workspace_id, get_user_id
+
+    db_mock = MagicMock()
+    app.dependency_overrides[get_db] = lambda: db_mock
+    app.dependency_overrides[get_workspace_id] = lambda: "00000000-0000-0000-0000-0000000000ab"
+    app.dependency_overrides[get_user_id] = lambda: "user_test"
+    return db_mock, TestClient(app, raise_server_exceptions=False)
+
+
+def _clear():
+    from app.main import app
+    app.dependency_overrides.clear()
+
+
+def _event(ts_iso: str, rule_id: str, input_summary: str) -> MagicMock:
+    e = MagicMock()
+    e.id = "abcd-1234"
+    e.ts = MagicMock(isoformat=lambda: ts_iso)
+    e.rule_id = rule_id
+    e.decision = "blocked"
+    e.tool_call = "write_file"
+    e.source = "hook"
+    e.ai_tool = "claude-code"
+    e.input_summary = input_summary
+    return e
+
+
+def _install_rows(db: MagicMock, rows: list):
+    """Stub the ORM query chain for the endpoint's read."""
+    q = MagicMock()
+    q.filter.return_value = q
+    q.order_by.return_value = q
+    q.limit.return_value = q
+    q.all.return_value = rows
+    db.query.return_value = q
+
+
+def test_endpoint_redacts_input_summary_before_returning():
+    db, client = _client()
+    secret = "sk" + "-" + ("X" * 30)
+    _install_rows(db, [_event("2026-09-10T00:00:00Z", "hipaa-x", f"leak: {secret}")])
+    try:
+        with patch(
+            "app.modules.guard.routers.events._org_ws_subquery",
+            return_value=MagicMock(),
+        ):
+            r = client.get("/guard/events/rule/hipaa-x/fires")
+        assert r.status_code == 200, r.text
+        body = r.json()
+        assert len(body) == 1
+        row = body[0]
+        # Property 9: raw secret must not surface.
+        assert secret not in row["input_summary_redacted"], (
+            "raw secret leaked into rule-fires response"
+        )
+        # Redacted marker present so caller sees SOMETHING happened.
+        assert "REDACTED" in row["input_summary_redacted"].upper()
+    finally:
+        _clear()
+
+
+def test_endpoint_hash_prefix_and_size_fields_populated():
+    db, client = _client()
+    raw = "hello world"
+    _install_rows(db, [_event("2026-09-10T00:00:00Z", "rule-A", raw)])
+    try:
+        with patch(
+            "app.modules.guard.routers.events._org_ws_subquery",
+            return_value=MagicMock(),
+        ):
+            r = client.get("/guard/events/rule/rule-A/fires")
+        assert r.status_code == 200
+        row = r.json()[0]
+        assert row["input_size_bytes"] == len(raw.encode("utf-8"))
+        assert row["input_hash_prefix"] is not None
+        # sha256("hello world") == "b94d27b9934d3e08a52e52d7da7dabfac484efe37a5380ee9088f7ace2efcde9"
+        assert row["input_hash_prefix"] == "b94d27b9934d3e08"
+    finally:
+        _clear()
+
+
+def test_endpoint_empty_result_returns_empty_list():
+    db, client = _client()
+    _install_rows(db, [])
+    try:
+        with patch(
+            "app.modules.guard.routers.events._org_ws_subquery",
+            return_value=MagicMock(),
+        ):
+            r = client.get("/guard/events/rule/nobody-fired-this/fires")
+        assert r.status_code == 200
+        assert r.json() == []
+    finally:
+        _clear()
+
+
+def test_endpoint_null_input_summary_yields_null_preview():
+    """When a row has no input_summary at all (e.g. approval-flow rows),
+    the endpoint returns null preview + zero size, not an error."""
+    db, client = _client()
+    _install_rows(db, [_event("2026-09-10T00:00:00Z", "rule-x", "")])
+    try:
+        with patch(
+            "app.modules.guard.routers.events._org_ws_subquery",
+            return_value=MagicMock(),
+        ):
+            r = client.get("/guard/events/rule/rule-x/fires")
+        assert r.status_code == 200
+        row = r.json()[0]
+        assert row["input_summary_redacted"] is None
+        assert row["input_hash_prefix"] is None
+        assert row["input_size_bytes"] == 0
+    finally:
+        _clear()

--- a/apps/web/src/app/(app)/theguard/policies/page.tsx
+++ b/apps/web/src/app/(app)/theguard/policies/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from "next/navigation"
 import { useGuardTeam } from "@/hooks/useGuardTeam"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { guard } from "@/lib/api"
-import type { GuardPolicy, GuardPolicyAction, GuardPolicyPatch } from "@/lib/api/guard"
+import type { GuardPolicy, GuardPolicyAction, GuardPolicyPatch, RuleFire } from "@/lib/api/guard"
 import { useGuardRole } from "@/hooks/useGuardRole"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 import AppShell from "@/components/AppShell"
@@ -171,6 +171,134 @@ function GateChips({ gates }: { gates?: string[] | null }) {
         </span>
       ))}
     </span>
+  )
+}
+
+// ─── SurfaceBadges (#1755 Slice 2) ─────────────────────────────────────────
+// Per-PEP verification chips: green when the PEP can enforce the rule, muted
+// when not_supported. Sourced from PolicyOut.derived_<surface> (backend
+// derives from rule.gates × PEP_CAPABILITIES). Falls back to muted when the
+// backend hasn't populated the field yet (never breaks the row).
+
+type SurfaceStatus = "hard" | "not_supported"
+const SURFACES: readonly { key: string; label: string }[] = [
+  { key: "mcp",     label: "MCP" },
+  { key: "proxy",   label: "Proxy" },
+  { key: "runtime", label: "Runtime" },
+  { key: "hook",    label: "Hook" },
+] as const
+
+function _normalizeStatus(v?: string | null): SurfaceStatus {
+  return v === "hard" ? "hard" : "not_supported"
+}
+
+function SurfaceBadges({ policy }: { policy: Policy }) {
+  const statuses: Record<string, SurfaceStatus> = {
+    mcp:     _normalizeStatus(policy.derived_mcp),
+    proxy:   _normalizeStatus(policy.derived_proxy),
+    runtime: _normalizeStatus(policy.derived_runtime),
+    hook:    _normalizeStatus(policy.derived_hook),
+  }
+  return (
+    <span style={{ display: "inline-flex", gap: 3, flexShrink: 0 }} title="PEP surfaces that can enforce this rule (green = hard)">
+      {SURFACES.map(({ key, label }) => {
+        const status = statuses[key]
+        const isHard = status === "hard"
+        return (
+          <span
+            key={key}
+            className={`sbadge ${isHard ? "ok" : ""}`}
+            style={{
+              textTransform: "uppercase",
+              fontSize: 9,
+              letterSpacing: ".06em",
+              padding: "0 5px",
+              opacity: isHard ? 1 : 0.35,
+              color: isHard ? undefined : "var(--text-muted)",
+              background: isHard ? undefined : "var(--surface-2)",
+              border: isHard ? undefined : "1px solid var(--border)",
+            }}
+            title={`${label} PEP: ${status}`}
+          >
+            {label}
+          </span>
+        )
+      })}
+    </span>
+  )
+}
+
+// ─── RuleFiresPanel (#1755 Slice 2) ───────────────────────────────────────
+// Shows the last N events that fired this rule. Server projects through
+// redact_secrets — raw input_summary NEVER lands here (Property 9). The
+// panel renders a redacted preview + short sha256 prefix + byte size so
+// consumers can dedupe / spot volume without needing the payload.
+
+function _formatFireTime(iso: string): string {
+  try {
+    const d = new Date(iso)
+    return d.toISOString().replace("T", " ").replace(/\..*/, "")
+  } catch {
+    return iso
+  }
+}
+
+function RuleFiresPanel({ state }: { state?: { loading: boolean; fires: RuleFire[]; error?: string } }) {
+  if (!state) return null
+  if (state.loading) {
+    return (
+      <div style={{ fontSize: 11.5, color: "var(--text-muted)", fontStyle: "italic" }}>
+        Loading recent firings…
+      </div>
+    )
+  }
+  if (state.error) {
+    return (
+      <div style={{ fontSize: 11.5, color: "var(--err)" }}>
+        Could not load firings: {state.error}
+      </div>
+    )
+  }
+  if (state.fires.length === 0) {
+    return (
+      <div style={{ fontSize: 11.5, color: "var(--text-muted)", fontStyle: "italic" }}>
+        No recent firings for this rule.
+      </div>
+    )
+  }
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+      {state.fires.map(fire => (
+        <div key={fire.id} style={{ display: "flex", flexDirection: "column", gap: 2, padding: "4px 8px", background: "var(--surface)", borderRadius: 5, border: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", gap: 8, alignItems: "center", fontSize: 11, color: "var(--text-2)" }}>
+            <span className="mono" style={{ fontSize: 10.5, color: "var(--text-muted)" }}>
+              {_formatFireTime(fire.ts)}
+            </span>
+            <span className={`sbadge ${fire.decision === "blocked" ? "err" : fire.decision === "warned" ? "warn" : "info"}`} style={{ textTransform: "uppercase", fontSize: 9, letterSpacing: ".06em", padding: "0 5px" }}>
+              {fire.decision}
+            </span>
+            <span style={{ color: "var(--text-muted)" }}>{fire.ai_tool}</span>
+            {fire.tool_call && (
+              <span className="mono" style={{ color: "var(--text-muted)" }}>{fire.tool_call}</span>
+            )}
+            <span style={{ marginLeft: "auto", color: "var(--text-muted)", fontSize: 10 }}>
+              {fire.input_size_bytes} B
+              {fire.input_hash_prefix && (
+                <>
+                  {" · "}
+                  <span className="mono">sha256:{fire.input_hash_prefix}…</span>
+                </>
+              )}
+            </span>
+          </div>
+          {fire.input_summary_redacted && (
+            <div className="mono" style={{ fontSize: 11, color: "var(--text-2)", background: "var(--surface-2)", borderRadius: 4, padding: "2px 6px", wordBreak: "break-all" }}>
+              {fire.input_summary_redacted}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
   )
 }
 
@@ -937,6 +1065,9 @@ function PoliciesContent() {
   const [exceptionSaving, setExceptionSaving] = useState(false)
   const [successBanner, setSuccessBanner] = useState<string | null>(null)
   const [gateFilter, setGateFilter] = useState<"all" | Gate>("all")  // #1733/#1750 Phase B
+  // #1755 Slice 2 — per-rule firings cache. Map ruleId → { loading, fires }.
+  // Populated lazily on expand (see toggleExpand below).
+  const [ruleFires, setRuleFires] = useState<Record<string, { loading: boolean; fires: RuleFire[]; error?: string }>>({})
 
   const canWrite = !permissionsLoading && permissions.canEditPolicies
 
@@ -1172,7 +1303,17 @@ function PoliciesContent() {
   function toggleExpand(id: string) {
     setExpandedIds(prev => {
       const next = new Set(prev)
-      next.has(id) ? next.delete(id) : next.add(id)
+      const isOpening = !next.has(id)
+      isOpening ? next.add(id) : next.delete(id)
+      // #1755 Slice 2 — lazy-fetch firings on first expand.
+      if (isOpening && !ruleFires[id]) {
+        setRuleFires(s => ({ ...s, [id]: { loading: true, fires: [] } }))
+        guard.events.ruleFires(authFetch, id, teamId ?? undefined)
+          .then(fires => setRuleFires(s => ({ ...s, [id]: { loading: false, fires } })))
+          .catch(err => setRuleFires(s => ({
+            ...s, [id]: { loading: false, fires: [], error: String(err?.message ?? err) },
+          })))
+      }
       return next
     })
   }
@@ -1281,7 +1422,9 @@ function PoliciesContent() {
                 const expanded = expandedIds.has(p.id)
                 const hasException = p.exception_active || p.exception_expired
                 const hasProse = !!(p.guarantee || (p.known_limitations && p.known_limitations.length > 0))
-                const hasDetails = !!(p.match_pattern || p.match_path_pattern || p.message || hasException || hasProse)
+                // #1755 Slice 2 — surface badges are always relevant to compliance
+                // officers, so every rule is expandable now.
+                const hasDetails = true || !!(p.match_pattern || p.match_path_pattern || p.message || hasException || hasProse)
                 const locked = !!p.non_overridable
                 return (
                   <div key={p.id} style={{ opacity: p.enabled ? 1 : 0.55 }}>
@@ -1386,6 +1529,11 @@ function PoliciesContent() {
                     {/* Expanded details */}
                     {expanded && hasDetails && (
                       <div style={{ margin: "4px 0 4px 12px", padding: "8px 12px", background: "var(--surface-2)", borderRadius: 8, display: "flex", flexWrap: "wrap", gap: 12 }}>
+                        {/* #1755 Slice 2 — PEP verified badges */}
+                        <div style={{ flexBasis: "100%", display: "flex", alignItems: "center", gap: 8 }}>
+                          <span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Enforced by</span>
+                          <SurfaceBadges policy={p} />
+                        </div>
                         {p.match_tool && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Tool </span><span className="mono" style={{ fontSize: 11.5, color: "var(--text-2)" }}>{p.match_tool}</span></div>}
                         {p.match_pattern && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Pattern </span><span className="mono" style={{ fontSize: 11, color: "var(--err)", background: "var(--err-bg)", borderRadius: 4, padding: "1px 6px" }}>{p.match_pattern}</span></div>}
                         {p.match_path_pattern && <div><span style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)" }}>Path </span><span className="mono" style={{ fontSize: 11, color: "var(--warn)", background: "var(--warn-bg)", borderRadius: 4, padding: "1px 6px" }}>{p.match_path_pattern}</span></div>}
@@ -1407,6 +1555,13 @@ function PoliciesContent() {
                             </ul>
                           </div>
                         )}
+                        {/* #1755 Slice 2 — Recent firings panel (redacted preview). */}
+                        <div style={{ flexBasis: "100%", paddingTop: 4, borderTop: "1px solid var(--border)" }}>
+                          <div style={{ fontSize: 10, fontWeight: 600, textTransform: "uppercase", letterSpacing: ".05em", color: "var(--text-muted)", marginBottom: 4 }}>
+                            Recent firings
+                          </div>
+                          <RuleFiresPanel state={ruleFires[p.id]} />
+                        </div>
                         {hasException && (
                           <div style={{ flexBasis: "100%", display: "flex", flexWrap: "wrap", gap: 12, paddingTop: 4, borderTop: "1px solid var(--border)" }}>
                             <div>

--- a/apps/web/src/components/guard/EnforcementCoverageMatrix.tsx
+++ b/apps/web/src/components/guard/EnforcementCoverageMatrix.tsx
@@ -59,6 +59,47 @@ function StatusBadge({ status }: { status: EnforcementStatus }) {
   )
 }
 
+// #1755 Slice 2 (real PR 5) — headline = hand-authored value (today's UI);
+// subtext = derived value from PEP capabilities × rule.gates. When they
+// disagree, a ⚠ marker tells the compliance officer this rule's metadata
+// is stale. Phase D will retire the hand-authored fields and the subtext
+// becomes the headline.
+function _divergent(authored: EnforcementStatus, derived?: string): boolean {
+  if (!derived) return false
+  // Only flag flips between the two derived-model values. authored's
+  // "conditional" / "advisory" are richer states derive doesn't emit yet
+  // — those are still valid, not divergent.
+  if (authored === "conditional" || authored === "advisory") return false
+  return authored !== derived
+}
+
+function StatusCell({ authored, derived }: { authored: EnforcementStatus; derived?: string }) {
+  const isDivergent = _divergent(authored, derived)
+  return (
+    <span style={{ display: "inline-flex", flexDirection: "column", alignItems: "center", gap: 2 }}>
+      <span style={{ display: "inline-flex", alignItems: "center", gap: 3 }}>
+        <StatusBadge status={authored} />
+        {isDivergent && (
+          <span
+            style={{ color: "var(--warn)", fontSize: 10, fontWeight: 700, cursor: "help" }}
+            title={`Hand-authored '${authored}' disagrees with derived '${derived}'. Rule metadata is stale — flag for Phase D cleanup.`}
+          >
+            ⚠
+          </span>
+        )}
+      </span>
+      {derived && (
+        <span
+          style={{ color: "var(--text-muted)", fontSize: 9, letterSpacing: ".05em", textTransform: "uppercase" }}
+          title="Derived from rule.gates × PEP capabilities (source of truth once #1750 Phase D retires the hand-authored fields)"
+        >
+          derived: {derived === "hard" ? "hard" : "n/s"}
+        </span>
+      )}
+    </span>
+  )
+}
+
 function formatAction(action: string): string {
   return action.replaceAll("_", " ").replace(/\b\w/g, letter => letter.toUpperCase())
 }
@@ -393,10 +434,10 @@ function FragmentRow({
             </div>
           </button>
         </td>
-        <td style={statusCellStyle}><StatusBadge status={row.proxy} /></td>
-        <td style={statusCellStyle}><StatusBadge status={row.hook} /></td>
-        <td style={statusCellStyle}><StatusBadge status={row.mcp} /></td>
-        <td style={statusCellStyle}><StatusBadge status={row.runtime} /></td>
+        <td style={statusCellStyle}><StatusCell authored={row.proxy} derived={row.derived_proxy} /></td>
+        <td style={statusCellStyle}><StatusCell authored={row.hook} derived={row.derived_hook} /></td>
+        <td style={statusCellStyle}><StatusCell authored={row.mcp} derived={row.derived_mcp} /></td>
+        <td style={statusCellStyle}><StatusCell authored={row.runtime} derived={row.derived_runtime} /></td>
         <td style={{ padding: "10px 12px", color: "var(--text-2)", fontSize: 11.5, lineHeight: 1.45 }}>{row.guarantee}</td>
       </tr>
       {expanded && (

--- a/apps/web/src/lib/api/guard.ts
+++ b/apps/web/src/lib/api/guard.ts
@@ -23,6 +23,12 @@ export interface GuardPolicy {
   non_overridable: boolean
   persona_affinity: string[]
   gates?: string[]  // #1733/#1750 Phase B — locked enum [action, prompt, response]
+  // #1755 Slice 2 — derived per-PEP surface status from rule.gates × PEP_CAPABILITIES.
+  // Values: "hard" | "not_supported" (locked; deploy-caveat statuses stay hand-authored).
+  derived_mcp?: string
+  derived_proxy?: string
+  derived_runtime?: string
+  derived_hook?: string
   guarantee?: string | null  // #1750 Phase B — hand-authored trust prose
   known_limitations?: string[]  // #1750 Phase B — hand-authored operational caveats
   tag: string | null
@@ -48,6 +54,22 @@ export interface GuardPolicyPatch {
   expires_at?: string
 }
 
+// #1755 Slice 2 — redacted rule-firing shape for the Policies UI panel.
+// Raw input_summary NEVER lands here (Property 9); only the redacted preview,
+// a sha256 prefix, and byte size for dedupe/volume signal.
+export interface RuleFire {
+  id: string
+  ts: string
+  rule_id: string | null
+  decision: string
+  tool_call: string | null
+  source: string
+  ai_tool: string
+  input_summary_redacted: string | null
+  input_hash_prefix: string | null
+  input_size_bytes: number
+}
+
 export type EnforcementStatus = "hard" | "conditional" | "advisory" | "not_supported"
 
 export interface GuardEnforcementCoverage {
@@ -64,6 +86,13 @@ export interface GuardEnforcementCoverage {
   hook: EnforcementStatus
   mcp: EnforcementStatus
   runtime: EnforcementStatus
+  // #1755 Slice 2 (real PR 5) — derived counterparts for divergence UI.
+  // Locked to "hard" | "not_supported" today; expands when derive_surface_status
+  // learns to model deploy-caveat statuses.
+  derived_proxy?: string
+  derived_hook?: string
+  derived_mcp?: string
+  derived_runtime?: string
   guarantee: string
   requires: string[]
   known_limitations: string[]
@@ -131,6 +160,12 @@ export const guard = {
     auditVerify: (f: AuthFetch, workspaceId: string) =>
       json<any>(f, `${base()}/events/audit/verify?workspace_id=${workspaceId}`),
     streamUrl: () => `${base()}/events/stream`,
+    // #1755 Slice 2 — redacted-preview firings for one rule (Policies UI panel).
+    ruleFires: (f: AuthFetch, ruleId: string, workspaceId?: string, limit = 20) => {
+      const params = new URLSearchParams({ limit: String(limit) })
+      if (workspaceId) params.set("workspace_id", workspaceId)
+      return json<RuleFire[]>(f, `${base()}/events/rule/${encodeURIComponent(ruleId)}/fires?${params}`)
+    },
   },
 
   policies: {

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -242,6 +242,18 @@ Lens is a well-behaved caller — no special path. LLM calls route through `guar
 
 The four rows above (excluding Lens) are the source of truth for `PEP_CAPABILITIES` in `apps/api/app/modules/guard/pep_registry.py`. `derive_surface_status(rule, surface)` reads this table + the rule's `gates` to compute per-rule enforcement status. `pack_coverage_matrix(db, pack_slug)` aggregates across a pack; the Policies UI reads it via `GET /guard/policies/packs/{slug}/coverage-matrix`.
 
+`PolicyOut` and `EnforcementCoverageOut` both carry `derived_<surface>` fields alongside the hand-authored `enforcement.<surface>` values. The Coverage tab renders both side-by-side; when they disagree, a ⚠ marker flags the rule as stale metadata (#1750 Phase D signal). Once Phase D retires the hand-authored fields, the derived subtext becomes the sole source of truth without any UI change.
+
+### Smoke test
+
+`scripts/smoke_1755.sh` verifies the end-to-end wiring against a running API:
+
+```bash
+API=http://localhost:8000 CONDUCT_TOKEN=cond_agt_xxx bash scripts/smoke_1755.sh
+```
+
+Checks: coverage endpoint returns `derived_<surface>` fields; pack coverage matrix populated for `conduct-base`; rule-fires endpoint redacts `input_summary`; count of authored↔derived divergences (Phase D readiness signal).
+
 ---
 
 ## 9. Failure modes prevented

--- a/scripts/smoke_1755.sh
+++ b/scripts/smoke_1755.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# #1755 Slice 2 — end-to-end smoke test against a running API.
+#
+# Verifies that the endpoints shipped in #1751 + #1755 respond with the
+# fields the Policies UI depends on. Assumes:
+#   - API running at ${API:-http://localhost:8000}
+#   - Valid CONDUCT_TOKEN env var (workspace member token or agent token)
+#   - Optional WORKSPACE_ID (falls back to a smoke test workspace)
+#
+# Run:
+#   API=http://localhost:8000 CONDUCT_TOKEN=cond_agt_xxx bash scripts/smoke_1755.sh
+#
+# Exit codes:
+#   0 — all checks pass
+#   1 — one or more assertions failed (details on stderr)
+#   2 — missing prerequisite (jq / curl / env var)
+
+set -euo pipefail
+
+API=${API:-http://localhost:8000}
+CONDUCT_TOKEN=${CONDUCT_TOKEN:-}
+WORKSPACE_ID=${WORKSPACE_ID:-}
+
+fail=0
+say()  { printf "\033[1;36m→\033[0m %s\n" "$*"; }
+ok()   { printf "  \033[32m✓\033[0m %s\n" "$*"; }
+bad()  { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; fail=1; }
+
+# ── Prerequisites ────────────────────────────────────────────────────
+command -v jq   >/dev/null || { echo "missing: jq"; exit 2; }
+command -v curl >/dev/null || { echo "missing: curl"; exit 2; }
+[[ -n "$CONDUCT_TOKEN" ]]  || { echo "missing: CONDUCT_TOKEN env"; exit 2; }
+
+hdr=(-H "Authorization: Bearer ${CONDUCT_TOKEN}" -H "Content-Type: application/json")
+
+# Resolve workspace_id if not provided — first workspace the token can see.
+if [[ -z "$WORKSPACE_ID" ]]; then
+  WORKSPACE_ID=$(curl -sS "${hdr[@]}" "${API}/whoami" | jq -r '.workspace_id // empty')
+  [[ -n "$WORKSPACE_ID" ]] || { echo "could not resolve WORKSPACE_ID"; exit 2; }
+fi
+qs="workspace_id=${WORKSPACE_ID}"
+
+say "API=${API}  WORKSPACE_ID=${WORKSPACE_ID}"
+
+# ── 1. Coverage matrix carries derived_<surface> per rule (#1755 PR 5) ─
+say "GET /guard/policies/coverage — derived_<surface> present"
+resp=$(curl -sS "${hdr[@]}" "${API}/guard/policies/coverage?${qs}")
+count=$(jq 'length' <<<"$resp")
+first=$(jq '.[0]' <<<"$resp")
+[[ "$count" -gt 0 ]] && ok "returned ${count} rules" || bad "empty coverage response"
+for k in derived_proxy derived_hook derived_mcp derived_runtime; do
+  v=$(jq -r ".${k} // empty" <<<"$first")
+  if [[ -n "$v" ]]; then
+    ok "${k}=${v}"
+  else
+    bad "${k} missing on first coverage row — PR 5 didn't ship or is behind main"
+  fi
+done
+
+# ── 2. Pack coverage matrix endpoint (#1751 PR 5) ───────────────────
+say "GET /guard/policies/packs/conduct-base/coverage-matrix"
+resp=$(curl -sS "${hdr[@]}" "${API}/guard/policies/packs/conduct-base/coverage-matrix?${qs}")
+total=$(jq -r '.total_rules' <<<"$resp")
+mcp_hard=$(jq -r '.by_surface.mcp.hard' <<<"$resp")
+action_ct=$(jq -r '.by_gate.action' <<<"$resp")
+if [[ "$total" -gt 0 && "$mcp_hard" -gt 0 && "$action_ct" -gt 0 ]]; then
+  ok "total_rules=${total}  by_surface.mcp.hard=${mcp_hard}  by_gate.action=${action_ct}"
+else
+  bad "coverage matrix zero-filled for conduct-base — pack not installed or endpoint broken"
+fi
+
+# ── 3. Rule fires endpoint returns redacted preview (#1755 PR 3) ─────
+say "GET /guard/events/rule/{first_rule}/fires — redacted"
+rule_id=$(jq -r '.[0].rule_id' <<<"$(curl -sS "${hdr[@]}" "${API}/guard/policies?${qs}" | jq '.[:1]')")
+if [[ -z "$rule_id" || "$rule_id" == "null" ]]; then
+  bad "could not pick a rule_id from /guard/policies — workspace empty?"
+else
+  resp=$(curl -sS "${hdr[@]}" "${API}/guard/events/rule/${rule_id}/fires?${qs}&limit=5")
+  n=$(jq 'length' <<<"$resp")
+  ok "rule_id=${rule_id}  fires_returned=${n}"
+  # Property 9: for any returned row, input_summary_redacted must NOT contain
+  # obvious secret markers. Absence of fires is also fine.
+  leaked=$(jq -r '.[] | select(.input_summary_redacted != null) | .input_summary_redacted' <<<"$resp" \
+           | grep -Ei '(sk-[a-z0-9]{20,}|xox[bp]-[0-9]+-[0-9]+|-----BEGIN.*PRIVATE KEY-----)' || true)
+  if [[ -z "$leaked" ]]; then
+    ok "no obvious raw secrets in redacted preview"
+  else
+    bad "possible raw secret in redacted preview: ${leaked}"
+  fi
+fi
+
+# ── 4. Divergence signal — Phase D readiness ────────────────────────
+say "Divergence: hand-authored vs derived"
+resp=$(curl -sS "${hdr[@]}" "${API}/guard/policies/coverage?${qs}")
+divergent=$(jq '[.[] | select(
+  ((.proxy == "hard" or .proxy == "not_supported") and .derived_proxy != null and .proxy != .derived_proxy) or
+  ((.hook == "hard" or .hook == "not_supported") and .derived_hook != null and .hook != .derived_hook) or
+  ((.mcp == "hard" or .mcp == "not_supported") and .derived_mcp != null and .mcp != .derived_mcp) or
+  ((.runtime == "hard" or .runtime == "not_supported") and .derived_runtime != null and .runtime != .derived_runtime)
+)] | length' <<<"$resp")
+if [[ "$divergent" -eq 0 ]]; then
+  ok "zero rules with authored↔derived divergence — Phase D can proceed for this workspace"
+else
+  ok "${divergent} rules diverge — Phase D signal (see server logs for details)"
+fi
+
+# ── Summary ─────────────────────────────────────────────────────────
+echo
+if [[ "$fail" -eq 0 ]]; then
+  printf "\033[32mSMOKE PASS\033[0m — every endpoint responds with the expected shape\n"
+else
+  printf "\033[31mSMOKE FAIL\033[0m — see errors above\n"
+fi
+exit "$fail"


### PR DESCRIPTION
## Summary

Ships **#1755** — Phase B Slice 2 of the Policies page rollout. Turns Property 8 (machine-verified PEP declarations) and Property 9 (raw payload never persists) from server-side invariants into customer-facing UI signals.

**One commit, six PR-scope units, 3 new test files, 1426/1426 tests pass, live-smoke PASS against local API.**

## Why

Property 8 says PEP capability declarations are machine-verified. Property 9 says raw payloads never leave the API. Both were true server-side but invisible to the customer. Slice 2 makes them visible:

- **Compliance officer** can now see per-PEP enforcement badges per rule + recent firings preview without a database query
- **Coverage tab** renders both hand-authored and derived status side-by-side, with a ⚠ marker flagging stale metadata for #1750 Phase D
- **Recent firings panel** shows the last N events that hit a rule, redacted through `redact_secrets` — matched-span + hash + size only, never raw payload

## What ships (six PR-scope units in one commit)

### PR 1 — `derived_<surface>` on `PolicyOut`
Every rule projection carries `derived_mcp` / `derived_proxy` / `derived_runtime` / `derived_hook` computed from `rule.gates × PEP capabilities`. Both projectors populate.

### PR 2 — `SurfaceBadges` on Policies page
Every rule row expands to show four chips (MCP / Proxy / Runtime / Hook). Green = hard, muted = not_supported. Fail-soft on undefined fields.

### PR 3 — `GET /guard/events/rule/{rule_id}/fires`
New endpoint. Auth: `require_permission("guard.activity.view_own")`. Returns last N events that fired the named rule, projected through `redact_secrets`. Adds sha256 prefix + byte size for dedupe/volume without payload.

### PR 4 — `RuleFiresPanel` on rule detail
Lazy-fetches firings on first expand. Renders redacted preview + decision chip + ai_tool + tool_call + size + hash prefix. Loading / error / empty states handled. **Nothing raw ever hits the DOM.**

### PR 5 — `EnforcementCoverageOut` + `StatusCell` divergence UI
Coverage tab shows **both** hand-authored (headline) and derived (subtext) per surface. When they disagree, a ⚠ marker with tooltip: "flag for Phase D cleanup." When Phase D retires the hand-authored fields, the subtext is already in place — no UI outage.

### PR 6 — smoke script + docs
`scripts/smoke_1755.sh` curls the three key endpoints against a running API and asserts the response shapes. Architecture doc §8 updated with a Slice 2 + smoke section.

## Modularity — no duplicates

- `derive_surface_status`, `PEP_CAPABILITIES` — imported from #1751, not duplicated
- `redact_secrets` — reused from `app.core.pii`
- `SurfaceBadges` and `StatusCell` — wrap existing chip primitives (`GateChips`, `StatusBadge`)
- Endpoint reuses `_org_ws_subquery` from `events.py`

## Live smoke — passed against local Docker API

```
→ GET /guard/policies/coverage — derived_<surface> present
  ✓ returned 49 rules
  ✓ derived_proxy=not_supported
  ✓ derived_hook=hard
  ✓ derived_mcp=hard
  ✓ derived_runtime=hard
→ GET /guard/policies/packs/conduct-base/coverage-matrix
  ✓ total_rules=46  by_surface.mcp.hard=40  by_gate.action=40
→ GET /guard/events/rule/{first_rule}/fires — redacted
  ✓ rule_id=production-change-v4  fires_returned=1
  ✓ no obvious raw secrets in redacted preview
→ Divergence: hand-authored vs derived
  ✓ 11 rules diverge — Phase D signal
SMOKE PASS — every endpoint responds with the expected shape
```

11 divergent rules is the **real-world signal** we designed the divergence log for. Compliance officers can now see this in the UI (⚠ marker), not just server logs.

## What this unblocks

- **#1750 Phase D** — safe to retire hand-authored `enforcement.<surface>` fields once divergence-log telemetry is clean. Coverage tab keeps rendering seamlessly.

## Verification

- 1426/1426 tests pass locally
- `tsc --noEmit` on `apps/web` clean
- `scripts/smoke_1755.sh` passes against local Docker API + real conduct-base pack

## Test plan

- [ ] CI green (full suite + drift check)
- [ ] Manual: open `/theguard/policies`, expand a rule → see `SurfaceBadges` + `RuleFiresPanel` in the details box
- [ ] Manual: switch to Coverage tab → per-surface cells now show two-line format (`Hard` + `derived: hard`); look for ⚠ on divergent rules
- [ ] Manual: `bash scripts/smoke_1755.sh` against staging after deploy → expect SMOKE PASS
- [ ] Manual: fire a `gates:[response]` rule (once one exists) and confirm the redacted preview appears in Recent Firings

## Follow-ups (not in this PR)

- **#1750 Phase D** — retire hand-authored `enforcement.<surface>` fields
- **Extend derive_surface_status** to model `conditional` / `advisory` deploy-caveat states (currently binary hard/not_supported)
- **UI test coverage** — the frontend has no React test framework wired yet; PR 2/4/5 rely on manual verification

Closes #1755.
