### PR TITLE
feat(web): Guard IA 1a — Proxy under Connections, Workflows label

### DIFF
--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,6 +1,8 @@
 "use client"
 
 import { useState, useEffect, useRef } from "react"
+import Link from "next/link"
+import { useRouter, useSearchParams } from "next/navigation"
 import { useAuth } from "@clerk/nextjs"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api"
@@ -10,7 +12,6 @@ import CanvasPanel from "@/components/settings/CanvasPanel"
 import EnvironmentsManager from "@/components/settings/EnvironmentsManager"
 import MembersManager from "@/components/settings/MembersManager"
 import PreferencesPanel from "@/components/settings/PreferencesPanel"
-import ProxySettings from "@/components/settings/ProxySettings"
 import LLMPrimitivesPanel from "@/components/settings/LLMPrimitivesPanel"
 import RateLimitsPanel from "@/components/settings/RateLimitsPanel"
 
@@ -21,7 +22,7 @@ const TABS: readonly SettingsTab<Tab>[] = [
   { key: "llm_primitives", label: "LLM Model Primitives" },
   { key: "preferences",    label: "Appearance" },
   { key: "canvas",         label: "Canvas" },
-  { key: "proxy",          label: "Proxy" },
+  { key: "proxy",          label: "Proxy → Guard" },
   { key: "rate_limits",    label: "Rate limits", adminOnly: true },
   { key: "members",        label: "Members & roles", adminOnly: true },
 ]
@@ -168,6 +169,15 @@ function OrgNameEditor({ getToken }: { getToken: (() => Promise<string | null>) 
 
 function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolean; workspaceId: string; getToken: (() => Promise<string | null>) | null }) {
   const [showTip, setShowTip] = useState(false)
+  const router = useRouter()
+  const searchParams = useSearchParams()
+
+  // Legacy alias: /settings?tab=proxy now lives at Guard → Connections.
+  useEffect(() => {
+    if (searchParams?.get("tab") === "proxy") {
+      router.replace("/theguard/connections/proxy")
+    }
+  }, [searchParams, router])
 
   useEffect(() => {
     if (typeof window !== "undefined") {
@@ -187,7 +197,16 @@ function SettingsPageInner({ isAdmin, workspaceId, getToken }: { isAdmin: boolea
     llm_primitives: <LLMPrimitivesPanel workspaceId={workspaceId} isAdmin={isAdmin} />,
     preferences:    <PreferencesPanel />,
     canvas:         <CanvasPanel />,
-    proxy:          <ProxySettings workspaceId={workspaceId} getToken={getToken} />,
+    proxy:          (
+      <div style={{ padding: 16, border: "1px solid var(--border)", borderRadius: 8, background: "var(--surface-2)" }}>
+        <p style={{ margin: 0, fontSize: 14, color: "var(--text-2)" }}>
+          Proxy configuration moved to{" "}
+          <Link href="/theguard/connections/proxy" style={{ color: "var(--link)", textDecoration: "underline" }}>
+            Guard → Connections → Proxy &amp; gateways
+          </Link>.
+        </p>
+      </div>
+    ),
     rate_limits:    <RateLimitsPanel isAdmin={isAdmin} />,
     members:        <MembersManager />,
   }

--- a/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { GuardShell } from "@/components/guard/GuardShell"
+import ProxySettings from "@/components/settings/ProxySettings"
+import { useWorkspace } from "@/lib/WorkspaceContext"
+
+export default function GuardProxyConnectionsPage() {
+  const { activeWorkspace } = useWorkspace()
+  const workspaceId = activeWorkspace?.id ?? ""
+
+  return (
+    <GuardShell>
+      <div style={{ maxWidth: 960 }}>
+        <h2 style={{ fontSize: 18, fontWeight: 650, margin: "8px 0 4px" }}>
+          Proxy &amp; gateways
+        </h2>
+        <p style={{ fontSize: 13, color: "var(--text-3)", margin: "0 0 20px" }}>
+          Route agent LLM traffic through Conduct so Guard can enforce prompt and response rules. Push upstream keys to the selected vault environment.
+        </p>
+        <ProxySettings workspaceId={workspaceId} />
+      </div>
+    </GuardShell>
+  )
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -140,7 +140,7 @@ function getBreadcrumbs(pathname: string, projects: Project[]): string[] {
 
 const PALETTE_COMMANDS = [
   { group: "BUILD", label: "Projects", href: "/projects", icon: "Grid" as const },
-  { group: "BUILD", label: "Agents", href: "/workflows", icon: "Flow" as const },
+  { group: "BUILD", label: "Workflows", href: "/workflows", icon: "Flow" as const },
   { group: "BUILD", label: "Registry", href: "/packs", icon: "Store" as const },
   { group: "OBSERVE", label: "Dashboard", href: "/dashboard", icon: "Spark" as const },
   { group: "OBSERVE", label: "Runs", href: "/runs", icon: "Pulse" as const },
@@ -1029,7 +1029,7 @@ function AppShellInnerContent({
 
             <SideNavItem
               href="/workflows"
-              label="Agents"
+              label="Workflows"
               icon={<Icons.Flow />}
               active={pathname.startsWith("/workflows")}
               collapsed={collapsed}


### PR DESCRIPTION
## Summary

Phase **1a** of the Guard six-section IA rollout (see private tracker for the plan). Ships small, reversible, no data or permission changes.

- New page `/theguard/connections/proxy` composing existing `ProxySettings` — Guard now owns Connections.
- Sidebar + command palette label `/workflows` renamed **Agents → Workflows** (distinguishes workflow definitions from agent identities).
- `/settings?tab=proxy` redirects to the new Guard page; the general Settings Proxy panel becomes a "moved" link card for one transition release.

**Files:** 3 (+48 / -5)

**Deferred to 1b (separate PR):** shared \`GUARD_SECTIONS\` const, GuardShell vertical rail, Guard Settings decomposition, Agent Identity route alias.

## Test plan

- [ ] \`npm run typecheck --workspace apps/web\` clean.
- [ ] Sidebar shows "Workflows" (not "Agents") linking to \`/workflows\`.
- [ ] Command palette shows "Workflows" under BUILD.
- [ ] Visiting \`/theguard/connections/proxy\` renders the existing Proxy config editor inside GuardShell.
- [ ] Save + push-to-vault still work from the new location.
- [ ] Visiting \`/settings?tab=proxy\` redirects to \`/theguard/connections/proxy\`.
- [ ] Visiting \`/settings\` and clicking the "Proxy → Guard" tab shows the "moved" card with a working link.