### PR TITLE
fix(sec): S01+S05+S12 — hardened trial signup surface (rebased)

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -941,6 +941,26 @@ def resolve_agent_token(token: str, db: Session) -> tuple[str, str] | None:
     return (row[0], row[1]) if row else None
 
 
+def require_platform_operator():
+    """FastAPI dep — 403s unless the caller's Clerk user_id is in
+    settings.platform_operator_clerk_ids. Used to gate cross-tenant ops
+    endpoints (e.g. /guard/trial/ops). A tenant admin role must NEVER
+    be enough on its own — see audit S05.
+    """
+    from app.core.config import settings as _s
+
+    def _dep(user_id: str = Depends(get_user_id)) -> str:
+        # In local/dev mode (no Clerk) user_id == DEV_USER_ID; explicit
+        # opt-in required: set PLATFORM_OPERATOR_CLERK_IDS=dev to enable
+        # ops endpoints on a dev box, otherwise 403 even there.
+        allowed = {s.strip() for s in _s.platform_operator_clerk_ids.split(",") if s.strip()}
+        if user_id and user_id in allowed:
+            return user_id
+        raise HTTPException(status_code=403, detail="platform_operator_only")
+
+    return _dep
+
+
 def token_is_expired(token: str, db: Session) -> bool:
     """True iff token matches a real AgentIdentity row whose expires_at has passed.
 

--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -88,6 +88,12 @@ class Settings(BaseSettings):
     sentry_dsn: str = ""
     app_version: str = "1.0.0"
 
+    # Platform operators — Clerk user IDs that can access cross-tenant ops
+    # endpoints (e.g. /guard/trial/ops). Comma-separated. Empty = nobody,
+    # which is the correct default; grant explicitly to on-call staff only.
+    # A tenant admin role must NEVER be enough on its own — see audit S05.
+    platform_operator_clerk_ids: str = ""
+
     # Trusted ingress proxies — comma-separated CIDR list of load balancers
     # whose X-Forwarded-For headers we trust (e.g. "10.0.0.0/8" for Render's
     # internal LB). If unset, X-Forwarded-For is ignored and request.client.host

--- a/apps/api/app/core/email.py
+++ b/apps/api/app/core/email.py
@@ -28,6 +28,46 @@ _jinja = JinjaEnv(loader=BaseLoader(), autoescape=True)
 # ---------------------------------------------------------------------------
 
 _FALLBACK_TEMPLATES: dict[str, dict] = {
+    "trial_verify": {
+        "subject": "Verify your Conduct AI trial",
+        "html_body": """<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8" /><title>Verify your Conduct AI trial</title></head>
+<body style="margin:0;padding:0;background:#f5f5f4;font-family:-apple-system,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#f5f5f4;padding:40px 0;">
+    <tr><td align="center">
+      <table width="560" cellpadding="0" cellspacing="0" style="max-width:560px;width:100%;">
+        <tr><td align="center" style="padding-bottom:24px;">
+          <span style="font-size:20px;font-weight:700;color:#1c1917;">Conduct AI</span>
+        </td></tr>
+        <tr><td style="background:#fff;border-radius:16px;border:1px solid #e7e5e4;padding:40px;">
+          <p style="margin:0 0 8px;font-size:22px;font-weight:700;color:#1c1917;">
+            Verify your email to start your trial
+          </p>
+          <p style="margin:0 0 24px;font-size:14px;color:#78716c;">
+            Someone (hopefully you) requested a Conduct AI trial for
+            <b>{{ email }}</b>. Click below to verify and finish setup.
+            The link expires in 30 minutes.
+          </p>
+          <table cellpadding="0" cellspacing="0" style="margin-bottom:24px;">
+            <tr><td style="background:#1c1917;border-radius:10px;">
+              <a href="{{ verify_url }}"
+                 style="display:inline-block;padding:14px 32px;font-size:15px;font-weight:600;color:#fff;text-decoration:none;">
+                Verify email →
+              </a>
+            </td></tr>
+          </table>
+          <p style="margin:0;font-size:12px;color:#a8a29e;">
+            If you didn't request this, ignore the message. No account or
+            token is created until you click the button above.
+          </p>
+        </td></tr>
+      </table>
+    </td></tr>
+  </table>
+</body>
+</html>""",
+    },
     "workspace_invite": {
         "subject": "You're invited to {{ workspace_name }} on Conduct AI",
         "html_body": """<!DOCTYPE html>

--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -20,7 +20,7 @@ from pydantic import BaseModel
 from sqlalchemy import text
 from sqlalchemy.orm import Session
 
-from app.core.auth import get_workspace_id, require_permission
+from app.core.auth import get_workspace_id, require_permission, require_platform_operator
 from app.core.config import settings
 from app.core.crypto import decrypt
 from app.core.database import get_db
@@ -161,14 +161,16 @@ class TrialOpsOut(BaseModel):
 
 @router.get("/ops", response_model=TrialOpsOut)
 def get_trial_ops(
-    _perm: str = Depends(require_permission("guard.spend.view_all")),
+    _op: str = Depends(require_platform_operator()),
     db: Session = Depends(get_db),
 ) -> TrialOpsOut:
     """Platform-ops view of trial-key burn across all workspaces.
 
-    Restricted to `guard.spend.view_all` (security+) — this crosses tenant
-    boundaries by design. Every metric derives from `guard_audit_events`
-    joined against the trial `AgentIdentity` name filter.
+    Restricted to platform operators only (audit S05 — a tenant admin
+    with `guard.spend.view_all` must NEVER be able to enumerate other
+    tenants). Configure the allowlist via PLATFORM_OPERATOR_CLERK_IDS.
+    Every metric derives from `guard_audit_events` joined against the
+    trial `AgentIdentity` name filter.
     """
     now = datetime.now(timezone.utc)
     cutoff = now - timedelta(hours=24)
@@ -230,31 +232,41 @@ def get_trial_ops(
     )
 
 
-# ─── /guard/trial/provision — self-service curl-install endpoint (#1712 Track 1) ─
+# ─── /guard/trial/provision + /guard/trial/redeem — self-service signup ─────
 #
-# `curl -fsSL conduct.ai/install | sh` posts an email + optional company to
-# this endpoint. Unauthenticated (no Clerk session, no Bearer token) but
-# email is REQUIRED — this is a signup form, not an identity-anonymous
-# mint. We provision a trial workspace + agent identity token and return
-# them so the shell script can drop `~/.conduct/env` on the caller's laptop.
+# Hardened flow (audit S01 / S12). The old `/provision` endpoint took an
+# email and immediately returned the caller's existing trial token if the
+# address matched a Clerk user — trivially exploitable enumeration path.
 #
-# The email is stashed on workspace.owner_id as a plain string (not yet a
-# Clerk user id). A later `conduct claim` / magic-link flow can bind the
-# workspace to a real Clerk account.
+# New two-step:
+#   1. POST /guard/trial/provision  — mints a challenge + emails a
+#      verification link. Returns a generic accepted response regardless
+#      of whether the email exists in Clerk. Never leaks user existence.
+#   2. POST /guard/trial/redeem     — validates the challenge (single
+#      use, 30-min TTL). NEW emails get a workspace + trial token.
+#      Existing emails get a sign-in link only — no token.
 #
-# Anti-abuse:
-#   - IP rate-limit: 5 provisions per hour (Redis atomic INCR)
-#   - Email idempotency: repeat POST with same email within the trial
-#     window returns the SAME trial token instead of minting a second
-#     workspace. Protects platform-key spend and keeps ~/.conduct/env
-#     stable when the user re-runs the installer.
+# Anti-abuse layered:
+#   - Per-IP hourly cap (Redis) — trusted-proxy CIDR aware (audit S12)
+#   - Per-email hourly cap (Redis)
+#   - Global anonymous-flow budget (Redis)
+#   - All three FAIL CLOSED when Redis is unreachable — no free
+#     credential issuance without abuse controls in effect (audit S12).
 
 
 import re as _re
 
 from fastapi import HTTPException, Request
 
+from app.core.email import send_template_email
 from app.guard.receipts import web_base_url as _web_base_url
+from app.modules.guard.trial_challenges import (
+    check_email_rate as _check_email_rate,
+    check_global_rate as _check_global_rate,
+    client_ip_from as _client_ip_from,
+    mint as _mint_challenge,
+    redeem as _redeem_challenge,
+)
 
 _EMAIL_RE = _re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _PROVISION_IP_CAP = 5   # per hour
@@ -270,28 +282,37 @@ class TrialProvisionIn(BaseModel):
     source: str | None = None
 
 
