### PR TITLE
fix(litellm-guard): rename fail_mode → unreachable_fallback (deprecation alias) — v0.2.5

### DIFF
--- a/packages/conduct-litellm-guard/README.md
+++ b/packages/conduct-litellm-guard/README.md
@@ -32,7 +32,7 @@ pip install conduct-litellm-guard
          mode: pre_call
          api_url: https://api.conductai.ai
          agent_token: os.environ/CONDUCT_AGENT_TOKEN
-         fail_mode: fail_closed
+         unreachable_fallback: fail_closed
    ```
 
    **Native (once [BerriAI/litellm#38143](https://github.com/BerriAI/litellm/pull/38143) merges):**
@@ -43,7 +43,7 @@ pip install conduct-litellm-guard
          guardrail: conduct
          mode: pre_call
          api_key: os.environ/CONDUCT_AGENT_TOKEN
-         fail_mode: fail_closed
+         unreachable_fallback: fail_closed
    ```
    The native form uses LiteLLM's idiomatic `api_base` / `api_key`
    parameter names. You still install this package —
@@ -82,7 +82,7 @@ Guard returns one of five verdicts:
 | `api_url`     | no       | `https://api.conductai.ai` | Point at a self-hosted Conduct API when needed.           |
 | `agent_token` | yes      | `CONDUCT_AGENT_TOKEN` env  | `cond_agt_*` token minted in the Conduct console.         |
 | `workspace_id`| no       | resolved from the token    | Usually unnecessary — the token owns its workspace.       |
-| `fail_mode`   | no       | `fail_closed`              | `fail_closed` blocks when Guard is unreachable, `fail_open` allows. |
+| `unreachable_fallback`   | no       | `fail_closed`              | `fail_closed` blocks when Guard is unreachable, `fail_open` allows. Renamed from `fail_mode` in v0.2.5 — the old name still works with a DeprecationWarning and is removed in v0.3.0. |
 | `timeout`     | no       | `8.0`                      | Seconds. Guard checks return in <100ms in the healthy path. |
 
 ## Session tracking

--- a/packages/conduct-litellm-guard/examples/config.yaml
+++ b/packages/conduct-litellm-guard/examples/config.yaml
@@ -31,7 +31,7 @@ guardrails:
       workspace_id: os.environ/CONDUCT_WORKSPACE_ID
       # fail_closed = deny if Guard is unreachable. Matches Conduct's
       # default posture across every enforcement surface.
-      fail_mode: fail_closed
+      unreachable_fallback: fail_closed
       # How long a single guard_check may take before the fail-mode
       # kicks in. 8s is generous — a healthy Guard responds in <100ms.
       timeout: 8.0

--- a/packages/conduct-litellm-guard/examples/proliferate/config.patch.yaml
+++ b/packages/conduct-litellm-guard/examples/proliferate/config.patch.yaml
@@ -11,7 +11,7 @@ guardrails:
       mode: pre_call
       api_url: https://api.conductai.ai
       agent_token: os.environ/CONDUCT_AGENT_TOKEN
-      fail_mode: fail_closed
+      unreachable_fallback: fail_closed
       # tool_name=workflow reuses existing pack rules that scope to
       # filesystem-write,workflow (e.g. conduct-owasp:no-aws-keys).
       # Drop this line once packs ship the llm_call scope natively.

--- a/packages/conduct-litellm-guard/pyproject.toml
+++ b/packages/conduct-litellm-guard/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "conduct-litellm-guard"
-version = "0.2.4"
+version = "0.2.5"
 description = "Runtime governance for AI agents. Conduct Guard as a LiteLLM guardrail — enforce runtime policy on every LLM call routed through LiteLLM."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/__init__.py
@@ -15,7 +15,7 @@ Basic usage in a LiteLLM ``config.yaml``::
           mode: pre_call
           api_url: https://api.conductai.ai
           agent_token: os.environ/CONDUCT_AGENT_TOKEN
