### PR TITLE
perf(web): P06 — drop WorkspaceProvider from marketing layout

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -1,19 +1,26 @@
 "use client"
 
 import { useState } from "react"
-import { WorkspaceProvider } from "@/lib/WorkspaceContext"
 import { CtaLink } from "@/components/marketing/CtaLink"
 
+// Audit P06: WorkspaceProvider used to wrap this layout so its refresh()
+// hit /projects on every marketing pageload (home, blog, docs, ...).
+// Anonymous visitors got a 401 they never saw; signed-in visitors paid a
+// wasted round trip on pages that don't need workspace state. Removed the
+// provider — useWorkspace() returns a safe default (activeWorkspace: null)
+// with no fetch when there is no provider up-tree. The four pages under
+// (marketing)/eval and (marketing)/benchmark still call useWorkspace() and
+// now render with activeWorkspace=null, which their downstream components
+// already handle. Signed-in users hitting those pages from marketing don't
+// get an auto-selected workspace — they pick one after clicking into the
+// app, same as any other cold entry point.
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
-  const clerkEnabled = !!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
   return (
-    <WorkspaceProvider clerkEnabled={clerkEnabled}>
-      <div className="marketing-v2 min-h-screen bg-white flex flex-col">
-        <MarketingNav />
-        <main className="flex-1">{children}</main>
-        <MarketingFooter />
-      </div>
-    </WorkspaceProvider>
+    <div className="marketing-v2 min-h-screen bg-white flex flex-col">
+      <MarketingNav />
+      <main className="flex-1">{children}</main>
+      <MarketingFooter />
+    </div>
   )
 }
 


### PR DESCRIPTION
## Summary
Audit P06 — marketing layout wrapped every public page in `WorkspaceProvider`, whose `useEffect refresh()` hit `/projects` on every pageload. Anonymous visitors (99% of marketing traffic) got an invisible 401. Signed-in visitors paid a wasted round trip on pages that don't need workspace state.

## Fix
- Remove `<WorkspaceProvider clerkEnabled={...}>` wrapper from `apps/web/src/app/(marketing)/layout.tsx`.
- `useWorkspace()` context default is safe (`activeWorkspace: null`, no fetch) when no provider is up-tree.
- The four pages under `(marketing)/eval` and `(marketing)/benchmark` still call `useWorkspace()` — they now render with `activeWorkspace=null`, which `EvalContent` and `BenchmarkContent` already handle.

## Behaviour change
Signed-in users visiting eval/benchmark pages from the marketing site no longer get an auto-selected workspace. They pick one after clicking into the app — same as any other cold entry point.

## Test plan
- [ ] CI green (tsc + lint)
- [ ] Load home page anonymously → no `/projects` request in Network tab
- [ ] Load home page signed-in → no `/projects` request in Network tab
- [ ] Visit `/eval` anonymously → page renders with no workspace fallback (existing behaviour)
- [ ] Sign into the app → `WorkspaceProvider` mounts normally under `(app)`