### PR TITLE
feat(guard): guard_check_prompt MCP verb + LiteLLM plugin routes prompts through it

### DIFF
--- a/apps/api/app/modules/guard/mcp_impls.py
+++ b/apps/api/app/modules/guard/mcp_impls.py
@@ -138,26 +138,33 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
     _run_id = arguments.get("conduct_run_id") or None
     _workflow = arguments.get("conduct_workflow") or None
     _prompt = arguments.get("prompt") or None
+    # Internal knobs (underscored so they never collide with JSON-Schema args)
+    # let guard_check_prompt_impl reuse this whole flow for the proxy PEP.
+    # Default preserves pre-#1770 behavior: agent persona, action gate,
+    # audit source="mcp".
+    _persona = arguments.get("_persona", "agent")
+    _gate = arguments.get("_gate", "action")
+    _source = arguments.get("_source", "mcp")
     # #1753 (2026-09-10): the `pack:` argument is retired. If a legacy client
     # still passes it, we ignore it silently and evaluate against the full
     # workspace policy (which is the correct behavior anyway — pack-scoping
     # was the buggy path that bypassed overrides).
     try:
-        rules = _get_rules(db, ws_uuid)
+        rules = _get_rules(db, ws_uuid, persona=_persona)
     except Exception as _eval_err:
         _cfg = db.query(GuardConfig).filter(GuardConfig.workspace_id == ws_uuid).first()
         if _cfg and not _cfg.deny_on_error:
             return f"advisory: policy eval error (fail-open): {_eval_err}"
-        _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", "policy_eval_error", ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+        _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", "policy_eval_error", ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
         return "BLOCKED — policy evaluation failed. Request denied by fail-closed default."
 
     _cfg = db.query(GuardConfig).filter(GuardConfig.workspace_id == ws_uuid).first()
     _advisory = _cfg.advisory_mode if _cfg else False
 
-    rule = _match_policy(inner_tool, inner_input, rules)
+    rule = _match_policy(inner_tool, inner_input, rules, gate=_gate)
 
     if rule is None:
