### PR TITLE
fix(sec): S04 — proxy runs every token through the same lifecycle gate

### DIFF
--- a/apps/api/alembic/versions/0121_agent_run_token_expires_at.py
+++ b/apps/api/alembic/versions/0121_agent_run_token_expires_at.py
@@ -1,0 +1,44 @@
+"""add expires_at to agent_run_tokens (audit S04)
+
+Bounded lifetime for run tokens so an abandoned/leaked token can't
+authenticate forever. Executor mints with `created_at + 24h` going
+forward; backfill existing rows the same way so the NOT NULL constraint
+lands safely.
+
+Revision ID: 0121
+Revises: 0120
+Create Date: 2026-09-11
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "0121"
+down_revision = "0120"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add nullable first so existing rows keep validating.
+    op.add_column(
+        "agent_run_tokens",
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    # Backfill: created_at + 24h. Existing runs older than 24h now have
+    # tokens that will start rejecting on next use — that's the intent,
+    # a token from a run that finished last week has no business
+    # authenticating today.
+    op.execute(
+        "UPDATE agent_run_tokens SET expires_at = created_at + INTERVAL '24 hours' WHERE expires_at IS NULL"
+    )
+    op.alter_column("agent_run_tokens", "expires_at", nullable=False)
+    op.create_index(
+        "ix_agent_run_tokens_expires_at",
+        "agent_run_tokens",
+        ["expires_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_agent_run_tokens_expires_at", table_name="agent_run_tokens")
+    op.drop_column("agent_run_tokens", "expires_at")

--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -466,12 +466,21 @@ def get_workspace_id(
     if not credentials:
         raise HTTPException(status_code=401, detail="Authorization header required")
 
-    # run_token (cond_run_*) — short-lived per-run token, validated by hash
+    # run_token (cond_run_*) — short-lived per-run token, validated by hash.
+    # Bounded lifetime (audit S04): reject expired tokens even when the
+    # run itself hasn't been invalidated yet. Matches the proxy check so a
+    # leaked cond_run_* can't authenticate via either surface.
     if credentials.credentials.startswith("cond_run_"):
         import hashlib as _h
+        from datetime import datetime as _dt, timezone as _tz
         from app.modules.agent_identity.run_token_model import AgentRunToken as _ART
         _hash = _h.sha256(credentials.credentials.encode()).hexdigest()
-        _rt = db.query(_ART).filter(_ART.token_hash == _hash, _ART.invalidated_at.is_(None)).first()
+        _now = _dt.now(_tz.utc)
+        _rt = db.query(_ART).filter(
+            _ART.token_hash == _hash,
+            _ART.invalidated_at.is_(None),
+            _ART.expires_at > _now,
+        ).first()
         if not _rt:
             raise HTTPException(status_code=401, detail="Invalid or expired run token")
         token_ws = str(_rt.workspace_id)

--- a/apps/api/app/modules/agent_identity/run_token_model.py
+++ b/apps/api/app/modules/agent_identity/run_token_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, DateTime, Text
+from sqlalchemy import Column, DateTime, Index, String, Text
 from sqlalchemy.dialects.postgresql import UUID
 from app.core.database import Base
 
@@ -18,3 +18,11 @@ class AgentRunToken(Base):
     created_at = Column(DateTime(timezone=True), nullable=False)
     first_used_at = Column(DateTime(timezone=True), nullable=True)
     invalidated_at = Column(DateTime(timezone=True), nullable=True)
+    # Bounded lifetime — audit S04. Executor mints with created_at + 24h;
+    # proxy rejects a token whose expires_at is in the past even if
+    # invalidated_at is still NULL.
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+
+    __table_args__ = (
+        Index("ix_agent_run_tokens_expires_at", "expires_at"),
+    )

--- a/apps/api/app/modules/guard/routers/proxy.py
+++ b/apps/api/app/modules/guard/routers/proxy.py
@@ -352,37 +352,42 @@ async def _proxy(
             if not _hdr_ws:
                 return _fail_closed(400, "X-Conductai-Workspace-Id required for run token calls")
             _token_hash = _rt_hashlib.sha256(_internal_key.encode()).hexdigest()
+            _now_rt = datetime.now(timezone.utc)
+            # Audit S04 — expires_at check. An abandoned or leaked run token
+            # can't authenticate past its bounded lifetime even if the run
+            # itself never got a chance to set invalidated_at.
             _rt = db.query(_AgentRunToken).filter(
                 _AgentRunToken.token_hash == _token_hash,
                 _AgentRunToken.workspace_id == uuid.UUID(_hdr_ws),
                 _AgentRunToken.invalidated_at == None,  # noqa: E711
+                _AgentRunToken.expires_at > _now_rt,
             ).first()
             if not _rt:
-                return _fail_closed(401, "Run token not found or already invalidated")
+                return _fail_closed(401, "Run token not found, expired, or already invalidated")
             _is_internal = True
             if not _rt.first_used_at:
-                _rt.first_used_at = datetime.now(timezone.utc)
+                _rt.first_used_at = _now_rt
                 db.commit()
 
         if _needs_agent_validation and not _is_internal:
+            # Audit S04 — was an inline decrypt loop over every AgentIdentity
+            # in the workspace, missing the lifecycle_state and token_type
+            # checks that _resolve_agent_token already applies. Now shares
+            # one code path so deactivated / expired / external identities
+            # are rejected here just like they are at the member-token door.
             _hdr_ws = request.headers.get("x-conductai-workspace-id", "")
             if not _hdr_ws:
                 return _fail_closed(400, "X-Conductai-Workspace-Id required for agent identity calls")
-            from app.modules.agent_identity.models import AgentIdentity as _AgentIdentity
-            from app.core.crypto import decrypt as _decrypt
-            for _cand in db.query(_AgentIdentity).filter(_AgentIdentity.workspace_id == _hdr_ws).all():
-                try:
-                    if _decrypt(_cand.token_encrypted).get("token") == _internal_key:
-                        from datetime import datetime, timezone as _tz
-                        if _cand.expires_at and _cand.expires_at < datetime.now(_tz.utc):
-                            return _fail_closed(401, "Agent Identity token expired — run `conduct guard sync` to refresh")
-                        _is_internal = True
-                        _agent_identity_id = _cand.id
-                        break
-                except Exception:
-                    pass
-            if not _is_internal:
-                return _fail_closed(401, "Agent Identity token not recognized")
+            from app.core.auth import _resolve_agent_token as _resolve_ai
+            from fastapi import HTTPException as _HTTPException
+            try:
+                _ai, _ = _resolve_ai(_internal_key, db)
+            except _HTTPException as _exc:
+                return _fail_closed(int(_exc.status_code), str(_exc.detail or "Agent Identity token not recognized"))
+            if str(_ai.workspace_id) != _hdr_ws:
+                return _fail_closed(401, "Agent Identity token does not belong to the requested workspace")
+            _is_internal = True
+            _agent_identity_id = _ai.id
 
         if _is_internal:
             workspace_id = request.headers.get("x-conductai-workspace-id", "")

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -326,7 +326,12 @@ def execute_run(run_id: str):
             import hashlib as _rth, uuid as _rtu
             from datetime import datetime as _rtdt, timedelta as _rttd, timezone as _rttz
             _pt = "cond_run_" + _rtu.uuid4().hex
-            _now = _rtdt.now(_rttz.utc)
+            # ponytail: local variable is _mint_now, not _now. The bare _now
+            # symbol is imported from app.runtime.runtime as a function used
+            # elsewhere in this file (execute_run:228/229/438) — a local
+            # rebind would shadow it function-wide and UnboundLocalError
+            # every caller that hits this branch first.
+            _mint_now = _rtdt.now(_rttz.utc)
             _mint_row = _AgentRunToken(
                 id=str(_rtu.uuid4()),
                 agent_identity_id=None,
@@ -335,11 +340,11 @@ def execute_run(run_id: str):
                 token_hash=_rth.sha256(_pt.encode()).hexdigest(),
                 token_prefix=_pt[:16],
                 token_encrypted=_rt_encrypt({"token": _pt}),
-                created_at=_now,
+                created_at=_mint_now,
                 # Bounded lifetime (audit S04). Runs that legitimately need
                 # longer than 24h are rare enough that re-minting on demand
                 # is fine; the alternative is unbounded token lifetime.
-                expires_at=_now + _rttd(hours=24),
+                expires_at=_mint_now + _rttd(hours=24),
             )
             try:
                 db.add(_mint_row)

--- a/apps/api/app/runtime/executor.py
+++ b/apps/api/app/runtime/executor.py
@@ -324,8 +324,9 @@ def execute_run(run_id: str):
         # Mint a fresh token if trigger-time mint failed or token is unrecoverable.
         if not _conduct_run_token:
             import hashlib as _rth, uuid as _rtu
-            from datetime import datetime as _rtdt, timezone as _rttz
+            from datetime import datetime as _rtdt, timedelta as _rttd, timezone as _rttz
             _pt = "cond_run_" + _rtu.uuid4().hex
+            _now = _rtdt.now(_rttz.utc)
             _mint_row = _AgentRunToken(
                 id=str(_rtu.uuid4()),
                 agent_identity_id=None,
@@ -334,7 +335,11 @@ def execute_run(run_id: str):
                 token_hash=_rth.sha256(_pt.encode()).hexdigest(),
                 token_prefix=_pt[:16],
                 token_encrypted=_rt_encrypt({"token": _pt}),
-                created_at=_rtdt.now(_rttz.utc),
+                created_at=_now,
+                # Bounded lifetime (audit S04). Runs that legitimately need
+                # longer than 24h are rare enough that re-minting on demand
+                # is fine; the alternative is unbounded token lifetime.
+                expires_at=_now + _rttd(hours=24),
             )
             try:
                 db.add(_mint_row)

--- a/apps/api/tests/guard/test_proxy_token_lifecycle.py
+++ b/apps/api/tests/guard/test_proxy_token_lifecycle.py
@@ -98,7 +98,7 @@ def test_run_token_expired_returns_none_from_auth_get_workspace_id():
 
     with patch("app.core.auth._clerk_enabled_dispatch", return_value=True):
         with pytest.raises(HTTPException) as exc:
-            get_workspace_id(explicit_ws=None, credentials=creds, db=db)
+            get_workspace_id(credentials=creds, ws_id=None, x_workspace_id=None, db=db)
     assert exc.value.status_code == 401
     assert "run token" in (exc.value.detail or "").lower()
 

--- a/apps/api/tests/guard/test_proxy_token_lifecycle.py
+++ b/apps/api/tests/guard/test_proxy_token_lifecycle.py
@@ -1,0 +1,108 @@
+"""Proxy token lifecycle tests (audit S04).
+
+The old proxy internal-agent path did its own decrypt loop over every
+AgentIdentity in the workspace, checked expires_at, and stopped there —
+skipping the lifecycle_state and token_type rejections that the shared
+resolver enforces at every other auth surface. A deactivated cond_agt_*
+could authenticate via the proxy long after any UI would allow it.
+
+Also covers the bounded-lifetime addition to cond_run_* tokens: an
+abandoned token can't authenticate past its expires_at even when the run
+itself never got a chance to write invalidated_at.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi import HTTPException
+
+
+# ── proxy path 2: internal agent identity via shared resolver ────────────
+
+def _mk_ai(workspace_id: str, lifecycle: str = "active", token_type: str = "cli", expires_at=None):
+    return SimpleNamespace(
+        id="ai_abc",
+        workspace_id=workspace_id,
+        lifecycle_state=lifecycle,
+        token_type=token_type,
+        expires_at=expires_at,
+        token_encrypted=b"blob",
+    )
+
+
+def test_resolve_agent_token_rejects_deactivated_identity():
+    """S04 core: deactivated cond_agt_ must not authenticate. The previous
+    proxy inline loop only checked expires_at, so a security team could
+    revoke an identity in the UI and it would still work via internal proxy.
+    """
+    from app.core.auth import _resolve_agent_token
+    db = MagicMock()
+    deactivated = _mk_ai("ws-123", lifecycle="deactivated")
+    db.query.return_value.filter.return_value.all.return_value = [deactivated]
+    with patch("app.core.crypto.decrypt", return_value={"token": "cond_agt_abc"}):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_agent_token("cond_agt_abc", db)
+    assert exc.value.status_code == 401
+    assert "deactivated" in (exc.value.detail or "").lower()
+
+
+def test_resolve_agent_token_rejects_external_identity():
+    """External (Okta-imported) identities must not authenticate via the
+    Conduct token path — audit S04 grouped this under lifecycle enforcement."""
+    from app.core.auth import _resolve_agent_token
+    db = MagicMock()
+    external = _mk_ai("ws-123", token_type="external")
+    db.query.return_value.filter.return_value.all.return_value = [external]
+    with patch("app.core.crypto.decrypt", return_value={"token": "cond_agt_abc"}):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_agent_token("cond_agt_abc", db)
+    assert exc.value.status_code == 401
+    assert "external" in (exc.value.detail or "").lower()
+
+
+def test_resolve_agent_token_rejects_expired_identity():
+    from app.core.auth import _resolve_agent_token
+    db = MagicMock()
+    expired = _mk_ai(
+        "ws-123",
+        expires_at=datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    db.query.return_value.filter.return_value.all.return_value = [expired]
+    with patch("app.core.crypto.decrypt", return_value={"token": "cond_agt_abc"}):
+        with pytest.raises(HTTPException) as exc:
+            _resolve_agent_token("cond_agt_abc", db)
+    assert exc.value.status_code == 401
+    assert "expired" in (exc.value.detail or "").lower()
+
+
+# ── proxy path 1 + auth.py: cond_run_ expiry bound ───────────────────────
+
+def test_run_token_expired_returns_none_from_auth_get_workspace_id():
+    """auth.py: a cond_run_ whose expires_at is in the past must be rejected
+    even when invalidated_at is still NULL. Bounded-lifetime property from
+    audit S04.
+    """
+    import hashlib
+    from unittest.mock import MagicMock
+
+    from app.core.auth import get_workspace_id
+    from fastapi.security import HTTPAuthorizationCredentials
+
+    # Filter with expires_at > now returns nothing → HTTPException
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="cond_run_" + "a" * 32)
+
+    with patch("app.core.auth._clerk_enabled_dispatch", return_value=True):
+        with pytest.raises(HTTPException) as exc:
+            get_workspace_id(explicit_ws=None, credentials=creds, db=db)
+    assert exc.value.status_code == 401
+    assert "run token" in (exc.value.detail or "").lower()
+
+    # Sanity: filter was called with expires_at > now on the AgentRunToken filter chain.
+    # Not asserting the exact SQLAlchemy call shape here — the effective
+    # behaviour (401 when the row doesn't satisfy the expires_at guard) is
+    # what matters.

