### PR TITLE
feat(web): Guard IA 1b — six-section vertical rail + 1a follow-ups

### DIFF
--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -707,7 +707,7 @@ function EmptyChecklist() {
     >
       <div style={{ fontWeight: 600, fontSize: 14, marginBottom: 4 }}>Get started with Conduct</div>
       <div style={{ fontSize: 12, color: "var(--text-muted)", marginBottom: 22 }}>
-        No agents yet. Follow these steps to automate your first engineering task.
+        No workflows yet. Follow these steps to automate your first engineering task.
       </div>
       <ol style={{ listStyle: "none", padding: 0, margin: 0, display: "flex", flexDirection: "column", gap: 16 }}>
         {steps.map((s, i) => (

--- a/apps/web/src/app/(app)/packs/page.tsx
+++ b/apps/web/src/app/(app)/packs/page.tsx
@@ -971,7 +971,7 @@ function RegistryContent({ getToken }: { getToken: (() => Promise<string | null>
 
             {/* Agent name */}
             <div className="flex flex-col gap-1.5">
-              <label className="text-xs font-medium text-stone-500">Agent name</label>
+              <label className="text-xs font-medium text-stone-500">Workflow name</label>
               <input
                 type="text"
                 value={agentName}

--- a/apps/web/src/app/(app)/projects/[id]/page.tsx
+++ b/apps/web/src/app/(app)/projects/[id]/page.tsx
@@ -263,7 +263,7 @@ function ProjectContent({ getToken, currentUserId }: {
           </div>
           <div style={{ marginLeft: "auto", display: "flex", gap: 9 }}>
             <Link href={`/workflows/new?project_id=${projectId}`} className="btn btn-primary" style={{ textDecoration: "none" }}>
-              + New agent
+              + New workflow
             </Link>
           </div>
         </div>
@@ -279,7 +279,7 @@ function ProjectContent({ getToken, currentUserId }: {
                 className="chip"
                 style={{ height: 30, cursor: "pointer", fontWeight: 600, background: on ? "var(--accent-weak)" : "var(--surface)", borderColor: on ? "var(--accent-ring)" : "var(--border)", color: on ? "var(--accent-text)" : "var(--text-2)" }}
               >
-                {t}
+                {t === "Agents" ? "Workflows" : "Runs"}
                 {/* P1-2: only show count when it has been loaded (not · 0 placeholder) */}
                 {t === "Agents" && <span style={{ opacity: .6, marginLeft: 1 }}>· {workflows.length}</span>}
                 {t === "Runs" && runs.length > 0 && <span style={{ opacity: .6, marginLeft: 1 }}>· {runs.length}</span>}
@@ -300,8 +300,8 @@ function ProjectContent({ getToken, currentUserId }: {
                 <input
                   value={q}
                   onChange={e => setQ(e.target.value)}
-                  placeholder="Search agents…"
-                  aria-label="Search agents"
+                  placeholder="Search workflows…"
+                  aria-label="Search workflows"
                   style={{ width: "100%", height: 36, padding: "0 12px 0 33px", borderRadius: 9, border: "1px solid var(--border)", background: "var(--surface)", color: "var(--text)", fontSize: 13.5, outline: "none" }}
                 />
               </div>
@@ -358,7 +358,7 @@ function ProjectContent({ getToken, currentUserId }: {
               </div>
             ) : workflows.length === 0 ? (
               <div style={{ padding: "60px 20px", textAlign: "center" }}>
-                <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No agents in this project</p>
+                <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No workflows in this project</p>
                 <p style={{ fontSize: 13.5, color: "var(--text-3)", marginBottom: 20 }}>Create a new agent or start from an agent template.</p>
                 <div style={{ display: "flex", gap: 10, justifyContent: "center" }}>
                   <Link href={`/workflows/new?project_id=${projectId}`} className="btn btn-primary" style={{ textDecoration: "none" }}>+ New agent</Link>
@@ -373,7 +373,7 @@ function ProjectContent({ getToken, currentUserId }: {
                   ))}
                 </div>
                 {rows.length === 0 && (
-                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No agents match.</div>
+                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No workflows match.</div>
                 )}
                 {rows.map(w => {
                   if (confirming === w.id) {

--- a/apps/web/src/app/(app)/projects/page.tsx
+++ b/apps/web/src/app/(app)/projects/page.tsx
@@ -687,9 +687,9 @@ function ProjectGridCard({
       <div style={{ borderTop: "1px solid var(--border)" }}>
         {agents.length === 0 ? (
           <div style={{ padding: "12px 18px", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>No agents yet</span>
+            <span style={{ fontSize: 12, color: "var(--text-muted)" }}>No workflows yet</span>
             <Link href={`/workflows/new?project_id=${project.id}`} className="btn btn-ghost btn-sm" style={{ fontSize: 11 }} onClick={(e: ReactMouseEvent<HTMLElement>) => e.stopPropagation()}>
-              + New agent
+              + New workflow
             </Link>
           </div>
         ) : (

--- a/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import ProxySettings from "@/components/settings/ProxySettings"
 import { useWorkspace } from "@/lib/WorkspaceContext"
@@ -9,16 +10,18 @@ export default function GuardProxyConnectionsPage() {
   const workspaceId = activeWorkspace?.id ?? ""
 
   return (
-    <GuardShell>
-      <div style={{ maxWidth: 960 }}>
-        <h2 style={{ fontSize: 18, fontWeight: 650, margin: "8px 0 4px" }}>
-          Proxy &amp; gateways
-        </h2>
-        <p style={{ fontSize: 13, color: "var(--text-3)", margin: "0 0 20px" }}>
-          Route agent LLM traffic through Conduct so Guard can enforce prompt and response rules. Push upstream keys to the selected vault environment.
-        </p>
-        <ProxySettings workspaceId={workspaceId} />
-      </div>
-    </GuardShell>
+    <AppShell>
+      <GuardShell>
+        <div style={{ maxWidth: 960 }}>
+          <h2 style={{ fontSize: 18, fontWeight: 650, margin: "8px 0 4px" }}>
+            Proxy &amp; gateways
+          </h2>
+          <p style={{ fontSize: 13, color: "var(--text-3)", margin: "0 0 20px" }}>
+            Route agent LLM traffic through Conduct so Guard can enforce prompt and response rules. Push upstream keys to the selected vault environment.
+          </p>
+          <ProxySettings workspaceId={workspaceId} />
+        </div>
+      </GuardShell>
+    </AppShell>
   )
 }

--- a/apps/web/src/app/(app)/workflows/[id]/settings/page.tsx
+++ b/apps/web/src/app/(app)/workflows/[id]/settings/page.tsx
@@ -271,7 +271,7 @@ export default function AgentSettingsPage() {
                             setDeleteError(null)
                           }
                         }}
-                        placeholder={workflow?.name ?? "Agent name"}
+                        placeholder={workflow?.name ?? "Workflow name"}
                         style={{
                           flex: 1,
                           border: "1px solid var(--err-bd)",

--- a/apps/web/src/app/(app)/workflows/new/page.tsx
+++ b/apps/web/src/app/(app)/workflows/new/page.tsx
@@ -229,10 +229,10 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" style={{ transform: "rotate(180deg)" }}>
             <path d="M9 18l6-6-6-6" />
           </svg>
-          Agents
+          Workflows
         </div>
 
-        <h1 className="page-title" style={{ fontSize: 22 }}>New agent</h1>
+        <h1 className="page-title" style={{ fontSize: 22 }}>New workflow</h1>
         <p className="page-sub" style={{ marginBottom: 22 }}>Choose a playbook and configure it — the webhook is registered automatically on create.</p>
 
         {/* Second pill routes to Lens — NL → block graph moved there. */}
@@ -244,7 +244,7 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
             <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
               <path d="M12 3l1.5 4.5L18 9l-4.5 1.5L12 15l-1.5-4.5L6 9l4.5-1.5z" /><path d="M19 15l.75 2.25L22 18l-2.25.75L19 21l-.75-2.25L16 18l2.25-.75z" />
             </svg>
-            Build agents from Lens
+            Build workflows from Lens
           </button>
         </div>
 
@@ -303,7 +303,7 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
                 {/* Agent name */}
                 <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
                   <label style={{ fontSize: 12, fontWeight: 600, color: "var(--text-2)" }}>
-                    Agent name <span style={{ fontWeight: 400, color: "var(--text-muted)" }}>— e.g. &ldquo;Autopilot — conductai prod&rdquo;</span>
+                    Workflow name <span style={{ fontWeight: 400, color: "var(--text-muted)" }}>— e.g. &ldquo;Autopilot — conductai prod&rdquo;</span>
                   </label>
                   <input value={agentName} onChange={e => setAgentName(e.target.value)}
                     placeholder={FRIENDLY_NAMES[template] ?? template} style={ni} />
@@ -405,7 +405,7 @@ function NewWorkflowForm({ getToken }: { getToken: (() => Promise<string | null>
                 <button className="btn btn-primary" style={{ height: 42, justifyContent: "center", marginTop: 4 }}
                   onClick={handleCreate}
                   disabled={loading || (GITHUB_WEBHOOK_SLUGS.has(template) && !selectedRepo)}>
-                  {loading ? "Creating…" : "Create agent"}
+                  {loading ? "Creating…" : "Create workflow"}
                 </button>
               </>
             )}

--- a/apps/web/src/app/(app)/workflows/page.tsx
+++ b/apps/web/src/app/(app)/workflows/page.tsx
@@ -279,11 +279,11 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
         {/* #14: "Agent" → "Workflow" in page headings */}
         <div className="page-head" style={{ display: "flex", alignItems: "flex-end" }}>
           <div>
-            <h1 className="page-title">Agents</h1>
-            <p className="page-sub">Every agent in this workspace — status, triggers, and 30-day reliability at a glance.</p>
+            <h1 className="page-title">Workflows</h1>
+            <p className="page-sub">Every workflow in this workspace — status, triggers, and 30-day reliability at a glance.</p>
           </div>
           <div style={{ marginLeft: "auto", display: "flex", gap: 9 }}>
-            <Link href="/workflows/new" className="btn btn-primary"><span>+</span> New agent</Link>
+            <Link href="/workflows/new" className="btn btn-primary"><span>+</span> New workflow</Link>
           </div>
         </div>
 
@@ -389,9 +389,9 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
         ) : !wfLoading && workflows.length === 0 ? (
           <div style={{ padding: "60px 20px", textAlign: "center" }}>
             {/* #14: "agent" → "workflow" in empty state */}
-            <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No agents yet</p>
-            <p style={{ fontSize: 13.5, color: "var(--text-3)", marginBottom: 20 }}>Pick a playbook template to create your first agent.</p>
-            <Link href="/workflows/new" className="btn btn-primary">+ New agent</Link>
+            <p style={{ fontWeight: 650, fontSize: 16, color: "var(--text)", marginBottom: 8 }}>No workflows yet</p>
+            <p style={{ fontSize: 13.5, color: "var(--text-3)", marginBottom: 20 }}>Pick a playbook template to create your first workflow.</p>
+            <Link href="/workflows/new" className="btn btn-primary">+ New workflow</Link>
           </div>
         ) : (
           <>
@@ -404,7 +404,7 @@ function WorkflowsContent({ getToken, currentUserId }: { getToken: (() => Promis
                   ))}
                 </div>
                 {rows.length === 0 && (
-                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No agents match.</div>
+                  <div style={{ padding: 40, textAlign: "center", color: "var(--text-muted)", fontSize: 13 }}>No workflows match.</div>
                 )}
                 {rows.map(w => {
                   if (confirming === w.id) {

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -13,6 +13,7 @@ import ErrorBoundary from "@/components/ui/ErrorBoundary"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { reportLayoutsApi, type ReportLayout } from "@/lib/reportBuilder/api"
 import { workspaces as workspacesApi, projects as projectsApi, organizations, runs, guard, workflows } from "@/lib/api"
+import { GUARD_SECTIONS } from "@/lib/navigation/guardSections"
 
 interface Project { id: string; name: string; agent_count: number; project_type?: string }
 
@@ -104,9 +105,12 @@ const Icons = {
 function getBreadcrumbs(pathname: string, projects: Project[]): string[] {
   if (pathname.startsWith('/dashboard')) return ['Dashboard']
   if (pathname.startsWith('/theguard/spend')) return ['Guard', 'Spend']
-  if (pathname.startsWith('/theguard/policies')) return ['Guard', 'Policies']
-  if (pathname.startsWith('/theguard/discovery')) return ['Guard', 'Discovery']
+  if (pathname.startsWith('/theguard/policies')) return ['Guard', 'Controls', 'Policies']
+  if (pathname.startsWith('/theguard/approvals')) return ['Guard', 'Controls', 'Approvals']
+  if (pathname.startsWith('/theguard/discovery')) return ['Guard', 'Agents', 'Discovery']
   if (pathname.startsWith('/theguard/activity')) return ['Guard', 'Activity']
+  if (pathname.startsWith('/theguard/connections/proxy')) return ['Guard', 'Connections', 'Proxy & gateways']
+  if (pathname.startsWith('/theguard/connections')) return ['Guard', 'Connections']
   if (pathname.startsWith('/theguard/settings')) return ['Guard', 'Settings']
   if (pathname.startsWith('/theguard/compliance')) return ['Guard', 'Compliance']
   if (pathname.startsWith('/governance')) return ['Governance']
@@ -122,8 +126,8 @@ function getBreadcrumbs(pathname: string, projects: Project[]): string[] {
   if (pathname.startsWith('/logs')) return ['Logs']
   if (pathname.startsWith('/runs')) return ['Runs']
   if (pathname.startsWith('/observability')) return ['Observability']
-  if (pathname === '/workflows') return ['Agents']
-  if (pathname.startsWith('/workflows/new')) return ['Canvas', 'New agent']
+  if (pathname === '/workflows') return ['Workflows']
+  if (pathname.startsWith('/workflows/new')) return ['Canvas', 'New workflow']
   if (pathname.startsWith('/workflows/')) return ['Canvas']
   const projectMatch = pathname.match(/\/projects\/([^/]+)/)
   if (projectMatch) {
@@ -146,11 +150,9 @@ const PALETTE_COMMANDS = [
   { group: "OBSERVE", label: "Runs", href: "/runs", icon: "Pulse" as const },
   { group: "GOVERN", label: "Runtime Governance", href: "/governance", icon: "Shield" as const },
   { group: "ASK", label: "Lens", href: "/lens", icon: "Spark" as const },
-  { group: "GOVERN", label: "Guard · Overview", href: "/theguard", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Spend", href: "/theguard/spend", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Policies", href: "/theguard/policies", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Agent Discovery", href: "/theguard/discovery", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Activity", href: "/theguard/activity", icon: "Shield" as const },
+  ...GUARD_SECTIONS.map(s => ({ group: "GOVERN" as const, label: `Guard · ${s.label}`, href: s.href, icon: "Shield" as const })),
+  { group: "GOVERN", label: "Guard · Compliance", href: "/theguard/compliance", icon: "Shield" as const },
+  { group: "GOVERN", label: "Guard · Settings", href: "/theguard/settings", icon: "Shield" as const },
   { group: "WORKSPACE", label: "Integrations", href: "/integrations", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Agent ID", href: "/agent-identity", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Settings · Vault", href: "/settings", icon: "Gear" as const },
@@ -844,20 +846,17 @@ function AppShellInnerContent({
                 href="/theguard"
                 label="Guard"
                 icon={<Icons.Shield />}
-                active={pathname.startsWith("/theguard")}
+                active={pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard")}
                 collapsed={collapsed}
               />
-              {/* Guard sub-nav */}
-              {pathname.startsWith("/theguard") && !collapsed && (
+              {/* Guard sub-nav — six-section IA. Compliance/Settings/Team Memory reachable via ⌘K.
+                  /logs/guard is Guard's Activity section, so it also opens this sub-nav. */}
+              {(pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard")) && !collapsed && (
                 <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 2, display: "flex", flexDirection: "column", gap: 1 }}>
-                  {[
-                    { label: "Overview",    href: "/theguard" },
-                    { label: "Policies",    href: "/theguard/policies" },
-                    { label: "Compliance",  href: "/theguard/compliance" },
-                    { label: "Team Memory", href: "/theguard/team-memory" },
-                    { label: "Settings",    href: "/theguard/settings", adminOnly: true },
-                  ].filter(sub => !sub.adminOnly || userRole === "admin").map(sub => {
-                    const subActive = sub.href === "/theguard" ? pathname === "/theguard" : pathname.startsWith(sub.href)
+                  {GUARD_SECTIONS.map(sub => {
+                    const subActive = sub.id === "overview"
+                      ? pathname === "/theguard"
+                      : sub.activePrefixes.some(p => pathname === p || pathname.startsWith(p + "/"))
                     return (
                       <Link
                         key={sub.href}

--- a/apps/web/src/components/OnboardingChecklist.tsx
+++ b/apps/web/src/components/OnboardingChecklist.tsx
@@ -77,7 +77,7 @@ export default function OnboardingChecklist({ hasProject, onNewProject }: Props)
     },
     {
       id: "agent",
-      label: "Create your first agent",
+      label: "Create your first workflow",
       detail: "Pick a template — Autopilot is a good start. It pre-wires a GitHub trigger and a Slack approval gate.",
       cta: "Choose template",
       href: "/workflows/new",
@@ -85,9 +85,9 @@ export default function OnboardingChecklist({ hasProject, onNewProject }: Props)
     },
     {
       id: "run",
-      label: "Run the agent",
-      detail: "Open the agent canvas, assign your environment from the dropdown, then hit ▶ Run.",
-      cta: "View agents",
+      label: "Run the workflow",
+      detail: "Open the workflow canvas, assign your environment from the dropdown, then hit ▶ Run.",
+      cta: "View workflows",
       href: "/workflows",
       done: hasRun,
     },
@@ -108,7 +108,7 @@ export default function OnboardingChecklist({ hasProject, onNewProject }: Props)
           </p>
           <p className="text-xs text-stone-400 mt-0.5">
             {allDone
-              ? "All steps complete — your first agent is ready to run."
+              ? "All steps complete — your first workflow is ready to run."
               : `${completedCount} of ${steps.length} steps done`}
           </p>
         </div>

--- a/apps/web/src/components/canvas/WorkflowSettingsPanel.tsx
+++ b/apps/web/src/components/canvas/WorkflowSettingsPanel.tsx
@@ -298,7 +298,7 @@ async function saveGuard(enabled = guardEnabled) {
                           setError(null)
                         }
                       }}
-                      placeholder={workflow?.name ?? "Agent name"}
+                      placeholder={workflow?.name ?? "Workflow name"}
                       style={{
                         flex: 1,
                         border: "1px solid var(--err-bd)",

--- a/apps/web/src/components/guard/GuardShell.tsx
+++ b/apps/web/src/components/guard/GuardShell.tsx
@@ -3,23 +3,7 @@
 import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { useGuardRole } from "@/hooks/useGuardRole"
-import type { GuardRole } from "@/hooks/useGuardRole"
-
-// ─── Tab definitions ──────────────────────────────────────────────────────────
-
-type TabDef = { href: string; label: string; roles?: GuardRole[] }
-
-// roles = undefined means visible to all; otherwise restrict to listed roles
-export const GUARD_TABS: TabDef[] = [
-  { href: "/logs/guard",           label: "Activity"    },
-  { href: "/theguard/spend",      label: "Spend"       },
-  { href: "/theguard/policies",   label: "Policies"    },
-  { href: "/theguard/approvals",  label: "Approvals"   },
-  { href: "/theguard/discovery",  label: "Agent Discovery" },
-  { href: "/theguard/compliance", label: "Compliance", roles: ["admin", "security"] },
-  { href: "/theguard/settings",   label: "Settings",   roles: ["admin"] },
-]
+import { GUARD_SECTIONS, activeGuardSection } from "@/lib/navigation/guardSections"
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -61,9 +45,7 @@ export function GuardShell({
 }: GuardShellProps) {
   const pathname = usePathname()
   const [, setTick] = useState(0)
-  const { role } = useGuardRole()
-
-  const visibleTabs = GUARD_TABS.filter(t => !t.roles || (role && t.roles.includes(role)))
+  const activeId = activeGuardSection(pathname ?? "")
 
   // Re-render every 10 s so the relative timestamp stays fresh
   useEffect(() => {
@@ -122,25 +104,38 @@ export function GuardShell({
         </div>
       </div>
 
-      {/* Tab nav */}
-      <div className="guard-tab-nav">
-        {visibleTabs.map(tab => {
-          const isActive = tab.href === "/theguard"
-            ? pathname === "/theguard"
-            : pathname?.startsWith(tab.href)
-          return (
-            <Link
-              key={tab.href}
-              href={tab.href}
-              className={`guard-tab${isActive ? " active" : ""}`}
-            >
-              {tab.label}
-            </Link>
-          )
-        })}
-      </div>
+      {/* Vertical rail + content — matches SettingsShell's pattern. */}
+      <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: 28, alignItems: "start" }}>
+        <nav aria-label="Guard sections" style={{ display: "flex", flexDirection: "column", gap: 2, borderRight: "1px solid var(--border)", paddingRight: 14 }}>
+          {GUARD_SECTIONS.map(s => {
+            const active = s.id === activeId
+            return (
+              <Link
+                key={s.id}
+                href={s.href}
+                aria-current={active ? "page" : undefined}
+                style={{
+                  display: "block",
+                  padding: "8px 12px",
+                  fontSize: 13.5,
+                  fontWeight: active ? 650 : 500,
+                  color: active ? "var(--text)" : "var(--text-3)",
+                  background: active ? "var(--surface-2)" : "transparent",
+                  borderRadius: 6,
+                  textDecoration: "none",
+                  transition: "background .12s, color .12s",
+                }}
+              >
+                {s.label}
+              </Link>
+            )
+          })}
+        </nav>
 
-      {children}
+        <div style={{ minWidth: 0 }}>
+          {children}
+        </div>
+      </div>
     </div>
   )
 }

--- a/apps/web/src/components/guard/__tests__/GuardShell.test.tsx
+++ b/apps/web/src/components/guard/__tests__/GuardShell.test.tsx
@@ -1,126 +1,28 @@
-import { describe, it, expect, vi, beforeEach } from "vitest"
+import { describe, it, expect, vi } from "vitest"
 import { render } from "@testing-library/react"
 import { screen } from "@testing-library/dom"
-import type { GuardRole } from "@/hooks/useGuardRole"
-import { GuardShell, GUARD_TABS } from "../GuardShell"
+import { GuardShell } from "../GuardShell"
+import { GUARD_SECTIONS } from "@/lib/navigation/guardSections"
 
 vi.mock("next/navigation", () => ({
   usePathname: () => "/theguard",
 }))
 
-const mockUseGuardRole = vi.fn<() => { role: GuardRole | null }>()
-vi.mock("@/hooks/useGuardRole", async () => {
-  const actual = await vi.importActual<typeof import("@/hooks/useGuardRole")>(
-    "@/hooks/useGuardRole",
-  )
-  return {
-    ...actual,
-    useGuardRole: () => mockUseGuardRole(),
-  }
-})
-
-function setRole(role: GuardRole | null) {
-  mockUseGuardRole.mockReturnValue({ role })
-}
-
-const PUBLIC_LABELS = ["Activity", "Spend", "Policies", "Approvals", "Discovery"]
-
-describe("GUARD_TABS static shape", () => {
-  it("restricts Compliance to admin + security", () => {
-    const compliance = GUARD_TABS.find(t => t.label === "Compliance")
-    expect(compliance?.roles).toEqual(["admin", "security"])
-  })
-
-  it("restricts Settings to admin only", () => {
-    const settings = GUARD_TABS.find(t => t.label === "Settings")
-    expect(settings?.roles).toEqual(["admin"])
-  })
-
-  it("marks public tabs (Activity, Spend, Policies, Approvals, Discovery) with no role gate", () => {
-    for (const label of PUBLIC_LABELS) {
-      const tab = GUARD_TABS.find(t => t.label === label)
-      expect(tab?.roles).toBeUndefined()
-    }
-  })
-})
-
-describe("GuardShell nav rendering by role", () => {
-  beforeEach(() => {
-    mockUseGuardRole.mockReset()
-  })
-
-  it("shows all 5 public tabs regardless of role (admin case)", () => {
-    setRole("admin")
+describe("GuardShell — six-section IA", () => {
+  it("renders every GUARD_SECTIONS entry as a nav link", () => {
     render(<GuardShell>content</GuardShell>)
-    for (const label of PUBLIC_LABELS) {
-      expect(screen.getByRole("link", { name: label })).toBeInTheDocument()
+    for (const s of GUARD_SECTIONS) {
+      expect(screen.getByRole("link", { name: s.label })).toBeInTheDocument()
     }
   })
 
-  it("shows all 5 public tabs when role is null (unauthenticated / loading)", () => {
-    setRole(null)
-    render(<GuardShell>content</GuardShell>)
-    for (const label of PUBLIC_LABELS) {
-      expect(screen.getByRole("link", { name: label })).toBeInTheDocument()
-    }
-  })
-
-  it("shows Compliance for admin", () => {
-    setRole("admin")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.getByRole("link", { name: "Compliance" })).toBeInTheDocument()
-  })
-
-  it("shows Compliance for security", () => {
-    setRole("security")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.getByRole("link", { name: "Compliance" })).toBeInTheDocument()
-  })
-
-  it("hides Compliance from developer", () => {
-    setRole("developer")
+  it("keeps Compliance and Settings OUT of the rail (palette-only)", () => {
     render(<GuardShell>content</GuardShell>)
     expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
-  })
-
-  it("hides Compliance from viewer", () => {
-    setRole("viewer")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
-  })
-
-  it("hides Compliance when role is null", () => {
-    setRole(null)
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
-  })
-
-  it("shows Settings for admin only", () => {
-    setRole("admin")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument()
-  })
-
-  it("hides Settings from security", () => {
-    setRole("security")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
-  })
-
-  it("hides Settings from developer", () => {
-    setRole("developer")
-    render(<GuardShell>content</GuardShell>)
-    expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
-  })
-
-  it("hides Settings from viewer", () => {
-    setRole("viewer")
-    render(<GuardShell>content</GuardShell>)
     expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
   })
 
   it("renders children inside the shell", () => {
-    setRole("admin")
     render(<GuardShell>hello body</GuardShell>)
     expect(screen.getByText("hello body")).toBeInTheDocument()
   })

--- a/apps/web/src/lib/navigation/guardSections.ts
+++ b/apps/web/src/lib/navigation/guardSections.ts
@@ -1,0 +1,41 @@
+// Guard six-section IA. Single source of truth for:
+// - AppShell palette + sidebar sub-nav + breadcrumbs
+// - GuardShell vertical rail
+//
+// Pages not represented here (compliance, settings, team-memory, approvals)
+// stay reachable via URL + ⌘K palette entries.
+
+export type GuardSectionId =
+  | "overview"
+  | "agents"
+  | "controls"
+  | "activity"
+  | "spend"
+  | "connections"
+
+export interface GuardSection {
+  id: GuardSectionId
+  label: string
+  href: string
+  activePrefixes: readonly string[]
+}
+
+export const GUARD_SECTIONS: readonly GuardSection[] = [
+  { id: "overview",    label: "Overview",    href: "/theguard",                   activePrefixes: ["/theguard"] },
+  { id: "agents",      label: "Agents",      href: "/theguard/discovery",         activePrefixes: ["/theguard/discovery"] },
+  { id: "controls",    label: "Controls",    href: "/theguard/policies",          activePrefixes: ["/theguard/policies", "/theguard/approvals"] },
+  { id: "activity",    label: "Activity",    href: "/logs/guard",                 activePrefixes: ["/logs/guard", "/theguard/activity", "/theguard/blocks"] },
+  { id: "spend",       label: "Spend",       href: "/theguard/spend",             activePrefixes: ["/theguard/spend"] },
+  { id: "connections", label: "Connections", href: "/theguard/connections/proxy", activePrefixes: ["/theguard/connections"] },
+]
+
+export function activeGuardSection(pathname: string): GuardSectionId | null {
+  if (pathname === "/theguard") return "overview"
+  for (const s of GUARD_SECTIONS) {
+    if (s.id === "overview") continue
+    if (s.activePrefixes.some(p => pathname === p || pathname.startsWith(p + "/"))) {
+      return s.id
+    }
+  }
+  return null
+}

--- a/apps/web/src/lib/reportBuilder/renderers.tsx
+++ b/apps/web/src/lib/reportBuilder/renderers.tsx
@@ -315,7 +315,7 @@ function ListBody({ data }: { data: WidgetData }) {
   }
   if (data.tool === "list_agent_status") {
     const rows = data.data
-    if (rows.length === 0) return <EmptyBody>No agents.</EmptyBody>
+    if (rows.length === 0) return <EmptyBody>No workflows.</EmptyBody>
     return (
       <ul style={{ listStyle: "none", padding: 0, margin: 0, fontSize: 12 }}>
         {rows.slice(0, 8).map((r, i) => (
@@ -423,7 +423,7 @@ function TableBody({ data }: { data: WidgetData }) {
 function AgentRowBody({ data }: { data: WidgetData }) {
   if (data.tool !== "list_agent_health") return null
   const rows = data.data
-  if (rows.length === 0) return <EmptyBody>No agents.</EmptyBody>
+  if (rows.length === 0) return <EmptyBody>No workflows.</EmptyBody>
   return (
     <div style={{ display: "flex", gap: 8, overflowX: "auto", paddingBottom: 4 }}>
       {rows.slice(0, 12).map((r) => {


### PR DESCRIPTION
## Summary

Phase **1b** of the Guard six-section IA rollout, plus two 1a follow-ups that were dropped by the squash-merge of #1833.

**1b — the actual six-section IA:**
- New \`lib/navigation/guardSections.ts\` — single source of truth for the six sections (Overview / Agents / Controls / Activity / Spend / Connections). Includes an \`activeGuardSection(pathname)\` matcher.
- \`AppShell.tsx\` — palette + sidebar sub-nav render from the shared const. Guard sidebar becomes active on \`/logs/guard\` too (Activity's canonical URL). Breadcrumbs extended for Connections + Approvals. Legacy \`Agents\`/\`New agent\` breadcrumb strings cleaned to \`Workflows\`/\`New workflow\`.
- \`GuardShell.tsx\` — horizontal \`guard-tab-nav\` row replaced with a **200px + 1fr vertical rail** (matching SettingsShell's pattern). Header / badges / live indicator / lastFetched timestamp preserved. \`GUARD_TABS\` export removed; \`useGuardRole\` dependency dropped.
- \`GuardShell.test.tsx\` — rewritten (15 tests → 3): asserts the six sections render, Compliance/Settings stay OUT of the rail, children render.

**1a follow-ups (missed by squash):**
- Wrap Guard Proxy page in \`AppShell\` so the sidebar renders (users on \`/theguard/connections/proxy\` today see no sidebar).
- Sweep 10 user-visible \"Agent\" copy strings to \"Workflow\" across \`/workflows\`, \`/projects/[id]\`, dashboard, onboarding, packs, report builder.

## Explicitly kept
- CSS class \`.guard-tab-nav\` in \`globals.css\` — Secure module still uses it.
- \`/theguard/discovery\` \"No agents discovered yet\" — that's Guard Agent Discovery (autonomous AI agents), distinct from workflows.
- Internal identifiers (\`renameAgent\`, \`deleteAgent\`, \`agentName\` state, \`AgentStatusPill\`) — Phase 2 refactor.
- Compliance, Guard Settings, Team Memory, Approvals: reachable via URL and ⌘K palette. Rail entries land in 1c with the child pages.

## Layout impact
GuardShell now grows a 220px vertical rail inside its 1240px container. Content columns shrink from ~1240px to ~1000px (−18%). Guard Spend has wide tables — may need horizontal scroll on narrow displays. Fine for 1b; polish is 1c+.

## Test plan
- [ ] Typecheck (\`npm run typecheck --workspace apps/web\`) clean.
- [ ] GuardShell.test.tsx passes.
- [ ] \`/theguard/connections/proxy\` now shows the app sidebar + Guard vertical rail with \"Connections\" highlighted.
- [ ] \`/theguard\`, \`/theguard/policies\`, \`/theguard/spend\`, \`/theguard/discovery\`, \`/logs/guard\` all render the same vertical rail with the correct section highlighted.
- [ ] Sidebar's \"Guard\" item shows the six sub-nav sections when any Guard page is active.
- [ ] ⌘K palette lists Overview / Agents / Controls / Activity / Spend / Connections + Compliance + Settings.
- [ ] \`/workflows\` page reads \"Workflows\" / \"New workflow\" throughout.
- [ ] \`/settings?tab=proxy\` still redirects to the new Guard page.