### PR TITLE
fix(web): /theguard/try adds anthropic-dangerous-direct-browser-access header — allow/warn verbs unblocked

### DIFF
--- a/apps/web/src/app/(app)/theguard/try/page.tsx
+++ b/apps/web/src/app/(app)/theguard/try/page.tsx
@@ -255,6 +255,11 @@ export default function GuardTryPage() {
               "X-Conductai-Internal": session.token,
               "X-Conductai-Workspace-Id": session.workspace_id,
               "anthropic-version": "2023-06-01",
+              // Anthropic 401s browser-originated calls unless this header
+              // is set — it's their opt-in for browser demos. Our /proxy
+              // forwards the request as-is to Anthropic, so the header
+              // needs to be sent from the browser.
+              "anthropic-dangerous-direct-browser-access": "true",
               "Content-Type": "application/json",
             },
             body: JSON.stringify({


### PR DESCRIPTION
## Summary

Allow + warn verbs on \`/theguard/try\` returned HTTP 401 with:

\`\`\`json
{
  \"type\": \"authentication_error\",
  \"message\": \"CORS requests must set 'anthropic-dangerous-direct-browser-access' header\"
}
\`\`\`

Block verb worked (Guard blocked before upstream reached — \`rule: proxy-no-prompt-injection\`). Prove verb worked (hits our audit-verify endpoint, not Anthropic). Only the two verbs that forwarded to Anthropic upstream failed.

## Root cause

Anthropic 401s any browser-originated call unless \`anthropic-dangerous-direct-browser-access: true\` is set — their opt-in for browser demos. Our \`/proxy\` forwards the request as-is to Anthropic, so the header has to come from the browser.

## Fix

Add the header in \`runVerb()\`'s messages fetch. Block still matches the pack rule and never reaches Anthropic; the extra header is harmless there. Prove uses a different URL and is unaffected.

## Verified today

- Block → HTTP 403 with \`\"rule\": \"proxy-no-prompt-injection\"\` ✓ (our conduct-base v2.17.0 extended pattern)
- Prove → HTTP 200 with \`\"valid\": true\` ✓ (audit chain intact)
- Allow / Warn → currently 401 from Anthropic — this PR fixes

## Test plan

- [x] TS check passes
- [ ] Preview deploy → all 4 verbs return non-401 verdicts
- [ ] Post-merge on prod → same

## Follow-up (unrelated, filed separately)

- Block receipt URL currently reads \`http://localhost:3000/theguard/blocks/...\` — dev URL leaking into prod responses. File separately.
- App-shell / sidebar / useAuthFetch race conditions cause session-load 401 + sidebar pop-in on first render. File separately.