### PR TITLE
fix(sec+ops): U08 noindex on (app) + O01 split /live and /ready + gate /metrics

### DIFF
--- a/apps/api/app/core/config.py
+++ b/apps/api/app/core/config.py
@@ -100,6 +100,12 @@ class Settings(BaseSettings):
     # is used. Never trust the *first* XFF value blindly — audit S12.
     trusted_proxy_cidrs: str = ""
 
+    # /metrics scrape token — audit O01. Empty in production means /metrics
+    # refuses every caller (fail-closed). Empty in local/development leaves
+    # the endpoint open so devs can `curl /metrics` without extra setup.
+    # Scrapers pass the value in header `X-Metrics-Token`.
+    metrics_token: str = ""
+
     class Config:
         env_file = ".env"
         extra = "ignore"  # tolerate stray legacy env vars so app boots cleanly

--- a/apps/api/app/main.py
+++ b/apps/api/app/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Request
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, FileResponse
 from fastapi.staticfiles import StaticFiles
@@ -102,10 +102,22 @@ async def favicon():
 
 
 @app.get("/metrics", include_in_schema=False)
-async def metrics():
+async def metrics(request: Request):
+    """Prometheus scrape endpoint. Audit O01 — was fully public.
+
+    Gated by header `X-Metrics-Token` matching `settings.metrics_token`.
+    Empty token in production refuses all callers (fail-closed). Local /
+    development still open so devs can `curl /metrics` without extra setup.
+    """
     from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
-    from starlette.responses import Response
-    return Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    from starlette.responses import Response as _Response
+
+    _tok = (settings.metrics_token or "").strip()
+    _hdr = (request.headers.get("x-metrics-token") or "").strip()
+    if settings.environment not in ("local", "development"):
+        if not _tok or _hdr != _tok:
+            return JSONResponse(status_code=401, content={"detail": "metrics_token_required"})
+    return _Response(generate_latest(), media_type=CONTENT_TYPE_LATEST)
 
 _origins = [o.strip() for o in settings.allowed_origins.split(",") if o.strip()]
 if not _origins:
@@ -240,7 +252,60 @@ def _startup() -> None:
 
 @app.get("/health")
 def health():
+    """Legacy alias for /live. render.yaml points healthCheckPath at /health;
+    kept for backward compat with existing deploys."""
     return {"status": "ok"}
+
+
+@app.get("/live")
+def live():
+    """Liveness — is this process running? Cheap, never touches DB/Redis.
+    Matches k8s liveness-probe semantics: return 200 if the event loop is
+    responsive, nothing else."""
+    return {"status": "ok"}
+
+
+@app.get("/ready")
+def ready(response: Response):
+    """Readiness — can this process serve traffic? Checks DB, Redis, and
+    schema head. Returns 503 if any dependency is unavailable so a load
+    balancer removes the pod until it recovers (audit O01).
+    """
+    from sqlalchemy import text as _t
+    from app.core.database import SessionLocal as _SL
+
+    checks: dict[str, str] = {}
+    ok = True
+
+    # DB — SELECT 1 with a short timeout. Also confirms Alembic head is
+    # readable, which is enough of a "schema present" signal without
+    # bolting on version comparisons.
+    db = _SL()
+    try:
+        db.execute(_t("SELECT 1"))
+        db.execute(_t("SELECT version_num FROM alembic_version LIMIT 1"))
+        checks["db"] = "ok"
+    except Exception as _exc:
+        checks["db"] = "unavailable"
+        ok = False
+        log.warning("ready.db_check_failed", err=str(_exc))
+    finally:
+        db.close()
+
+    # Redis — PING. Callers hit it for rate limits, queue, and challenge
+    # storage; skipping this would let a broken Redis serve 200s.
+    try:
+        import redis as _redis
+        r = _redis.Redis.from_url(settings.redis_url, socket_connect_timeout=1, socket_timeout=1)
+        r.ping()
+        checks["redis"] = "ok"
+    except Exception as _exc:
+        checks["redis"] = "unavailable"
+        ok = False
+        log.warning("ready.redis_check_failed", err=str(_exc))
+
+    response.status_code = 200 if ok else 503
+    return {"status": "ok" if ok else "not_ready", "checks": checks}
 
 
 @app.get("/health/sandbox")

