### PR TITLE
chore(sec): stop uploading session cookies + accurate CI job title

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   api:
-    name: API — lint + typecheck + test
+    name: API — lint + migrate + test
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/web-smoke.yml
+++ b/.github/workflows/web-smoke.yml
@@ -131,11 +131,17 @@ jobs:
 
       - name: Upload auth-setup diagnostics on failure
         # auth-setup.ts writes URL/body dumps + screenshots under .auth/*.png
-        # when globalSetup fails. Grab them so we can see what the browser
-        # actually landed on.
+        # when globalSetup fails. ONLY the screenshots + text dumps — the
+        # same directory also holds Playwright storageState JSON with live
+        # session cookies for the test users, which must NEVER ship as an
+        # artifact (audit S14). Explicit allowlist by extension.
         if: failure()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: auth-setup-diagnostics
-          path: apps/web/.auth
+          path: |
+            apps/web/.auth/*.png
+            apps/web/.auth/*.txt
+            apps/web/.auth/*.log
+          if-no-files-found: ignore
           retention-days: 7


### PR DESCRIPTION
## Summary

Two safe security tightenings from the 2026-09-11 external audit (baseline `c918c6e0`).

**S14 (P0 Critical):** `.github/workflows/web-smoke.yml` uploaded the entire `apps/web/.auth` directory as a public artifact on failure. That directory contains Playwright `storageState.json` files — live session cookies for the test users. Any historical failure since this workflow existed potentially exposed those cookies for 7 days per run.

**Fix:** artifact `path` is now a strict allowlist (`*.png`, `*.txt`, `*.log`). Screenshots + text dumps still ship for debugging; storage-state JSON never does. `if-no-files-found: ignore` so the step no-ops cleanly when nothing matches.

**Q01 (partial):** the API CI job was named "API — lint + typecheck + test" but has no Python typecheck step. Renamed to "API — lint + migrate + test" — accurate to what actually runs. Adding a real `mypy` pass is a separate change (needs a ratchet against existing debt).

## What's NOT in this PR

- Flake8 `|| true` removal — repo currently has ~2,019 flake8 violations; removing `|| true` would red every PR. Filed as a follow-up: needs a ratchet approach (baseline count, fail only on increase).
- `render.yaml ENVIRONMENT=production` — YAML change alone doesn't update env vars on an already-provisioned Render service; needs a dashboard step. Filed as a runbook task.
- The 5 harder P0s (S01, S02, S03, S06, S07) — filed as separate issues in `conduct-internal`.

## Audit trail

- Historical `.auth` artifacts: any workflow run since this step was added is potentially compromised. Recommendation: rotate the Playwright test user credentials as a precaution. Actual exposure depends on whether any historical run failed and whether the artifact was accessed within its 7-day retention.

## Test plan

- [ ] CI runs green on this PR
- [ ] Trigger a deliberate failure in web-smoke → confirm artifact contains only png/txt/log files, no `.json`
- [ ] After merge, rotate Playwright test-user credentials as a precaution