-        _record_event(db, ws_uuid, inner_tool, inner_input, "allowed", None, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+        _record_event(db, ws_uuid, inner_tool, inner_input, "allowed", None, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
         return "ok"
 
     action = rule.get("action", "audit")
@@ -169,11 +176,11 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
         _guidance_suffix = f"\n\nGUIDANCE — {_guidance_text}"
 
     if _advisory:
-        _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+        _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
         return f"advisory: {message} [rule: {rule_id}]{_guidance_suffix}"
 
     if action == "block":
-        _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+        _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
         return f"BLOCKED — {message}  [rule: {rule_id}]{_guidance_suffix}"
 
     if action == "warn":
@@ -185,7 +192,7 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
         ).first()
         if already_warned:
             return "ok"
-        _record_event(db, ws_uuid, inner_tool, inner_input, "warned", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+        _record_event(db, ws_uuid, inner_tool, inner_input, "warned", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
         return f"WARNING — {message}  [rule: {rule_id}]{_guidance_suffix}"
 
     if action == "approval":
@@ -206,10 +213,10 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
 
         verdict, block_reason = _approval.resume_verdict(prior)
         if verdict == "proceed":
-            _record_event(db, ws_uuid, inner_tool, inner_input, "allowed", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+            _record_event(db, ws_uuid, inner_tool, inner_input, "allowed", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
             return "ok"
         if verdict == "block":
-            _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+            _record_event(db, ws_uuid, inner_tool, inner_input, "blocked", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
             return f"BLOCKED — {block_reason}  [rule: {rule_id}]{_guidance_suffix}"
         if verdict == "wait":
             return _approval.pending_marker(prior)
@@ -229,8 +236,48 @@ def guard_check_impl(ctx: GuardCtx, **arguments) -> str:
         return _approval.pending_marker(req)
 
     # audit action fires the side-effect but returns "ok" to the agent
-    _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt)
+    _record_event(db, ws_uuid, inner_tool, inner_input, "audited", rule_id, ai_tool, user_email, session_id, conductai_run_id=_run_id, conductai_workflow=_workflow, prompt=_prompt, source=_source)
     return "ok"
+
+
+def guard_check_prompt_impl(ctx: GuardCtx, **arguments) -> str:
+    """Prompt-gate variant of guard_check.
+
+    Callers at the LLM egress boundary (LiteLLM plugin, LangChain callbacks,
+    custom proxies) hit this before the prompt reaches the model. Evaluates
+    proxy-persona rules against the prompt text; returns the same envelope
+    guard_check does so response parsers stay shared.
+
+    Property 8: MCP is the *transport*; the proxy PEP is the *enforcement
+    point* — declared capabilities ``{prompt, response}`` unchanged.
+
+    Fixes silent pass-through where proxy rules (e.g. `no-conduct-tokens`,
+    `proxy-no-credential-leak`) never fired for LiteLLM plugin traffic
+    because the plugin was hitting the action-gate MCP path.
+    """
+    prompt = arguments.get("prompt") or ""
+    if not prompt:
+        return "ERROR — 'prompt' argument is required (the outbound LLM prompt text)."
+
+    tool_input = {"prompt": prompt}
+    model = arguments.get("model")
+    provider = arguments.get("provider")
+    if model:
+        tool_input["model"] = model
+    if provider:
+        tool_input["provider"] = provider
+
+    return guard_check_impl(
+        ctx,
+        tool_name="llm_call",
+        tool_input=tool_input,
+        prompt=prompt,
+        conduct_run_id=arguments.get("conduct_run_id"),
+        conduct_workflow=arguments.get("conduct_workflow"),
+        _persona="proxy",
+        _gate="prompt",
+        _source="proxy",
+    )
 
 
 def guard_test_impl(ctx: GuardCtx, **arguments) -> str:
@@ -744,6 +791,7 @@ _GUARD_TOOL_IMPLS: dict[str, Any] = {
     'guard_status': guard_status_impl,
     'conduct_current_workspace': conduct_current_workspace_impl,
     'guard_check': guard_check_impl,
+    'guard_check_prompt': guard_check_prompt_impl,
     'guard_test': guard_test_impl,
     'guard_sync': guard_sync_impl,
     'guard_enable': guard_enable_impl,

--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -88,6 +88,29 @@ _TOOLS = [
         },
     },
     {
+        "name": "guard_check_prompt",
+        "description": (
+            "Prompt-gate variant of guard_check. Callers at the LLM egress "
+            "boundary (LiteLLM plugin, LangChain callbacks, custom proxies) "
+            "hit this before their prompt reaches the model. Evaluates "
+            "proxy-persona rules against the prompt text; returns the same "
+            "'ok' / 'WARNING —' / 'BLOCKED —' / 'PENDING approval —' envelope "
+            "guard_check does, so response parsers are shared. "
+            "MCP is the transport; the proxy PEP is what enforces (Property 8)."
+        ),
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "prompt":   {"type": "string", "description": "The outbound prompt text about to be sent to the model."},
+                "model":    {"type": "string", "description": "Model identifier, e.g. 'claude-3-5-sonnet', 'gpt-4o'."},
+                "provider": {"type": "string", "description": "Upstream provider, e.g. 'anthropic', 'openai', 'bedrock'."},
+                "conduct_run_id":   {"type": "string", "description": "Optional. Conduct run ID if called from within a workflow run."},
+                "conduct_workflow": {"type": "string", "description": "Optional. Conduct workflow slug if called from within a workflow run."},
+            },
+            "required": ["prompt"],
+        },
+    },
+    {
         "name": "guard_test",
         "description": (
             "Dry-run a single pack against a candidate tool call. "
@@ -455,9 +478,22 @@ def _project_rule(r: dict) -> dict:
     return out
 
 
-def _get_rules(db: Session, ws_uuid: uuid.UUID) -> list[dict]:
-    """Active ruleset for the agent persona — governs what AI does on the machine."""
-    rules = compute_policy(db, ws_uuid, "agent")
+def _get_rules(db: Session, ws_uuid: uuid.UUID, persona: str = "agent") -> list[dict]:
+    """Active ruleset for the requested persona.
+
+    Two personas today (locked by rule schema, not this function):
+      - ``"agent"``  — governs what AI does on the machine. MCP + hook + runtime
+                        PEPs call this. Gate: ``action``.
+      - ``"proxy"``  — governs outbound LLM traffic. LLM proxy PEP calls this
+                        directly; the ``guard_check_prompt`` MCP verb also calls
+                        this so LiteLLM-style callers can reach proxy rules
+                        without a new transport. Gate: ``prompt`` (``response``
+                        when that path lands).
+
+    Property 8 stays clean: MCP is the *transport*; the proxy PEP is the
+    *enforcement point* that declares ``{prompt, response}`` capability.
+    """
+    rules = compute_policy(db, ws_uuid, persona)
     return [_project_rule(r) for r in rules]
 
 

--- a/apps/api/app/tools/registrations/guard.py
+++ b/apps/api/app/tools/registrations/guard.py
@@ -40,6 +40,7 @@ _ANNOTATIONS: dict[str, ToolAnnotations] = {
     "guard_status":              ToolAnnotations(read_only=True),
     "conduct_current_workspace": ToolAnnotations(read_only=True, idempotent=True),
     "guard_check":               ToolAnnotations(open_world=True),
+    "guard_check_prompt":        ToolAnnotations(open_world=True),
     "guard_test":                ToolAnnotations(read_only=True),
     "guard_sync":              ToolAnnotations(read_only=True),
     "guard_enable":            ToolAnnotations(read_only=True),

--- a/apps/api/tests/guard/test_guard_check_prompt_verb.py
+++ b/apps/api/tests/guard/test_guard_check_prompt_verb.py
@@ -1,0 +1,145 @@
+"""guard_check_prompt MCP verb — proxy-persona / prompt-gate variant.
+
+Fixes silent pass-through where the LiteLLM plugin's traffic hit the
+action-gate guard_check verb and never saw proxy-persona rules like
+`no-conduct-tokens` / `proxy-no-credential-leak`. Per Guard architecture
+§8, MCP is transport; the proxy PEP declares {prompt, response} — this
+verb is the MCP-transport entry into that PEP.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.modules.guard.mcp_impls import GuardCtx, guard_check_prompt_impl
+
+
+WS_UUID = uuid.UUID("00000000-0000-0000-0000-0000000000aa")
+
+
+def _ctx() -> GuardCtx:
+    return GuardCtx(
+        db=MagicMock(),
+        ws_uuid=WS_UUID,
+        workspace_id=str(WS_UUID),
+        resolved_token="cond_agt_test",
+        clerk_user_id="clerk-abc",
+        user_email="sudhi@example.com",
+        ai_tool="litellm",
+        session_id="test-session-1",
+    )
+
+
+def test_missing_prompt_returns_error():
+    result = guard_check_prompt_impl(_ctx())
+    assert result.startswith("ERROR")
+    assert "prompt" in result
+
+
+def test_forwards_proxy_persona_prompt_gate_and_proxy_source():
+    """The wrapper must call guard_check_impl with the persona/gate/source
+    overrides that route to the proxy PEP path."""
+    captured: dict = {}
+
+    def _fake_impl(ctx, **kwargs):
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    with patch("app.modules.guard.mcp_impls.guard_check_impl", side_effect=_fake_impl):
+        result = guard_check_prompt_impl(
+            _ctx(),
+            prompt="hello, world",
+            model="claude-3-5-sonnet",
+            provider="anthropic",
+        )
+
+    assert result == "ok"
+    kw = captured["kwargs"]
+    assert kw["_persona"] == "proxy"
+    assert kw["_gate"] == "prompt"
+    assert kw["_source"] == "proxy"
+    # The wrapper packs prompt/model/provider into tool_input so downstream
+    # regex matchers see them; also passes prompt at the top level so the
+    # audit trail has the raw text (redacted at record time).
+    assert kw["tool_name"] == "llm_call"
+    assert kw["tool_input"]["prompt"] == "hello, world"
+    assert kw["tool_input"]["model"] == "claude-3-5-sonnet"
+    assert kw["tool_input"]["provider"] == "anthropic"
+    assert kw["prompt"] == "hello, world"
+
+
+def test_omits_optional_fields_when_not_supplied():
+    captured: dict = {}
+
+    def _fake_impl(ctx, **kwargs):
+        captured["kwargs"] = kwargs
+        return "ok"
+
+    with patch("app.modules.guard.mcp_impls.guard_check_impl", side_effect=_fake_impl):
+        guard_check_prompt_impl(_ctx(), prompt="hello")
+
+    ti = captured["kwargs"]["tool_input"]
+    assert ti == {"prompt": "hello"}  # no model / provider keys
+
+
+def test_end_to_end_block_on_credential_prompt():
+    """Proxy-rule matching a credential pattern must BLOCK when invoked via
+    the prompt-gate verb. This is the exact case the LiteLLM plugin was
+    silently missing before this change."""
+    proxy_rule = {
+        "rule_id": "test-no-fake-key",
+        "match_pattern": r"sk_live_[0-9a-zA-Z]{20,}",
+        "action": "block",
+        "message": "Credential detected in prompt.",
+        "gates": ["prompt"],
+    }
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=[proxy_rule]), \
+         patch("app.modules.guard.mcp_impls._record_event") as rec, \
+         patch("app.modules.guard.mcp_impls.GuardConfig"):
+        # Ensure the GuardConfig query returns None (no advisory mode).
+        _ctx_obj = _ctx()
+        _ctx_obj.db.query.return_value.filter.return_value.first.return_value = None
+
+        result = guard_check_prompt_impl(
+            _ctx_obj,
+            prompt="my token is sk_live_abcdef0123456789abcdef",
+            model="claude-3-5-sonnet",
+            provider="anthropic",
+        )
+
+    assert result.startswith("BLOCKED"), result
+    assert "test-no-fake-key" in result
+    # Audit row landed with source="proxy" (not "mcp") so Guard Activity
+    # attributes to the correct surface. _record_event positional layout:
+    # (db, ws_uuid, tool_name, tool_input, decision, rule_id, ai_tool, ...)
+    assert rec.called
+    args = rec.call_args.args
+    assert args[4] == "blocked"
+    assert args[5] == "test-no-fake-key"
+    assert rec.call_args.kwargs.get("source") == "proxy"
+
+
+def test_end_to_end_allow_when_no_rule_matches():
+    """No proxy rule matches → returns 'ok' + writes an allowed receipt."""
+    with patch("app.modules.guard.mcp_impls._get_rules", return_value=[]), \
+         patch("app.modules.guard.mcp_impls._record_event") as rec:
+        _ctx_obj = _ctx()
+        _ctx_obj.db.query.return_value.filter.return_value.first.return_value = None
+        result = guard_check_prompt_impl(_ctx_obj, prompt="hello, nothing suspicious")
+    assert result == "ok"
+    assert rec.call_args.args[4] == "allowed"
+    assert rec.call_args.args[5] is None
+    assert rec.call_args.kwargs.get("source") == "proxy"
+
+
+def test_get_rules_pulls_proxy_persona():
+    """Sanity check: _get_rules must accept and forward the persona arg."""
+    from app.modules.guard.routers.mcp import _get_rules
+
+    with patch("app.modules.guard.routers.mcp.compute_policy") as cp:
+        cp.return_value = [{"id": "r1", "persona": "proxy"}]
+        _get_rules(db=MagicMock(), ws_uuid=WS_UUID, persona="proxy")
+
+    assert cp.call_args.args[2] == "proxy"

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -237,8 +237,11 @@ Add here without migration.
 | Runtime | action (via PreBlock) | `apps/api/app/runtime/blocks/` |
 | CLI hook | action | `packages/conduct-cli/` PreToolUse |
 | Lens | action, prompt, response | `apps/api/app/modules/glens/routers/chat.py` + `tools/registrations/lens/` |
+| LiteLLM plugin | prompt (response deferred) | `packages/conduct-litellm-guard/` |
 
 Lens is a well-behaved caller — no special path. LLM calls route through `guarded_completion` → `LLMClient` → proxy. Tool calls route through Lens tool registry → `guard_check` → MCP PEP.
+
+The LiteLLM plugin is also a well-behaved caller: it sits at the LiteLLM `pre_call` boundary — a prompt-gate concern — and dispatches through the new `guard_check_prompt` MCP verb. Transport = MCP; enforcement point = the LLM proxy PEP (proxy-persona rules, `gate="prompt"`, audit `source="proxy"`). `PEP_CAPABILITIES["mcp"]` stays `{action}`; the plugin's row above documents the effective gate the caller reaches, not a new MCP capability.
 
 The four rows above (excluding Lens) are the source of truth for `PEP_CAPABILITIES` in `apps/api/app/modules/guard/pep_registry.py`. `derive_surface_status(rule, surface)` reads this table + the rule's `gates` to compute per-rule enforcement status. `pack_coverage_matrix(db, pack_slug)` aggregates across a pack; the Policies UI reads it via `GET /guard/policies/packs/{slug}/coverage-matrix`.
 

--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.1.1"
+version = "0.2.0"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -19,5 +19,5 @@ Basic usage in a LiteLLM ``config.yaml``::
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 __all__ = ["ConductGuard", "GuardDecision", "__version__"]

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
@@ -1,8 +1,15 @@
-"""Thin async client for Conduct Guard's ``guard_check`` MCP tool.
+"""Thin async client for Conduct Guard's ``guard_check_prompt`` MCP tool.
 
 Isolated from the guardrail class so the transport can be swapped for a
-mock in tests. Speaks JSON-RPC 2.0 over HTTP — same shape any MCP client
-uses to reach ``/guard/mcp``.
+mock in tests. Speaks JSON-RPC 2.0 over HTTP against the new ``/mcp``
+endpoint (the legacy ``/guard/mcp`` deprecation is #1230).
+
+Why ``guard_check_prompt`` and not ``guard_check``? Per Guard architecture
+§8, MCP is an *action*-gate PEP. LiteLLM sits at the LLM egress boundary —
+a *prompt*-gate concern. Calling ``guard_check`` (action gate) makes
+every proxy-persona rule (credential-leak patterns, prompt-injection
+canaries, PII filters) silently miss. ``guard_check_prompt`` runs the
+same evaluator against proxy-persona rules and returns the same envelope.
 """
 from __future__ import annotations
 
@@ -40,34 +47,37 @@ class GuardCheckClient:
     async def guard_check(
         self,
         *,
-        tool_name: str,
-        tool_input: dict[str, Any],
+        prompt: str,
+        model: str | None = None,
+        provider: str | None = None,
         session_id: str | None = None,
-        prompt: str | None = None,
     ) -> str:
-        """Call the ``guard_check`` tool and return the text payload.
+        """Call the ``guard_check_prompt`` tool and return the text payload.
 
         Returns strings that start with ``"ok"``, ``"advisory:"``,
         ``"WARNING —"``, ``"BLOCKED —"``, or ``"PENDING approval —"``.
-        Callers parse the prefix to decide what to do."""
-        arguments: dict[str, Any] = {
-            "tool_name": tool_name,
-            "tool_input": tool_input,
-        }
-        if prompt is not None:
-            arguments["prompt"] = prompt
+        Callers parse the prefix to decide what to do.
+
+        Method name kept as ``guard_check`` for source-compat with existing
+        guardrail callers; the wire-level tool is ``guard_check_prompt``.
+        """
+        arguments: dict[str, Any] = {"prompt": prompt}
+        if model is not None:
+            arguments["model"] = model
+        if provider is not None:
+            arguments["provider"] = provider
 
         payload = {
             "jsonrpc": "2.0",
             "id": str(uuid.uuid4()),
             "method": "tools/call",
-            "params": {"name": "guard_check", "arguments": arguments},
+            "params": {"name": "guard_check_prompt", "arguments": arguments},
         }
 
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
-            "User-Agent": "conduct-litellm-guard/0.1.0",
+            "User-Agent": "conduct-litellm-guard/0.2.0",
             # Server reads this to populate the DEVELOPER/TOOL column
             # in the audit dashboard. Defaults to 'litellm' so audit
             # rows land under a clear surface name instead of 'unknown'.

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -167,10 +167,11 @@ class ConductGuard(CustomGuardrail):
         self._agent_token = token
         self._workspace_id = workspace_id or os.environ.get("CONDUCT_WORKSPACE_ID")
         self._fail_mode: FailMode = fail_mode
-        # Overridable per-config so existing pack rules that scope to
-        # 'workflow' / 'filesystem-write' can catch LLM traffic without
-        # editing the pack. Default 'llm_call' is what future packs will
-        # scope to natively.
+        # Kept for config-compat; no longer used. The plugin now routes
+        # through guard_check_prompt (prompt-gate → proxy-persona rules),
+        # so match_tool is not the filter — match_pattern on the prompt is.
+        # Existing configs that set `tool_name: llm_call` (or workflow /
+        # action) continue to load without error; the value is ignored.
         self._tool_name = tool_name
         self._client = GuardCheckClient(
             api_url=self._api_url,
@@ -211,17 +212,18 @@ class ConductGuard(CustomGuardrail):
     # ── Public helpers usable outside LiteLLM ─────────────────────────
 
     async def check(self, *, data: dict[str, Any], call_type: str) -> GuardDecision:
-        """Run one ``guard_check`` for the given LiteLLM request payload."""
-        tool_input = _build_tool_input(data, call_type)
+        """Run one ``guard_check_prompt`` for the given LiteLLM request payload."""
         session_id = _extract_session_id(data)
-        prompt = _extract_prompt_text(data)
+        prompt = _extract_prompt_text(data) or ""
+        model = data.get("model") or None
+        provider = _extract_provider(data)
 
         try:
             raw = await self._client.guard_check(
-                tool_name=self._tool_name,
-                tool_input=tool_input,
-                session_id=session_id,
                 prompt=prompt,
+                model=model,
+                provider=provider,
+                session_id=session_id,
             )
         except GuardCheckError as e:
             log.warning("conduct_guard: eval error %s — applying %s", e, self._fail_mode)
@@ -296,21 +298,17 @@ def _extract_prompt_text(data: dict[str, Any]) -> str | None:
     return None
 
 
-def _build_tool_input(data: dict[str, Any], call_type: str) -> dict[str, Any]:
-    """Compact payload for the ``tool_input`` field. Includes a truncated
-    view of the last user message so existing Guard rules that match
-    against ``tool_input`` fire the same way for LLM calls as they do
-    for shell / write_file. Truncation caps the field at 4KB so a
-    16-turn RAG conversation doesn't blow the audit row size."""
-    messages = data.get("messages") or []
-    return {
-        "model": data.get("model"),
-        "call_type": call_type,
-        "message_count": len(messages),
-        "temperature": data.get("temperature"),
-        "max_tokens": data.get("max_tokens"),
-        "stream": bool(data.get("stream")),
-        # Content is what content-match rules (prompt injection, secrets,
-        # PII, etc) look for. Same shape as tool_input.command for bash.
-        "content": _extract_prompt_text(data) or "",
-    }
+def _extract_provider(data: dict[str, Any]) -> str | None:
+    """Best-effort read of the upstream provider name from a LiteLLM request.
+
+    LiteLLM sometimes routes purely by ``model`` (``anthropic/claude-3-5-...``);
+    sometimes callers pass ``custom_llm_provider`` explicitly. Prefer the
+    explicit value; else split the model prefix on the first ``/``.
+    """
+    explicit = data.get("custom_llm_provider") or data.get("provider")
+    if explicit:
+        return str(explicit)
+    model = data.get("model") or ""
+    if "/" in model:
+        return model.split("/", 1)[0]
+    return None

--- a/packages/conduct-litellm-guard/upstream-docs/conduct.md
+++ b/packages/conduct-litellm-guard/upstream-docs/conduct.md
@@ -23,10 +23,10 @@ At `/theguard/policies`, enable one of the shipped packs
 `conduct-eu-ai-act`, `conduct-nist-ai-rmf`, `conduct-iso-42001`, and
 more), or author a custom rule with:
 
-- **TOOL:** `llm_call` — matches every LLM call routed through the
-  plugin.
-- **PATTERN:** any regex that should trigger the rule (matched against
-  the last user message in `tool_input.content`).
+- **PERSONA:** `proxy` — the plugin runs at the prompt gate, so proxy-persona
+  rules are the ones that fire against every outbound LLM prompt.
+- **PATTERN:** any regex that should trigger the rule (matched against the
+  outbound prompt text — same shape the LLM proxy sees).
 - **ACTION:** `block`, `warn`, `audit`, or `approval`.
 
 ## 2. Install the plugin
@@ -74,7 +74,7 @@ guardrails:
 | `api_base`      | no       | `https://api.conductai.ai` | Point at a self-hosted Conduct API when needed.                          |
 | `workspace_id`  | no       | resolved from the token    | Usually unnecessary — the token owns its workspace.                      |
 | `fail_mode`     | no       | `fail_closed`              | `fail_closed` blocks when Guard is unreachable; `fail_open` allows.      |
-| `tool_name`     | no       | `llm_call`                 | Guard tool scope. Set to `workflow` to reuse existing non-LLM packs.     |
+| `tool_name`     | no       | `llm_call`                 | Deprecated in 0.2.0 — accepted for config-compat, ignored at runtime. The plugin now hits the `guard_check_prompt` MCP verb, so rule matching is by `match_pattern` on the outbound prompt, not by `match_tool`. Delete the field on your next config edit. |
 | `timeout`       | no       | `8.0`                      | Seconds. Guard responds in <100ms in the healthy path.                   |
 
 ## 4. Start LiteLLM Gateway
@@ -105,12 +105,11 @@ the call in the Conduct console under **Guard → Activity**.
 </TabItem>
 <TabItem label="Blocked call" value="blocked">
 
-If your active packs include a rule that matches AWS access-key
-patterns (for example, `conduct-owasp` ships `no-aws-keys` scoped to
-`filesystem-write,workflow`), a request containing that pattern is
-blocked. Use a well-known-fake AWS access-key format (a string
-starting with `AKIA` followed by 16 uppercase alphanumerics) as the
-prompt:
+If your active packs include a proxy-persona rule that matches AWS access-key
+patterns (for example, `conduct-owasp` ships `no-aws-keys` at the prompt
+gate), a request containing that pattern is blocked. Use a well-known-fake
+AWS access-key format (a string starting with `AKIA` followed by 16
+uppercase alphanumerics) as the prompt:
 
 ```shell
 curl http://localhost:4000/v1/chat/completions \


### PR DESCRIPTION
## Summary

Fixes a silent pass-through in the LiteLLM plugin. Proxy-persona rules (`no-conduct-tokens`, `proxy-no-credential-leak`, prompt-injection canaries) never fired for LiteLLM traffic because the plugin hit `guard_check` — the **action-gate** MCP verb — which loads `persona="agent"` rules only.

Per `docs/guard/architecture.md` §8, MCP is an action-gate PEP. LiteLLM sits at the LLM egress boundary — a prompt-gate concern. The correct fix is a peer verb whose transport is MCP but whose enforcement point is the LLM proxy PEP.

**Verified against prod pre-fix:**
```
POST /mcp guard_check tool_name=llm_call prompt="sk_live_abcdef..." → "ok"   ← wrong, should BLOCK
```

## Changes

### API — new verb + factored evaluator

- `routers/mcp.py::_get_rules` gains a `persona` parameter (default `"agent"` — pre-existing callers unchanged)
- `routers/mcp.py::_TOOLS` adds a `guard_check_prompt` schema with sharp args: `{prompt, model, provider}`
- `mcp_impls.py::guard_check_impl` accepts internal `_persona / _gate / _source` overrides so the same decision→string envelope, advisory-mode fallback, warn-dedupe, and approval flow are reused by the new verb without a refactor
- `mcp_impls.py::guard_check_prompt_impl` wraps with `_persona="proxy", _gate="prompt", _source="proxy"` so audit rows land under `source="proxy"` and Guard Activity attributes correctly
- `tools/registrations/guard.py` annotates the new verb `open_world`

### Plugin — switches transport, drops action-gate baggage

- `_client.py` posts to `guard_check_prompt` with `{prompt, model, provider}` instead of `guard_check` with `{tool_name, tool_input, prompt}`
- `guardrail.py::check` builds the prompt/model/provider payload directly; `_build_tool_input` helper deleted (dead)
- `_extract_provider` added — reads `custom_llm_provider` / `provider` / first path segment of `model`
- `tool_name` kwarg kept for config-compat, silently ignored (docstring explains)
- `pyproject.toml` + `__init__.py` + `User-Agent` bump 0.1.1 → 0.2.0
- `upstream-docs/conduct.md` draft (held for BerriAI/litellm#38143 follow-up) reflects `persona=proxy` / prompt-gate story

### Arch doc

- `docs/guard/architecture.md` §8 adds a LiteLLM plugin row and clarifies that `PEP_CAPABILITIES["mcp"]` stays `{action}` — the row records the effective gate a caller reaches, not a new MCP capability

## Rejected paths

- **Merging personas in `_get_rules`** — violates Property 8 (MCP would enforce gates it doesn't declare). CI snapshot test in `tests/guard/test_pep_registry.py` would catch it, and §9 explicitly names this as the drift the architecture prevents.
- **Separate `/guard/proxy/pre-check` HTTP endpoint** — extra transport for no gain; plugin already speaks MCP.
- **Extending `guard_check` with a `gate` arg** — overloads one verb with two contracts. Discovery via `tools/list` is worse.

## Composition with existing shipwork

- Verified badges (#1755) already read `source` for the Activity feed — new `source="proxy"` value slots in without UI change.
- Divergence log (#1763 pending) is unaffected — new rules would be `persona="proxy"` with `gates: ["prompt"]` explicitly declared, no divergence.
- Cedar gate (#1768) is unaffected — different PEP, different gate.

## Test plan

- [x] `pytest tests/guard/test_guard_check_prompt_verb.py -v` — 6 pass
- [x] `pytest tests/guard/ tests/test_cedar_import_guard_gate.py -q` — 1435 pass, no regressions
- [x] `pytest packages/conduct-litellm-guard/tests/ -q` — 19 pass
- [x] Plugin importability check — `v0.2.0 imports ok`
- [ ] After deploy: `POST /mcp guard_check_prompt {"prompt": "sk_live_..."}` → expect `BLOCKED — ... [rule: proxy-no-credential-leak]`
- [ ] After plugin release: LiteLLM `pre_call` with a credential-shaped prompt → LiteLLM returns 400 with the block reason
- [ ] Guard Activity feed shows the row under `source="proxy"`, redacted preview intact

## Rollback

Revert commit. No schema changes, no migrations. Existing `guard_check` callers unchanged. Plugin 0.1.1 remains installable and functional (still using the old verb — silently misses proxy rules until users upgrade).

## Follow-ups (not in this PR)

- **BerriAI/litellm#38143** — check if the upstream PR embeds `_client.py` or just registers our package as a guardrail. If embedded, push a small update; if registered, no upstream change needed.
- **Plugin PyPI release** — cut 0.2.0 after this merges + API deploys.
- **`guard_check_response`** — response-gate variant. Deferred until LiteLLM `post_call` support is added on the plugin.