### PR TITLE
fix(web): useAuthFetch auto-retries once on 401 to bridge Clerk session refresh race

### DIFF
--- a/apps/web/src/hooks/useAuthFetch.ts
+++ b/apps/web/src/hooks/useAuthFetch.ts
@@ -29,13 +29,30 @@ export function useAuthFetch() {
 
   const authFetch = useCallback(
     async (url: string, options: RequestInit = {}): Promise<Response> => {
-      const token = await getToken()
-      const headers: Record<string, string> = {
-        ...(options.headers as Record<string, string> | undefined),
+      const buildHeaders = (bearer: string | null) => {
+        const h: Record<string, string> = {
+          ...(options.headers as Record<string, string> | undefined),
+        }
+        if (bearer) h["Authorization"] = `Bearer ${bearer}`
+        if (activeWorkspace?.id) h["X-Workspace-ID"] = activeWorkspace.id
+        return h
       }
-      if (token) headers["Authorization"] = `Bearer ${token}`
-      if (activeWorkspace?.id) headers["X-Workspace-ID"] = activeWorkspace.id
-      return fetch(url, { ...options, headers })
+
+      const token = await getToken()
+      const res = await fetch(url, { ...options, headers: buildHeaders(token) })
+
+      // 401-then-retry: Clerk's SDK refreshes session tokens in a background
+      // web worker. First page load can fire an authFetch before the worker
+      // has minted a fresh JWT — first call returns 401, retry with a
+      // just-refreshed token succeeds. One retry only; genuine auth
+      // failures still surface to the caller after that.
+      if (res.status === 401) {
+        const retried = await getToken({ skipCache: true } as never)
+        if (retried && retried !== token) {
+          return fetch(url, { ...options, headers: buildHeaders(retried) })
+        }
+      }
+      return res
     },
     [getToken, activeWorkspace],
   )


### PR DESCRIPTION
## Summary

Fixes the class of \"first-render 401 that goes away on retry\" bugs that surfaced repeatedly today. Same root cause explains:

- \`/theguard/try\` session-load flap on first render (\"session load failed: 401, retry\" → click retry → works)
- \`/organizations\`, \`/workspaces/UUID/*\` first-render 401 burst
- Sidebar nav items pop-in after a beat (they gate on responses that first-load 401'd)

## Root cause

Clerk's SDK refreshes session JWTs in a background web worker. During the first ~100-500ms of a page load (or right after signup completes), \`useAuthFetch\` may fire before the worker has minted a fresh token. First call returns 401; the worker finishes; a manual retry (with the now-fresh token) succeeds.

## Fix

Catch the first 401 in the fetch wrapper, request a fresh token with \`skipCache: true\` (forces the worker to hand us its latest), retry once with the new token. If \`skipCache\` returns the same token OR nothing changed, we surface the original 401 to the caller — no infinite loop on genuine auth failures.

\`\`\`ts
if (res.status === 401) {
  const retried = await getToken({ skipCache: true } as never)
  if (retried && retried !== token) {
    return fetch(url, { ...options, headers: buildHeaders(retried) })
  }
}
return res
\`\`\`

## Failure semantics unchanged

- Real invalid/expired tokens still surface 401 to the caller after the retry.
- No looping.
- Refresh only happens on the specific failure signal (HTTP 401).
- Non-401 responses fall through the fast path.

## What this does NOT fix

Filed separately:
- \`fix(web): gate app shell + sidebar on WorkspaceContext ready state\` — the retry helps but the *ideal* fix is to not render workspace-scoped components until context has resolved. That's a bigger UX refactor.

## Test plan

- [x] TypeScript check passes
- [ ] Preview URL — hard-refresh \`/theguard/try\` after signup: no \"session load failed\" flap
- [ ] Preview URL — hard-refresh anywhere in the app: no first-render 401 burst in the console
- [ ] Post-merge on prod — same

## Related

- Continues the \`/theguard/try\` end-to-end unblock arc (10 PRs today).
- \`useAuthFetch\` is used by essentially every authenticated fetch in the app — one hook fix ripples widely.