### PR TITLE
fix(web): redirect conductai.ai → app.conductai.ai for app-only paths

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -95,6 +95,23 @@ function _applySecurityHeaders(res: NextResponse, pathname: string): NextRespons
 const isAppSubdomain = (req: NextRequest) =>
   req.headers.get("host")?.startsWith("app.")
 
+// Marketing-domain root hosts (prod only). Preview URLs, staging, and the
+// app subdomain are intentionally excluded so marketing→app redirects only
+// fire where the app subdomain actually exists.
+const MARKETING_PROD_HOSTS = new Set(["conductai.ai", "www.conductai.ai"])
+
+// Paths that only make sense on the app subdomain. Includes the console
+// prefixes plus Clerk's sign-in/sign-up routes — Clerk's SDK issues
+// relative redirects, so a click on conductai.ai/... clicked from marketing
+// nav would otherwise sign the user in on the wrong subdomain and scope
+// the session cookie to marketing (post-signup then lands on marketing
+// home instead of /theguard/try).
+const APP_ONLY_PATH_PREFIXES = [...APP_ROUTE_PREFIXES, "/sign-in", "/sign-up"]
+
+function _isAppOnlyPath(pathname: string): boolean {
+  return APP_ONLY_PATH_PREFIXES.some((p) => pathname === p || pathname.startsWith(p + "/"))
+}
+
 const MARKETING_TO_APP: Record<string, string> = {
   "/guard": "/theguard",
   "/registry": "/packs",
@@ -125,6 +142,20 @@ const clerkHandler = clerkMiddleware(async (auth, req) => {
 })
 
 export default async function middleware(req: NextRequest, evt: unknown) {
+  // Marketing → app subdomain redirect. Fires before Clerk so unauthed
+  // navigations to /sign-in, /sign-up, /theguard/*, etc. from the
+  // marketing domain end up on app.conductai.ai — matches where Clerk
+  // sessions are scoped and where the CSP-protected console lives.
+  // Guarded to prod marketing hosts only (preview URLs untouched).
+  const _host = req.headers.get("host")
+  if (_host && MARKETING_PROD_HOSTS.has(_host) && _isAppOnlyPath(req.nextUrl.pathname)) {
+    const target = new URL(
+      req.nextUrl.pathname + req.nextUrl.search,
+      "https://app.conductai.ai",
+    )
+    return NextResponse.redirect(target, 308)
+  }
+
   // Run the Clerk handler first — it may redirect, in which case we still
   // want CSP headers on the redirect response so the browser never sees
   // an unprotected error page.


### PR DESCRIPTION
## Summary

Every marketing \"Start Discovery\" / \"Sign in\" click on \`conductai.ai\` was minting a Clerk session on the wrong subdomain. Post-signup users landed on \`https://conductai.ai/\` (marketing home) instead of \`/theguard/try\`, and later authenticated navigations flapped between subdomains.

## Root cause

20+ marketing pages use relative \`href=\"/sign-up\"\`, \`href=\"/sign-in\"\` (grep verified). On a browser at \`conductai.ai/...\`, these resolve to \`conductai.ai/sign-up\` — the same Next.js app serves the route (under the \`(app)\` route group), but the Clerk session cookie ends up scoped to \`conductai.ai\` instead of \`app.conductai.ai\`. Clerk's post-signup \`signUpFallbackRedirectUrl=\"/theguard/try\"\` (relative) then resolves against \`conductai.ai/\`, and \`middleware.ts:105\` doesn't fire the app-root redirect (its guard only matches \`host.startsWith(\"app.\")\`).

## Fix

One middleware rule at the top of the request pipeline in \`apps/web/src/middleware.ts\`:

\`\`\`typescript
const MARKETING_PROD_HOSTS = new Set([\"conductai.ai\", \"www.conductai.ai\"])
const APP_ONLY_PATH_PREFIXES = [...APP_ROUTE_PREFIXES, \"/sign-in\", \"/sign-up\"]

// Inside middleware(), before Clerk:
if (MARKETING_PROD_HOSTS.has(host) && isAppOnlyPath(pathname)) {
  return NextResponse.redirect(new URL(pathname + search, \"https://app.conductai.ai\"), 308)
}
\`\`\`

**One place, zero component changes.** Marketing hrefs stay relative, middleware forwards them.

## Guard rails

- Only fires on the two prod marketing hosts (\`conductai.ai\`, \`www.conductai.ai\`). Preview URLs (\`pr-XXXX-...vercel.app\`), staging (\`staging.conductai.ai\`), and the app subdomain itself all fall through unchanged.
- 308 preserves POST method (matters for form submissions).
- Runs before Clerk so no session state is needed to decide the redirect.
- Query params preserved via \`pathname + search\`.

## Downstream effect

| Click / navigation | Before | After |
|---|---|---|
| \`conductai.ai\` → nav \"Sign in\" | \`conductai.ai/sign-in\`, session scoped wrong | 308 → \`app.conductai.ai/sign-in\` |
| \`conductai.ai/discovery\` → \"Start Discovery\" | \`conductai.ai/sign-up\`, same issue | 308 → \`app.conductai.ai/sign-up\` |
| User types \`conductai.ai/theguard/try\` | Serves under wrong subdomain | 308 → \`app.conductai.ai/theguard/try\` |
| Post-signup Clerk redirect | Stays on marketing domain | Lands on \`app.conductai.ai/theguard/try\` |
| Preview URL (\`pr-XXXX-...vercel.app/sign-up\`) | Serves normally | Serves normally (host guard skips redirect) |

## Test plan

- [x] TypeScript check passes
- [ ] Preview URL — \`pr-XXXX-...vercel.app/sign-up\` still serves the sign-up page (no redirect)
- [ ] Preview URL — signup completes cleanly on the preview
- [ ] Post-merge on prod — visit \`conductai.ai/sign-up\` → auto-redirect to \`app.conductai.ai/sign-up\` (URL bar changes)
- [ ] Post-merge on prod — click any \"Start Discovery\" button on marketing → redirect happens transparently → signup form loads on \`app.\`
- [ ] Post-merge on prod — complete a fresh signup → land on \`app.conductai.ai/theguard/try\` (not marketing home)

## Related

- Continues the \`/theguard/try\` end-to-end unblock arc (#1799 S13 → #1801 CSP → #1802 pack + redirect → #1806 agent-mode → #1808 CSP audit → #1811 ClerkProvider pin → **this**)
- Once merged + verified, the entire \`marketing → sign-up → /theguard/try → 4 verbs\` flow is provably green for a new user