### PR TITLE
fix(sec): events.py trusts only configured ingress CIDRs for client IP

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -88,6 +88,12 @@ class Settings(BaseSettings):
     sentry_dsn: str = ""
     app_version: str = "1.0.0"
 
+    # Trusted ingress proxies — comma-separated CIDR list of load balancers
+    # whose X-Forwarded-For headers we trust (e.g. "10.0.0.0/8" for Render's
+    # internal LB). If unset, X-Forwarded-For is ignored and request.client.host
+    # is used. Never trust the *first* XFF value blindly — audit S12.
+    trusted_proxy_cidrs: str = ""
+
     class Config:
         env_file = ".env"
         extra = "ignore"  # tolerate stray legacy env vars so app boots cleanly

--- a/apps/api/app/modules/guard/routers/events.py
+++ b/apps/api/app/modules/guard/routers/events.py
@@ -5,6 +5,7 @@ GET  /guard/events/stream   — SSE real-time feed
 """
 import asyncio
 import hashlib
+import ipaddress
 import json
 from datetime import datetime, timezone
 
@@ -18,10 +19,54 @@ from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
 from app.core.auth import get_workspace_id, require_permission, _clerk_enabled, _verify_clerk_token
+from app.core.config import settings
 from app.core.database import SessionLocal, get_db
 from app.core.pii import redact_secrets
 from app.models.workspace import Workspace
 from app.modules.guard.models import DiscoveredAgent, GuardAuditEvent, GuardConfig, GuardSession, GuardSpendBudget, chain_hash_for_insert, get_policy_hash
+
+
+def _trusted_cidrs() -> list[ipaddress._BaseNetwork]:
+    """Parsed TRUSTED_PROXY_CIDRS. Small enough to recompute per call — the
+    hot path here is DB-bound, not this.
+    """
+    out: list[ipaddress._BaseNetwork] = []
+    for chunk in (settings.trusted_proxy_cidrs or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            out.append(ipaddress.ip_network(chunk, strict=False))
+        except ValueError:
+            log.warning("guard.events.trusted_proxy_cidr_invalid", cidr=chunk)
+    return out
+
+
+def _client_ip_from(request: Request) -> str | None:
+    """Extract the caller's IP, respecting only configured trusted proxies
+    (audit S12 — same rule as /guard/trial/*).
+
+    Without TRUSTED_PROXY_CIDRS, ignore X-Forwarded-For entirely and use
+    request.client.host — blindly trusting the first XFF value lets any
+    anonymous caller forge the recorded session IP. With CIDRs set, walk
+    XFF right-to-left and return the first non-trusted hop.
+    """
+    trusted = _trusted_cidrs()
+    if not trusted:
+        return request.client.host if request.client else None
+    xff = (request.headers.get("x-forwarded-for") or "").strip()
+    if not xff:
+        return request.client.host if request.client else None
+    hops = [h.strip() for h in xff.split(",") if h.strip()]
+    for hop in reversed(hops):
+        try:
+            ip = ipaddress.ip_address(hop)
+        except ValueError:
+            continue
+        if not any(ip in net for net in trusted):
+            return hop
+    log.warning("guard.events.all_xff_hops_trusted", xff=xff)
+    return hops[0] if hops else (request.client.host if request.client else None)
 
 router = APIRouter(prefix="/guard/events", tags=["guard"])
 
@@ -705,10 +750,12 @@ def ingest_event(
             session.event_count += 1
             if body.decision in ("blocked", "warned"):
                 session.violations_count += 1
-            # Capture IP and OS on first event for this session
+            # Capture IP and OS on first event for this session.
+            # Uses trusted-proxy-aware parsing (audit S12) — blindly reading
+            # the first X-Forwarded-For hop let a caller forge the recorded
+            # IP on their own session rows. See _client_ip_from above.
             if not session.client_ip:
-                forwarded = request.headers.get("x-forwarded-for")
-                session.client_ip = (forwarded.split(",")[0].strip() if forwarded else None) or (request.client.host if request.client else None)
+                session.client_ip = _client_ip_from(request)
             if not session.os_info and body.os_info:
                 session.os_info = body.os_info[:128]
             if not session.hostname and body.hostname:

--- a/apps/api/tests/guard/test_events_client_ip.py
+++ b/apps/api/tests/guard/test_events_client_ip.py
@@ -1,0 +1,47 @@
+"""Unit tests for events.py _client_ip_from (audit S12 follow-up to #1790).
+
+The old code trusted the first X-Forwarded-For value blindly, letting a
+caller forge the IP recorded on their own session rows. New behaviour:
+XFF is ignored unless TRUSTED_PROXY_CIDRS is configured, and when it is
+we walk from the rightmost hop and take the first non-trusted address.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+
+def _mk_request(*, xff: str | None, client_host: str):
+    headers = {"x-forwarded-for": xff} if xff else {}
+    return SimpleNamespace(
+        headers=headers,
+        client=SimpleNamespace(host=client_host),
+    )
+
+
+def test_client_ip_ignores_xff_without_trusted_cidrs():
+    from app.modules.guard.routers import events
+    with patch.object(events, "settings", SimpleNamespace(trusted_proxy_cidrs="")):
+        req = _mk_request(xff="1.2.3.4, 5.6.7.8", client_host="10.0.0.5")
+        assert events._client_ip_from(req) == "10.0.0.5"
+
+
+def test_client_ip_walks_xff_from_right_when_trusted_cidrs_set():
+    from app.modules.guard.routers import events
+    with patch.object(events, "settings", SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff="1.2.3.4, 10.0.0.5, 10.0.0.6", client_host="10.0.0.6")
+        assert events._client_ip_from(req) == "1.2.3.4"
+
+
+def test_client_ip_ignores_malformed_xff_hop():
+    from app.modules.guard.routers import events
+    with patch.object(events, "settings", SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff="1.2.3.4, not-an-ip, 10.0.0.5", client_host="10.0.0.5")
+        assert events._client_ip_from(req) == "1.2.3.4"
+
+
+def test_client_ip_falls_back_when_xff_missing():
+    from app.modules.guard.routers import events
+    with patch.object(events, "settings", SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff=None, client_host="203.0.113.5")
+        assert events._client_ip_from(req) == "203.0.113.5"


### PR DESCRIPTION
## Summary
Follow-up to #1790 — same first-XFF trust bug (audit S12) in `events.py:710`. Any authenticated caller could set `X-Forwarded-For` on their own request to spoof `session.client_ip` in Guard's audit chain.

## Fix
- Add `TRUSTED_PROXY_CIDRS` to `Settings` (idempotent with #1790 — either PR merges first, the other gets a trivial config.py conflict).
- Inline `_client_ip_from(request)` in `events.py`: ignores XFF entirely when no CIDRs are configured; walks XFF right-to-left when they are.
- Small unit test covers the four cases (no CIDRs, trusted walk, malformed hop, XFF missing).

## Test plan
- [ ] CI green
- [ ] With `TRUSTED_PROXY_CIDRS=10.0.0.0/8` + a spoofed `X-Forwarded-For: 1.2.3.4, 10.0.0.5` from within the LB, the recorded IP is 1.2.3.4 (real client), not the spoof
- [ ] Without CIDRs configured, `session.client_ip` equals `request.client.host`

Closes #1792.