### PR TITLE
fix(runtime): MCP tool name regex — swap :: separator for __ (Anthropic 400)

### DIFF
--- a/apps/api/app/runtime/blocks/brain_block.py
+++ b/apps/api/app/runtime/blocks/brain_block.py
@@ -58,6 +58,22 @@ def _cache_set(run_id: str | None, block_id: str | None, turn: int, response_jso
     except Exception:
         pass
 
+# MCP tool naming — Anthropic tools API requires ^[a-zA-Z0-9_-]{1,128}$.
+# Prior joins used `::` which fails validation and broke every workflow
+# with MCP tools attached (self-driving-network-approval-demo regression,
+# 2026-09-10). We sanitize both halves to that alphabet and join with `__`,
+# and mirror the sanitization when building the server-name lookup map so
+# tool_use responses route back correctly.
+# ponytail: server.name authored to contain `__` will split ambiguously;
+# document convention rather than encode a fully-reversible scheme.
+_MCP_JOIN_SEP = "__"
+
+
+def _mcp_safe_name(s: str) -> str:
+    import re as _re
+    return _re.sub(r"[^A-Za-z0-9_-]", "-", s or "")
+
+
 # Re-imported here so block files can be imported standalone; also re-exported for
 # any caller that used to import BRAIN_TOOLS from executor.
 BRAIN_TOOLS = [
@@ -273,8 +289,9 @@ def _load_workspace_mcp_tools(
             tool_name = t.get("name", "")
             if not tool_name:
                 continue
+            _joined = f"{_mcp_safe_name(server.name)}{_MCP_JOIN_SEP}{_mcp_safe_name(tool_name)}"[:128]
             tools.append({
-                "name": f"{server.name}::{tool_name}",
+                "name": _joined,
                 "description": (
                     f"[MCP:{server.name}] {t.get('description', '')}"
                 ).strip(),
@@ -697,7 +714,9 @@ def _execute_brain(
                     _McpServer.workspace_id == workspace_id
                 ).all()
                 for s in servers:
-                    _mcp_server_cache[s.name] = s
+                    # Key by the sanitized form used in tool names so the parse
+                    # round-trips. Retain raw name in the value for downstream use.
+                    _mcp_server_cache[_mcp_safe_name(s.name)] = s
             except Exception as exc:
                 log.warning("brain.mcp_dispatch.map_failed", error=str(exc))
             return _mcp_server_cache
@@ -953,9 +972,9 @@ def _execute_brain(
                     }
 
                 try:
-                    if "::" in tc.name:
-                        # MCP tool dispatch — server_name::tool_name
-                        _mcp_server_name, _mcp_tool_name = tc.name.split("::", 1)
+                    if _MCP_JOIN_SEP in tc.name:
+                        # MCP tool dispatch — server-name__tool-name (see _mcp_safe_name).
+                        _mcp_server_name, _mcp_tool_name = tc.name.split(_MCP_JOIN_SEP, 1)
 
                         # Guard check before every MCP tool call
                         if state.get("__guard_enabled") and db and workspace_id:

--- a/apps/api/tests/test_brain_block_config_parity.py
+++ b/apps/api/tests/test_brain_block_config_parity.py
@@ -187,7 +187,7 @@ def test_mcp_selection_none_returns_all_servers():
         tools = _load_workspace_mcp_tools("ws-1", None, db, selected_ids=None)
     # Two servers × one tool each = 2 tools total
     assert len(tools) == 2
-    assert {"gh::t1", "slack::t1"} == {t["name"] for t in tools}
+    assert {"gh__t1", "slack__t1"} == {t["name"] for t in tools}
 
 
 def test_mcp_selection_all_sentinel_returns_all_servers():
@@ -198,7 +198,7 @@ def test_mcp_selection_all_sentinel_returns_all_servers():
         return_value=([{"name": "t1", "description": "d"}], None),
     ):
         tools = _load_workspace_mcp_tools("ws-1", None, db, selected_ids=["all"])
-    assert {"gh::t1", "slack::t1"} == {t["name"] for t in tools}
+    assert {"gh__t1", "slack__t1"} == {t["name"] for t in tools}
 
 
 def test_mcp_selection_empty_list_returns_all_servers():
@@ -209,7 +209,7 @@ def test_mcp_selection_empty_list_returns_all_servers():
         return_value=([{"name": "t1", "description": "d"}], None),
     ):
         tools = _load_workspace_mcp_tools("ws-1", None, db, selected_ids=[])
-    assert {"gh::t1", "slack::t1"} == {t["name"] for t in tools}
+    assert {"gh__t1", "slack__t1"} == {t["name"] for t in tools}
 
 
 def test_mcp_selection_specific_ids_filters_to_subset():
@@ -225,5 +225,5 @@ def test_mcp_selection_specific_ids_filters_to_subset():
     ):
         tools = _load_workspace_mcp_tools("ws-1", None, db, selected_ids=["s1", "s3"])
     # slack (s2) must be filtered out
-    assert {"gh::t1", "linear::t1"} == {t["name"] for t in tools}
-    assert not any(t["name"].startswith("slack::") for t in tools)
+    assert {"gh__t1", "linear__t1"} == {t["name"] for t in tools}
+    assert not any(t["name"].startswith("slack__") for t in tools)


### PR DESCRIPTION
## Summary

**Production regression fix.** Anthropic tightened `tools[].name` validation. Our MCP tool-name join has used `::` as an internal separator for weeks, and it never matched their `^[a-zA-Z0-9_-]{1,128}$` regex — but the validator only started rejecting it recently.

Every workflow with at least one registered MCP tool hit HTTP 400 on the first upstream call.

## Repro

Any brain block with `mcp_server_ids` non-empty. Seen live on `self_driving_network_approval_demo`:

```
anthropic.BadRequestError: Error code: 400 —
tools.5.custom.name: String should match pattern '^[a-zA-Z0-9_-]{1,128}$'
```

Index 5 = the first MCP tool (indexes 0–4 are `BRAIN_TOOLS`).

## Fix

1. **`_mcp_safe_name(s)`** helper at module top of `brain_block.py` — replaces any character outside `[A-Za-z0-9_-]` with `-`.
2. **`_MCP_JOIN_SEP = "__"`** constant. Double underscore is safe against Anthropic's regex AND unambiguous — server/tool names never contain it by convention (unlike single `_` or single `-`).
3. Three sites now use the helper + constant:
   - Tool-list build (`_load_workspace_mcp_tools`)
   - Server-name lookup map (`_get_mcp_server_map`)
   - Tool-use response parse (in the brain loop)
4. Updated 5 test assertions that hard-coded the old `::` format.

## Why `__`, not `-`

`-` and `_` both appear naturally in server names (`postgres-prod`, `github_prod_us`) and tool names (`create-issue`, `read_file`). Splitting on a single dash or underscore would parse `postgres-prod-create-issue` as `("postgres", "prod-create-issue")` — wrong server, silent misroute. `__` is rare enough in either half to be a clean sentinel.

## Blast radius

- Additive semantics; all three sites share one helper.
- Existing MCP integrations continue to work — the model sees sanitized tool names and returns them verbatim; server lookup is now sanitization-aware.
- No schema change, no migration.
- No wire-format change with any external system except the Anthropic tools payload (which is exactly what we're fixing).

## Verification

- `brain_block_config_parity` tests: 10/10 pass locally
- Manual: re-ran the failing playbook against local Docker API → deploy_prod brain block proceeds past the tool-list validation

## Test plan

- [ ] CI green
- [ ] Manual: run any workflow with MCP tools registered — should not hit the 400 anymore
- [ ] Manual: run `self_driving_network_approval_demo` end-to-end — deploy_prod block reaches the run_shell call

## Related

- `brain_block.py:277` — the offending `::` join, present since `22b7e995` (well before recent guard work)
- No relation to #1737 / #1733 / #1751 / #1755 — pre-existing latent bug exposed by an Anthropic-side validator change

Fixes the immediate production regression.
