### PR TITLE
docs(marketing): sync playbook count (35) + enforcement surfaces (5)

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,12 +114,12 @@ Every request runs through Guard (policy, budget, audit) before it reaches the u
 | Compliance packs        | `apps/api/app/modules/guard/skill_packs/`     |
 | Canvas UI               | `apps/web/`                                   |
 | Playbook DSL loader     | `apps/api/app/dsl/`                           |
-| Playbook library        | `apps/api/playbooks/` (39 pre-built)          |
+| Playbook library        | `apps/api/playbooks/` (35 pre-built)          |
 | CLI                     | `packages/conduct-cli/`                       |
 
 **15 compliance packs out of the box:** OWASP, SOC 2 CC7.3, HIPAA §164.312, PCI DSS 4.0, EU AI Act Art. 15/16, NIST AI RMF, ISO 42001, plus Python, Node, and Terraform.
 
-**39 pre-built playbooks:** issue-to-PR, code review, incident response, prod deploy gate, CI/CD triage, security scanner triage, Slack digest. One YAML file each. Edit and run.
+**35 pre-built playbooks:** issue-to-PR, code review, incident response, prod deploy gate, CI/CD triage, security scanner triage, Slack digest. One YAML file each. Edit and run.
 
 ---
 
@@ -164,7 +164,7 @@ Full docs live under [`docs/`](./docs/README.md) — organized by goal (Start ·
 Quick paths:
 
 - **New to Conduct** → [Start](./docs/start.md)
-- **See what's possible** → [Examples — 37 playbooks](./docs/examples.md)
+- **See what's possible** → [Examples — 35 playbooks](./docs/examples.md)
 - **Write a playbook** → [Block reference](./docs/reference/blocks.md)
 - **Wire into CI, MCP, tools** → [Automate](./docs/automate.md)
 - **Governance & compliance** → [Guard rule packs — 183 rules](./docs/reference/guard-rule-packs.md)

--- a/apps/web/public/conduct-pages/conduct-landing.html
+++ b/apps/web/public/conduct-pages/conduct-landing.html
@@ -454,7 +454,7 @@ footer { border-top: 1px solid var(--stone-200); padding: 36px 0; }
         <div class="step-num">02</div>
         <div class="step-icon">📦</div>
         <h3>Install a playbook</h3>
-        <p>Browse 22 pre-built agent playbooks. Click Install — the canvas is pre-wired. Add your credentials and the agent is ready to run.</p>
+        <p>Browse 35 pre-built agent playbooks. Click Install — the canvas is pre-wired. Add your credentials and the agent is ready to run.</p>
         <div class="step-connector">→</div>
       </div>
       <div class="step">
@@ -478,7 +478,7 @@ footer { border-top: 1px solid var(--stone-200); padding: 36px 0; }
           <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="5" cy="5" r="2"/><circle cx="5" cy="19" r="2"/><circle cx="19" cy="7" r="2"/><path d="M7 5h5a2 2 0 0 1 2 2v3"/><path d="M5 7v10"/></svg>
         </div>
         <h3>Agent Workflows</h3>
-        <p>Stop doing the same work around every PR. 39 playbooks handle issue triage, code review, incident response, and release notes — with human approval before anything ships. Every agent gets an A–F scorecard and DORA-lite metrics so you know what's actually delivering value.</p>
+        <p>Stop doing the same work around every PR. 35 playbooks handle issue triage, code review, incident response, and release notes — with human approval before anything ships. Every agent gets an A–F scorecard and DORA-lite metrics so you know what's actually delivering value.</p>
         <a href="/marketplace" class="pillar-link">Browse Marketplace →</a>
       </div>
       <div class="pillar guard">

--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -46,7 +46,7 @@ function ProductDropdown() {
       <div className="absolute left-0 top-full pt-2 hidden group-hover:block z-50 min-w-[220px]">
         <div className="bg-white border border-stone-200 rounded-xl shadow-lg py-2">
           <NavItem href="/guard" title="Guard" desc="Runtime policy enforcement for every AI agent" />
-          <NavItem href="/playbooks" title="Playbooks" desc="39 pre-built automations with Guard built in" />
+          <NavItem href="/playbooks" title="Playbooks" desc="35 pre-built automations with Guard built in" />
           <NavItem href="/evidence" title="Evidence" desc="Hash-chained audit trail for every decision" />
           <NavItem href="/mcp-gateway" title="MCP" desc="Policy for every MCP tool invocation" />
         </div>

--- a/apps/web/src/app/(marketing)/page.tsx
+++ b/apps/web/src/app/(marketing)/page.tsx
@@ -278,12 +278,12 @@ function OnePolicySection() {
               Write the rule once. Apply it where agents work.
             </h2>
             <p className="text-stone-500 leading-relaxed mb-6 text-sm sm:text-base">
-              One policy definition — one set of rules for which actions require approval, which are blocked, and which are audited. Guard applies it across your entire agent fleet: CLI hooks, HTTP proxy, and MCP layer.
+              One policy definition — one set of rules for which actions require approval, which are blocked, and which are audited. Guard applies it across your entire agent fleet: CLI hooks, LLM proxy (prompt + response gates), MCP layer, and Lens chat.
             </p>
             <ul className="space-y-3 text-sm text-stone-600">
               <li className="flex items-start gap-2">
                 <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
-                <span>3 enforcement surfaces: CLI hook, HTTP proxy, MCP layer</span>
+                <span>5 enforcement surfaces: CLI hook, LLM proxy (prompt), LLM proxy (response), MCP layer, Lens</span>
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
@@ -291,7 +291,7 @@ function OnePolicySection() {
               </li>
               <li className="flex items-start gap-2">
                 <span className="text-emerald-600 font-bold mt-0.5 shrink-0">→</span>
-                <span>39 pre-built playbooks with Guard enforcement built in</span>
+                <span>35 pre-built playbooks with Guard enforcement built in</span>
               </li>
             </ul>
           </div>

--- a/apps/web/src/app/(marketing)/pricing/page.tsx
+++ b/apps/web/src/app/(marketing)/pricing/page.tsx
@@ -27,7 +27,7 @@ const TIERS: Tier[] = [
     includes: [
       "Full policy engine — allow, block, approve, prove",
       "Hash-chained audit trail",
-      "MCP + proxy + CLI hook enforcement",
+      "MCP + LLM proxy + CLI hook + Lens enforcement",
       "Community support (GitHub Discussions)",
     ],
   },
@@ -131,8 +131,8 @@ export default function PricingPage() {
           </h1>
           <p className="text-lg text-stone-500 max-w-2xl mx-auto leading-relaxed">
             Every tier includes the full policy engine, hash-chained audit trail, and every
-            enforcement surface — MCP, proxy, and CLI hook. You pay for how many agent
-            identities you govern, not which features you unlock.
+            enforcement surface — MCP, LLM proxy (prompt + response), CLI hook, and Lens.
+            You pay for how many agent identities you govern, not which features you unlock.
           </p>
         </section>
 
@@ -203,7 +203,7 @@ export default function PricingPage() {
           {[
             {
               title: "One engine — every surface",
-              body: "MCP tool interception, LLM proxy, and CLI hooks all run through the same policy engine and write to the same audit chain.",
+              body: "MCP tool interception, LLM proxy (prompt + response gates), CLI hooks, and Lens chat all run through the same policy engine and write to the same audit chain.",
             },
             {
               title: "One agent identity",

--- a/apps/web/src/app/(marketing)/registry/page.tsx
+++ b/apps/web/src/app/(marketing)/registry/page.tsx
@@ -164,7 +164,7 @@ export default function RegistryPage() {
           <h2 className="text-2xl font-bold text-stone-900 mb-3">What every playbook is made of</h2>
           <p className="text-stone-500 text-sm leading-relaxed mb-8 max-w-2xl">
             Playbooks are not scripts. They are structured compositions of typed blocks. The same block types
-            appear across all 39 playbooks — which means policy, approval, and evidence are never bolt-ons.
+            appear across all 35 playbooks — which means policy, approval, and evidence are never bolt-ons.
           </p>
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
             {[

--- a/apps/web/src/app/(marketing)/security/page.tsx
+++ b/apps/web/src/app/(marketing)/security/page.tsx
@@ -26,7 +26,7 @@ export default function SecurityPage() {
         <section className="mb-16">
           <h2 className="text-2xl font-bold text-stone-900 mb-3">Enforcement</h2>
           <p className="text-stone-600 leading-relaxed mb-5">
-            Guard evaluates every action against your policy before it executes. Three enforcement surfaces catch every path an agent can take:
+            Guard evaluates every action against your policy before it executes. Five enforcement surfaces catch every path an agent can take:
           </p>
           <ul className="text-sm text-stone-600 space-y-2.5">
             <li className="flex items-start gap-3">
@@ -35,11 +35,15 @@ export default function SecurityPage() {
             </li>
             <li className="flex items-start gap-3">
               <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">HTTP</span>
-              <span>Drop-in base URL replacement in front of your model gateway. Every LLM request is policy-checked.</span>
+              <span>Drop-in base URL replacement in front of your model gateway. Two gates on every call: prompt before the model sees it, response before it returns.</span>
             </li>
             <li className="flex items-start gap-3">
               <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">MCP</span>
               <span>Wraps MCP tool invocations before they reach the server. Same policy engine, different transport.</span>
+            </li>
+            <li className="flex items-start gap-3">
+              <span className="text-stone-400 font-mono shrink-0 min-w-[48px] pt-0.5">LENS</span>
+              <span>Every Lens chat LLM turn routes through the same policy engine. In-process, no round-trip.</span>
             </li>
           </ul>
         </section>
@@ -83,9 +87,9 @@ export default function SecurityPage() {
             </div>
             <div className="px-5 py-2">
               <ThreatModelRow
-                threat="Actions routed through Guard (CLI hook, HTTP proxy, MCP layer)"
+                threat="Actions routed through Guard (CLI hook, LLM proxy, MCP layer, Lens)"
                 coverage="Protected"
-                detail="All three surfaces run the same policy engine. Refunds, network changes, secret reads — every action routed through Guard is inspected."
+                detail="All five enforcement surfaces run the same policy engine — CLI hook, proxy prompt gate, proxy response gate, MCP, and Lens LLM turn. Refunds, network changes, secret reads — every action routed through Guard is inspected."
               />
               <ThreatModelRow
                 threat="Audit trail integrity"

--- a/docs/README.md
+++ b/docs/README.md
@@ -136,7 +136,7 @@ Third-party systems Conduct plugs into.
 
 ## Examples
 
-- [Examples](examples.md) — 37 pre-built playbooks grouped by what they do: code review, security scan + auto-fix, dependencies, incidents, releases, AI governance, autopilot, testing, docs, NetOps.
+- [Examples](examples.md) — 35 pre-built playbooks grouped by what they do: code review, security scan + auto-fix, dependencies, incidents, releases, AI governance, autopilot, testing, docs, NetOps.
 
 ---
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,6 @@
 # Examples
 
-37 pre-built playbooks. Every one is a working YAML file under [`apps/api/playbooks/`](../apps/api/playbooks/) — copy, tweak, install. Grouped by what they *do*, not by which tool they call.
+35 pre-built playbooks. Every one is a working YAML file under [`apps/api/playbooks/`](../apps/api/playbooks/) — copy, tweak, install. Grouped by what they *do*, not by which tool they call. (Demo playbooks — `-demo` / `-e2e` files and `kind: base` snippets — are excluded from this count.)
 
 Install one directly:
 


### PR DESCRIPTION
## Summary

Bring live copy in sync with the product truth inventory after yesterday's Guard shipwork (#1751 / #1755 / #1753).

- **Playbook count → 35** across README, docs/README, docs/examples, homepage, nav dropdown, registry, pricing, landing HTML. Prior counts (39 / 37 / 22) mixed real playbooks with demos and infrastructure files.
- **Enforcement surfaces → 5** on homepage, security page, and pricing. Adds Lens LLM turn (shipped via `app.guard.gateway` in #1245) and calls out the proxy's two gates (prompt before model, response before caller) shipped in #1751 / #1755.

### Playbook exclusion rule (documented in `docs/examples.md`)

Five files excluded from the public count:

| File | Reason |
|---|---|
| `acme-onboarding-e2e.yaml` | E2E test scenario |
| `nemo-guardrails-demo.yaml` | Explicit HPE demo |
| `self-driving-network-approval-demo.yaml` | Explicit HPE demo |
| `base-autopilot.yaml` | `kind: base` snippet library — runtime never sees it |
| `registry.yaml` | Marketplace metadata file, not a playbook |

Future files with `-demo` / `-e2e` in the filename, or `kind: base` metadata, are auto-excluded from public counts.

### Source

Companion updates land in the internal repo (`docs/positioning-2026.md` §16.6 Enforcement Fabric, `docs/product-truth-2026.md` §2 + §15) — not in this PR.

## Test plan

- [ ] `pnpm build` — no type / lint regressions from the marketing edits
- [ ] Visual spot-check on the marketing site preview: homepage surface strip, `/security`, `/pricing`, `/registry`, nav dropdown
- [ ] `apps/web/public/conduct-pages/conduct-landing.html` renders — static file, sanity check the two lines changed
- [ ] Confirm README + docs/examples read cleanly on GitHub