### PR TITLE
fix(sec): CSP — worker-src blob: + Cloudflare Turnstile (Clerk audit P0 items)

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -25,10 +25,14 @@ function _isAppRoute(pathname: string): boolean {
 
 function _cspFor(pathname: string): string {
   // Common building blocks. Clerk lives on cdn.clerk.com / *.clerk.accounts.dev.
+  // challenges.cloudflare.com is Clerk's bot-detection provider (Cloudflare
+  // Turnstile) — Clerk 5 uses it by default for suspicious sign-ups. Must
+  // appear in both script-src and frame-src (challenge widget = an iframe
+  // that loads a script).
   // 'unsafe-inline' on script-src is retained on marketing because the current
   // theme init and JSON-LD are inlined; tighten in a follow-up once we
   // migrate those to a nonce-based approach.
-  const _selfClerk = "'self' https://cdn.clerk.com https://clerk.conductai.ai"
+  const _selfClerk = "'self' https://cdn.clerk.com https://clerk.conductai.ai https://challenges.cloudflare.com"
   const _connect = "'self' https://api.conductai.ai https://clerk.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:"
   const _img = "'self' data: https:"
   const _font = "'self' https://fonts.gstatic.com data:"

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -39,6 +39,14 @@ function _cspFor(pathname: string): string {
     `font-src ${_font}`,
     `style-src ${_style}`,
     `connect-src ${_connect}`,
+    // worker-src: Clerk's browser SDK creates blob-URL web workers for
+    // background session-token refresh. Without an explicit worker-src
+    // directive browsers fall back to script-src, which doesn't allow
+    // blob:. Result: workers get blocked, Clerk can't refresh tokens,
+    // every authenticated API call returns 401. Third CSP escape hatch
+    // found the hard way (S13 shipped without clerk.conductai.ai in
+    // connect-src → #1801; then this).
+    "worker-src 'self' blob:",
     "frame-ancestors 'none'",
     "form-action 'self'",
     "base-uri 'self'",


### PR DESCRIPTION
## Summary

Two P0 gaps from today's Clerk-CSP audit, folded into one deploy. Both silently broke Clerk features that "worked in dev" (Clerk auto-passes low-risk requests without hitting these paths) but would/did break real users at scale.

## Fix 1 — worker-src 'self' blob:

**Symptom:** every signed-in user hitting \`/guard/trial/session\`, \`/organizations\`, \`/projects\` (and any other authenticated endpoint) returned HTTP 401. Console showed:

\`\`\`
Creating a worker from 'blob:https://app.conductai.ai/...' violates the following
Content Security Policy directive: \"script-src 'self' https://cdn.clerk.com
https://clerk.conductai.ai 'unsafe-inline' 'unsafe-eval'\". Note that 'worker-src'
was not explicitly set, so 'script-src' is used as a fallback.
\`\`\`

Root cause chain:
1. Clerk's browser SDK creates blob-URL web workers for background session-token refresh.
2. CSP had \`script-src\` but no \`worker-src\` → browsers fell back to \`script-src\`, which didn't allow \`blob:\`.
3. Worker refused → Clerk can't refresh tokens → session goes stale → API 401s everything.

Fix: add \`worker-src 'self' blob:\` to the shared \`_base\` CSP directive.

## Fix 2 — Cloudflare Turnstile origins for Clerk bot detection

**Symptom:** silent so far in dev/low-traffic — Sudhi's own signup today didn't trigger Turnstile because Clerk scored it as low-risk. But under real traffic, Clerk 5 routes high-risk (or a percentage sample of) sign-ups through Cloudflare Turnstile bot-detection. Without CSP allowance, the challenge iframe fails to render and the sign-up hangs / errors.

Fix: add \`https://challenges.cloudflare.com\` to the \`_selfClerk\` building block (which is spread into both \`script-src\` and \`frame-src\` for both the \`(app)\` and marketing CSP branches).

## Third CSP escape hatch in under 12 hours

- S13 (#1799) shipped route-scoped CSP without a Clerk-integration audit.
- #1801 — \`connect-src\` missing \`clerk.conductai.ai\` → Clerk sign-in XHR blocked.
- **This PR** — \`worker-src\` missing (blocked session refresh) + Turnstile origins (blocks bot-detection at sign-up).

Proper Clerk CSP audit done today captured remaining P1/P2 gaps:

- **P1:** \`clerk-telemetry.com\` in \`connect-src\` (telemetry silently drops, no user-facing break).
- **P1:** \`form-action\` allowlist for Clerk OAuth callback URLs — latent trip-wire before social sign-in is enabled.
- **P2:** tighten \`img-src\` from \`'self' data: https:\` (wildcard) to specific origins.

Filing P1/P2 as follow-up issues so they don't rot.

## Test plan

- [x] TypeScript check passes
- [x] Local audit of Clerk 5 SDK CSP requirements against current middleware
- [ ] Preview URL — signed-in user opens \`/theguard/try\`, session loads without 401. Zero CSP violations in browser console.
- [ ] Preview URL — attempt a fresh sign-up from an incognito window; Turnstile widget (if triggered) renders cleanly.
- [ ] Post-merge on prod — same two checks on \`app.conductai.ai\`. All 4 verbs on \`/theguard/try\` work.

## Related

- Same file/pattern as #1799 (S13) and #1801
- Unblocks the full \`/sign-up → /theguard/try → 4 verbs\` new-user flow
- P1/P2 follow-ups filed as separate issues