--- a/apps/api/app/middleware/logging.py
+++ b/apps/api/app/middleware/logging.py
@@ -23,7 +23,7 @@ class LoggingMiddleware(BaseHTTPMiddleware):
         # structured logs). Render's nginx access log is outside our control;
         # the long-term mitigation is #800 (header auth) + #810 (drop URL
         # fallback when Claude.ai web supports headers).
-        if request.url.path not in ("/health", "/health/sandbox"):
+        if request.url.path not in ("/health", "/health/sandbox", "/live", "/ready"):
             log.info(
                 "http.request",
                 method=request.method,

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -8,7 +8,18 @@
 // ClerkProvider). Skip prerender for the whole subtree.
 export const dynamic = "force-dynamic"
 
+import type { Metadata } from "next"
 import AppSegment from "./AppSegment"
+
+// Audit U08: root metadata declared everything indexable and defaulted
+// canonical to the homepage. Authenticated console routes must NEVER be
+// indexed — they surface workspace data behind a session — and must NEVER
+// self-report as the homepage in the DOM. Set both here so the (app)
+// subtree overrides root regardless of what individual pages export.
+export const metadata: Metadata = {
+  robots: { index: false, follow: false, nocache: true },
+  alternates: { canonical: null },
+}
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
   return <AppSegment>{children}</AppSegment>

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,5 +1,9 @@
 import type { MetadataRoute } from "next"
 
+// Audit U08: robots policy missed several authenticated route families
+// added after this file last shipped. Belt-and-braces against
+// (app)/layout.tsx's noindex header — a good crawler respects both;
+// a rogue one respects at most robots.txt.
 export default function robots(): MetadataRoute.Robots {
   return {
     rules: [
@@ -21,6 +25,15 @@ export default function robots(): MetadataRoute.Robots {
           "/settings/",
           "/setup/",
           "/workflows/",
+          // Added — every (app) route below the ones the file already had.
+          "/agent-identity/",
+          "/cli-auth/",
+          "/credentials/",
+          "/lens/",
+          "/logs/",
+          "/marketplace/",
+          "/packs/",
+          "/theguard/",
           "/sign-in",
           "/sign-up",
           "/accept-invite",


### PR DESCRIPTION
## Summary
Two related-but-independent audit findings paired because they're both single-day config wins.

### U08 — SEO leak
Root layout declared `robots: { index: true, follow: true }` and `alternates: { canonical: 'https://conductai.ai' }`. Authenticated console pages inherited both — Google could crawl `/theguard/*`, `/lens`, `/dashboard`, etc., and every one self-reported as the homepage in the DOM.

- `(app)/layout.tsx` exports metadata with `robots: { index: false, follow: false, nocache: true }` and `alternates: { canonical: null }` — cascades over root regardless of what individual pages export.
- `robots.ts` disallow list gets the newer authenticated route prefixes.

### O01 — /health always green + /metrics wide open
`/health` returned constant `{"status":"ok"}` regardless of DB/Redis state. `/metrics` was fully public.

- `/live` — pure liveness (matches k8s probe semantics)
- `/ready` — checks DB (`SELECT 1` + `alembic_version` read) and Redis (`PING`); 503 if any dep is down
- `/health` kept as backward-compat alias for `/live` (Render's `healthCheckPath`)
- `/metrics` now checks `X-Metrics-Token` against `settings.metrics_token` in non-local envs; empty token = fail-closed 401
- `LoggingMiddleware` skips `/live` and `/ready` so probes don't spam

## ⚠️ Deploy checklist

Before merging, set in Render dashboard:

- [ ] `METRICS_TOKEN` on `delegator-api` — any random string. Existing Prometheus scrapers (if any) need this value in the `X-Metrics-Token` header or they'll start 401ing.
- [ ] Consider switching Render's `healthCheckPath` to `/ready` if you want the LB to actually take down unhealthy pods. `/health` stays working; `/ready` gives real readiness signal.

## Test plan
- [ ] `GET /live` → 200 always
- [ ] `GET /ready` with DB up + Redis up → 200 `{status:"ok", checks:{db:"ok",redis:"ok"}}`
- [ ] `GET /ready` with Redis down → 503 `checks.redis="unavailable"`
- [ ] `GET /metrics` in production without header → 401
- [ ] `GET /metrics` in production with valid header → 200 Prometheus output
- [ ] `GET /metrics` in local (no METRICS_TOKEN set, env=development) → 200 (dev convenience preserved)
- [ ] Google Search Console: `/theguard/*` marked noindex
- [ ] View source on `/lens` → `<meta name="robots" content="noindex,nofollow">`