### PR TITLE
fix(sec): CSP connect-src missing clerk.conductai.ai — Clerk sign-in blocked on prod

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -29,7 +29,7 @@ function _cspFor(pathname: string): string {
   // theme init and JSON-LD are inlined; tighten in a follow-up once we
   // migrate those to a nonce-based approach.
   const _selfClerk = "'self' https://cdn.clerk.com https://clerk.conductai.ai"
-  const _connect = "'self' https://api.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:"
+  const _connect = "'self' https://api.conductai.ai https://clerk.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:"
   const _img = "'self' data: https:"
   const _font = "'self' https://fonts.gstatic.com data:"
   const _style = "'self' 'unsafe-inline' https://fonts.googleapis.com"


### PR DESCRIPTION
## Summary

Prod signup + sign-in on `app.conductai.ai` are broken. Every Clerk XHR is refused before it hits the wire:

```
Refused to connect to 'https://clerk.conductai.ai/v1/client/sign_ins'
because it violates the CSP directive:
connect-src 'self' https://api.conductai.ai https://clerk.com
  https://*.clerk.accounts.dev wss:
```

## Root cause

S13 (#1799) route-scoped CSP added Clerk's custom domain (`clerk.conductai.ai`) to `script-src` and `frame-src` via the shared `_selfClerk` string. But `_connect` was hand-authored separately and only listed the generic `clerk.com` and `*.clerk.accounts.dev` origins.

Clerk's browser SDK talks to the workspace's custom Frontend API host — `clerk.conductai.ai` — so every sign-in / sign-up XHR is refused by the browser's CSP enforcement.

## Fix

One-line change in `apps/web/src/middleware.ts` — add `https://clerk.conductai.ai` to `_connect` so `script-src`, `frame-src`, and `connect-src` stay symmetric.

## Merge gate — please verify on the preview URL before promoting

Once Vercel finishes the preview build:

```bash
curl -sI <preview-url>/sign-up | grep -i content-security-policy | grep -c clerk.conductai.ai
```

Must return **2** (once inside the `script-src`/`frame-src` block via `_selfClerk`, once inside `connect-src` from this PR).

Then complete a real sign-up flow on the preview URL — no CSP errors in the browser console.

## Test plan

- [ ] Preview deploy returns CSP with `clerk.conductai.ai` in `connect-src`.
- [ ] Sign-up on preview completes without CSP errors.
- [ ] Sign-in on preview completes without CSP errors.
- [ ] After merge → prod: repeat the two above on `app.conductai.ai`.

## Follow-up (not this PR)

The two strings `_selfClerk` and `_connect` share the same Clerk custom-domain intent but are edited independently — that's how this bug slipped through. Consider factoring `CLERK_ORIGINS = ["https://cdn.clerk.com", "https://clerk.conductai.ai"]` and interpolating into both, so future Clerk domain changes touch one place.