### PR TITLE
fix(sec): S13 — Narratr off auth pages + route-scoped CSP

### DIFF
--- a/apps/web/src/app/(marketing)/layout.tsx
+++ b/apps/web/src/app/(marketing)/layout.tsx
@@ -16,11 +16,22 @@ import { CtaLink } from "@/components/marketing/CtaLink"
 // app, same as any other cold entry point.
 export default function MarketingLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="marketing-v2 min-h-screen bg-white flex flex-col">
-      <MarketingNav />
-      <main className="flex-1">{children}</main>
-      <MarketingFooter />
-    </div>
+    <>
+      <div className="marketing-v2 min-h-screen bg-white flex flex-col">
+        <MarketingNav />
+        <main className="flex-1">{children}</main>
+        <MarketingFooter />
+      </div>
+      {/*
+        Audit S13: Narratr blog widget + brand embed. Loaded here so they
+        only run on marketing routes — never on authenticated console pages
+        where a third-party script would see workspace data in the DOM.
+        The CSP in src/middleware.ts also enforces this at the browser as
+        belt-and-braces against a rogue future import.
+      */}
+      <script src="https://narratr.ai/widget.js" data-brand-key="c7ae7b0c-2b6" async></script>
+      <script src="https://narratr.ai/embed.js" data-brand="conductai" async></script>
+    </>
   )
 }
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -144,6 +144,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     for(var i=0;i<SEMANTIC.length;i++) r.removeProperty(SEMANTIC[i]);
   })()`
 
+  // Audit S13: Narratr scripts used to load here in the root layout, so
+  // they ran on every authenticated page — /theguard, /lens, /credentials,
+  // /logs, etc. A third-party script on those surfaces can read the DOM
+  // (workspace names, spend rows, rule bodies, event contents) and would
+  // deliver code execution to every dashboard if the vendor's domain were
+  // ever compromised. Moved to (marketing)/layout.tsx so only public pages
+  // load them. CSP set by src/middleware.ts enforces this at the browser
+  // as belt-and-braces against a rogue future import.
   if (clerkEnabled) {
     return (
       <ClerkProvider afterSignInUrl="/workflows" afterSignUpUrl="/setup">
@@ -154,8 +162,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           </head>
           <body>
             {children}
-            <script src="https://narratr.ai/widget.js" data-brand-key="c7ae7b0c-2b6" async></script>
-            <script src="https://narratr.ai/embed.js" data-brand="conductai" async></script>
           </body>
         </html>
       </ClerkProvider>
@@ -169,7 +175,6 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
       </head>
       <body>
         {children}
-        <script src="https://narratr.ai/widget.js" data-brand-key="c7ae7b0c-2b6" async></script>
       </body>
     </html>
   )

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -3,6 +3,83 @@ import { type NextRequest, NextResponse } from "next/server"
 
 const isPublicRoute = createRouteMatcher(["/", "/sign-in(.*)", "/sign-up(.*)", "/compare", "/privacy", "/terms", "/benchmark(.*)", "/eval(.*)", "/registry", "/playbooks", "/token-guardrails", "/docs(.*)", "/accept-invite(.*)", "/sdd(.*)", "/tools(.*)", "/about(.*)", "/blog(.*)", "/share(.*)", "/solutions(.*)", "/partners(.*)", "/guard", "/evidence", "/mcp-gateway", "/security", "/deployment", "/pricing", "/open-source", "/router", "/team-os", "/frameworks(.*)", "/discovery", "/book-demo", "/use-cases", "/what-is-conduct-ai", "/api/mcp/guard/oauth/(.*)", "/.well-known/(.*)",])
 
+// Audit S13 — route-scoped Content Security Policy.
+//
+// Authenticated console routes (path prefixes below) get a strict script-src
+// that disallows every third-party origin including narratr.ai. Public
+// marketing routes get a looser policy that permits the vendor scripts
+// (Narratr widget + embed) still needed for the blog / branded widgets.
+//
+// Both branches share the same default security headers (X-Content-Type-Options,
+// Referrer-Policy, X-Frame-Options) so a mistake in one branch doesn't leave
+// the other unprotected.
+const APP_ROUTE_PREFIXES = [
+  "/agent-identity", "/cli-auth", "/credentials", "/dashboard", "/integrations",
+  "/lens", "/logs", "/marketplace", "/packs", "/projects", "/secure", "/settings",
+  "/setup", "/theguard", "/workflows",
+]
+
+function _isAppRoute(pathname: string): boolean {
+  return APP_ROUTE_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + "/"))
+}
+
+function _cspFor(pathname: string): string {
+  // Common building blocks. Clerk lives on cdn.clerk.com / *.clerk.accounts.dev.
+  // 'unsafe-inline' on script-src is retained on marketing because the current
+  // theme init and JSON-LD are inlined; tighten in a follow-up once we
+  // migrate those to a nonce-based approach.
+  const _selfClerk = "'self' https://cdn.clerk.com https://clerk.conductai.ai"
+  const _connect = "'self' https://api.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:"
+  const _img = "'self' data: https:"
+  const _font = "'self' https://fonts.gstatic.com data:"
+  const _style = "'self' 'unsafe-inline' https://fonts.googleapis.com"
+  const _base = [
+    "default-src 'self'",
+    `img-src ${_img}`,
+    `font-src ${_font}`,
+    `style-src ${_style}`,
+    `connect-src ${_connect}`,
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "base-uri 'self'",
+    "object-src 'none'",
+    "upgrade-insecure-requests",
+  ]
+
+  if (_isAppRoute(pathname)) {
+    // Strict — no third-party script origins, no vendor widgets.
+    return [
+      `script-src ${_selfClerk} 'unsafe-inline' 'unsafe-eval'`,
+      `frame-src ${_selfClerk}`,
+      ...(_base),
+    ].join("; ")
+  }
+  // Marketing — permit narratr.ai and standard analytics; still deny inline
+  // frames from anywhere except self+clerk.
+  return [
+    `script-src ${_selfClerk} https://narratr.ai 'unsafe-inline' 'unsafe-eval'`,
+    `frame-src ${_selfClerk} https://narratr.ai`,
+    ...(_base),
+  ].join("; ")
+}
+
+function _applySecurityHeaders(res: NextResponse, pathname: string): NextResponse {
+  // Enforce CSP only in production. Local dev + preview deploys often have
+  // different API URLs (localhost:8000, api-git-branch.vercel.app, ...) that
+  // aren't easily enumerated in a static header — we ship Report-Only there
+  // so the console flags violations without breaking work-in-progress
+  // deploys. Prod gets the enforcing header that actually protects users.
+  const _cspHeader = process.env.NODE_ENV === "production"
+    ? "Content-Security-Policy"
+    : "Content-Security-Policy-Report-Only"
+  res.headers.set(_cspHeader, _cspFor(pathname))
+  res.headers.set("X-Content-Type-Options", "nosniff")
+  res.headers.set("Referrer-Policy", "strict-origin-when-cross-origin")
+  res.headers.set("X-Frame-Options", "DENY")
+  res.headers.set("Permissions-Policy", "camera=(), microphone=(), geolocation=()")
+  return res
+}
+
 const isAppSubdomain = (req: NextRequest) =>
   req.headers.get("host")?.startsWith("app.")
 