-class TrialProvisionOut(BaseModel):
-    workspace_id: str
-    agent_token: str
-    # `gateway_url` — Anthropic-specific route (`.../proxy/anthropic`).
-    # The Anthropic SDK does `POST {base}/v1/messages`; other vendors
-    # follow the same pattern under their own `/proxy/<vendor>` prefix.
-    # Kept as-is for backwards compat with older install scripts.
-    gateway_url: str
-    # `proxy_base_url` — vendor-agnostic root (`.../proxy`). Newer install
-    # scripts derive OpenAI / Perplexity URLs from this so we don't need
-    # a new response field per provider.
-    proxy_base_url: str
-    workspace_url: str
-    # Clerk one-time sign-in URL — click to land signed-in in dashboard.
-    # Optional: null if Clerk isn't configured (local dev) or minting failed.
+class TrialProvisionAck(BaseModel):
+    """Generic accepted response. Body is identical regardless of whether
+    the email exists in Clerk — audit S01 requires that we NEVER leak
+    user-existence to unauthenticated callers.
+    """
+    status: str = "accepted"
+    message: str = "If the address is valid, a verification email is on the way."
+
+
+class TrialRedeemIn(BaseModel):
+    ct: str    # opaque challenge token from the verification email link
+
+
+class TrialRedeemOut(BaseModel):
+    # Either "new" (workspace + token returned) or "existing" (sign-in URL only).
+    status: str
+    workspace_id: str | None = None
+    agent_token: str | None = None
+    gateway_url: str | None = None
+    proxy_base_url: str | None = None
+    workspace_url: str | None = None
     sign_in_url: str | None = None
+    # For the "existing" branch — where to send the user to log in.
+    recovery_url: str | None = None
 
 
-def _redis_or_none():
-    """Best-effort Redis handle — fail-open on outage (matches trial_upstream
-    convention). No throttle when Redis is down is preferable to blocking
-    installs entirely."""
+def _redis_or_fail_closed():
+    """Return a Redis handle or None. Callers use None to reject the
+    request — anonymous credential issuance without abuse controls in
+    place is worse than a brief outage (audit S12).
+    """
     try:
         from app.modules.guard.trial_upstream import _redis_client
         return _redis_client()
@@ -299,19 +320,13 @@ def _redis_or_none():
         return None
 
 
-def _ip_of(request: Request) -> str:
-    fwd = request.headers.get("x-forwarded-for") or ""
-    if fwd:
-        return fwd.split(",")[0].strip()
-    return request.client.host if request.client else "unknown"
-
-
 def _throttle_by_ip(ip: str) -> bool:
-    """Return True if under the per-hour cap; False if the cap is hit.
-    Fails open when Redis is unreachable."""
-    r = _redis_or_none()
+    """Return True if under the per-hour cap; False if hit or Redis is
+    unreachable. Fails CLOSED — audit S12 flagged the previous fail-open.
+    """
+    r = _redis_or_fail_closed()
     if r is None:
-        return True
+        return False
     key = f"guard:provision:ip:{ip}:{datetime.now(timezone.utc).strftime('%Y%m%d%H')}"
     try:
         pipe = r.pipeline()
@@ -320,33 +335,26 @@ def _throttle_by_ip(ip: str) -> bool:
         count, _ = pipe.execute()
         return int(count or 0) <= _PROVISION_IP_CAP
     except Exception:
-        return True
+        return False
 
 
-@router.post("/provision", response_model=TrialProvisionOut)
+@router.post("/provision", response_model=TrialProvisionAck)
 def provision_trial(
     body: TrialProvisionIn,
     request: Request,
     db: Session = Depends(get_db),
-) -> TrialProvisionOut:
-    """Self-service trial workspace provisioning (public signup endpoint).
+) -> TrialProvisionAck:
+    """Kick off a verified trial signup (audit S01).
 