-          fail_mode: fail_closed
+          unreachable_fallback: fail_closed
 """
 from conduct_litellm_guard.guardrail import ConductGuard, GuardDecision
 

--- a/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
+++ b/packages/conduct-litellm-guard/src/conduct_litellm_guard/guardrail.py
@@ -198,7 +198,17 @@ class ConductGuard(CustomGuardrail):
         api_url: str | None = None,
         agent_token: str | None = None,
         workspace_id: str | None = None,
-        fail_mode: FailMode = "fail_closed",
+        # Rename per BerriAI/litellm#38143 (yucheng-berri, Sep 2026).
+        # `fail_mode` silently defaulted to fail-open on typo in the config
+        # field name. `unreachable_fallback` matches the typed field in
+        # LitellmParams (Pydantic-validated), so a typo now surfaces a
+        # config error instead of quietly bypassing the safe default.
+        unreachable_fallback: FailMode | None = None,
+        # Deprecated alias — keep for one release cycle (through 0.2.x).
+        # Callers using the old name get a DeprecationWarning; combined
+        # with the ``or`` chain below, an unset value falls through to
+        # the ``fail_closed`` default.
+        fail_mode: FailMode | None = None,
         tool_name: str = "llm_call",
         timeout: float = 8.0,
         # LiteLLM CustomGuardrail kwargs — accept and forward.
@@ -218,7 +228,15 @@ class ConductGuard(CustomGuardrail):
             )
         self._agent_token = token
         self._workspace_id = workspace_id or os.environ.get("CONDUCT_WORKSPACE_ID")
-        self._fail_mode: FailMode = fail_mode
+        if fail_mode is not None:
+            import warnings as _w
+            _w.warn(
+                "ConductGuard: `fail_mode=` is deprecated in favor of "
+                "`unreachable_fallback=` and will be removed in v0.3.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        self._unreachable_fallback: FailMode = unreachable_fallback or fail_mode or "fail_closed"
         # Kept for config-compat; no longer used. The plugin now routes
         # through guard_check_prompt (prompt-gate → proxy-persona rules),
         # so match_tool is not the filter — match_pattern on the prompt is.
@@ -278,8 +296,8 @@ class ConductGuard(CustomGuardrail):
                 session_id=session_id,
             )
         except GuardCheckError as e:
-            log.warning("conduct_guard: eval error %s — applying %s", e, self._fail_mode)
-            if self._fail_mode == "fail_closed":
+            log.warning("conduct_guard: eval error %s — applying %s", e, self._unreachable_fallback)
+            if self._unreachable_fallback == "fail_closed":
                 return GuardDecision(
                     verdict="block",
                     raw=str(e),
@@ -287,8 +305,8 @@ class ConductGuard(CustomGuardrail):
                 )
             return GuardDecision(verdict="allow", raw="fail_open")
         except Exception as e:  # network, timeout, unexpected
-            log.warning("conduct_guard: transport error %s — applying %s", e, self._fail_mode)
-            if self._fail_mode == "fail_closed":
+            log.warning("conduct_guard: transport error %s — applying %s", e, self._unreachable_fallback)
+            if self._unreachable_fallback == "fail_closed":
                 return GuardDecision(
                     verdict="block",
                     raw=str(e),

--- a/packages/conduct-litellm-guard/tests/test_guardrail.py
+++ b/packages/conduct-litellm-guard/tests/test_guardrail.py
@@ -139,13 +139,13 @@ class TestPreCallHook:
 
 class TestFailModes:
     async def test_fail_closed_blocks_on_network_error(self) -> None:
-        g = ConductGuard(fail_mode="fail_closed")
+        g = ConductGuard(unreachable_fallback="fail_closed")
         g._client.guard_check = AsyncMock(side_effect=RuntimeError("connection refused"))
         decision = await g.check(data={}, call_type="completion")
         assert decision.verdict == "block"
 
     async def test_fail_open_allows_on_network_error(self) -> None:
-        g = ConductGuard(fail_mode="fail_open")
+        g = ConductGuard(unreachable_fallback="fail_open")
         g._client.guard_check = AsyncMock(side_effect=RuntimeError("connection refused"))
         decision = await g.check(data={}, call_type="completion")
         assert decision.verdict == "allow"
@@ -156,6 +156,22 @@ class TestFailModes:
         monkeypatch.delenv("CONDUCT_AGENT_TOKEN", raising=False)
         with pytest.raises(ValueError, match="agent_token"):
             ConductGuard()
+
+    def test_legacy_fail_mode_kwarg_still_works_with_deprecation_warning(self) -> None:
+        """`fail_mode=` was renamed to `unreachable_fallback=` per
+        BerriAI/litellm#38143 (yucheng-berri, Sep 2026). Legacy callers
+        (v0.2.4 and earlier) must keep working for one release cycle with
+        a DeprecationWarning nudging them to migrate. Removal in v0.3.0."""
+        with pytest.warns(DeprecationWarning, match="fail_mode.*deprecated"):
+            g = ConductGuard(fail_mode="fail_open")
+        assert g._unreachable_fallback == "fail_open"
+
+    def test_unreachable_fallback_wins_over_legacy_fail_mode_when_both_given(self) -> None:
+        """If a caller passes both, the new name wins so nobody is
+        surprised by a silent downgrade to the deprecated field."""
+        with pytest.warns(DeprecationWarning):
+            g = ConductGuard(unreachable_fallback="fail_closed", fail_mode="fail_open")
+        assert g._unreachable_fallback == "fail_closed"
 
 
 # ── Session-ID chain ───────────────────────────────────────────────────

--- a/packages/conduct-litellm-guard/upstream-docs/conduct.md
+++ b/packages/conduct-litellm-guard/upstream-docs/conduct.md
@@ -55,7 +55,7 @@ guardrails:
       mode: pre_call
       api_key: os.environ/CONDUCT_AGENT_TOKEN
       api_base: https://api.conductai.ai         # optional, defaults to hosted
-      fail_mode: fail_closed                      # or fail_open
+      unreachable_fallback: fail_closed                      # or fail_open
       default_on: true
 ```
 
@@ -73,7 +73,7 @@ guardrails:
 | `api_key`       | yes      | `CONDUCT_AGENT_TOKEN` env  | `cond_agt_*` token minted in the Conduct console.                        |
 | `api_base`      | no       | `https://api.conductai.ai` | Point at a self-hosted Conduct API when needed.                          |
 | `workspace_id`  | no       | resolved from the token    | Usually unnecessary — the token owns its workspace.                      |
-| `fail_mode`     | no       | `fail_closed`              | `fail_closed` blocks when Guard is unreachable; `fail_open` allows.      |
+| `unreachable_fallback`     | no       | `fail_closed`              | `fail_closed` blocks when Guard is unreachable; `fail_open` allows.      |
 | `tool_name`     | no       | `llm_call`                 | Deprecated in 0.2.0 — accepted for config-compat, ignored at runtime. The plugin now hits the `guard_check_prompt` MCP verb, so rule matching is by `match_pattern` on the outbound prompt, not by `match_tool`. Delete the field on your next config edit. |
 | `timeout`       | no       | `8.0`                      | Seconds. Guard responds in <100ms in the healthy path.                   |
 


### PR DESCRIPTION
## Summary

Renames the \`ConductGuard\` constructor kwarg \`fail_mode\` → \`unreachable_fallback\` per [BerriAI/litellm#38143](https://github.com/BerriAI/litellm/pull/38143) yucheng-berri CHANGES_REQUESTED review. Old name kept as a deprecated alias for one release cycle (through 0.2.x), removal in v0.3.0.

## Why

Yucheng's original concern: the config field \`fail_mode\` silently fell back to fail-open on typo, because a misnamed field just wasn't read and the default was permissive. LiteLLM's shim already reads the typed \`LitellmParams.unreachable_fallback\` field (Pydantic-validated) so a typo now surfaces a config error there. This PR completes the alignment on our standalone package side so anyone importing \`ConductGuard\` directly gets the same benefit.

## Changes

- **\`ConductGuard.__init__\`** — accepts \`unreachable_fallback: FailMode\` as the primary kwarg; \`fail_mode: FailMode | None\` kept as deprecated alias emitting a \`DeprecationWarning\`. \`unreachable_fallback\` wins if both are given (no silent downgrade to the deprecated field).
- **Internal state** — \`self._fail_mode\` → \`self._unreachable_fallback\` (2 log lines, 2 fail-mode branches in \`check()\`).
- **Version** — 0.2.4 → 0.2.5.
- **Tests** — updated to use \`unreachable_fallback=\`; two new tests lock the deprecation-warning path and the \"both given, new wins\" behavior. 30/30 pass locally.
- **Docs** — README, config examples, module docstring, and upstream-docs/conduct.md all swept to \`unreachable_fallback\`. Note added on the README config table row so upgraders know both names accept.

## Backward compat

Zero breaking. Existing 0.2.4 callers continue to work with a stderr DeprecationWarning nudging them to migrate. LiteLLM users unaffected — the shim already uses \`unreachable_fallback\` at the config level.

## After merge

- Ship 0.2.5 to PyPI: \`cd packages/conduct-litellm-guard && python -m build && twine upload dist/*\`
- Small follow-up PR to BerriAI/litellm branch \`feat/guardrails-conduct\` bumping the shim's \`_import_error_message\` version pin from \`>=0.2.4\` → \`>=0.2.5\` **and** changing the internal call from \`fail_mode=unreachable_fallback\` → \`unreachable_fallback=unreachable_fallback\` so the shim doesn't trip its own deprecation warning on every guardrail init.

## Test plan

- [x] Local unit tests: 30/30 pass in the worktree
- [ ] After merge: PyPI 0.2.5 published, verify via \`pip install conduct-litellm-guard==0.2.5\` from a fresh venv
- [ ] Ship the shim tweak PR to BerriAI/litellm; verify Bugbot re-runs green
- [ ] Reply to yucheng on #38143 with the summary

## Related

- BerriAI/litellm#38143 — the LiteLLM plugin PR this addresses
- yucheng-berri's CHANGES_REQUESTED review (2026-09-10 23:47 UTC) — the source of the ask