### PR TITLE
ci: add publish-nemo-guard workflow (mirror of publish-litellm-guard)

### DIFF
--- a/.github/workflows/publish-nemo-guard.yml
+++ b/.github/workflows/publish-nemo-guard.yml
@@ -1,0 +1,59 @@
+name: Publish conduct-nemo-guard to PyPI
+
+on:
+  push:
+    tags:
+      - "nemo-guard/v*"   # trigger on tags like nemo-guard/v0.2.0
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install package + test deps
+        working-directory: packages/conduct-nemo-guard
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        working-directory: packages/conduct-nemo-guard
+        run: pytest tests/ -v
+
+  publish:
+    needs: test
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      # Trusted publishing via PyPI OIDC — no API token stored in the repo.
+      # PyPI project settings must list this workflow as a trusted publisher:
+      #   Owner: sseshachala
+      #   Repo:  conductai
+      #   Workflow: publish-nemo-guard.yml
+      #   Environment: pypi
+      id-token: write
+      contents: read
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.11"
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Build package
+        working-directory: packages/conduct-nemo-guard
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
+        with:
+          packages-dir: packages/conduct-nemo-guard/dist/


### PR DESCRIPTION
## Summary

Missing workflow for `conduct-nemo-guard` — the `nemo-guard/v0.2.0` tag was pushed with #1778's merge but nothing listens for it, so nothing publishes to PyPI. Direct mirror of `publish-litellm-guard.yml` with two swaps (package name + workflow name).

## Retag plan (after merge)

The tag on `nemo-guard/v0.2.0` currently points at the pre-workflow commit. Delete + re-tag from new HEAD so the workflow fires:

```bash
git checkout main && git pull
git tag -d nemo-guard/v0.2.0
git push origin :refs/tags/nemo-guard/v0.2.0
git tag nemo-guard/v0.2.0 $(git rev-parse HEAD)
git push origin nemo-guard/v0.2.0
```

## PyPI setup — one-time before first publish

Before the workflow can successfully publish, add a trusted-publisher entry under the `conduct-nemo-guard` project on PyPI:

- Owner: `sseshachala`
- Repo: `conductai`
- Workflow: `publish-nemo-guard.yml`
- Environment: `pypi`

Then the OIDC id-token exchange handles publish without needing a token in the repo.

## Test plan

- [ ] Merge this PR
- [ ] Retag `nemo-guard/v0.2.0` from new HEAD
- [ ] Workflow fires, tests pass, publish succeeds
- [ ] `pip install --upgrade conduct-nemo-guard` reports `0.2.0`