### PR TITLE
fix(guard): /theguard/try demo verbs use agent-mode auth on /proxy (fixes #1804)

### DIFF
--- a/apps/api/app/modules/guard/routers/trial.py
+++ b/apps/api/app/modules/guard/routers/trial.py
@@ -40,6 +40,7 @@ class TrialSessionOut(BaseModel):
     days_remaining: int
     token: str | None
     gateway_url: str
+    workspace_id: str  # /theguard/try browser sends this in X-Conductai-Workspace-Id
     cap_used: int
     cap_max: int
 
@@ -98,6 +99,7 @@ def get_trial_session(
                 plan=plan, expired=False, ineligible=True, reason="active_workspace",
                 days_remaining=0, token=None,
                 gateway_url=settings.conduct_proxy_url,
+                workspace_id=workspace_id,
                 cap_used=0, cap_max=TRIAL_DAILY_CAP,
             )
         seed_trial(db, workspace_id)
@@ -116,6 +118,7 @@ def get_trial_session(
         return TrialSessionOut(
             plan=plan, expired=True, days_remaining=0,
             token=None, gateway_url=settings.conduct_proxy_url,
+            workspace_id=workspace_id,
             cap_used=0, cap_max=TRIAL_DAILY_CAP,
         )
 
@@ -137,6 +140,7 @@ def get_trial_session(
         days_remaining=days_remaining if not expired else 0,
         token=token,
         gateway_url=settings.conduct_proxy_url,
+        workspace_id=workspace_id,
         cap_used=get_trial_cap_used(db, workspace_id, str(identity.id)),
         cap_max=TRIAL_DAILY_CAP,
     )

--- a/apps/api/tests/test_trial_session_endpoint.py
+++ b/apps/api/tests/test_trial_session_endpoint.py
@@ -83,6 +83,9 @@ def test_on_demand_seed_when_no_trial_identity(empty_ws):
     assert out.cap_used == 0
     assert out.cap_max == TRIAL_DAILY_CAP
     assert out.gateway_url  # non-empty
+    # #1804 — workspace_id must be surfaced so the browser can send it
+    # in X-Conductai-Workspace-Id when calling /proxy in agent-mode.
+    assert out.workspace_id == ws_id
 
     plan_now = db.execute(
         text("SELECT plan FROM workspaces WHERE id = :ws"), {"ws": ws_id},

--- a/apps/web/src/app/(app)/theguard/try/page.tsx
+++ b/apps/web/src/app/(app)/theguard/try/page.tsx
@@ -15,6 +15,7 @@ interface TrialSession {
   days_remaining: number
   token: string | null
   gateway_url: string
+  workspace_id: string
   cap_used: number
   cap_max: number
 }
@@ -241,12 +242,18 @@ export default function GuardTryPage() {
       const path = verb.key === "prove"
         ? `${API}/guard/events/audit/verify`
         : `${session.gateway_url}/anthropic/v1/messages`
+      // /guard/events/audit/verify (prove) accepts the agent token via
+      // Authorization: Bearer directly. /proxy/* requires the agent token
+      // via X-Conductai-Internal + X-Conductai-Workspace-Id — that's the
+      // agent-mode auth path (see #1804/#1805 for why we don't widen the
+      // Bearer slot at /proxy).
       const opts: RequestInit = verb.key === "prove"
         ? { method: "GET", headers: { Authorization: `Bearer ${session.token}` } }
         : {
             method: "POST",
             headers: {
-              Authorization: `Bearer ${session.token}`,
+              "X-Conductai-Internal": session.token,
+              "X-Conductai-Workspace-Id": session.workspace_id,
               "anthropic-version": "2023-06-01",
               "Content-Type": "application/json",
             },


### PR DESCRIPTION
## Summary

Every new signup clicking allow/warn/block on \`/theguard/try\` saw HTTP 401 (\"Missing or malformed Conduct member token\"). Only prove worked. See #1804 for full root cause.

Fix: browser sends the trial agent token via \`X-Conductai-Internal\` + \`X-Conductai-Workspace-Id\` (the agent-mode header pair already supported at \`proxy.py:372-390\`), not \`Authorization: Bearer\` (which requires a member/Clerk token). No auth-guard change on the server.

## Changes

- \`apps/api/app/modules/guard/routers/trial.py\` — add \`workspace_id\` to \`TrialSessionOut\` (three return paths).
- \`apps/web/src/app/(app)/theguard/try/page.tsx\` — \`TrialSession\` interface gets \`workspace_id\`; \`runVerb()\` swaps header shape for the \`/anthropic/v1/messages\` call. \`prove\` verb (audit-verify endpoint) keeps \`Authorization: Bearer\` because that route accepts agent tokens directly.
- \`apps/api/tests/test_trial_session_endpoint.py\` — assert \`workspace_id\` round-trips.

## Why not touch \`/proxy\` auth

Widening the Bearer slot to accept trial agent tokens (\"Option B\" on #1804) was considered and rejected — parked as #1805. Auth-guard changes in the highest-blast-radius file in the API for zero customer value.

Long-term the browser should call a Clerk-session-authenticated backend endpoint that invokes the proxy server-side (\"Option C\") — filed on #1804 for the next trial UX pass.

## Test plan

- [x] Local unit test asserts \`workspace_id\` round-trips
- [ ] Preview deploy — fresh signup, land on \`/theguard/try\`, click each verb:
  - allow → HTTP 200 with completion body
  - warn → HTTP 200 with warning annotation
  - block → 4xx with \`BLOCKED — Prompt injection pattern detected — request blocked. [rule: proxy-no-prompt-injection]\`
  - prove → HTTP 200 with \`\"valid\":true\`
- [ ] Post-merge on prod — repeat the four checks on \`app.conductai.ai\`
- [ ] Close #1804 once verified in prod

## Related

- Fixes #1804
- Rejected: #1805 (Option B)
- Roadmap: Option C from #1804