### PR TITLE
feat(web): Guard IA 1c — URL-addressable settings tabs

### DIFF
--- a/apps/web/src/app/(app)/theguard/agents/page.tsx
+++ b/apps/web/src/app/(app)/theguard/agents/page.tsx
@@ -3,13 +3,14 @@ import { redirect } from "next/navigation"
 // Guard IA 1c: Agents section canonical URL. Redirects to the existing
 // Agent Identity page until the physical move in Phase 2.
 // Preserves any incoming query (e.g. ?tab=tokens) so deep links keep working.
-export default function GuardAgentsPage({
+export default async function GuardAgentsPage({
   searchParams,
 }: {
-  searchParams?: Record<string, string | string[] | undefined>
+  searchParams?: Promise<Record<string, string | string[] | undefined>>
 }) {
+  const params = (await searchParams) ?? {}
   const qs = new URLSearchParams()
-  for (const [k, v] of Object.entries(searchParams ?? {})) {
+  for (const [k, v] of Object.entries(params)) {
     if (typeof v === "string") qs.set(k, v)
     else if (Array.isArray(v) && v[0]) qs.set(k, v[0])
   }

--- a/apps/web/src/app/(app)/theguard/agents/page.tsx
+++ b/apps/web/src/app/(app)/theguard/agents/page.tsx
@@ -1,0 +1,18 @@
+import { redirect } from "next/navigation"
+
+// Guard IA 1c: Agents section canonical URL. Redirects to the existing
+// Agent Identity page until the physical move in Phase 2.
+// Preserves any incoming query (e.g. ?tab=tokens) so deep links keep working.
+export default function GuardAgentsPage({
+  searchParams,
+}: {
+  searchParams?: Record<string, string | string[] | undefined>
+}) {
+  const qs = new URLSearchParams()
+  for (const [k, v] of Object.entries(searchParams ?? {})) {
+    if (typeof v === "string") qs.set(k, v)
+    else if (Array.isArray(v) && v[0]) qs.set(k, v[0])
+  }
+  const suffix = qs.toString()
+  redirect(suffix ? `/agent-identity?${suffix}` : "/agent-identity")
+}

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -846,12 +846,12 @@ function AppShellInnerContent({
                 href="/theguard"
                 label="Guard"
                 icon={<Icons.Shield />}
-                active={pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard")}
+                active={pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard") || pathname.startsWith("/agent-identity")}
                 collapsed={collapsed}
               />
               {/* Guard sub-nav — six-section IA. Compliance/Settings/Team Memory reachable via ⌘K.
                   /logs/guard is Guard's Activity section, so it also opens this sub-nav. */}
-              {(pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard")) && !collapsed && (
+              {(pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard") || pathname.startsWith("/agent-identity")) && !collapsed && (
                 <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 2, display: "flex", flexDirection: "column", gap: 1 }}>
                   {GUARD_SECTIONS.map(sub => {
                     const subActive = sub.id === "overview"

--- a/apps/web/src/components/SettingsShell.tsx
+++ b/apps/web/src/components/SettingsShell.tsx
@@ -16,7 +16,8 @@
  * title — SettingsShell then renders only the left rail + panels.
  */
 
-import { useState, type ReactNode } from "react"
+import { useEffect, useState, type ReactNode } from "react"
+import { usePathname, useRouter, useSearchParams } from "next/navigation"
 import AppShell from "@/components/AppShell"
 
 export interface SettingsTab<K extends string> {
@@ -48,7 +49,26 @@ export function SettingsShell<K extends string>({
 }) {
   const visibleTabs = tabs.filter(t => !t.adminOnly || isAdmin)
   const firstKey = visibleTabs[0]?.key as K
-  const [activeTab, setActiveTab] = useState<K>(initialTab ?? firstKey)
+
+  // URL-aware: ?tab=<key> wins over initialTab. Falls back cleanly when no query.
+  const searchParams = useSearchParams()
+  const router = useRouter()
+  const pathname = usePathname()
+  const urlTab = searchParams?.get("tab") as K | null
+  const urlTabValid = urlTab != null && visibleTabs.some(t => t.key === urlTab)
+  const [activeTab, setActiveTab] = useState<K>(urlTabValid ? (urlTab as K) : (initialTab ?? firstKey))
+
+  // Sync selection when browser back/forward changes ?tab=
+  useEffect(() => {
+    if (urlTabValid && urlTab !== activeTab) setActiveTab(urlTab as K)
+  }, [urlTab, urlTabValid, activeTab])
+
+  function selectTab(key: K) {
+    setActiveTab(key)
+    const params = new URLSearchParams(searchParams?.toString() ?? "")
+    params.set("tab", key)
+    router.replace(`${pathname}?${params.toString()}`, { scroll: false })
+  }
 
   const body = (
     <>
@@ -81,7 +101,7 @@ export function SettingsShell<K extends string>({
                 aria-selected={active}
                 aria-controls={`tabpanel-${t.key}`}
                 id={`tab-${t.key}`}
-                onClick={() => setActiveTab(t.key)}
+                onClick={() => selectTab(t.key)}
                 style={{
                   textAlign: "left",
                   padding: "8px 12px",

--- a/apps/web/src/lib/navigation/guardSections.ts
+++ b/apps/web/src/lib/navigation/guardSections.ts
@@ -22,7 +22,7 @@ export interface GuardSection {
 
 export const GUARD_SECTIONS: readonly GuardSection[] = [
   { id: "overview",    label: "Overview",    href: "/theguard",                   activePrefixes: ["/theguard"] },
-  { id: "agents",      label: "Agents",      href: "/theguard/discovery",         activePrefixes: ["/theguard/discovery"] },
+  { id: "agents",      label: "Agents",      href: "/theguard/discovery",         activePrefixes: ["/theguard/discovery", "/theguard/agents", "/agent-identity"] },
   { id: "controls",    label: "Controls",    href: "/theguard/policies",          activePrefixes: ["/theguard/policies", "/theguard/approvals"] },
   { id: "activity",    label: "Activity",    href: "/logs/guard",                 activePrefixes: ["/logs/guard", "/theguard/activity", "/theguard/blocks"] },
   { id: "spend",       label: "Spend",       href: "/theguard/spend",             activePrefixes: ["/theguard/spend"] },


### PR DESCRIPTION
## Summary

Phase **1c** of the Guard six-section IA rollout — small addressability improvements. No sidebar or rail changes.

- **SettingsShell URL-aware:** reads `?tab=` on mount, syncs on browser back/forward, writes on click via `router.replace`. Bookmarking `/theguard/settings?tab=notifications` now opens Notifications directly. Falls back to `initialTab` when the query is missing or invalid.
- **`/theguard/agents` URL alias:** server-side redirect to `/agent-identity`, preserving any incoming query so `?tab=tokens` deep links keep working. Rail landing is unchanged (still `/theguard/discovery`) — this URL is for people who type or bookmark the canonical Agents path.
- **Highlight follows the redirect:** `guardSections.ts` Agents `activePrefixes` extended to `[/theguard/discovery, /theguard/agents, /agent-identity]`. AppShell Guard sub-nav trigger extended to `/agent-identity` so the sidebar Guard group stays open with Agents highlighted after the redirect lands.

## Diff
4 files, +32 / −6.

| File | Delta |
|---|---|
| \`SettingsShell.tsx\` | +19 / −3 (URL sync) |
| \`theguard/agents/page.tsx\` | +18 new (server redirect) |
| \`guardSections.ts\` | +1 / −1 (activePrefixes extended) |
| \`AppShell.tsx\` | +1 / −1 (trigger extension) |

## Deferred to Phase 2
Canonical section-child URLs like \`/theguard/policies/enforcement\`, \`/theguard/connections/notifications\`, \`/theguard/connections/sync\`, \`/theguard/spend/optimization\` don't ship here. The panels are all inline JSX inside the 940-line \`/theguard/settings/page.tsx\` — extracting them cleanly is Phase 2 §6.5 step 2. Users can bookmark \`/theguard/settings?tab=<key>\` today for the same addressability.

## Test plan
- [ ] \`npm run typecheck --workspace apps/web\` clean (verified locally).
- [ ] GuardShell tests still pass (verified locally, 3/3).
- [ ] \`/theguard/settings?tab=enforcement\` opens Enforcement directly.
- [ ] \`/theguard/settings?tab=notifications\`, \`?tab=sync\`, \`?tab=guardrails\` all work.
- [ ] Clicking a tab in Guard Settings updates the URL in place; browser back returns to the previous tab.
- [ ] Same for general \`/settings?tab=<key>\`.
- [ ] \`/theguard/agents\` redirects to \`/agent-identity\`.
- [ ] \`/theguard/agents?tab=tokens\` redirects to \`/agent-identity?tab=tokens\`.
- [ ] On \`/agent-identity\`, the AppShell sidebar shows Guard expanded with Agents highlighted.
- [ ] Existing \`/settings?tab=proxy\` legacy redirect (1a) still works.

## Next: Phase 1d
Layout refactor — pin the Guard rail truly-left against the page edge (not indented inside the 1240px container), header aligns to the content column, add a collapse toggle for the rail (icon-only strip when collapsed).