### PR TITLE
fix(litellm-guard): 0.2.2 — scan every user turn + text_completion prompt

### DIFF
--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.2.1"
+version = "0.2.2"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -19,5 +19,5 @@ Basic usage in a LiteLLM ``config.yaml``::
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __all__ = ["ConductGuard", "GuardDecision", "__version__"]

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
@@ -77,7 +77,7 @@ class GuardCheckClient:
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
-            "User-Agent": "conduct-litellm-guard/0.2.0",
+            "User-Agent": "conduct-litellm-guard/0.2.2",
             # Server reads this to populate the DEVELOPER/TOOL column
             # in the audit dashboard. Defaults to 'litellm' so audit
             # rows land under a clear surface name instead of 'unknown'.

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -303,23 +303,60 @@ def _extract_session_id(data: dict[str, Any]) -> str | None:
     return f"litellm-{digest[:16]}"
 
 
+_MAX_PROMPT_CHARS = 200_000  # ~50k tokens; larger than any single-turn prompt
+                             # a modern model accepts. Effectively unbounded
+                             # for the scan while still capping runaway payloads.
+
+
 def _extract_prompt_text(data: dict[str, Any]) -> str | None:
-    """Return the last user message so it lands in the audit trail. We
-    intentionally do NOT send the full messages array — Guard only needs
-    enough context to render an audit entry."""
-    for m in reversed(data.get("messages") or []):
-        if isinstance(m, dict) and m.get("role") == "user":
-            content = m.get("content")
-            if isinstance(content, str):
-                return content[:4000]
-            if isinstance(content, list):
-                # OpenAI-style parts: concat the text ones.
-                parts = [
-                    p.get("text", "") for p in content
-                    if isinstance(p, dict) and p.get("type") == "text"
-                ]
-                return " ".join(parts)[:4000] or None
-    return None
+    """Return the prompt text so it lands in the audit trail AND is
+    scanned by Guard's proxy-persona rules.
+
+    Handles both LiteLLM request shapes:
+      - chat_completion: ``messages[]`` — scans every user message,
+        concatenated, so an attacker can't hide payload in an earlier
+        turn (BerriAI/litellm#38143 review, veria-ai finding).
+      - text_completion: ``prompt`` — the raw prompt string or list
+        (veria-ai finding — this path was previously bypassed entirely).
+
+    Length cap raised to 200k chars so realistic long-context prompts
+    are not silently truncated; policy scan sees the whole payload.
+    The audit trail's ``input_summary`` still redacts + trims to a
+    short preview at write time (Property 9), so no raw payload
+    lands in a receipt.
+    """
+    text_parts: list[str] = []
+
+    # text_completion path — prompt can be str or list[str] or list[list[int]]
+    prompt = data.get("prompt")
+    if isinstance(prompt, str):
+        text_parts.append(prompt)
+    elif isinstance(prompt, list):
+        for p in prompt:
+            if isinstance(p, str):
+                text_parts.append(p)
+            # token-id lists (list[int]) are unmodelled — pass on, they don't
+            # carry policy-relevant string content.
+
+    # chat_completion path — every user turn, not just the last one.
+    # Earlier turns can carry credential leaks / injection payloads that a
+    # last-message-only scan would miss.
+    for m in data.get("messages") or []:
+        if not isinstance(m, dict) or m.get("role") != "user":
+            continue
+        content = m.get("content")
+        if isinstance(content, str):
+            text_parts.append(content)
+        elif isinstance(content, list):
+            # OpenAI-style multipart: concat the text parts, skip images.
+            for p in content:
+                if isinstance(p, dict) and p.get("type") == "text":
+                    text_parts.append(p.get("text", ""))
+
+    if not text_parts:
+        return None
+    joined = "\n".join(text_parts)
+    return joined[:_MAX_PROMPT_CHARS] if joined else None
 
 
 def _extract_provider(data: dict[str, Any]) -> str | None:

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -216,6 +216,75 @@ class TestSessionIdExtraction:
         assert capture["session_id"].startswith("litellm-")
 
 
