### PR TITLE
fix(runs): seed Lens session so canvas Run auto-opens the RunBubble

### DIFF
--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -317,12 +317,6 @@ def create_run(
         import uuid as _uuid_std
         from app.modules.glens.models import GlensChatSession
         lens_session_id = _uuid_std.uuid4()
-        db.add(GlensChatSession(
-            id=lens_session_id,
-            workspace_id=workflow.workspace_id,
-            title=f"Run: {workflow.name}",
-            messages="[]",
-        ))
 
     run = Run(
         workflow_version_id=workflow.current_version_id,
@@ -333,6 +327,30 @@ def create_run(
         max_turns=max_turns,
         session_id=lens_session_id,
     )
+
+    if body.create_lens_session:
+        # Pre-seed the session with a run_started envelope so /lens/{id} renders
+        # the RunBubble immediately on redirect, without waiting for the worker
+        # to publish the first event. Frontend rehydration matches on
+        # `p.run_started?.run_id` (GLensChatPage.selectSession).
+        import json as _json_std
+        run_started_msg = {
+            "role": "assistant",
+            "content": _json_std.dumps({
+                "run_started": {
+                    "run_id": str(run.id),
+                    "workflow_name": workflow.name,
+                    "status": "pending",
+                }
+            }),
+        }
+        db.add(GlensChatSession(
+            id=lens_session_id,
+            workspace_id=workflow.workspace_id,
+            title=f"Run: {workflow.name}",
+            messages=_json_std.dumps([run_started_msg]),
+        ))
+
     db.add(run)
     db.commit()  # single commit — session + run land together or neither does
     db.refresh(run)

--- a/apps/api/app/routers/runs.py
+++ b/apps/api/app/routers/runs.py
@@ -312,13 +312,20 @@ def create_run(
     # SQLAlchemy's default fire on flush) so `run.session_id` can carry it
     # without an intermediate commit — if Run insert fails, both roll back
     # and no ghost session appears in the sidebar.
+    import uuid as _uuid_std
+    # Mint run.id upfront so the seeded run_started envelope can reference it
+    # without needing a pre-commit flush. SQLAlchemy's Python-side default
+    # doesn't fire on __init__ — only on flush — so `str(run.id)` before add
+    # would resolve to "None".
+    run_id = _uuid_std.uuid4()
+
     lens_session_id = None
     if body.create_lens_session:
-        import uuid as _uuid_std
         from app.modules.glens.models import GlensChatSession
         lens_session_id = _uuid_std.uuid4()
 
     run = Run(
+        id=run_id,
         workflow_version_id=workflow.current_version_id,
         workspace_id=workflow.workspace_id,
         triggered_by=body.triggered_by,
@@ -338,7 +345,7 @@ def create_run(
             "role": "assistant",
             "content": _json_std.dumps({
                 "run_started": {
-                    "run_id": str(run.id),
+                    "run_id": str(run_id),
                     "workflow_name": workflow.name,
                     "status": "pending",
                 }

--- a/apps/api/tests/test_create_run_lens_session.py
+++ b/apps/api/tests/test_create_run_lens_session.py
@@ -159,7 +159,16 @@ def test_create_lens_session_flag_mints_and_links(ws_and_workflow):
     ), {"sid": result.session_id, "ws": ws_uuid}).first()
     assert sess is not None
     assert sess[0] == "Run: Test WF"
-    assert sess[1] == "[]"
+    # Session is pre-seeded with a run_started envelope so /lens/{id} renders
+    # the RunBubble on redirect — frontend rehydration keys off p.run_started.
+    import json as _json
+    msgs = _json.loads(sess[1])
+    assert len(msgs) == 1
+    assert msgs[0]["role"] == "assistant"
+    payload = _json.loads(msgs[0]["content"])
+    assert payload["run_started"]["run_id"] == str(result.id)
+    assert payload["run_started"]["workflow_name"] == "Test WF"
+    assert payload["run_started"]["status"] == "pending"
     # Token + AgentIdentity mint lazily on first chat message; both stay NULL
     # here. That's the whole point — canvas Run doesn't need chat auth.
     assert sess[2] is None


### PR DESCRIPTION
## Summary
Canvas → Run → confirms max_turns → redirects to `/lens/{session_id}`. On arrival, the session name showed in the sidebar but the main pane rendered the opener screen instead of the RunBubble, and clicking the sidebar didn't help either.

## Root cause
`POST /workflows/{id}/runs` with `create_lens_session=true` was minting the `GlensChatSession` row with `messages="[]"`. Frontend fetches messages via `GLensChatPage.selectSession` → sets `hasThread = messages.length > 0` → false → opener screen renders. RunBubble rehydration expected a persisted `run_started` envelope that never got written.

## Fix
`apps/api/app/routers/runs.py` — when `create_lens_session=true`, pre-seed the session `messages` with one assistant envelope:
```json
{"run_started": {"run_id": "...", "workflow_name": "...", "status": "pending"}}
```
Frontend rehydration at `GLensChatPage.tsx:1892` already matches on `p.run_started?.run_id` → RunBubble renders immediately on redirect. No client change.

Updated test `test_create_lens_session_flag_mints_and_links` to assert the seeded envelope shape.

## Test plan
- [ ] Canvas → Run on any workflow → confirm redirect lands on `/lens/{id}` with the RunBubble visible (not the opener chips).
- [ ] Click the session in the sidebar → still shows the RunBubble.
- [ ] Verify Slack HITL / RunBubble live updates still flow through (no regression in SSE path).
- [ ] `pytest apps/api/tests/test_create_run_lens_session.py -q` green.