### PR TITLE
fix(sec): CSP connect-src add img.clerk.com — Clerk avatar loader was blocked

### DIFF
--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -33,7 +33,13 @@ function _cspFor(pathname: string): string {
   // theme init and JSON-LD are inlined; tighten in a follow-up once we
   // migrate those to a nonce-based approach.
   const _selfClerk = "'self' https://cdn.clerk.com https://clerk.conductai.ai https://challenges.cloudflare.com"
-  const _connect = "'self' https://api.conductai.ai https://clerk.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:"
+  // img.clerk.com — Clerk's UserButton avatar loader uses fetch() (not
+  // an <img> tag), so it goes through connect-src instead of img-src.
+  // Missed in the 2026-09-11 CSP audit because we assumed the img-src
+  // wildcard covered it. Silent break: user avatars fail + Clerk's SDK
+  // logs repeated CSP violations, which correlates with a session-token
+  // stall we saw around the same time.
+  const _connect = "'self' https://api.conductai.ai https://clerk.conductai.ai https://clerk.com https://*.clerk.accounts.dev https://img.clerk.com wss:"
   const _img = "'self' data: https:"
   const _font = "'self' https://fonts.gstatic.com data:"
   const _style = "'self' 'unsafe-inline' https://fonts.googleapis.com"


### PR DESCRIPTION
## Symptom

Console repeat-spam:
\`\`\`
Connecting to 'https://img.clerk.com/eyJ0eXBl...' violates the following Content Security Policy directive:
\"connect-src 'self' https://api.conductai.ai https://clerk.conductai.ai https://clerk.com https://*.clerk.accounts.dev wss:\"
\`\`\`

Correlated with a 401 storm on every authenticated API call (\`/organizations\`, \`/workspaces/.../report-layouts\`, \`/guard/trial/session\`, etc.) in the same page load. Fresh signup, freshly-created workspace \`58177357-84cd-4f2f-826b-d019a2ce3a78\`.

## Root cause

Clerk's UserButton avatar loader uses \`fetch()\` (not \`<img>\` tag), so it goes through \`connect-src\` instead of \`img-src\`. Missed in the 2026-09-11 audit (#1809) — assumed the img-src wildcard covered it. That was wrong; the fetch is a distinct code path with a distinct CSP directive.

## Fix

One line — add \`https://img.clerk.com\` to \`_connect\` in \`middleware.ts\`. Same pattern as #1801 (Clerk custom domain) and #1808 (Cloudflare Turnstile).

## Debugging the 401 storm

Two hypotheses about the correlated 401s:

1. **Cascade from this CSP violation** — Clerk's SDK, when its avatar fetch repeatedly fails a CSP check, may enter a partially-degraded state that stalls session-token acquisition. If so, this PR resolves both symptoms.
2. **RBAC not seeded on fresh workspace** — the newly-created user might not have any role granted on their workspace, so every route with \`require_permission(...)\` returns 401 regardless of what Clerk sends. Would need a separate fix.

**Post-merge test:** hard-refresh the affected user's session. If 401s resolve → hypothesis 1 confirmed, we're done. If 401s persist → filed as a separate issue targeting workspace RBAC seeding on new user creation.

## Follow-up

Remaining P1 items from #1809 still apply:
- \`clerk-telemetry.com\` in \`connect-src\` (Clerk telemetry drops)
- \`form-action\` allowlist for Clerk OAuth callback URLs (latent trip-wire before enabling social sign-in)

Both non-breaking today. Filed on #1809.

## Test plan

- [x] TypeScript check passes
- [ ] Preview deploy — signed-in user opens \`/theguard/try\`, no CSP violations on \`img.clerk.com\`, session loads without 401
- [ ] Post-merge on prod — Sudhi hard-refreshes his existing session, reports whether 401s resolve or persist