--- a/apps/api/tests/test_token_paths.py
+++ b/apps/api/tests/test_token_paths.py
@@ -76,11 +76,13 @@ class TestGetWorkspaceIdRunToken:
                 self.name = name
             def __eq__(self, other): return True   # filter() accepts this
             def is_(self, v): return True
+            def __gt__(self, other): return True   # audit S04: expires_at > _now filter
 
         class ART:
             token_hash = _Col("token_hash")
             workspace_id = _Col("workspace_id")
             invalidated_at = _Col("invalidated_at")
+            expires_at = _Col("expires_at")
         return ART
 
     def _make_db(self, row):


### PR DESCRIPTION
## Summary
Audit S04 finding — the proxy internal-agent path decrypted every AgentIdentity in the workspace to match a cond_agt_ token, checked expires_at, and stopped. That skipped lifecycle_state and token_type rejections that _resolve_agent_token has enforced at every other auth surface since #1037. A cond_agt_ that had been deactivated in the UI kept working via internal proxy calls indefinitely. Same finding covered the missing bounded lifetime on cond_run_* run tokens.

## Fix
- proxy.py path 2 (cond_agt_ via x-conductai-internal) routes through _resolve_agent_token. Deactivated / expired identities and external-source tokens rejected consistently.
- proxy.py path 1 (cond_run_ via x-conductai-internal) adds expires_at > now() to the filter.
- auth.py (cond_run_ member-token surface) adds the same expires_at check so both surfaces agree.
- agent_run_tokens gains expires_at (migration 0121, backfilled created_at + 24h). Executor mints with expires_at = created_at + 24h.

## Deploy checklist
1. Run migration 0121 before rolling out the new code — agent_run_tokens.expires_at flips to NOT NULL and the backfill uses created_at + 24h. Rows older than 24h will start rejecting on their next authentication attempt (correct behaviour — token from last week has no business authenticating today).
2. No env-var changes.

## Test plan
- [ ] CI green
- [ ] Deactivate a cond_agt_ in the UI, try a proxy call using x-conductai-internal → 401 (was 200 pre-fix)
- [ ] External-source identity (Okta-imported) via internal path → 401
- [ ] Expired cond_agt_ via internal path → 401
- [ ] Cond_run_ token with expires_at in the past → 401 on both /proxy and any endpoint that goes through get_workspace_id
- [ ] Normal run auth continues to work (valid cond_run_, cond_agt_)

Refs conduct-internal thread on 7 open security findings (S04 first).