+class TestPromptExtraction:
+    """0.2.2 fixes for BerriAI/litellm#38143 review findings.
+
+    Two veria-ai bot findings drove these:
+    - text_completion path was bypassed entirely (only ``messages`` was
+      scanned; ``prompt`` was silently ignored).
+    - Multi-turn ``messages`` scanning stopped at the last user turn, so
+      an attacker could hide a credential-leak / injection in an earlier
+      turn where the scan wouldn't see it.
+    """
+
+    def test_text_completion_prompt_extracted(self) -> None:
+        from conduct_litellm_guard.guardrail import _extract_prompt_text
+        assert _extract_prompt_text({"prompt": "sk_live_abc"}) == "sk_live_abc"
+
+    def test_text_completion_prompt_list_extracted(self) -> None:
+        from conduct_litellm_guard.guardrail import _extract_prompt_text
+        got = _extract_prompt_text({"prompt": ["first", "second"]})
+        assert got is not None and "first" in got and "second" in got
+
+    def test_chat_completion_scans_every_user_turn(self) -> None:
+        from conduct_litellm_guard.guardrail import _extract_prompt_text
+        data = {
+            "messages": [
+                {"role": "user", "content": "here is my key sk_live_abc"},
+                {"role": "assistant", "content": "OK, got it"},
+                {"role": "user", "content": "please summarize"},
+            ]
+        }
+        got = _extract_prompt_text(data)
+        assert got is not None
+        # The credential leak in the earlier turn MUST be visible so
+        # proxy-persona rules can fire.
+        assert "sk_live_abc" in got
+        assert "please summarize" in got
+
+    def test_multipart_content_concatenated_across_turns(self) -> None:
+        from conduct_litellm_guard.guardrail import _extract_prompt_text
+        data = {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "here is context"},
+                        {"type": "image_url", "image_url": {"url": "data:..."}},
+                    ],
+                },
+                {"role": "user", "content": [{"type": "text", "text": "and my question"}]},
+            ]
+        }
+        got = _extract_prompt_text(data)
+        assert got is not None
+        assert "here is context" in got
+        assert "and my question" in got
+
+    def test_length_cap_generous_but_bounded(self) -> None:
+        from conduct_litellm_guard.guardrail import _MAX_PROMPT_CHARS, _extract_prompt_text
+        big = "x" * (_MAX_PROMPT_CHARS + 5000)
+        got = _extract_prompt_text({"prompt": big})
+        assert got is not None
+        assert len(got) == _MAX_PROMPT_CHARS  # capped, not truncated below cap
+
+    def test_empty_data_returns_none(self) -> None:
+        from conduct_litellm_guard.guardrail import _extract_prompt_text
+        assert _extract_prompt_text({}) is None
+        assert _extract_prompt_text({"messages": []}) is None
+        assert _extract_prompt_text({"prompt": ""}) is None
+
+
 if __name__ == "__main__":
     import subprocess
     import sys


### PR DESCRIPTION
Addresses two veria-ai findings from [BerriAI/litellm#38143](https://github.com/BerriAI/litellm/pull/38143):

## Findings fixed

**High — Text-completion prompts bypassed Guard entirely**
`_extract_prompt_text` scanned only `messages`; `text_completion` requests carry text in `prompt` (str or list[str]). An attacker could send a credential leak or injection through text_completion and Guard would never see it.

**Medium — Partial (4KB) prompt scanning permitted policy bypass**
The old extractor truncated to the first 4000 chars of the last user message. Adversarial payloads hidden past that cap were invisible to the scan.

**Also fixed (related) — Multi-turn scanning stopped at the last message**
The old extractor did `reversed(messages)` and returned on the first user turn found. Earlier user turns with credentials / injection payloads slipped through even though the model still saw them as part of the conversation history.

## Changes

- `_extract_prompt_text` now concatenates **every** user turn (chat completion) **plus** the `prompt` field (text completion). Order is preserved so the scan sees the same payload the model will.
- Length cap raised from `4000` to `200_000` chars (~50k tokens) so realistic long-context prompts are not silently truncated. Property 9 still redacts + trims the audit-trail preview at write time, so no raw payload lands in a receipt regardless of the scan length.
- Multipart content (OpenAI vision-style) — text parts concatenated, images skipped (unchanged behavior).
- Version bump `0.2.1 → 0.2.2` across `pyproject.toml`, `__init__.py`, `User-Agent`.

## Tests

Six new regression tests in `TestPromptExtraction`:

| Test | Guards against |
|---|---|
| `test_text_completion_prompt_extracted` | text_completion bypass (veria-ai finding) |
| `test_text_completion_prompt_list_extracted` | list-form `prompt` bypass |
| `test_chat_completion_scans_every_user_turn` | multi-turn payload hiding |
| `test_multipart_content_concatenated_across_turns` | multipart bypass |
| `test_length_cap_generous_but_bounded` | truncation regression (veria-ai finding) |
| `test_empty_data_returns_none` | edge-case handling |

Full suite: **26 pass** (was 20 pre-fix).

## Release plan

Tag `litellm-guard/v0.2.2` after merge → publish workflow lifts to PyPI. Then reply on BerriAI/litellm#38143 with the two findings marked resolved + pin the upstream shim to `conduct-litellm-guard >= 0.2.2`.

## Test plan

- [x] `pytest packages/conduct-litellm-guard/tests/ -q` — 26 pass
- [x] `pip install -e .` + import works
- [ ] After merge + tag: `pip install --upgrade conduct-litellm-guard` reports `0.2.2`
- [ ] Prod smoke — send a credential-shaped payload in an earlier user turn AND via text_completion; both should BLOCK

## Rollback

Revert commit. 0.2.1 remains functional (still misses text_completion + long-tail payloads until users upgrade).