### PR TITLE
chore(release): conduct-cli 0.12.0 + conduct-litellm-guard 0.2.0

### DIFF
--- a/packages/conduct-cli/pyproject.toml
+++ b/packages/conduct-cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-cli"
-version = "0.11.0"
+version = "0.12.0"
 description = "Runtime governance for AI agents. CLI for Conduct AI — secure, govern, install agents, manage projects, run tests"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
Rolls up all CLI + plugin work shipped since the last tagged builds so we can cut PyPI releases and tag on main.

## conduct-cli 0.11.0 → 0.12.0

- #1746 `/guard/mcp` URLs migrated to `/mcp` everywhere (#1230 Phase 5a)
- #1742 streamable HTTP compliance + OAuth 2.1 authz code + DCR (#1734 sub-6)
- #1720 `curl | sh` installer + make-shareable + trial-detection fixes
- #1719 trial teardown sweeper
- #1718 block-receipt deep-link + Lens seed + hook printer
- #1560 `--lens` flag on `conduct run`
- policy sync + agent-booster indexing improvements at login time

## conduct-litellm-guard 0.1.1 → 0.2.0 (bumped in #1770, ratcheted forward here)

- new `guard_check_prompt` MCP verb wiring — proxy-persona rules fire against outbound prompts through the plugin (`proxy-no-credential-leak`, `proxy-no-prompt-injection`, `proxy-no-pii-prompt`, `proxy-fix-this-code-intent`)
- `tool_name` kwarg silently deprecated (config-compat)
- `match_prompt` / `match_provider` / `match_model` now honoured (#1771)
- upstream doc draft aligned with the new tool name / arg shape (held for BerriAI/litellm#38143 follow-up)

## Release trigger — GitHub Actions handles PyPI

Existing workflows (`.github/workflows/publish-cli.yml`, `publish-litellm-guard.yml`) auto-build + publish to PyPI on tag push. No local `twine upload` needed.

```bash
# on main after merge
git checkout main && git pull
SHA=$(git rev-parse HEAD)
git tag cli/v0.12.0 $SHA
git tag litellm-guard/v0.2.0 $SHA
git push origin cli/v0.12.0 litellm-guard/v0.2.0
```

The workflows run tests before publish. If tests fail, no PyPI release lands.

## Test plan

- [x] `git diff` is a single one-line version bump (`0.11.0 → 0.12.0` in `packages/conduct-cli/pyproject.toml`)
- [ ] After merge + tag push: `publish-cli` workflow green, `pip install --upgrade conduct-cli` reports `0.12.0`
- [ ] After merge + tag push: `publish-litellm-guard` workflow green, `pip install --upgrade conduct-litellm-guard` reports `0.2.0`
- [ ] `conduct login` output shows the version bump

## Rollback

Delete tag(s) + yank PyPI releases (`twine yank` or PyPI UI). No repo state to revert beyond that.