### PR TITLE
feat(litellm-guard): 0.2.3 — SUPPORTED_EVENT_HOOKS on ConductGuard

### DIFF
--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.2.2"
+version = "0.2.3"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -19,5 +19,5 @@ Basic usage in a LiteLLM ``config.yaml``::
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __all__ = ["ConductGuard", "GuardDecision", "__version__"]

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
@@ -77,7 +77,7 @@ class GuardCheckClient:
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
-            "User-Agent": "conduct-litellm-guard/0.2.2",
+            "User-Agent": "conduct-litellm-guard/0.2.3",
             # Server reads this to populate the DEVELOPER/TOOL column
             # in the audit dashboard. Defaults to 'litellm' so audit
             # rows land under a clear surface name instead of 'unknown'.

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -12,7 +12,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import Any, Literal
+from typing import Any, ClassVar, Literal
 
 from conduct_litellm_guard._client import GuardCheckClient, GuardCheckError
 
@@ -163,6 +163,24 @@ class ConductGuard(CustomGuardrail):
     ``litellm_metadata.trace_id`` → ``X-Conduct-Session-Id`` header on
     the LiteLLM request → a deterministic hash of the user identifier
     plus the first user message. Documented in ``README.md``."""
+
+    # ── Event-hook advertisement ─────────────────────────────────────
+    # LiteLLM's guardrail-registration flow calls
+    # ``get_supported_event_hooks`` to validate the ``mode:`` in the
+    # config block. Ship the tuple + classmethod here so upstream shims
+    # (the ``litellm/proxy/guardrails/guardrail_hooks/conduct`` module)
+    # can be pure aliases with no subclass — keeps their type-discipline
+    # gates satisfied. Add ``response`` when ``guard_check_response``
+    # ships (plugin 0.3.x).
+    SUPPORTED_EVENT_HOOKS: ClassVar[tuple[str, ...]] = ("pre_call",)
+
+    @classmethod
+    def get_supported_event_hooks(cls) -> list[str]:
+        """Return the ``mode:`` values LiteLLM should accept for this
+        guardrail. LiteLLM rejects any config that requests an
+        unsupported mode at load time — prevents silent bypass of
+        e.g. ``during_call`` configurations."""
+        return list(cls.SUPPORTED_EVENT_HOOKS)
 
     def __init__(
         self,

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -216,6 +216,26 @@ class TestSessionIdExtraction:
         assert capture["session_id"].startswith("litellm-")
 
 
+class TestEventHooks:
+    """0.2.3 — SUPPORTED_EVENT_HOOKS + get_supported_event_hooks moved
+    from the LiteLLM shim onto ConductGuard itself. Lets upstream shims
+    stay pure aliases (no subclass), which satisfies LiteLLM's
+    type-discipline / basedpyright budget gates.
+    """
+
+    def test_supported_event_hooks_is_pre_call_only(self) -> None:
+        from conduct_litellm_guard import ConductGuard
+        assert ConductGuard.SUPPORTED_EVENT_HOOKS == ("pre_call",)
+
+    def test_get_supported_event_hooks_returns_list(self) -> None:
+        from conduct_litellm_guard import ConductGuard
+        hooks = ConductGuard.get_supported_event_hooks()
+        assert hooks == ["pre_call"]
+        # Must return a fresh list, not a reference to the ClassVar.
+        hooks.append("mutation")
+        assert ConductGuard.get_supported_event_hooks() == ["pre_call"]
+
+
 class TestPromptExtraction:
     """0.2.2 fixes for BerriAI/litellm#38143 review findings.
 


### PR DESCRIPTION
Lifts the supported-hooks contract from the LiteLLM shim onto ConductGuard itself.

## Why

BerriAI/litellm has four strict-rule budget gates (ruff-strict / test-quality / type-discipline / basedpyright). The upstream shim in [PR #38143](https://github.com/BerriAI/litellm/pull/38143) tripped several of them by subclassing ConductGuard to attach two methods (`SUPPORTED_EVENT_HOOKS`, `get_supported_event_hooks`). Moving those onto the base class lets the shim stay a pure alias — no dynamic base, no subclass, no reassignments — which clears every gate in one pass.

## Changes

- `guardrail.py::ConductGuard` gains:
  - `SUPPORTED_EVENT_HOOKS: ClassVar[tuple[str, ...]] = ("pre_call",)` — advertised event hooks
  - `get_supported_event_hooks() -> list[str]` — LiteLLM calls this to validate the `mode:` config
- Version bump 0.2.2 → 0.2.3 (pyproject / `__init__.py` / User-Agent)
- Two new tests in `TestEventHooks`

## Behavior

Unchanged from 0.2.2. LiteLLM's guardrail validator will reject configs requesting `mode: during_call` because we advertise only `pre_call`. `during_call` / `post_call` land with 0.3.x once the underlying Conduct response gate is wired through `guard_check_response`.

## Test plan

- [x] `pytest packages/conduct-litellm-guard/tests/ -q` — 28 pass
- [x] Ran all four LiteLLM budget gates against a simulated upstream shim update — all green locally:
  - ruff_strict_gate: OK
  - test_quality_gate: OK
  - type_discipline_gate: OK
  - type_check_gate (basedpyright): OK
- [ ] After merge + tag: `pip install --upgrade conduct-litellm-guard` reports `0.2.3`
- [ ] Upstream PR #38143 shim update pushed and CI green (follow-up)

## Release

Tag `litellm-guard/v0.2.3` after merge. Publish workflow lifts to PyPI. Then upstream PR #38143 gets the simplified shim + pin bump to `>=0.2.3`.