### PR TITLE
fix(litellm-guard): 0.2.4 — SUPPORTED_EVENT_HOOKS uses enum, not str

### DIFF
--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.2.3"
+version = "0.2.4"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -19,5 +19,5 @@ Basic usage in a LiteLLM ``config.yaml``::
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __all__ = ["ConductGuard", "GuardDecision", "__version__"]

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/_client.py
@@ -77,7 +77,7 @@ class GuardCheckClient:
         headers = {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
-            "User-Agent": "conduct-litellm-guard/0.2.3",
+            "User-Agent": "conduct-litellm-guard/0.2.4",
             # Server reads this to populate the DEVELOPER/TOOL column
             # in the audit dashboard. Defaults to 'litellm' so audit
             # rows land under a clear surface name instead of 'unknown'.

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -23,7 +23,12 @@ log = logging.getLogger(__name__)
 # (e.g. running the unit tests without a real LiteLLM install).
 try:
     from litellm.integrations.custom_guardrail import CustomGuardrail  # type: ignore
+    from litellm.types.guardrails import GuardrailEventHooks as _LiteLLMHooks  # type: ignore
     _LITELLM_AVAILABLE = True
+    # LiteLLM's guardrail registry scans SUPPORTED_EVENT_HOOKS and calls
+    # ``.value`` on each entry — must be the ``GuardrailEventHooks`` enum,
+    # not a bare string. Regression fix in 0.2.4 (BerriAI/litellm#38143).
+    _PRE_CALL_HOOK: Any = _LiteLLMHooks.pre_call
 except Exception:  # pragma: no cover — exercised via test double
     _LITELLM_AVAILABLE = False
 
@@ -35,6 +40,8 @@ except Exception:  # pragma: no cover — exercised via test double
             self.guardrail_name = kwargs.get("guardrail_name")
             self.event_hook = kwargs.get("event_hook")
             self.default_on = kwargs.get("default_on", True)
+
+    _PRE_CALL_HOOK = "pre_call"
 
 
 Verdict = Literal["allow", "advisory", "warning", "block", "approval", "unknown"]
@@ -172,10 +179,13 @@ class ConductGuard(CustomGuardrail):
     # can be pure aliases with no subclass — keeps their type-discipline
     # gates satisfied. Add ``response`` when ``guard_check_response``
     # ships (plugin 0.3.x).
-    SUPPORTED_EVENT_HOOKS: ClassVar[tuple[str, ...]] = ("pre_call",)
+    # LiteLLM's registry scan calls ``.value`` on each entry — must be
+    # the ``GuardrailEventHooks`` enum member when LiteLLM is installed
+    # (the only case anyone actually uses this class in prod).
+    SUPPORTED_EVENT_HOOKS: ClassVar[tuple[Any, ...]] = (_PRE_CALL_HOOK,)
 
     @classmethod
-    def get_supported_event_hooks(cls) -> list[str]:
+    def get_supported_event_hooks(cls) -> list:
         """Return the ``mode:`` values LiteLLM should accept for this
         guardrail. LiteLLM rejects any config that requests an
         unsupported mode at load time — prevents silent bypass of

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -217,23 +217,30 @@ class TestSessionIdExtraction:
 
 
 class TestEventHooks:
-    """0.2.3 — SUPPORTED_EVENT_HOOKS + get_supported_event_hooks moved
-    from the LiteLLM shim onto ConductGuard itself. Lets upstream shims
-    stay pure aliases (no subclass), which satisfies LiteLLM's
-    type-discipline / basedpyright budget gates.
+    """0.2.3+ — SUPPORTED_EVENT_HOOKS + get_supported_event_hooks live on
+    ConductGuard so upstream shims stay pure aliases. 0.2.4 changes the
+    entry type from ``str`` to the ``GuardrailEventHooks`` enum member
+    because LiteLLM's guardrail registry scans SUPPORTED_EVENT_HOOKS and
+    calls ``.value`` on each entry — the string version tripped
+    AttributeError on other guardrails' tests.
     """
 
-    def test_supported_event_hooks_is_pre_call_only(self) -> None:
+    def test_supported_event_hooks_carries_pre_call(self) -> None:
         from conduct_litellm_guard import ConductGuard
-        assert ConductGuard.SUPPORTED_EVENT_HOOKS == ("pre_call",)
+        assert len(ConductGuard.SUPPORTED_EVENT_HOOKS) == 1
+        (entry,) = ConductGuard.SUPPORTED_EVENT_HOOKS
+        # LiteLLM's registry does ``entry.value`` — that expression must
+        # yield the wire string ``"pre_call"``.
+        assert getattr(entry, "value", entry) == "pre_call"
 
-    def test_get_supported_event_hooks_returns_list(self) -> None:
+    def test_get_supported_event_hooks_returns_fresh_list(self) -> None:
         from conduct_litellm_guard import ConductGuard
         hooks = ConductGuard.get_supported_event_hooks()
-        assert hooks == ["pre_call"]
+        assert len(hooks) == 1
+        assert getattr(hooks[0], "value", hooks[0]) == "pre_call"
         # Must return a fresh list, not a reference to the ClassVar.
         hooks.append("mutation")
-        assert ConductGuard.get_supported_event_hooks() == ["pre_call"]
+        assert len(ConductGuard.get_supported_event_hooks()) == 1
 
 
 class TestPromptExtraction:


### PR DESCRIPTION
BerriAI/litellm's guardrail registry scans \`SUPPORTED_EVENT_HOOKS\` and calls \`.value\` on each entry. 0.2.3 shipped bare strings, which raised \`AttributeError: 'str' object has no attribute 'value'\` on three upstream tests (\`test_add_guardrail_settings_restricts_hide_secrets_to_pre_call\`, \`test_get_guardrail_ui_settings_returns_per_provider_supported_modes\`, \`test_ui_settings_map_matches_runtime_supported_event_hooks\`) — same three that failed pre-0.2.3 for a different reason (None registration), so the cascade broke unrelated guardrails' provider-specific-params tests too.

## Fix

Import \`GuardrailEventHooks\` from \`litellm.types.guardrails\` inside the existing lazy-import block that already pulls \`CustomGuardrail\`. Fallback to the bare string when litellm isn't installed (bare unit-test scenario).

\`SUPPORTED_EVENT_HOOKS\` entry type changes from \`str\` to \`Any\` (the entry is the \`GuardrailEventHooks.pre_call\` enum member in prod; \`str\` fallback in bare tests). Test assertions rewritten to check \`.value == "pre_call"\` on the entry — same expression LiteLLM's registry runs, so the test regression-guards the exact upstream failure.

Version bump 0.2.3 → 0.2.4 (pyproject / \`__init__.py\` / User-Agent).

## Test plan

- [x] \`pytest packages/conduct-litellm-guard/tests/ -q\` — 28 pass
- [x] \`ConductGuard.get_supported_event_hooks()[0].value == "pre_call"\` — verified locally
- [ ] After merge + tag \`litellm-guard/v0.2.4\` → \`pip install --upgrade conduct-litellm-guard\` → 0.2.4 → BerriAI/litellm#38143's three failing tests pass

## Release

Tag \`litellm-guard/v0.2.4\` after merge → publish workflow lifts to PyPI → upstream PR #38143 pin bumps to \`>=0.2.4\`.