### PR TITLE
fix(litellm-guard): add fastapi to [dev] deps — CI regression from #1776

### DIFF
--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -31,6 +31,10 @@ dev = [
     "pytest>=7",
     "pytest-asyncio>=0.21",
     "respx>=0.20",
+    # 0.2.1 regression test asserts ConductGuardBlocked inherits from
+    # fastapi.HTTPException. FastAPI is transitively present inside the
+    # LiteLLM proxy at runtime; adding it here so pytest CI can import it.
+    "fastapi>=0.100",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Summary

Publish workflow for `litellm-guard/v0.2.1` failed at the test step:

```
E       ModuleNotFoundError: No module named 'fastapi'
FAILED tests/test_guardrail.py::TestPreCallHook::test_block_is_http_400_not_500
```

The new regression test added in #1776 asserts `ConductGuardBlocked` inherits from `fastapi.HTTPException`. FastAPI is transitively present at runtime inside the LiteLLM proxy (which is why the plugin's runtime code works), but it wasn't in `[dev]` extras, so bare `pip install -e ".[dev]" && pytest` in CI can't import it.

## Fix

One-line dep addition to `[project.optional-dependencies].dev`. Runtime code unchanged — the try/except ImportError fallback still handles environments without FastAPI.

## Retag plan (after merge)

The v0.2.1 tag currently points at the pre-fix commit and the publish job was skipped (not failed → skipped on test failure), so no PyPI release went out. Retag from the new HEAD:

```bash
git checkout main && git pull
git tag -d litellm-guard/v0.2.1
git push origin :refs/tags/litellm-guard/v0.2.1
git tag litellm-guard/v0.2.1 $(git rev-parse HEAD)
git push origin litellm-guard/v0.2.1
```

Publish workflow re-runs, lands 0.2.1 on PyPI.

## Test plan

- [x] `pip install -e ".[dev]" && pytest tests/ -q` locally → 20 pass
- [ ] Publish workflow green after retag