### PR TITLE
fix(web): /theguard/try demo uses current Anthropic Haiku model (was deprecated 3.5)

### DIFF
--- a/apps/web/src/app/(app)/theguard/try/page.tsx
+++ b/apps/web/src/app/(app)/theguard/try/page.tsx
@@ -119,7 +119,7 @@ function curlFor(verb: Verb, token: string, gatewayUrl: string): string {
   -H "Authorization: Bearer ${token}"`
   }
   const body = JSON.stringify({
-    model: "claude-3-5-haiku-20241022",
+    model: "claude-haiku-4-5-20251001",
     max_tokens: 128,
     messages: [{ role: "user", content: verb.prompt }],
   })
@@ -258,7 +258,7 @@ export default function GuardTryPage() {
               "Content-Type": "application/json",
             },
             body: JSON.stringify({
-              model: "claude-3-5-haiku-20241022",
+              model: "claude-haiku-4-5-20251001",
               max_tokens: 128,
               messages: [{ role: "user", content: verb.prompt }],
             }),


### PR DESCRIPTION
## Summary

Allow + warn verbs on \`/theguard/try\` returned HTTP 404 from Anthropic:

\`\`\`json
{\"type\":\"not_found_error\",\"message\":\"model: claude-3-5-haiku-20241022\"}
\`\`\`

## Root cause

\`page.tsx\` hardcoded \`claude-3-5-haiku-20241022\` (Oct 2024 model), which Anthropic has since deprecated or restricted from newer accounts. Both the browser call body and the \"Copy curl\" panel text used it.

## Fix

Update to \`claude-haiku-4-5-20251001\` (current Haiku 4.5, released Oct 2025). Two occurrences (line 122 curl template, line 261 fetch body). Outbound traffic still routes through our \`/proxy\` unchanged.

## Follow-up worth doing (filed separately, not this PR)

Hardcoding a model in the demo is fragile — every Anthropic deprecation silently breaks the trial. Cleaner architecture:

1. \`/guard/trial/session\` returns a \`default_model\` field resolved from \`workspace_llm_primitives\` via \`runtime/model_router.resolve_for_workspace()\`. Browser uses \`session.default_model\`.
2. Or a small server endpoint \`/guard/trial/demo/{verb}\` that owns model selection + upstream call server-side, so the browser sends only the verb key.

Both make the demo resilient to future model deprecations and keep the LLM primitives system as the single source of truth (per the workspace-scoped LLM architecture rule in feedback_llm_primitives_architecture).

## Test plan

- [x] TS check passes
- [ ] Preview deploy — allow returns a Claude completion, warn returns advisory annotation
- [ ] Post-merge on prod — same

## Related

- Completes the /theguard/try E2E arc (allow ✓ warn ✓ block ✓ prove ✓)