@@ -35,15 +112,20 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
   }
 })
 
-export default function middleware(req: NextRequest, evt: unknown) {
-  if (!process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY) {
-    if (process.env.NODE_ENV === "production") {
-      // Refuse to serve protected routes without auth in production
-      return new NextResponse("Auth not configured", { status: 503 })
-    }
-    return NextResponse.next()
-  }
-  return clerkHandler(req, evt as never)
+export default async function middleware(req: NextRequest, evt: unknown) {
+  // Run the Clerk handler first — it may redirect, in which case we still
+  // want CSP headers on the redirect response so the browser never sees
+  // an unprotected error page.
+  const _clerkResp = process.env.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY
+    ? await clerkHandler(req, evt as never)
+    : (process.env.NODE_ENV === "production"
+        ? new NextResponse("Auth not configured", { status: 503 })
+        : NextResponse.next())
+
+  // Clerk's middleware returns undefined for pass-through; NextResponse
+  // constructor gives us a fresh headers-writable response.
+  const _res = _clerkResp instanceof NextResponse ? _clerkResp : NextResponse.next()
+  return _applySecurityHeaders(_res, req.nextUrl.pathname)
 }
 
 export const config = {


### PR DESCRIPTION
## Summary
Two joined pieces of the same fix:

### 1. Narratr scripts removed from auth pages
`narratr.ai/widget.js` and `narratr.ai/embed.js` used to load from the root layout, so a third-party script ran on every authenticated console page: `/theguard`, `/lens`, `/credentials`, `/logs`, everywhere. That script could read the DOM (workspace names, spend rows, rule bodies, event content) and would deliver arbitrary code execution to every logged-in user's dashboard if narratr.ai were ever compromised.

- `app/layout.tsx`: scripts removed from both branches (Clerk-enabled + fallback)
- `(marketing)/layout.tsx`: scripts loaded here so they still run on marketing routes

### 2. Route-scoped CSP + standard security headers
`middleware.ts` now sets Content-Security-Policy plus `X-Content-Type-Options`, `Referrer-Policy`, `X-Frame-Options`, `Permissions-Policy` on every response.

- **App routes** (`/theguard`, `/lens`, `/credentials`, `/logs`, ...): `script-src` limited to `'self'` + Clerk. narratr.ai blocked as belt-and-braces even if a future import leaks it into an authenticated page.
- **Marketing routes**: same base plus `narratr.ai` in `script-src`/`frame-src`.
- Both: `frame-ancestors 'none'`, `form-action 'self'`, `object-src 'none'`.

**Enforcement mode:**
- **Prod:** `Content-Security-Policy` (enforcing)
- **Dev + preview:** `Content-Security-Policy-Report-Only` (surfaces violations without breaking local API URLs)

## Known relaxations (follow-ups)
- `'unsafe-inline'` + `'unsafe-eval'` still allowed on `script-src` — theme init + JSON-LD inline; Clerk uses eval. Migrate to nonce-based scripts in a later PR to tighten.
- `img-src` allows `https:` broadly. Locking down to specific hosts is a follow-up.

## Test plan
- [ ] Marketing home: view source → Narratr scripts present; console → no CSP violations for marketing origins
- [ ] Marketing `/blog`: Narratr widget still renders
- [ ] Sign in, land on `/theguard`: view source → no Narratr script tags; DevTools Network → no requests to narratr.ai
- [ ] Response headers on any authenticated route: `Content-Security-Policy` present, `script-src` does NOT include narratr.ai
- [ ] Response headers on marketing route: `script-src` DOES include `https://narratr.ai`
- [ ] Try to iframe conductai.ai in an external test page → refused by `X-Frame-Options: DENY` + `frame-ancestors 'none'`
- [ ] Watch browser console for CSP report-only violations on preview build → address any unexpected origins before this hits prod