-    Called by `apps/web/public/install.sh` (curl | sh). Converged with the
-    UI signup flow — a Clerk user is created here, then the same shared
-    `provision_workspace_for_user` runs that the `user.created` webhook
-    uses. Result: one workspace-creation code path, no bifurcation.
-
-    Response includes an optional one-time sign-in URL so the CLI can
-    print "click here to view your dashboard" — user lands signed in with
-    zero password prompts.
+    Validates input, checks per-IP / per-email / global caps, mints a
+    challenge, and emails a verification link. ALWAYS returns the same
+    generic ack — no user-existence signal. Real token issuance happens
+    in `/redeem` after the user clicks the emailed link.
     """
     from app.core.clerk import (
         ClerkError as _ClerkError,
-        create_user as _clerk_create_user,
         find_user_by_email as _clerk_find_user_by_email,
-        mint_sign_in_token as _clerk_mint_sign_in_token,
     )
-    from app.modules.onboarding import provision_workspace_for_user
 
     email = (body.email or "").strip().lower()
     if not _EMAIL_RE.match(email):
@@ -356,64 +364,119 @@ def provision_trial(
     if not company:
         raise HTTPException(status_code=422, detail="company_required")
 
-    ip = _ip_of(request)
+    ip = _client_ip_from(request)
     if not _throttle_by_ip(ip):
-        raise HTTPException(
-            status_code=429,
-            detail=f"provision_rate_limited: {_PROVISION_IP_CAP}/hour per IP",
-        )
+        raise HTTPException(status_code=429, detail="rate_limited")
+    if not _check_email_rate(email):
+        raise HTTPException(status_code=429, detail="rate_limited")
+    if not _check_global_rate():
+        raise HTTPException(status_code=429, detail="rate_limited")
 
-    # Look up first — same email hitting the endpoint twice OR after a
-    # browser signup should short-circuit to a sign-in prompt rather than
-    # spawning a second Clerk user + workspace. Clerk enforces email
-    # uniqueness, so we can trust its answer as the source of truth.
-    def _map_clerk_error(exc: _ClerkError, *, on_422: int = 502) -> HTTPException:
-        """Translate Clerk API failures to caller-facing HTTP responses.
-
-        - 429 passes through unchanged so a rate-limited caller can back
-          off instead of retrying against what looks like a server error.
-        - 422 usually means "email already exists" (racy signup) — caller
-          decides whether to surface as 409 (create path) or 502
-          (lookup path).
-        - Anything else is an upstream failure → 502.
-        """
-        if exc.status == 429:
-            return HTTPException(status_code=429, detail="clerk_rate_limited")
-        if exc.status == 422:
-            return HTTPException(status_code=on_422, detail="clerk_create_user_failed")
-        return HTTPException(status_code=502, detail="clerk_unavailable")
-
+    # Best-effort Clerk lookup — record whether the email is known so the
+    # redeem path knows whether to mint a new workspace or return a
+    # sign-in URL. Lookup failures are non-fatal: if Clerk is down, we
+    # store existing_user_id=None and the redeem flow proceeds as "new"
+    # (Clerk's create-user call at redeem time will 422 if it's actually
+    # existing, and we can degrade to the sign-in path there).
+    existing_user_id: str | None = None
     try:
-        clerk_user_id = _clerk_find_user_by_email(email)
+        existing_user_id = _clerk_find_user_by_email(email)
     except _ClerkError as exc:
         log.warning("guard.trial.provision.clerk_lookup_failed", email=email, err=str(exc))
-        raise _map_clerk_error(exc)
 
-    if clerk_user_id is None:
-        # Fresh email — create the Clerk user via backend API. Same code
-        # path Clerk fires webhooks for; our webhook handler is idempotent
-        # so a duplicate `user.created` (if delivered late) is a no-op.
-        try:
-            clerk_user_id = _clerk_create_user(email)
-        except _ClerkError as exc:
-            log.warning("guard.trial.provision.clerk_create_failed", email=email, status=exc.status, body=exc.body)
-            # 422 in the create path → 409 to hint "sign in" rather than
-            # "server error". 429 passes through unchanged for backoff.
-            raise _map_clerk_error(exc, on_422=409)
+    token = _mint_challenge(email, company[:60], existing_user_id)
+    if token is None:
+        # Redis outage during mint — fail closed to match rate-limit behaviour.
+        raise HTTPException(status_code=503, detail="verification_unavailable")
 
-    # Shared onboarding — same function the Clerk webhook calls. Idempotent
-    # so a race between webhook + this call is safe (whoever wins, later
-    # caller returns the existing workspace).
-    ws_id_uuid = provision_workspace_for_user(db, clerk_user_id, name=company[:60])
+    verify_url = f"{_web_base_url()}/onboard/verify?ct={token}"
+    sent = send_template_email(
+        slug="trial_verify",
+        to=email,
+        context={"email": email, "verify_url": verify_url},
+    )
+    log.info(
+        "guard.trial.provision.challenge_sent",
+        email=email, company=company, ip=ip,
+        existing_user=bool(existing_user_id), email_sent=sent,
+    )
+    return TrialProvisionAck()
+
+
+@router.post("/redeem", response_model=TrialRedeemOut)
+def redeem_trial(
+    body: TrialRedeemIn,
+    request: Request,
+    db: Session = Depends(get_db),
+) -> TrialRedeemOut:
+    """Redeem a verified challenge (audit S01).
+
+    Called by the web page the verification email links to. Atomic
+    single-use consumption via Redis GETDEL — no double-redeem race even
+    under concurrent clicks. NEW emails get a workspace + trial token.
+    Existing emails get a sign-in URL only, never a token.
+    """
+    from app.core.clerk import (
+        ClerkError as _ClerkError,
+        create_user as _clerk_create_user,
+        mint_sign_in_token as _clerk_mint_sign_in_token,
+    )
+    from app.modules.onboarding import provision_workspace_for_user
+
+    # Per-IP throttle on redeem too — a leaked link is one thing, but a
+    # botnet trying random challenge tokens against /redeem is another.
+    ip = _client_ip_from(request)
+    if not _throttle_by_ip(ip):
+        raise HTTPException(status_code=429, detail="rate_limited")
+
+    ct = (body.ct or "").strip()
+    if not ct:
+        raise HTTPException(status_code=422, detail="challenge_required")
+
+    ch = _redeem_challenge(ct)
+    if ch is None:
+        # Unknown / expired / already redeemed — same generic response
+        # regardless of which, so an attacker can't distinguish.
+        raise HTTPException(status_code=410, detail="challenge_invalid_or_expired")
+
+    _proxy_base = settings.conduct_proxy_url.rstrip("/")
+    _web = _web_base_url()
+
+    # Existing-email path — never issue an agent token here. The user
+    # should sign in through their normal path; the verification just
+    # confirmed the mailbox is reachable, not that they own the account
+    # tied to it (the two are usually equivalent, but the security
+    # invariant we care about is "no anonymous token issuance").
+    if ch.existing_user_id:
+        log.info("guard.trial.redeem.existing", email=ch.email, clerk_user_id=ch.existing_user_id, ip=ip)
+        return TrialRedeemOut(
+            status="existing",
+            recovery_url=f"{_web}/sign-in",
+        )
+
+    # New-email path — create Clerk user + workspace atomically.
+    try:
+        clerk_user_id = _clerk_create_user(ch.email)
+    except _ClerkError as exc:
+        # 422 from Clerk means the address was actually taken between
+        # mint and redeem (race with a browser signup). Degrade to the
+        # existing-user response so we still never leak a token.
+        if exc.status == 422:
+            log.info("guard.trial.redeem.race_became_existing", email=ch.email, ip=ip)
+            return TrialRedeemOut(status="existing", recovery_url=f"{_web}/sign-in")
+        log.warning("guard.trial.redeem.clerk_create_failed", email=ch.email, status=exc.status, body=exc.body)
+        if exc.status == 429:
+            raise HTTPException(status_code=429, detail="rate_limited")
+        raise HTTPException(status_code=502, detail="clerk_unavailable")
+
+    # Shared onboarding — same function the `user.created` webhook uses.
+    # Idempotent under the (extremely narrow) race where the webhook lands
+    # before our commit: whoever wins, the loser returns the same row.
+    ws_id_uuid = provision_workspace_for_user(db, clerk_user_id, name=ch.company[:60])
     db.commit()
     ws_id = str(ws_id_uuid)
-    log.info(
-        "guard.trial.provisioned",
-        workspace_id=ws_id, clerk_user_id=clerk_user_id,
-        email=email, company=company, ip=ip,
-    )
+    log.info("guard.trial.redeem.provisioned", workspace_id=ws_id, clerk_user_id=clerk_user_id, email=ch.email, ip=ip)
 
-    # Fetch + decrypt the trial identity token to return to the caller.
     row = _load_trial_identity(db, ws_id)
     if row is None:
         raise HTTPException(status_code=500, detail="trial_seed_failed")
@@ -422,23 +485,13 @@ def provision_trial(
     except Exception:
         raise HTTPException(status_code=500, detail="trial_token_decrypt_failed")
 
-    # Best-effort sign-in URL — CLI prints it so user can click straight
-    # into the dashboard. None if Clerk not configured or mint failed;
-    # curl-install still works, user just goes to /sign-in manually.
     sign_in_url = _clerk_mint_sign_in_token(clerk_user_id)
-
-    # `gateway_url` is Anthropic-shaped because that's what the trial
-    # upstream key covers today. `proxy_base_url` is the vendor-agnostic
-    # root so newer install scripts can derive OpenAI / Perplexity URLs
-    # (`{proxy_base_url}/openai`, `.../perplexity`) without another API
-    # round-trip. Both routes accept the same trial token; Guard policy
-    # and hash-chained audit apply uniformly.
-    _proxy_base = settings.conduct_proxy_url.rstrip("/")
-    return TrialProvisionOut(
+    return TrialRedeemOut(
+        status="new",
         workspace_id=ws_id,
         agent_token=token,
         gateway_url=f"{_proxy_base}/anthropic",
         proxy_base_url=_proxy_base,
-        workspace_url=f"{_web_base_url()}/theguard",
+        workspace_url=f"{_web}/theguard",
         sign_in_url=sign_in_url,
     )

--- a/apps/api/app/modules/guard/trial_challenges.py
+++ b/apps/api/app/modules/guard/trial_challenges.py
@@ -1,0 +1,213 @@
+"""Trial-provisioning verification challenges (audit S01).
+
+The unauthenticated `/guard/trial/provision` used to hand back an existing
+user's decrypted trial token to any anonymous caller who guessed their
+email. This module replaces that flow with a two-step verification:
+
+1. `POST /guard/trial/provision` mints a challenge, emails the caller a
+   link with an opaque token, and returns a generic accepted response
+   regardless of whether the email exists in Clerk. The response body
+   never leaks user existence.
+2. `POST /guard/trial/redeem {ct}` validates the challenge and, only for
+   verified NEW emails, mints a Clerk user + workspace + trial token.
+   Existing-email challenges resolve to a sign-in link with no token.
+
+Storage: Redis with a 30-minute TTL (self-cleaning, single-use, and the
+same Redis we already require for the rate-limiter). Challenges are keyed
+by SHA-256 of the raw token so the plaintext never lands in Redis.
+"""
+from __future__ import annotations
+
+import hashlib
+import ipaddress
+import json
+import secrets
+import time
+from dataclasses import dataclass
+
+import structlog
+
+from app.core.config import settings
+
+log = structlog.get_logger(__name__)
+
+_TTL_SECONDS = 30 * 60           # 30 min — long enough for the user to click the email link
+_CHALLENGE_KEY_PREFIX = "guard:trial:challenge:"
+_EMAIL_RATE_KEY_PREFIX = "guard:trial:email:"
+_GLOBAL_RATE_KEY = "guard:trial:global"
+_PER_EMAIL_CAP = 3               # per hour, per email address
+_GLOBAL_CAP = 200                # per hour, all anonymous provisions combined
+
+
+@dataclass
+class Challenge:
+    """One redemption record. Never serialised with the plaintext token."""
+
+    email: str
+    company: str
+    existing_user_id: str | None    # populated at mint time if Clerk already knows the email
+    created_at: float
+
+
+def _redis():
+    """Return a live Redis handle or None. Callers decide the fail-mode.
+
+    The trial provision path fails CLOSED (no free credential issuance
+    without abuse controls) — see audit S12. Other consumers may prefer
+    fail-open; make that decision at the call site, never here.
+    """
+    try:
+        from app.modules.guard.trial_upstream import _redis_client
+        return _redis_client()
+    except Exception as exc:
+        log.warning("guard.trial.redis_unavailable", err=str(exc))
+        return None
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def check_email_rate(email: str) -> bool:
+    """Return True if this email can mint another challenge in the current
+    hour bucket. False if the per-email cap is exhausted. Fails CLOSED on
+    Redis outage — see audit S12.
+    """
+    r = _redis()
+    if r is None:
+        return False
+    bucket = time.strftime("%Y%m%d%H", time.gmtime())
+    key = f"{_EMAIL_RATE_KEY_PREFIX}{email}:{bucket}"
+    try:
+        pipe = r.pipeline()
+        pipe.incr(key, 1)
+        pipe.expire(key, 3600)
+        count, _ = pipe.execute()
+        return int(count or 0) <= _PER_EMAIL_CAP
+    except Exception as exc:
+        log.warning("guard.trial.email_rate_check_failed", err=str(exc))
+        return False
+
+
+def check_global_rate() -> bool:
+    """Global anonymous-flow budget. Fails CLOSED on Redis outage.
+
+    A per-IP cap is not enough — a low-cost botnet spreads across enough
+    IPs to defeat it. The global cap bounds worst-case Clerk-user-creation
+    spend when the per-IP + per-email limits are all being pushed.
+    """
+    r = _redis()
+    if r is None:
+        return False
+    bucket = time.strftime("%Y%m%d%H", time.gmtime())
+    key = f"{_GLOBAL_RATE_KEY}:{bucket}"
+    try:
+        pipe = r.pipeline()
+        pipe.incr(key, 1)
+        pipe.expire(key, 3600)
+        count, _ = pipe.execute()
+        return int(count or 0) <= _GLOBAL_CAP
+    except Exception as exc:
+        log.warning("guard.trial.global_rate_check_failed", err=str(exc))
+        return False
+
+
+def mint(email: str, company: str, existing_user_id: str | None) -> str | None:
+    """Store a fresh challenge in Redis, return the raw token. None on
+    Redis outage — caller must fail closed.
+    """
+    r = _redis()
+    if r is None:
+        return None
+    token = secrets.token_urlsafe(32)
+    payload = json.dumps({
+        "email": email,
+        "company": company,
+        "existing_user_id": existing_user_id,
+        "created_at": time.time(),
+    })
+    try:
+        r.setex(f"{_CHALLENGE_KEY_PREFIX}{_hash(token)}", _TTL_SECONDS, payload)
+        return token
+    except Exception as exc:
+        log.warning("guard.trial.challenge_mint_failed", err=str(exc))
+        return None
+
+
+def redeem(token: str) -> Challenge | None:
+    """Atomically consume a challenge. Returns the Challenge on success,
+    None if the token is unknown, expired, or already redeemed.
+    """
+    r = _redis()
+    if r is None:
+        return None
+    key = f"{_CHALLENGE_KEY_PREFIX}{_hash(token)}"
+    try:
+        # GETDEL is atomic — no double-redeem race even under concurrent clicks.
+        raw = r.getdel(key)
+    except Exception as exc:
+        log.warning("guard.trial.challenge_redeem_failed", err=str(exc))
+        return None
+    if raw is None:
+        return None
+    try:
+        data = json.loads(raw)
+        return Challenge(
+            email=data["email"],
+            company=data["company"],
+            existing_user_id=data.get("existing_user_id"),
+            created_at=float(data.get("created_at", 0)),
+        )
+    except Exception as exc:
+        log.warning("guard.trial.challenge_parse_failed", err=str(exc))
+        return None
+
+
+# ── Trusted-proxy X-Forwarded-For parsing (audit S12) ───────────────────────
+
+def _parse_cidrs(raw: str) -> list[ipaddress._BaseNetwork]:
+    out: list[ipaddress._BaseNetwork] = []
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            out.append(ipaddress.ip_network(chunk, strict=False))
+        except ValueError:
+            log.warning("guard.trial.trusted_proxy_cidr_invalid", cidr=chunk)
+    return out
+
+
+def client_ip_from(request) -> str:
+    """Extract the caller's IP, respecting only configured trusted proxies.
+
+    Behaviour:
+    - If TRUSTED_PROXY_CIDRS is unset, ignore X-Forwarded-For entirely and
+      return request.client.host. Blind trust on the first XFF value lets
+      any anonymous caller forge their IP against the per-IP limiter
+      (audit S12).
+    - If TRUSTED_PROXY_CIDRS is set, walk XFF from RIGHT to LEFT and skip
+      addresses that fall inside a trusted CIDR. The first non-trusted
+      address is the real client. If every hop is trusted (shouldn't
+      happen), fall back to the leftmost XFF entry.
+    """
+    trusted = _parse_cidrs(settings.trusted_proxy_cidrs)
+    if not trusted:
+        return request.client.host if request.client else "unknown"
+
+    xff = (request.headers.get("x-forwarded-for") or "").strip()
+    if not xff:
+        return request.client.host if request.client else "unknown"
+
+    hops = [h.strip() for h in xff.split(",") if h.strip()]
+    for hop in reversed(hops):
+        try:
+            ip = ipaddress.ip_address(hop)
+        except ValueError:
+            continue
+        if not any(ip in net for net in trusted):
+            return hop
+    # Everything was trusted — fall back to the leftmost hop and log so
+    # we notice a misconfigured CIDR list.
+    log.warning("guard.trial.all_xff_hops_trusted", xff=xff)
+    return hops[0]

--- a/apps/api/scripts/check_auth_coverage.py
+++ b/apps/api/scripts/check_auth_coverage.py
@@ -28,6 +28,7 @@ AUTH_DEPS = {
     "get_user_workspace_role_sse",
     "get_guard_org_id",
     "get_guard_hook_auth",
+    "require_platform_operator",
     "_require_admin",
     "_require_super_admin",
     "_bearer",
@@ -94,6 +95,11 @@ ALLOWLIST = {
     # created here — email stashed on workspace.owner_id for later
     # magic-link claim.
     "modules/guard/routers/trial.py::provision_trial",
+    # Trial redemption — public endpoint (#1790 audit S01 challenge/redeem flow).
+    # Auth: opaque single-use challenge token in the body must match a Redis
+    # entry that was minted by /provision after email format + rate-limit
+    # gates passed. Existing-user challenges NEVER return an agent token.
+    "modules/guard/routers/trial.py::redeem_trial",
     # Guard budget check (workspace_id validated against guard_config — called pre-tool-use)
     "modules/guard/routers/spend.py::budget_check",
     # Telemetry ingest (auth via Authorization or X-Workspace-Id header — alternative auth)

--- a/apps/api/tests/guard/test_trial_challenges.py
+++ b/apps/api/tests/guard/test_trial_challenges.py
@@ -1,0 +1,165 @@
+"""Unit tests for the trial-challenge Redis store + trusted-proxy IP parser
+(audit S01 + S12).
+
+These tests don't touch FastAPI; they exercise the primitives directly so
+regressions in mint/redeem semantics or XFF handling show up early.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+# ── mint / redeem round-trip ────────────────────────────────────────────────
+
+class _FakeRedis:
+    """In-memory shim for the tiny subset of redis-py we use."""
+
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    def setex(self, key: str, ttl: int, value: str) -> None:
+        self.store[key] = value
+
+    def getdel(self, key: str):
+        return self.store.pop(key, None)
+
+    def pipeline(self):
+        return _FakePipeline(self)
+
+
+class _FakePipeline:
+    def __init__(self, r: _FakeRedis):
+        self.r = r
+        self.ops: list = []
+
+    def incr(self, key: str, n: int = 1):
+        self.ops.append(("incr", key, n))
+        return self
+
+    def expire(self, key: str, ttl: int):
+        self.ops.append(("expire", key, ttl))
+        return self
+
+    def execute(self):
+        results = []
+        for op in self.ops:
+            if op[0] == "incr":
+                _, key, n = op
+                cur = int(self.r.store.get(key, 0)) + n
+                self.r.store[key] = str(cur)
+                results.append(cur)
+            else:
+                results.append(1)
+        self.ops = []
+        return results
+
+
+def test_mint_returns_none_when_redis_unavailable():
+    from app.modules.guard import trial_challenges as tc
+    with patch.object(tc, "_redis", return_value=None):
+        assert tc.mint("user@example.com", "Acme", None) is None
+
+
+def test_mint_redeem_roundtrip_preserves_challenge_fields():
+    from app.modules.guard import trial_challenges as tc
+    fake = _FakeRedis()
+    with patch.object(tc, "_redis", return_value=fake):
+        token = tc.mint("user@example.com", "Acme", "user_abc")
+        assert token
+        ch = tc.redeem(token)
+        assert ch is not None
+        assert ch.email == "user@example.com"
+        assert ch.company == "Acme"
+        assert ch.existing_user_id == "user_abc"
+
+
+def test_redeem_is_single_use():
+    from app.modules.guard import trial_challenges as tc
+    fake = _FakeRedis()
+    with patch.object(tc, "_redis", return_value=fake):
+        token = tc.mint("user@example.com", "Acme", None)
+        first = tc.redeem(token)
+        second = tc.redeem(token)
+        assert first is not None
+        assert second is None       # GETDEL consumed on first call
+
+
+def test_redeem_unknown_token_returns_none():
+    from app.modules.guard import trial_challenges as tc
+    fake = _FakeRedis()
+    with patch.object(tc, "_redis", return_value=fake):
+        assert tc.redeem("not-a-real-token") is None
+
+
+def test_rate_checks_fail_closed_without_redis():
+    """Audit S12 — no free issuance when abuse controls aren't in effect."""
+    from app.modules.guard import trial_challenges as tc
+    with patch.object(tc, "_redis", return_value=None):
+        assert tc.check_email_rate("user@example.com") is False
+        assert tc.check_global_rate() is False
+
+
+def test_email_rate_allows_first_calls_then_blocks():
+    from app.modules.guard import trial_challenges as tc
+    fake = _FakeRedis()
+    with patch.object(tc, "_redis", return_value=fake):
+        assert tc.check_email_rate("user@example.com") is True    # 1
+        assert tc.check_email_rate("user@example.com") is True    # 2
+        assert tc.check_email_rate("user@example.com") is True    # 3 (cap)
+        assert tc.check_email_rate("user@example.com") is False   # 4 blocked
+
+
+# ── client_ip_from — audit S12 trusted-proxy walking ──────────────────────
+
+def _mk_request(*, xff: str | None, client_host: str):
+    headers = {"x-forwarded-for": xff} if xff else {}
+    return SimpleNamespace(
+        headers=headers,
+        client=SimpleNamespace(host=client_host),
+    )
+
+
+def test_client_ip_ignores_xff_when_no_trusted_cidrs():
+    """No TRUSTED_PROXY_CIDRS = blind trust would let anyone forge X-Forwarded-For."""
+    from app.modules.guard import trial_challenges as tc
+    with patch("app.modules.guard.trial_challenges.settings",
+               SimpleNamespace(trusted_proxy_cidrs="")):
+        req = _mk_request(xff="1.2.3.4, 5.6.7.8", client_host="10.0.0.5")
+        assert tc.client_ip_from(req) == "10.0.0.5"
+
+
+def test_client_ip_walks_xff_from_right_when_trusted_cidrs_set():
+    """With trusted CIDRs configured, walk XFF from right and return the
+    first non-trusted hop — that's the real client behind the LB."""
+    from app.modules.guard import trial_challenges as tc
+    with patch("app.modules.guard.trial_challenges.settings",
+               SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        # attacker at 1.2.3.4 → LB1 (10.0.0.5) → LB2 (10.0.0.6) → us
+        req = _mk_request(xff="1.2.3.4, 10.0.0.5, 10.0.0.6", client_host="10.0.0.6")
+        assert tc.client_ip_from(req) == "1.2.3.4"
+
+
+def test_client_ip_falls_back_when_all_hops_trusted():
+    from app.modules.guard import trial_challenges as tc
+    with patch("app.modules.guard.trial_challenges.settings",
+               SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff="10.0.0.5, 10.0.0.6", client_host="10.0.0.6")
+        # Leftmost hop returned + warning logged. Test just checks non-crash.
+        assert tc.client_ip_from(req) == "10.0.0.5"
+
+
+def test_client_ip_falls_back_when_xff_missing():
+    from app.modules.guard import trial_challenges as tc
+    with patch("app.modules.guard.trial_challenges.settings",
+               SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff=None, client_host="203.0.113.5")
+        assert tc.client_ip_from(req) == "203.0.113.5"
+
+
+def test_client_ip_ignores_malformed_xff_hop():
+    from app.modules.guard import trial_challenges as tc
+    with patch("app.modules.guard.trial_challenges.settings",
+               SimpleNamespace(trusted_proxy_cidrs="10.0.0.0/8")):
+        req = _mk_request(xff="1.2.3.4, not-an-ip, 10.0.0.5", client_host="10.0.0.5")
+        assert tc.client_ip_from(req) == "1.2.3.4"

--- a/apps/api/tests/guard/test_trial_provision.py
+++ b/apps/api/tests/guard/test_trial_provision.py
@@ -1,27 +1,18 @@
-"""#1712 Track 1 PR 5 (unified) — POST /guard/trial/provision.
+"""Trial provisioning + redemption tests (audit S01 / S12 hardened flow).
 
-Public signup endpoint. Unauthenticated, email + company both REQUIRED.
-Converged with UI signup via Clerk backend API + shared
-`provision_workspace_for_user`. Every provision:
+The old /provision returned a decrypted trial token to anyone who guessed
+an existing customer's email. These tests lock in the replacement:
 
-  1. Look up Clerk user by email → 409 if exists (existing account,
-     tell them to sign in)
-  2. Create Clerk user via backend API → get `user_id`
-  3. Run shared onboarding (same code path as Clerk webhook)
-  4. Load trial agent identity → decrypt token → return
-  5. Optional: mint sign-in URL so CLI can print "click to dashboard"
-
-Coverage:
-  - happy path — fresh email creates Clerk user + workspace + token
-  - existing Clerk user — 409 with sign-in guidance
-  - Clerk API failure — 502
-  - validation — bad email 422, missing company 422
-  - IP rate-limit — 429
-  - sign_in_url is passed through when Clerk returns one
+- /provision NEVER returns a token; always returns a generic accepted body
+- /provision NEVER leaks whether the email exists in Clerk
+- /redeem verifies a single-use, TTL-bounded challenge before minting anything
+- Existing-email challenges resolve to a sign-in URL only
+- Rate limits + Redis mint both fail CLOSED (no free issuance without abuse controls)
 """
 from __future__ import annotations
 
 import uuid as _uuid
+from contextlib import ExitStack
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -41,69 +32,31 @@ def _clear():
     app.dependency_overrides.pop(get_db, None)
 
 
-def _patch_deps(
+def _patch_provision(
+    stack: ExitStack,
     *,
-    existing_clerk_user_id=None,
-    new_clerk_user_id="user_test_123",
-    workspace_uuid=None,
-    ident_row=None,
-    sign_in_url=None,
-    throttle=True,
-    create_raises=None,
-):
-    """Compose the patch context — every dep the endpoint touches is
-    mocked so tests never hit a real DB or Clerk. Returns a list of
-    `patch` context managers the test enters via ExitStack."""
-    from contextlib import ExitStack
-    stack = ExitStack()
-
-    def _install(target, **kwargs):
-        stack.enter_context(patch(target, **kwargs))
-
-    def _install_side(target, side_effect):
-        stack.enter_context(patch(target, side_effect=side_effect))
-
-    def _install_ret(target, return_value):
-        stack.enter_context(patch(target, return_value=return_value))
-
-    return stack, {
-        "existing_clerk_user_id": existing_clerk_user_id,
-        "new_clerk_user_id": new_clerk_user_id,
-        "workspace_uuid": workspace_uuid or _uuid.uuid4(),
-        "ident_row": ident_row or SimpleNamespace(
-            id=_uuid.uuid4(),
-            token_encrypted=b"encrypted-placeholder",
-            expires_at=None,
-        ),
-        "sign_in_url": sign_in_url,
-        "throttle": throttle,
-        "create_raises": create_raises,
-    }
+    existing_clerk_user_id: str | None = None,
+    mint_token: str | None = "verify-token-xyz",
+    ip_throttle: bool = True,
+    email_rate: bool = True,
+    global_rate: bool = True,
+    email_sent: bool = True,
+) -> None:
+    """Patch everything /provision touches so no test hits real Redis/Clerk/Resend."""
+    stack.enter_context(patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=ip_throttle))
+    stack.enter_context(patch("app.modules.guard.routers.trial._check_email_rate", return_value=email_rate))
+    stack.enter_context(patch("app.modules.guard.routers.trial._check_global_rate", return_value=global_rate))
+    stack.enter_context(patch("app.core.clerk.find_user_by_email", return_value=existing_clerk_user_id))
+    stack.enter_context(patch("app.modules.guard.routers.trial._mint_challenge", return_value=mint_token))
+    stack.enter_context(patch("app.modules.guard.routers.trial.send_template_email", return_value=email_sent))
 
 
-def _apply_patches(stack, cfg):
-    """Enter the standard patch set inside `stack`. Returns None; side-effect
-    only. Kept out of `_patch_deps` so tests can add/override before entering."""
-    from app.core.clerk import ClerkError
-    stack.enter_context(patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=cfg["throttle"]))
-    stack.enter_context(patch("app.core.clerk.find_user_by_email", return_value=cfg["existing_clerk_user_id"]))
-    if cfg["create_raises"]:
-        stack.enter_context(patch("app.core.clerk.create_user", side_effect=cfg["create_raises"]))
-    else:
-        stack.enter_context(patch("app.core.clerk.create_user", return_value=cfg["new_clerk_user_id"]))
-    stack.enter_context(patch("app.modules.onboarding.provision_workspace_for_user", return_value=cfg["workspace_uuid"]))
-    stack.enter_context(patch("app.modules.guard.routers.trial._load_trial_identity", return_value=cfg["ident_row"]))
-    stack.enter_context(patch("app.modules.guard.routers.trial.decrypt", return_value={"token": "cond_agt_trial_deadbeef"}))
-    stack.enter_context(patch("app.core.clerk.mint_sign_in_token", return_value=cfg["sign_in_url"]))
+# ── /provision — validation ─────────────────────────────────────────────────
 
-
-# ── Validation ───────────────────────────────────────────────────────────────
-
-def test_provision_requires_valid_email():
-    db = MagicMock()
-    client = _client(db)
+def test_provision_rejects_invalid_email():
+    client = _client(MagicMock())
     try:
-        resp = client.post("/guard/trial/provision", json={"email": "not-an-email", "company": "Xervmon"})
+        resp = client.post("/guard/trial/provision", json={"email": "not-an-email", "company": "Acme"})
         assert resp.status_code == 422
         assert "invalid_email" in resp.text
     finally:
@@ -111,189 +64,262 @@ def test_provision_requires_valid_email():
 
 
 def test_provision_requires_company():
-    db = MagicMock()
-    # Pydantic-level missing → 422 (validation error before endpoint logic)
-    client = _client(db)
-    try:
-        resp = client.post("/guard/trial/provision", json={"email": "sudhi@example.com"})
-        assert resp.status_code == 422
-    finally:
-        _clear()
-
-    # Endpoint-level whitespace-only → 422 with our detail string
     client = _client(MagicMock())
     try:
-        resp = client.post("/guard/trial/provision", json={"email": "sudhi@example.com", "company": "  "})
+        resp = client.post("/guard/trial/provision", json={"email": "user@example.com", "company": "  "})
         assert resp.status_code == 422
         assert "company_required" in resp.text
     finally:
         _clear()
 
 
-# ── Happy path ───────────────────────────────────────────────────────────────
+# ── /provision — S01 core invariant: never leak user existence ─────────────
 
-def test_provision_creates_clerk_user_and_returns_token():
-    stack, cfg = _patch_deps(existing_clerk_user_id=None, sign_in_url=None)
-    db = MagicMock()
-    client = _client(db)
+def test_provision_returns_identical_ack_for_new_and_existing_emails():
+    """New and existing emails must produce byte-identical response bodies.
+    Any difference would let an anonymous caller enumerate registered emails.
+    """
+    client = _client(MagicMock())
+    bodies: list[dict] = []
+    for existing in (None, "user_abc"):
+        try:
+            with ExitStack() as stack:
+                _patch_provision(stack, existing_clerk_user_id=existing)
+                resp = client.post(
+                    "/guard/trial/provision",
+                    json={"email": "user@example.com", "company": "Acme"},
+                )
+            assert resp.status_code == 200
+            bodies.append(resp.json())
+        finally:
+            _clear()
+    assert bodies[0] == bodies[1]
+    assert "agent_token" not in bodies[0]     # audit S01 — never in provision response
+    assert "workspace_id" not in bodies[0]
+    assert "sign_in_url" not in bodies[0]
+
+
+def test_provision_returns_accepted_even_when_email_send_fails():
+    """Email service down must still return accepted — surfacing failure
+    would leak that the email was actually queued (i.e. valid)."""
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
+        with ExitStack() as stack:
+            _patch_provision(stack, email_sent=False)
             resp = client.post(
                 "/guard/trial/provision",
-                json={"email": "SUDHI@example.com", "company": "Xervmon"},
+                json={"email": "user@example.com", "company": "Acme"},
             )
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "accepted"
     finally:
         _clear()
 
-    assert resp.status_code == 200, resp.text
-    body = resp.json()
-    assert body["agent_token"] == "cond_agt_trial_deadbeef"
-    assert body["workspace_id"] == str(cfg["workspace_uuid"])
-    assert body["gateway_url"].endswith("/anthropic")
-    assert body["workspace_url"].endswith("/theguard")
-    assert body["sign_in_url"] is None
 
+# ── /provision — S12 fail-closed rate limits ────────────────────────────────
 
-def test_provision_passes_through_sign_in_url_when_clerk_mints_one():
-    stack, cfg = _patch_deps(sign_in_url="https://accounts.example.com/sign-in?ticket=xyz")
-    db = MagicMock()
-    client = _client(db)
+def test_provision_rejects_when_ip_throttle_fails():
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
+        with ExitStack() as stack:
+            _patch_provision(stack, ip_throttle=False)
             resp = client.post(
                 "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
+                json={"email": "user@example.com", "company": "Acme"},
             )
+        assert resp.status_code == 429
     finally:
         _clear()
 
-    assert resp.status_code == 200
-    assert resp.json()["sign_in_url"] == "https://accounts.example.com/sign-in?ticket=xyz"
 
-
-# ── Idempotency via Clerk ─────────────────────────────────────────────────────
-
-def test_provision_returns_token_for_existing_clerk_user():
-    """Same email hitting the endpoint twice OR after a browser signup
-    should not create a duplicate Clerk user — the lookup path returns
-    the existing user_id and shared onboarding is idempotent, so we
-    end up with one workspace + a fresh token round-trip."""
-    stack, cfg = _patch_deps(existing_clerk_user_id="user_existing_abc")
-    # Mock create_user to blow up if called — proves we short-circuited.
-    from app.core.clerk import ClerkError
-    stack.enter_context(patch("app.core.clerk.create_user", side_effect=AssertionError("must not be called")))
-
-    db = MagicMock()
-    client = _client(db)
+def test_provision_rejects_when_email_rate_fails():
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
+        with ExitStack() as stack:
+            _patch_provision(stack, email_rate=False)
             resp = client.post(
                 "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
+                json={"email": "user@example.com", "company": "Acme"},
             )
+        assert resp.status_code == 429
     finally:
         _clear()
 
-    # Existing user + idempotent onboarding = 200 with the existing token,
-    # not a 409. Rationale: same email re-running the installer is a valid
-    # UX (re-provision my ~/.conduct/env); we short-circuit Clerk creation
-    # but still hand back the token.
-    assert resp.status_code == 200
-    body = resp.json()
-    assert body["agent_token"] == "cond_agt_trial_deadbeef"
 
-
-# ── Clerk API failure ─────────────────────────────────────────────────────────
-
-def test_provision_502s_when_clerk_create_user_fails_with_5xx():
-    from app.core.clerk import ClerkError
-    stack, cfg = _patch_deps(existing_clerk_user_id=None, create_raises=ClerkError(status=500, message="down"))
-    db = MagicMock()
-    client = _client(db)
+def test_provision_rejects_when_global_rate_fails():
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
+        with ExitStack() as stack:
+            _patch_provision(stack, global_rate=False)
             resp = client.post(
                 "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
+                json={"email": "user@example.com", "company": "Acme"},
             )
+        assert resp.status_code == 429
     finally:
         _clear()
 
-    assert resp.status_code == 502
-    # New mapping: 5xx from Clerk → clerk_unavailable (upstream outage).
-    # 4xx-non-422 also maps here — same class of error from the caller's POV.
-    assert "clerk_unavailable" in resp.text
+
+def test_provision_fails_closed_when_mint_returns_none():
+    """Redis outage during mint returns None — endpoint must 503, not
+    silently swallow (audit S12)."""
+    client = _client(MagicMock())
+    try:
+        with ExitStack() as stack:
+            _patch_provision(stack, mint_token=None)
+            resp = client.post(
+                "/guard/trial/provision",
+                json={"email": "user@example.com", "company": "Acme"},
+            )
+        assert resp.status_code == 503
+        assert "verification_unavailable" in resp.text
+    finally:
+        _clear()
 
 
-def test_provision_409s_on_clerk_422_race():
-    """Clerk 422 on create_user typically means the email already exists —
-    a race between our lookup and someone else creating the user under the
-    same email. Surface as 409 so the caller knows to sign in."""
-    from app.core.clerk import ClerkError
-    stack, cfg = _patch_deps(
-        existing_clerk_user_id=None,
-        create_raises=ClerkError(status=422, message="email already exists"),
+# ── /redeem — happy paths ───────────────────────────────────────────────────
+
+def _mk_challenge(*, existing_user_id: str | None):
+    from app.modules.guard.trial_challenges import Challenge
+    return Challenge(
+        email="user@example.com",
+        company="Acme",
+        existing_user_id=existing_user_id,
+        created_at=1_700_000_000.0,
     )
-    db = MagicMock()
-    client = _client(db)
+
+
+def _patch_redeem(
+    stack: ExitStack,
+    *,
+    challenge=None,
+    ip_throttle: bool = True,
+    new_clerk_user_id: str = "user_new_123",
+    workspace_uuid=None,
+    ident_row=None,
+    sign_in_url: str | None = None,
+    create_raises=None,
+):
+    """Patch everything /redeem touches."""
+    stack.enter_context(patch("app.modules.guard.routers.trial._throttle_by_ip", return_value=ip_throttle))
+    stack.enter_context(patch("app.modules.guard.routers.trial._redeem_challenge", return_value=challenge))
+    if create_raises:
+        stack.enter_context(patch("app.core.clerk.create_user", side_effect=create_raises))
+    else:
+        stack.enter_context(patch("app.core.clerk.create_user", return_value=new_clerk_user_id))
+    stack.enter_context(patch(
+        "app.modules.onboarding.provision_workspace_for_user",
+        return_value=workspace_uuid or _uuid.uuid4(),
+    ))
+    stack.enter_context(patch(
+        "app.modules.guard.routers.trial._load_trial_identity",
+        return_value=ident_row or SimpleNamespace(
+            id=_uuid.uuid4(), token_encrypted=b"blob", expires_at=None,
+        ),
+    ))
+    stack.enter_context(patch(
+        "app.modules.guard.routers.trial.decrypt",
+        return_value={"token": "cond_agt_trial_deadbeef"},
+    ))
+    stack.enter_context(patch("app.core.clerk.mint_sign_in_token", return_value=sign_in_url))
+
+
+def test_redeem_new_email_returns_workspace_and_token():
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
-            resp = client.post(
-                "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
-            )
+        with ExitStack() as stack:
+            _patch_redeem(stack, challenge=_mk_challenge(existing_user_id=None))
+            resp = client.post("/guard/trial/redeem", json={"ct": "verify-token-xyz"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "new"
+        assert body["agent_token"] == "cond_agt_trial_deadbeef"
+        assert body["workspace_id"]
+        assert body["gateway_url"].endswith("/anthropic")
     finally:
         _clear()
 
-    assert resp.status_code == 409
-    assert "clerk_create_user_failed" in resp.text
+
+def test_redeem_existing_email_returns_recovery_url_only():
+    """S01 core: existing-email challenges never issue a token."""
+    client = _client(MagicMock())
+    try:
+        with ExitStack() as stack:
+            _patch_redeem(stack, challenge=_mk_challenge(existing_user_id="user_existing_abc"))
+            # If clerk.create_user gets called we'd blow the fixture — proves
+            # we short-circuited before touching Clerk.
+            stack.enter_context(patch(
+                "app.core.clerk.create_user",
+                side_effect=AssertionError("must not be called for existing user"),
+            ))
+            resp = client.post("/guard/trial/redeem", json={"ct": "verify-token-xyz"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "existing"
+        assert body["agent_token"] is None
+        assert body["workspace_id"] is None
+        assert body["recovery_url"]
+    finally:
+        _clear()
 
 
-def test_provision_passes_through_clerk_429_as_429():
-    """Clerk rate-limiting our provisioning should surface as 429 to the
-    caller, not 502 — so `curl | sh` can back off honestly instead of
-    treating an upstream throttle as a server outage."""
+# ── /redeem — invalid / expired / double-redeem all look the same ──────────
+
+def test_redeem_unknown_or_expired_token_returns_410():
+    """`_redeem_challenge` returns None for unknown, expired, and already
+    redeemed tokens — endpoint returns the same 410 for all three so an
+    attacker can't distinguish."""
+    client = _client(MagicMock())
+    try:
+        with ExitStack() as stack:
+            _patch_redeem(stack, challenge=None)
+            resp = client.post("/guard/trial/redeem", json={"ct": "anything"})
+        assert resp.status_code == 410
+        assert "challenge_invalid_or_expired" in resp.text
+    finally:
+        _clear()
+
+
+def test_redeem_requires_ct():
+    client = _client(MagicMock())
+    try:
+        with ExitStack() as stack:
+            _patch_redeem(stack, challenge=None)
+            resp = client.post("/guard/trial/redeem", json={"ct": "  "})
+        assert resp.status_code == 422
+        assert "challenge_required" in resp.text
+    finally:
+        _clear()
+
+
+def test_redeem_rate_limited_by_ip():
+    client = _client(MagicMock())
+    try:
+        with ExitStack() as stack:
+            _patch_redeem(stack, challenge=_mk_challenge(existing_user_id=None), ip_throttle=False)
+            resp = client.post("/guard/trial/redeem", json={"ct": "verify-token-xyz"})
+        assert resp.status_code == 429
+    finally:
+        _clear()
+
+
+def test_redeem_clerk_422_race_degrades_to_existing():
+    """Race: user signs up in browser between /provision and /redeem.
+    Clerk's create_user returns 422 (email taken). Instead of leaking
+    that fact, degrade to the same 'existing' response."""
     from app.core.clerk import ClerkError
-    stack, cfg = _patch_deps(
-        existing_clerk_user_id=None,
-        create_raises=ClerkError(status=429, message="too many requests"),
-    )
-    db = MagicMock()
-    client = _client(db)
+    client = _client(MagicMock())
     try:
-        with stack:
-            _apply_patches(stack, cfg)
-            resp = client.post(
-                "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
+        with ExitStack() as stack:
+            _patch_redeem(
+                stack,
+                challenge=_mk_challenge(existing_user_id=None),
+                create_raises=ClerkError(status=422, message="email exists"),
             )
+            resp = client.post("/guard/trial/redeem", json={"ct": "verify-token-xyz"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["status"] == "existing"
+        assert body["agent_token"] is None
     finally:
         _clear()
-
-    assert resp.status_code == 429
-    assert "clerk_rate_limited" in resp.text
-
-
-# ── Rate-limit ────────────────────────────────────────────────────────────────
-
-def test_provision_ip_rate_limit_returns_429():
-    stack, cfg = _patch_deps(throttle=False)
-    db = MagicMock()
-    client = _client(db)
-    try:
-        with stack:
-            _apply_patches(stack, cfg)
-            resp = client.post(
-                "/guard/trial/provision",
-                json={"email": "sudhi@example.com", "company": "Xervmon"},
-            )
-    finally:
-        _clear()
-
-    assert resp.status_code == 429
-    assert "provision_rate_limited" in resp.text

--- a/apps/api/tests/test_trial_ops_endpoint.py
+++ b/apps/api/tests/test_trial_ops_endpoint.py
@@ -112,7 +112,11 @@ def workspaces():
 
 
 def _call(db):
-    return get_trial_ops(_perm="security", db=db)
+    # Endpoint dep name changed from `_perm` (guard.spend.view_all) to `_op`
+    # (require_platform_operator) — audit S05 fix in #1790. Test bypasses the
+    # dep by calling the function directly, so any string value satisfies the
+    # positional/keyword contract.
+    return get_trial_ops(_op="test_operator", db=db)
 
 
 def test_reports_active_workspaces_and_total_spend(workspaces):

--- a/apps/web/public/install.sh
+++ b/apps/web/public/install.sh
@@ -1,22 +1,22 @@
 #!/bin/sh
-# conduct.ai — self-service trial installer (#1712 Track 1 gap 3).
+# conduct.ai — self-service trial installer (#1712 Track 1, hardened per audit S01).
 #
 # Usage:
 #   curl -fsSL https://conductai.ai/install | sh
 #
-# Prompts for email + company, calls /guard/trial/provision, drops
-# ~/.conduct/env with ANTHROPIC_BASE_URL + trial cond_agt_trial_* token,
-# and prints a copy-pasteable trip-a-block command.
+# Prompts for email + company, calls /guard/trial/provision to send a
+# verification email, then asks the user to paste back the verification
+# URL from that email. Redeems the challenge and drops ~/.conduct/env
+# with ANTHROPIC_BASE_URL + trial cond_agt_trial_* token.
+#
+# Why two steps: the old one-shot flow returned an existing user's
+# token to anyone who guessed their email (audit S01). The two-step
+# flow proves ownership of the mailbox before any credential is issued.
 #
 # Design notes:
 #   - POSIX sh, not bash. Works on macOS default sh (dash-like) + Linux.
 #   - Reads from /dev/tty so `curl | sh` still gets user input.
-#   - Prefers python3 for JSON parsing (installed everywhere modern devs
-#     care about); falls back to sed if python3 is unavailable.
-#   - Env file is written via mktemp + mv. mktemp(1) creates the
-#     temporary file with owner-only permissions by default on POSIX
-#     systems, and mv preserves that so the destination inherits the
-#     restricted access — no explicit permission-modifying call needed.
+#   - Prefers python3 for JSON parsing.
 
 set -e
 
@@ -32,7 +32,6 @@ RESET=$(printf '\033[0m')
 printf '\n%sConductGuard trial installer%s\n' "$BOLD" "$RESET"
 printf '%s7-day trial, 200 requests/day, no credit card.%s\n\n' "$DIM" "$RESET"
 
-# ── Prompt for email + company via /dev/tty (survives curl | sh piping) ──────
 if [ ! -t 0 ] && [ ! -r /dev/tty ]; then
     printf '%serror: no tty available for prompts.%s\n' "$YELLOW" "$RESET" >&2
     printf 'Re-run as: sh <(curl -fsSL %s/install)\n' "$CONDUCT_API_URL" >&2
@@ -53,12 +52,9 @@ if [ -z "$COMPANY" ]; then
     exit 1
 fi
 
-# ── Provision ────────────────────────────────────────────────────────────────
-printf '\n%sProvisioning trial workspace...%s\n' "$DIM" "$RESET"
+# ── Step 1 — request the verification email ─────────────────────────────────
+printf '\n%sRequesting verification email...%s\n' "$DIM" "$RESET"
 
-# Escape JSON payload. No jq dependency — printf-based encoder handles the
-# small surface (email + company). Quotes/backslashes stripped since real
-# email/company names don't contain them.
 ESC_EMAIL=$(printf '%s' "$EMAIL" | tr -d '"\\')
 ESC_COMPANY=$(printf '%s' "$COMPANY" | tr -d '"\\')
 PAYLOAD=$(printf '{"email":"%s","company":"%s"}' "$ESC_EMAIL" "$ESC_COMPANY")
@@ -76,47 +72,78 @@ if [ "$HTTP_CODE" != "200" ]; then
     exit 1
 fi
 
-# ── Parse response ───────────────────────────────────────────────────────────
-# Require python3 for JSON parsing — the sed fallback was fragile on URLs
-# containing quotes or Unicode escapes. Modern macOS/Linux dev machines
-# ship python3 by default; the very few that don't can install via
-# Homebrew / apt / pyenv before re-running the installer.
-if ! command -v python3 >/dev/null 2>&1; then
-    printf '%serror: python3 is required to parse the trial response.%s\n' "$YELLOW" "$RESET" >&2
-    printf 'Install python3 (macOS: brew install python; Linux: apt install python3),\n' >&2
-    printf 'then re-run this installer. Every response field below is JSON:\n\n' >&2
+printf '%s✓ Verification email sent to %s%s\n\n' "$GREEN" "$EMAIL" "$RESET"
+printf '%sOpen the email and paste the verification URL below.%s\n' "$BOLD" "$RESET"
+printf '%s(The link expires in 30 minutes. Existing accounts get a sign-in link only — no token.)%s\n\n' "$DIM" "$RESET"
+
+# ── Step 2 — user pastes the verify URL back ────────────────────────────────
+printf 'Verify URL: '
+read VERIFY_URL < /dev/tty
+if [ -z "$VERIFY_URL" ]; then
+    printf '%serror: verify URL is required.%s\n' "$YELLOW" "$RESET" >&2
+    exit 1
+fi
+
+# Extract the ct=... token from the URL (supports both ?ct=... and &ct=...).
+CT=$(printf '%s' "$VERIFY_URL" | sed -n 's/.*[?&]ct=\([^&]*\).*/\1/p')
+if [ -z "$CT" ]; then
+    printf '%serror: could not find ct=... token in URL.%s\n' "$YELLOW" "$RESET" >&2
+    printf 'Expected format: %s/onboard/verify?ct=...\n' "$CONDUCT_API_URL" >&2
+    exit 1
+fi
+
+printf '\n%sRedeeming challenge...%s\n' "$DIM" "$RESET"
+
+REDEEM_PAYLOAD=$(printf '{"ct":"%s"}' "$CT")
+HTTP_RESPONSE=$(curl -sS -w '\n%{http_code}' \
+    -X POST "$CONDUCT_API_URL/guard/trial/redeem" \
+    -H 'content-type: application/json' \
+    -d "$REDEEM_PAYLOAD")
+HTTP_CODE=$(printf '%s\n' "$HTTP_RESPONSE" | tail -n1)
+HTTP_BODY=$(printf '%s\n' "$HTTP_RESPONSE" | sed '$d')
+
+if [ "$HTTP_CODE" != "200" ]; then
+    printf '%serror: redeem failed (HTTP %s)%s\n' "$YELLOW" "$HTTP_CODE" "$RESET" >&2
     printf '%s\n' "$HTTP_BODY" >&2
     exit 1
 fi
 
-# One python invocation extracts every field — cheaper than five separate
-# json.load calls and gives us a single failure point if the shape changes.
-# `gateway_url` is the Anthropic-specific route (kept for backwards compat).
-# `proxy_base_url` is the vendor-agnostic root so we can derive OpenAI /
-# Perplexity URLs client-side without another API round-trip.
+# ── Parse response ───────────────────────────────────────────────────────────
+if ! command -v python3 >/dev/null 2>&1; then
+    printf '%serror: python3 is required to parse the redeem response.%s\n' "$YELLOW" "$RESET" >&2
+    printf 'Install python3 (macOS: brew install python; Linux: apt install python3),\n' >&2
+    printf 'then re-run this installer. The redeem response was:\n\n' >&2
+    printf '%s\n' "$HTTP_BODY" >&2
+    exit 1
+fi
+
 _parsed=$(printf '%s' "$HTTP_BODY" | python3 -c '
 import json, sys
 d = json.load(sys.stdin)
-print(d["agent_token"])
-print(d["gateway_url"])
+print(d.get("status") or "")
+print(d.get("agent_token") or "")
+print(d.get("gateway_url") or "")
 print(d.get("proxy_base_url") or "")
-print(d["workspace_url"])
+print(d.get("workspace_url") or "")
 print(d.get("sign_in_url") or "")
+print(d.get("recovery_url") or "")
 ')
-AGENT_TOKEN=$(printf '%s\n' "$_parsed" | sed -n '1p')
-GATEWAY_URL=$(printf '%s\n' "$_parsed" | sed -n '2p')
-PROXY_BASE_URL=$(printf '%s\n' "$_parsed" | sed -n '3p')
-WORKSPACE_URL=$(printf '%s\n' "$_parsed" | sed -n '4p')
-SIGN_IN_URL=$(printf '%s\n' "$_parsed" | sed -n '5p')
+STATUS=$(printf '%s\n' "$_parsed" | sed -n '1p')
+AGENT_TOKEN=$(printf '%s\n' "$_parsed" | sed -n '2p')
+GATEWAY_URL=$(printf '%s\n' "$_parsed" | sed -n '3p')
+PROXY_BASE_URL=$(printf '%s\n' "$_parsed" | sed -n '4p')
+WORKSPACE_URL=$(printf '%s\n' "$_parsed" | sed -n '5p')
+SIGN_IN_URL=$(printf '%s\n' "$_parsed" | sed -n '6p')
+RECOVERY_URL=$(printf '%s\n' "$_parsed" | sed -n '7p')
 
-# Derive OpenAI base from proxy_base_url. Anthropic already lives on
-# GATEWAY_URL. Skipped if the backend hasn't started returning
-# proxy_base_url yet (older deploys) — user can still trip a block via
-# Anthropic; OpenAI just doesn't get wired.
-if [ -n "$PROXY_BASE_URL" ]; then
-    OPENAI_BASE_URL="${PROXY_BASE_URL}/openai"
-else
-    OPENAI_BASE_URL=""
+# Existing-account path — no token. Point user at sign-in and exit cleanly.
+if [ "$STATUS" = "existing" ]; then
+    printf '\n%s✓ This email is already registered.%s\n' "$GREEN" "$RESET"
+    if [ -n "$RECOVERY_URL" ]; then
+        printf '  Sign in at:  %s%s%s\n\n' "$BOLD" "$RECOVERY_URL" "$RESET"
+    fi
+    printf '%sYour existing trial token is available inside the dashboard once signed in.%s\n' "$DIM" "$RESET"
+    exit 0
 fi
 
 if [ -z "$AGENT_TOKEN" ]; then
@@ -125,11 +152,14 @@ if [ -z "$AGENT_TOKEN" ]; then
     exit 1
 fi
 
+if [ -n "$PROXY_BASE_URL" ]; then
+    OPENAI_BASE_URL="${PROXY_BASE_URL}/openai"
+else
+    OPENAI_BASE_URL=""
+fi
+
 # ── Write env file with restricted access ────────────────────────────────────
 mkdir -p "$(dirname "$ENV_FILE")"
-# mktemp(1) creates files owner-only by default. mv preserves that mode so
-# the destination env file isn't world-readable — same effect as an
-# explicit permission-modifying call, without invoking one.
 TMP_ENV=$(mktemp)
 cat > "$TMP_ENV" <<EOF
 # ConductGuard trial — 7 days, 200 Anthropic requests/day


### PR DESCRIPTION
Rebased version of #1790 after #1793 merged (which added `trusted_proxy_cidrs` to config.py first). Same 4 commits, replay clean on top of current main.

Closes #1790 as superseded.

See #1790 body for full summary + test plan + deploy checklist. Nothing changed in behaviour or scope.