### PR TITLE
fix(auth): get_workspace_id falls back to DB lookup when JWT org_id is missing — fixes fresh-signup 403 storm

### DIFF
--- a/apps/api/app/core/auth.py
+++ b/apps/api/app/core/auth.py
@@ -517,11 +517,47 @@ def get_workspace_id(
         _assert_workspace_member(db, explicit_ws, user_id)
         return explicit_ws
 
-    workspace_id = claims.get("org_id") or claims.get("sub")
-    if not workspace_id:
-        raise HTTPException(status_code=401, detail="No workspace in token claims")
+    # Prefer JWT org_id claim when it's a real workspace UUID we know about.
+    # Fresh signups often haven't refreshed the JWT to include org_id yet
+    # (Clerk creates the org async), so we fall through to a DB lookup.
+    import re as _re
+    import uuid as _uuid
+    _uuid_re = r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$"
 
-    return workspace_id
+    org_claim = claims.get("org_id")
+    if org_claim and _re.match(_uuid_re, str(org_claim), _re.I):
+        return str(org_claim)
+
+    # Fallback: resolve the user's own workspace from the DB. Owner path
+    # first (matches provision_workspace_for_user + /projects auto-create),
+    # then workspace_users for invited/added members.
+    from sqlalchemy import text as _text
+    row = db.execute(
+        _text("SELECT id FROM workspaces WHERE owner_id = :uid ORDER BY created_at ASC LIMIT 1"),
+        {"uid": user_id},
+    ).fetchone()
+    if row:
+        return str(row.id)
+
+    row = db.execute(
+        _text(
+            "SELECT workspace_id FROM workspace_users "
+            "WHERE clerk_user_id = :uid ORDER BY joined_at ASC LIMIT 1"
+        ),
+        {"uid": user_id},
+    ).fetchone()
+    if row:
+        return str(row.workspace_id)
+
+    # No workspace resolvable. Previously we returned claims.get("sub") here
+    # (the Clerk user_id), which then failed the UUID regex downstream and
+    # surfaced as 403 "Not a member of this workspace" — misleading. Now we
+    # 401 with a clear message so operators know the user has no provisioned
+    # workspace yet (webhook race or provisioning failure).
+    raise HTTPException(
+        status_code=401,
+        detail="No workspace found for user — sign in again or wait for org provisioning to complete",
+    )
 
 
 def get_user_workspace_role(


### PR DESCRIPTION
## Symptom

Every fresh Clerk signup hit HTTP 403 on every authenticated API call (\`/guard/trial/session\`, \`/workspaces/UUID/*\`, \`/runs\`, \`/organizations\`, ...) despite a valid Clerk session and a freshly-provisioned workspace. Surfaced on \`/theguard/try\` as \"session load failed: 401\" (turned into 403 after Clerk's worker refreshed the token).

## Root cause

\`auth.py:520\` (before this fix):

\`\`\`python
workspace_id = claims.get(\"org_id\") or claims.get(\"sub\")
\`\`\`

Clerk creates the user's organization asynchronously and only includes \`org_id\` in the JWT after the session refreshes. For a fresh signup:
- \`claims[\"sub\"]\` = the Clerk user_id (\`user_XXX\`)
- \`claims[\"org_id\"]\` = None (Clerk still provisioning OR JWT cached)

The fallback returned the user_id string as the workspace_id. Every downstream check then failed:
- \`_assert_workspace_member\` did a UUID regex match and 403'd
- Any \`/workspaces/user_XXX/...\` path 404'd
- The user was \"not a member\" of a \"workspace\" whose ID was their own identifier

## Fix

Rank JWT \`org_id\` claim above DB lookup, but only when it's a valid UUID. Otherwise fall back to a DB lookup keyed on \`user_id\`:

1. \`workspaces.owner_id = user_id\` (matches both \`provision_workspace_for_user\` and the \`/projects\` auto-create path)
2. \`workspace_users(clerk_user_id = user_id)\` for members added via invite

If neither resolves, 401 with an explicit \"no workspace\" message so operators can distinguish this from real permission-denied 403s.

## Why this is safe

- Ownership + membership are already the authoritative source used by \`_assert_workspace_member\` and \`check_permission\`; we're just using them one call earlier.
- No new privilege — the caller could always resolve their own workspace by hitting \`/projects\`; we're skipping the extra round-trip.
- Same DB path used by both the Clerk webhook (\`onboarding.py\`) and the \`/projects\` auto-create (\`projects.py:305\`), so both provisioning routes are covered.
- Explicit \`workspace_id\` query param (the primary path) is untouched — that still hits \`_assert_workspace_member\` for cross-tenant safety.

## Trace of the full arc (why this fix is the linchpin)

Today's arc has been peeling this onion:

| # | Issue | Fix |
|---|---|---|
| #1799 (S13) | Route-scoped CSP (foundation) | Shipped-broken CSP |
| #1801 | \`connect-src clerk.conductai.ai\` | Clerk sign-in unblocked |
| #1802 | conduct-base v2.17.0 + redirect props | Block canary + demo landing |
| #1806 | \`/theguard/try\` verbs use agent-mode | Browser verbs work |
| #1808 | \`worker-src blob:\` + Turnstile | Session refresh works |
| #1811 | ClerkProvider signInUrl/signUpUrl | No Account Portal detour |
| #1812 | Marketing → app subdomain redirect | Session scoped right |
| #1813 | \`img.clerk.com\` in connect-src | Avatar fetches work |
| **#1815** | **This — workspace_id fallback** | **Fresh signups can call the API at all** |

The prior fixes made Clerk's session cookie reach the API cleanly. This fix makes the API actually resolve the user's workspace when the JWT hasn't caught up.

## Test plan

- [x] Python syntax check passes
- [ ] Preview deploy — fresh incognito signup with new alias, click all 4 verbs on \`/theguard/try\`. All succeed.
- [ ] Post-merge on prod — same test on \`app.conductai.ai\`. Existing sudhi+berri+test@ account still works (regression).
- [ ] Verify explicit \`?workspace_id=OTHER_WORKSPACE\` from a user who doesn't own that workspace still 403s (cross-tenant safety unchanged).