### PR TITLE
fix(lens): approve/reject flips run status optimistically

### DIFF
--- a/apps/web/src/components/glens/GLensChatPage.tsx
+++ b/apps/web/src/components/glens/GLensChatPage.tsx
@@ -1049,7 +1049,7 @@ function ActionConfirmBubble({
 
   const isMutation = toolName !== "decide_approval"  // heuristic — decide is itself an approve/reject
 
-  async function _postRunAction(url: string, body?: unknown, onOk?: (data: Record<string, unknown>) => void) {
+  async function _postRunAction(url: string, body?: unknown, onOk?: (data: Record<string, unknown>) => void, onError?: () => void) {
     if (runBusy || !runData?.workflow_id || !resolvedRunId) return
     setRunBusy(true); setRunActionErr(null)
     try {
@@ -1061,12 +1061,14 @@ function ActionConfirmBubble({
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         setRunActionErr((err as { detail?: string }).detail ?? `Request failed (${res.status})`)
+        onError?.()
         return
       }
       const data = await res.json().catch(() => ({}))
       onOk?.(data as Record<string, unknown>)
     } catch {
       setRunActionErr("Network error")
+      onError?.()
     } finally {
       setRunBusy(false)
     }
@@ -1074,8 +1076,20 @@ function ActionConfirmBubble({
 
   const runStatus = runData?.status ?? null
   const runCancel = () => _postRunAction(`${API}/workflows/${runData!.workflow_id}/runs/${resolvedRunId}/cancel`)
-  const runDecide = (decision: "approved" | "rejected") =>
-    _postRunAction(`${API}/workflows/${runData!.workflow_id}/runs/${resolvedRunId}/approve`, { decision })
+  // Optimistic — flip status locally so approve/reject buttons vanish and the
+  // panel updates instantly. If the POST fails, _postRunAction sets
+  // runActionErr and we revert; SSE will otherwise confirm the transition.
+  const runDecide = (decision: "approved" | "rejected") => {
+    if (!runData || !resolvedRunId) return
+    const prevStatus = runData.status
+    setRunData(prev => prev ? { ...prev, status: decision === "approved" ? "running" : "cancelled" } : prev)
+    _postRunAction(
+      `${API}/workflows/${runData.workflow_id}/runs/${resolvedRunId}/approve`,
+      { decision },
+      undefined,
+      () => setRunData(prev => prev ? { ...prev, status: prevStatus } : prev),
+    )
+  }
   const runRetry = () => {
     // #1480 Gap 3 parity — reuse original inputs, strip block outputs + system keys.
     const runStateRec = (runData?.state ?? {}) as Record<string, unknown>
@@ -1430,7 +1444,7 @@ function RunBubble({
     })
   })
 
-  async function _postAction(url: string, body?: unknown, onOk?: (data: Record<string, unknown>) => void) {
+  async function _postAction(url: string, body?: unknown, onOk?: (data: Record<string, unknown>) => void, onError?: () => void) {
     if (busy || !workflowId) return
     setBusy(true); setActionErr(null)
     try {
@@ -1442,6 +1456,7 @@ function RunBubble({
       if (!res.ok) {
         const err = await res.json().catch(() => ({}))
         setActionErr((err as { detail?: string }).detail ?? `Request failed (${res.status})`)
+        onError?.()
         setBusy(false)
         return
       }
@@ -1449,14 +1464,26 @@ function RunBubble({
       onOk?.(data as Record<string, unknown>)
     } catch {
       setActionErr("Network error")
+      onError?.()
     } finally {
       setBusy(false)
     }
   }
 
   const cancelRun = () => _postAction(`${API}/workflows/${workflowId}/runs/${runId}/cancel`)
-  const decideRun = (decision: "approved" | "rejected") =>
-    _postAction(`${API}/workflows/${workflowId}/runs/${runId}/approve`, { decision })
+  // Optimistic — flip status locally so approve/reject buttons vanish and the
+  // bubble/panel updates instantly. SSE run.status_changed will confirm; if the
+  // POST fails we revert and _postAction surfaces the error via actionErr.
+  const decideRun = (decision: "approved" | "rejected") => {
+    const prevStatus = status
+    setStatus(decision === "approved" ? "running" : "cancelled")
+    _postAction(
+      `${API}/workflows/${workflowId}/runs/${runId}/approve`,
+      { decision },
+      undefined,
+      () => setStatus(prevStatus),
+    )
+  }
   const retryRun = () => {
     // #1480 Gap 3 — reuse the original run's inputs. runState + blocks give
     // us enough to reconstruct: strip out per-block outputs (keys equal to

--- a/apps/web/src/components/runs/RunDetailPanel.tsx
+++ b/apps/web/src/components/runs/RunDetailPanel.tsx
@@ -123,17 +123,24 @@ export default function RunDetailPanel({ workflowId, runId, embedded = false, in
   }
 
   async function handleApproval(decision: "approved" | "rejected") {
+    // Optimistic — flip both approval bubble state and run status BEFORE the
+    // POST so the panel updates instantly. If the request fails, revert.
+    const prevStatus = run?.status
     setApprovingRun(true)
+    setApprovalDecision(decision)
+    setRun(prev => prev ? { ...prev, status: decision === "approved" ? "running" : "cancelled" } : prev)
     try {
-      await authFetch(
+      const res = await authFetch(
         `${API}/workflows/${workflowId}/runs/${runId}/approve`,
         { method: "POST", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ decision }) }
       )
-      setApprovalDecision(decision)
-      setRun(prev => prev ? { ...prev, status: decision === "approved" ? "running" : "cancelled" } : prev)
+      if (!res.ok) {
+        setApprovalDecision(null)
+        if (prevStatus) setRun(prev => prev ? { ...prev, status: prevStatus } : prev)
+      }
     } catch {
-      // non-fatal — show decision optimistically
-      setApprovalDecision(decision)
+      setApprovalDecision(null)
+      if (prevStatus) setRun(prev => prev ? { ...prev, status: prevStatus } : prev)
     } finally { setApprovingRun(false) }
   }
 


### PR DESCRIPTION
## Summary
- Approve/Reject in Lens now updates the panel **on click**, not after the network round-trip.
- Three handlers converted (RunBubble, ActionConfirmBubble, RunDetailPanel.handleApproval).
- If the POST fails, status reverts and the error surfaces via existing actionErr/runActionErr state.

## Root cause
Every approve handler awaited `authFetch(/approve)` before touching visible state. Between click and network response the buttons only dimmed — the panel looked frozen until an SSE \`run.status_changed\` event landed. Users read that as "nothing is happening."

## Fix
Flip \`run.status\` (or \`runData.status\`) locally on click. \`_postAction\` / \`_postRunAction\` gained an optional \`onError\` callback that reverts state if the request fails. SSE still confirms the transition on success — no double-flip because status is already at the target value.

## Test plan
- [ ] Run a workflow that pauses for approval; click Approve → buttons vanish immediately, panel shows running state, no visible wait
- [ ] Same, click Reject → panel shows cancelled state immediately
- [ ] Simulate a 500 from /approve → panel reverts to paused, error banner shows
- [ ] Approve from the RunDetailPanel Approvals tab → same instant behavior
- [ ] SSE stream lands with run.status_changed → no visible re-flicker (status already matches)

_Independent of #1784 (refactor). Either can merge first; the loser rebases mechanically._