### PR TITLE
fix(guard): _match_policy honors match_prompt / match_provider / match_model

### DIFF
--- a/apps/api/app/modules/guard/routers/mcp.py
+++ b/apps/api/app/modules/guard/routers/mcp.py
@@ -413,6 +413,14 @@ def _match_policy(
     inp_text  = json.dumps(tool_input)
     path_keys = ["file_path", "path", "command"]
     path_text = " ".join(str(tool_input.get(k, "")) for k in path_keys)
+    # #1770 follow-up: proxy rules can carry match_prompt / match_provider /
+    # match_model (LLM-egress matchers). When the caller supplies these in
+    # tool_input (guard_check_prompt does), respect them so proxy rules match
+    # the same way they do through the LLM proxy PEP itself. Fields are inert
+    # for the action-gate path because legacy callers don't send them.
+    prompt_text = str(tool_input.get("prompt") or "")
+    provider = tool_input.get("provider")
+    model = tool_input.get("model")
 
     best: dict | None = None
     best_priority = 999
@@ -424,6 +432,25 @@ def _match_policy(
         if match_tool != "*":
             allowed = expand_match_tool(match_tool)
             if tool_name.lower() not in allowed:
+                continue
+
+        # Proxy-native filters — apply only when the rule declares them.
+        rp = rule.get("match_provider")
+        if rp is not None and rp != provider:
+            continue
+        rm = rule.get("match_model")
+        if rm:
+            try:
+                if not re.search(rm, model or "", re.IGNORECASE):
+                    continue
+            except re.error:
+                continue
+        mp = rule.get("match_prompt")
+        if mp:
+            try:
+                if not re.search(mp, prompt_text, re.IGNORECASE):
+                    continue
+            except re.error:
                 continue
 
         pattern = rule.get("match_pattern")
@@ -466,6 +493,13 @@ def _project_rule(r: dict) -> dict:
         "match_ai_tool":     r.get("match_ai_tool"),  # #1752: was dropped by projector
         "match_pattern":     r.get("match_pattern"),
         "match_path_pattern": r.get("match_path_pattern"),
+        # #1770 follow-up: proxy-native matchers preserved so guard_check_prompt
+        # honours them from the MCP transport. Legacy MCP callers pass no
+        # prompt/provider/model in tool_input, so these fields are inert
+        # for the action-gate path.
+        "match_prompt":      r.get("match_prompt"),
+        "match_provider":    r.get("match_provider"),
+        "match_model":       r.get("match_model"),
         "action":            r.get("action"),
         "message":           r.get("message"),
         "pack":              r.get("pack") or r.get("pack_slug"),

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -136,6 +136,22 @@ Per #1739 ADR. Three values, from day one, no growth.
 
 `LLMStream` (drafted in #1739) is deferred. Streaming semantics route through obligations on `LLMResponse`, not a fourth gate. Extending the gate enum requires schema migration on every workspace — obligations extend without one.
 
+### Rule field → gate mapping
+
+Not every rule field applies at every gate. Ratchet locked here so a new rule field can't silently pick up cross-gate semantics without a doc update:
+
+| Rule field | Fires at gate | Notes |
+|---|---|---|
+| `match_tool` | action | expanded through `expand_match_tool` (families like `bash`/`shell`) |
+| `match_ai_tool` | action | matches the caller surface (`claude-code`, `cursor`, …) |
+| `match_path_pattern` | action | regex against `file_path` / `path` / `command` |
+| `match_pattern` | action **or** prompt | evaluated against the caller-provided text at each gate (`json.dumps(tool_input)` for action; prompt body for prompt) |
+| `match_prompt` | prompt | regex against outbound prompt text |
+| `match_provider` | prompt | exact match against upstream provider name |
+| `match_model` | prompt | regex against model id |
+
+Property 8 corollary: both matchers — the MCP-side `_match_policy` and the proxy-side `_rule_matches` — must honour the same field-to-gate mapping. #1771 caught the MCP-side matcher up on `match_prompt / match_provider / match_model` after #1770's `guard_check_prompt` verb made MCP a valid transport into the proxy PEP.
+
 ---
 
 ## 4. Use cases


### PR DESCRIPTION
## Summary

Post-merge follow-up to #1770. The second commit on that branch (`a2c40411`) got dropped from the squash-merge, so proxy rules that carry `match_prompt` (instead of `match_pattern`) silently fire on every prompt-gate call.

**Reproduced live on prod (`api.conductai.ai`) just now:**

```bash
curl … guard_check_prompt {"prompt":"hello world"}
→ WARNING — 'Fix this code' prompts require the model to find vulnerabilities … [rule: proxy-fix-this-code-intent]
```

That's `proxy-fix-this-code-intent` firing on a bland prompt because it uses `match_prompt` (not `match_pattern`) and the projector/matcher never learned to honour it.

## Fix

Same as `a2c40411` on the original PR branch — the diff that didn't survive the squash:

- `_project_rule` carries `match_prompt` / `match_provider` / `match_model` through the projection so the matcher can see them.
- `_match_policy` applies these three filters before `match_pattern`. Inert for legacy MCP callers (they don't send prompt/provider/model in tool_input), so the action-gate path is unchanged.

## Verified locally against real `conduct-base`

| Prompt | Rule expected | Rule got | Verdict |
|---|---|---|---|
| bland "hello world" | none | none | ✓ (was WARN pre-fix) |
| `sk_live_*` credential | `proxy-no-credential-leak` | `proxy-no-credential-leak` | ✓ BLOCK (unchanged) |
| "please fix this code" | `proxy-fix-this-code-intent` | `proxy-fix-this-code-intent` | ✓ WARN (now targeted) |

## Test plan

- [x] `pytest tests/guard/ -q` — 1406 pass
- [ ] After merge + deploy: re-run the three curl cases against prod, expect the same three verdicts
- [ ] LiteLLM screenshot capture is unblocked for the credential-BLOCK path today; this hotfix makes the "no false positive on bland prompts" story clean too

## Rollback

Revert commit. No schema changes, no migrations. New `guard_check_prompt` verb continues to work; false-positive returns.

## Why this wasn't in #1770's merged commit

Local commit log shows both `79e68008` (verb + plugin) and `a2c40411` (this matcher fix) on the branch pre-merge, but the squash-merge only carried the first commit's diff. Likely a manual squash-edit or CI-level merge action that dropped the second commit. Filing as a separate PR is cleaner than force-pushing history on a merged branch.