### PR TITLE
fix(sec): pin ClerkProvider signInUrl/signUpUrl to our own routes

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -155,6 +155,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   if (clerkEnabled) {
     return (
       <ClerkProvider
+        signInUrl="/sign-in"
+        signUpUrl="/sign-up"
         signInFallbackRedirectUrl="/theguard"
         signUpFallbackRedirectUrl="/theguard/try"
       >


### PR DESCRIPTION
## Symptom

Signed-out user clicks \"Sign up\" (from any surface: post-logout landing, marketing nav, Clerk-issued button) → redirected to \`https://accounts.conductai.ai/sign-up\` → sees a Vercel/Cloudflare crash page (500 / 403 depending on timing).

## Root cause

\`ClerkProvider\` previously only set the *fallback* redirect URLs — where to go AFTER sign-in/sign-up completes. It didn't tell Clerk where the sign-in/sign-up PAGES themselves live.

Clerk 5 with a custom domain defaults to its **Account Portal** at \`accounts.<domain>\` when \`signInUrl\`/\`signUpUrl\` are absent. That portal is Clerk-hosted infrastructure sitting behind Cloudflare, currently flaky for our custom domain (provisioning or config issues on Clerk's side).

## Fix

Two lines in \`apps/web/src/app/layout.tsx\`:

\`\`\`tsx
<ClerkProvider
  signInUrl=\"/sign-in\"
  signUpUrl=\"/sign-up\"
  signInFallbackRedirectUrl=\"/theguard\"
  signUpFallbackRedirectUrl=\"/theguard/try\"
>
\`\`\`

Now every Clerk-initiated redirect goes to **our** Next.js routes, served by our Vercel deployment, with our CSP, our audit trail, our uptime. Zero dependency on Clerk's Account Portal availability.

## Related follow-ups (not in this PR)

- **Remove/disable \`accounts.conductai.ai\` entirely** — nobody in our app needs Clerk's hosted portal now that sign-up/sign-in are pinned. Worth removing the DNS entry so an accidental link (e.g. someone copy-pasting an old bookmark) doesn't hit a broken external surface.
- Same domain landing page ideally 404s cleanly with a redirect to \`app.conductai.ai\` instead of the current Vercel/Cloudflare crash.

## Test plan

- [x] TypeScript check passes
- [ ] Preview URL — sign out from an authenticated session, click any \"Sign up\" / \"Sign in\" link, land on OUR \`/sign-up\` or \`/sign-in\` (URL bar shows \`app.conductai.ai\`, not \`accounts.conductai.ai\`)
- [ ] Preview URL — after signup, redirects to \`/theguard/try\` (the fallback URL — unchanged)
- [ ] Post-merge on prod — repeat both above on \`app.conductai.ai\`