### PR TITLE
fix(litellm-guard): map policy blocks to HTTP 400 instead of 500 (0.2.1)

### DIFF
--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.2.0"
+version = "0.2.1"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -19,5 +19,5 @@ Basic usage in a LiteLLM ``config.yaml``::
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __all__ = ["ConductGuard", "GuardDecision", "__version__"]

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -118,13 +118,37 @@ def _extract_rule_id(text: str) -> str | None:
     return tail[:end].strip() if end >= 0 else None
 
 
-class ConductGuardBlocked(Exception):
-    """Raised inside the pre-call hook to abort a LiteLLM request. LiteLLM
-    surfaces the message to the caller; keep it short and rule-scoped."""
+try:
+    # Prefer FastAPI's HTTPException so LiteLLM's exception handler maps
+    # the block to HTTP 400 instead of the default 500 "internal error".
+    # A guardrail block is a bad-request semantic — the caller sent
+    # something disallowed by policy. LiteLLM already depends on FastAPI.
+    from fastapi import HTTPException as _BlockBase  # type: ignore[import-not-found]
+    _BLOCK_STATUS = 400
+except ImportError:  # pragma: no cover — FastAPI is always present under LiteLLM
+    _BlockBase = Exception  # type: ignore[misc,assignment]
+    _BLOCK_STATUS = None
+
+
+class ConductGuardBlocked(_BlockBase):
+    """Raised inside the pre-call hook to abort a LiteLLM request.
+
+    Inherits from ``fastapi.HTTPException`` when available so LiteLLM's
+    exception handler surfaces the block as HTTP 400 (bad-request semantic
+    for a policy violation) — not the misleading 500 default that a plain
+    ``Exception`` subclass falls through to. Falls back to a plain
+    ``Exception`` if FastAPI isn't importable (won't happen inside the
+    LiteLLM proxy, but keeps the module importable in bare unit tests).
+    """
 
     def __init__(self, decision: GuardDecision):
         self.decision = decision
-        super().__init__(decision.message or decision.raw or "Blocked by Conduct Guard")
+        msg = decision.message or decision.raw or "Blocked by Conduct Guard"
+        if _BLOCK_STATUS is not None:
+            # HTTPException signature: (status_code, detail)
+            super().__init__(status_code=_BLOCK_STATUS, detail=msg)
+        else:
+            super().__init__(msg)
 
 
 class ConductGuard(CustomGuardrail):

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -106,6 +106,26 @@ class TestPreCallHook:
             await g.async_pre_call_hook(None, None, data, "completion")
         assert exc.value.decision.rule_id == "no-prod-secrets"
 
+    async def test_block_is_http_400_not_500(self) -> None:
+        """0.2.1 fix: ConductGuardBlocked inherits from fastapi.HTTPException
+        so LiteLLM's exception handler maps blocks to HTTP 400 instead of
+        the default 500. Regression test — LiteLLM users see the correct
+        bad-request status for a policy block.
+        """
+        from fastapi import HTTPException
+        g = _guard()
+        g._client.guard_check = AsyncMock(
+            return_value="BLOCKED — credential detected [rule: proxy-no-credential-leak]"
+        )
+        data = {"model": "gpt-4o", "messages": [{"role": "user", "content": "sk_live_..."}]}
+        with pytest.raises(ConductGuardBlocked) as exc:
+            await g.async_pre_call_hook(None, None, data, "completion")
+        # HTTPException carries a numeric status_code that LiteLLM propagates
+        # through its exception handler.
+        assert isinstance(exc.value, HTTPException)
+        assert exc.value.status_code == 400
+        assert "credential" in exc.value.detail.lower()
+
     async def test_pending_approval_also_raises(self) -> None:
         """PENDING approval must block the request while HITL runs — the
         LiteLLM caller cannot wait indefinitely."""


### PR DESCRIPTION
## Summary

Plugin 0.2.0 raises `ConductGuardBlocked(Exception)` — a plain Python `Exception` subclass. LiteLLM's proxy exception handler doesn't know what to do with it, falls through to HTTP 500 *Internal Server Error*. Users see 500s for every policy block in their proxy logs and reasonably think the plugin crashed.

Semantically a policy block is a bad-request — the caller sent something disallowed. HTTP 400 is the correct status.

## Fix

Make `ConductGuardBlocked` inherit from `fastapi.HTTPException` with `status_code=400`. LiteLLM's handler propagates both the code and the detail message. FastAPI is already a transitive dep of the LiteLLM proxy — zero new dependency.

Graceful fallback: if FastAPI is not importable (bare unit-test context, no proxy), fall back to plain `Exception` with the same message so the module stays loadable.

## Test plan

- [x] `pytest packages/conduct-litellm-guard/tests/ -q` — 20 pass, including the new regression: `isinstance(exc.value, HTTPException) and exc.value.status_code == 400`
- [ ] After merge + tag: `pip install --upgrade conduct-litellm-guard` → 0.2.1
- [ ] Restart LiteLLM proxy → `curl` a credential prompt → **HTTP 400** in `access.log` (was 500)
- [ ] `examples/test_conduct_guardrail.py` — check 3 / 4 / 8 now pass by status code alone (already pass by body-content check)

## Release

Tag `litellm-guard/v0.2.1` after merge. The publish workflow handles PyPI.

## Reproduction (pre-fix, live on 0.2.0)

```
POST /v1/chat/completions   {"messages":[{"content":"sk_live_..."}]}
→ HTTP 500 Internal Server Error
  ConductGuardBlocked: Credential detected in prompt … [rule: proxy-no-credential-leak]
```

## Post-fix

```
POST /v1/chat/completions   {"messages":[{"content":"sk_live_..."}]}
→ HTTP 400 Bad Request
  {"detail":"Credential detected in prompt … [rule: proxy-no-credential-leak]"}
```

## Rollback

Revert commit + retag `litellm-guard/v0.2.0`. No wire format change beyond the HTTP status, no config surface change.