### PR TITLE
feat(web): Guard IA 1d — collapsible truly-left rail + admin cluster

### DIFF
--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -849,37 +849,7 @@ function AppShellInnerContent({
                 active={pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard") || pathname.startsWith("/agent-identity")}
                 collapsed={collapsed}
               />
-              {/* Guard sub-nav — six-section IA. Compliance/Settings/Team Memory reachable via ⌘K.
-                  /logs/guard is Guard's Activity section, so it also opens this sub-nav. */}
-              {(pathname.startsWith("/theguard") || pathname.startsWith("/logs/guard") || pathname.startsWith("/agent-identity")) && !collapsed && (
-                <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 2, display: "flex", flexDirection: "column", gap: 1 }}>
-                  {GUARD_SECTIONS.map(sub => {
-                    const subActive = sub.id === "overview"
-                      ? pathname === "/theguard"
-                      : sub.activePrefixes.some(p => pathname === p || pathname.startsWith(p + "/"))
-                    return (
-                      <Link
-                        key={sub.href}
-                        href={sub.href}
-                        style={{
-                          display: "block",
-                          padding: "5px 10px",
-                          borderRadius: 7,
-                          fontSize: 13,
-                          fontWeight: subActive ? 600 : 400,
-                          color: subActive ? "var(--accent-text)" : "var(--text-3)",
-                          background: subActive ? "var(--accent-weak)" : "transparent",
-                          textDecoration: "none",
-                        }}
-                        onMouseEnter={(e: ReactMouseEvent<HTMLElement>) => { if (!subActive) (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)" }}
-                        onMouseLeave={(e: ReactMouseEvent<HTMLElement>) => { if (!subActive) (e.currentTarget as HTMLAnchorElement).style.background = "transparent" }}
-                      >
-                        {sub.label}
-                      </Link>
-                    )
-                  })}
-                </div>
-              )}
+              {/* Guard sub-nav removed — GuardShell now owns the section rail so both don't render the same six items. */}
               <SideNavItem
                 href="/secure"
                 label="Secure"

--- a/apps/web/src/components/guard/GuardShell.tsx
+++ b/apps/web/src/components/guard/GuardShell.tsx
@@ -3,7 +3,12 @@
 import { useEffect, useState } from "react"
 import Link from "next/link"
 import { usePathname } from "next/navigation"
-import { GUARD_SECTIONS, activeGuardSection } from "@/lib/navigation/guardSections"
+import { useGuardRole } from "@/hooks/useGuardRole"
+import { GUARD_SECTIONS, activeGuardSection, type GuardSectionId } from "@/lib/navigation/guardSections"
+
+const COLLAPSE_KEY = "guard:railCollapsed"
+const RAIL_EXPANDED = 200
+const RAIL_COLLAPSED = 56
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -17,19 +22,82 @@ function relativeTime(ts: Date | null | undefined): string {
   return `${Math.floor(min / 60)}h ago`
 }
 
+function SectionIcon({ id }: { id: GuardSectionId }) {
+  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
+  switch (id) {
+    case "overview":    return <svg {...common}><path d="M3 3h7v7H3zm11 0h7v7h-7zM3 14h7v7H3zm11 0h7v7h-7z" /></svg>
+    case "agents":      return <svg {...common}><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M23 21v-2a4 4 0 00-3-3.87M16 3.13a4 4 0 010 7.75" /></svg>
+    case "controls":    return <svg {...common}><rect x="3" y="11" width="18" height="11" rx="2" /><path d="M7 11V7a5 5 0 0110 0v4" /></svg>
+    case "activity":    return <svg {...common}><polyline points="22 12 18 12 15 21 9 3 6 12 2 12" /></svg>
+    case "spend":       return <svg {...common}><path d="M12 2v20M17 5H9.5a3.5 3.5 0 000 7h5a3.5 3.5 0 010 7H6" /></svg>
+    case "connections": return <svg {...common}><path d="M9 3v4M15 3v4M9 7a3 3 0 000 6h6a3 3 0 000-6M12 13v8" /></svg>
+  }
+}
+
+function ComplianceIcon() {
+  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
+  return <svg {...common}><path d="M9 12l2 2 4-4" /><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
+}
+
+function SettingsIcon() {
+  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
+  return <svg {...common}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" /></svg>
+}
+
+function ChevronLeft() {
+  return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+}
+
+function ChevronRight() {
+  return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+}
+
+// ─── Rail item ────────────────────────────────────────────────────────────────
+
+function RailItem({
+  href, label, icon, active, collapsed,
+}: {
+  href: string
+  label: string
+  icon: React.ReactNode
+  active: boolean
+  collapsed: boolean
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
+      aria-label={collapsed ? label : undefined}
+      title={collapsed ? label : undefined}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: collapsed ? "8px" : "8px 12px",
+        justifyContent: collapsed ? "center" : "flex-start",
+        fontSize: 13.5,
+        fontWeight: active ? 650 : 500,
+        color: active ? "var(--text)" : "var(--text-3)",
+        background: active ? "var(--surface-2)" : "transparent",
+        borderRadius: 6,
+        textDecoration: "none",
+        transition: "background .12s, color .12s",
+      }}
+    >
+      <span style={{ display: "flex", flexShrink: 0 }}>{icon}</span>
+      {!collapsed && <span>{label}</span>}
+    </Link>
+  )
+}
+
 // ─── Props ────────────────────────────────────────────────────────────────────
 
 export interface GuardShellProps {
   children: React.ReactNode
-  /** Shown in the header as "last updated X ago". Omit to hide the timestamp. */
   lastFetched?: Date | null
-  /** Controls the green "live" / grey "offline" badge. Defaults to true. */
   live?: boolean
-  /** Agent rule count — shown in header badge. */
   agentCount?: number | null
-  /** Proxy rule count — shown in header badge. */
   proxyCount?: number | null
-  /** Shows "Advisory" badge when Guard is in advisory mode. */
   advisory?: boolean
 }
 
@@ -46,93 +114,162 @@ export function GuardShell({
   const pathname = usePathname()
   const [, setTick] = useState(0)
   const activeId = activeGuardSection(pathname ?? "")
+  const { role } = useGuardRole()
 
-  // Re-render every 10 s so the relative timestamp stays fresh
+  const [collapsed, setCollapsed] = useState(false)
+
+  // Hydrate collapse state from localStorage on mount.
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try { if (window.localStorage.getItem(COLLAPSE_KEY) === "1") setCollapsed(true) } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try { window.localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0") } catch { /* ignore */ }
+  }, [collapsed])
+
+  // Re-render every 10s so the "last updated" timestamp stays fresh.
   useEffect(() => {
     const t = setInterval(() => setTick(n => n + 1), 10_000)
     return () => clearInterval(t)
   }, [])
 
-  return (
-    <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
-      {/* Page head */}
-      <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
-        <div>
-          <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
-            <h1 style={{ fontSize: 22, fontWeight: 700, color: "var(--text)", letterSpacing: "-.02em", margin: 0 }}>
-              Guard
-            </h1>
-            {live ? (
-              <span className="sbadge ok" style={{ marginTop: 2 }}>
-                <span className="conduct-pulse-dot" />
-                live
-              </span>
-            ) : (
-              <span className="sbadge" style={{ marginTop: 2, background: "var(--surface-3)", color: "var(--text-muted)", border: "1px solid var(--border)" }}>
-                offline
-              </span>
-            )}
-            {advisory && (
-              <span style={{ marginTop: 2, fontSize: 11, fontWeight: 700, padding: "2px 9px", borderRadius: 20, background: "var(--warn-bg)", color: "var(--warn)", border: "1px solid var(--warn-bd)", letterSpacing: ".04em" }}>
-                ADVISORY
-              </span>
-            )}
-            {(agentCount != null || proxyCount != null) && (
-              <span style={{
-                marginTop: 2,
-                fontSize: 11.5,
-                fontWeight: 600,
-                padding: "2px 8px",
-                borderRadius: 6,
-                background: "var(--surface-2)",
-                color: "var(--text-2)",
-                border: "1px solid var(--border)",
-              }}>
-                {agentCount ?? 0} agent · {proxyCount ?? 0} proxy
-              </span>
-            )}
-          </div>
-          <p style={{ fontSize: 13, color: "var(--text-3)", marginTop: 5 }}>
-            MDM for AI coding tools — when a hard cap is hit, every tool call across Claude Code, Codex, and Cursor is blocked immediately and your security team is notified on Slack.
-          </p>
-        </div>
-        <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
-          {lastFetched != null
-            ? <>last updated: {relativeTime(lastFetched)}</>
-            : null
-          }
-        </div>
-      </div>
+  const showCompliance = role === "admin" || role === "security"
+  const showSettings   = role === "admin"
+  const hasAdminItems  = showCompliance || showSettings
 
-      {/* Vertical rail + content — matches SettingsShell's pattern. */}
-      <div style={{ display: "grid", gridTemplateColumns: "200px 1fr", gap: 28, alignItems: "start" }}>
-        <nav aria-label="Guard sections" style={{ display: "flex", flexDirection: "column", gap: 2, borderRight: "1px solid var(--border)", paddingRight: 14 }}>
-          {GUARD_SECTIONS.map(s => {
-            const active = s.id === activeId
-            return (
-              <Link
-                key={s.id}
-                href={s.href}
-                aria-current={active ? "page" : undefined}
-                style={{
-                  display: "block",
-                  padding: "8px 12px",
-                  fontSize: 13.5,
-                  fontWeight: active ? 650 : 500,
-                  color: active ? "var(--text)" : "var(--text-3)",
-                  background: active ? "var(--surface-2)" : "transparent",
-                  borderRadius: 6,
-                  textDecoration: "none",
-                  transition: "background .12s, color .12s",
-                }}
-              >
-                {s.label}
-              </Link>
-            )
-          })}
+  const isComplianceActive = pathname?.startsWith("/theguard/compliance") ?? false
+  const isSettingsActive   = pathname?.startsWith("/theguard/settings") ?? false
+
+  const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "auto 1fr", minHeight: "100%" }}>
+      {/* Truly-left rail: flush against content-area edge, extends full height. */}
+      <aside style={{
+        width: railWidth,
+        borderRight: "1px solid var(--border)",
+        padding: "24px 8px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        transition: "width .15s ease",
+      }}>
+        <nav aria-label="Guard sections" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {GUARD_SECTIONS.map(s => (
+            <RailItem
+              key={s.id}
+              href={s.href}
+              label={s.label}
+              icon={<SectionIcon id={s.id} />}
+              active={s.id === activeId}
+              collapsed={collapsed}
+            />
+          ))}
         </nav>
 
-        <div style={{ minWidth: 0 }}>
+        {/* Admin cluster — bottom of rail, role-gated. */}
+        {hasAdminItems && (
+          <>
+            <div style={{ margin: "12px 8px 6px", borderTop: "1px solid var(--border)" }} />
+            <nav aria-label="Guard admin" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+              {showCompliance && (
+                <RailItem
+                  href="/theguard/compliance"
+                  label="Compliance"
+                  icon={<ComplianceIcon />}
+                  active={isComplianceActive}
+                  collapsed={collapsed}
+                />
+              )}
+              {showSettings && (
+                <RailItem
+                  href="/theguard/settings"
+                  label="Settings"
+                  icon={<SettingsIcon />}
+                  active={isSettingsActive}
+                  collapsed={collapsed}
+                />
+              )}
+            </nav>
+          </>
+        )}
+
+        {/* Collapse toggle */}
+        <button
+          onClick={() => setCollapsed(c => !c)}
+          aria-label={collapsed ? "Expand Guard nav" : "Collapse Guard nav"}
+          title={collapsed ? "Expand" : "Collapse"}
+          style={{
+            marginTop: "auto",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 6,
+            padding: "8px",
+            border: "none",
+            background: "transparent",
+            color: "var(--text-3)",
+            cursor: "pointer",
+            fontSize: 12,
+            borderRadius: 6,
+          }}
+          onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--surface-2)" }}
+          onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent" }}
+        >
+          {collapsed ? <ChevronRight /> : <><ChevronLeft /><span>Collapse</span></>}
+        </button>
+      </aside>
+
+      {/* Right column: header + content, centered inside. */}
+      <div style={{ padding: "28px 24px 48px", minWidth: 0 }}>
+        <div style={{ maxWidth: 1080, margin: "0 auto" }}>
+          <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
+            <div>
+              <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
+                <h1 style={{ fontSize: 22, fontWeight: 700, color: "var(--text)", letterSpacing: "-.02em", margin: 0 }}>
+                  Guard
+                </h1>
+                {live ? (
+                  <span className="sbadge ok" style={{ marginTop: 2 }}>
+                    <span className="conduct-pulse-dot" />
+                    live
+                  </span>
+                ) : (
+                  <span className="sbadge" style={{ marginTop: 2, background: "var(--surface-3)", color: "var(--text-muted)", border: "1px solid var(--border)" }}>
+                    offline
+                  </span>
+                )}
+                {advisory && (
+                  <span style={{ marginTop: 2, fontSize: 11, fontWeight: 700, padding: "2px 9px", borderRadius: 20, background: "var(--warn-bg)", color: "var(--warn)", border: "1px solid var(--warn-bd)", letterSpacing: ".04em" }}>
+                    ADVISORY
+                  </span>
+                )}
+                {(agentCount != null || proxyCount != null) && (
+                  <span style={{
+                    marginTop: 2,
+                    fontSize: 11.5,
+                    fontWeight: 600,
+                    padding: "2px 8px",
+                    borderRadius: 6,
+                    background: "var(--surface-2)",
+                    color: "var(--text-2)",
+                    border: "1px solid var(--border)",
+                  }}>
+                    {agentCount ?? 0} agent · {proxyCount ?? 0} proxy
+                  </span>
+                )}
+              </div>
+              <p style={{ fontSize: 13, color: "var(--text-3)", marginTop: 5 }}>
+                MDM for AI coding tools — when a hard cap is hit, every tool call across Claude Code, Codex, and Cursor is blocked immediately and your security team is notified on Slack.
+              </p>
+            </div>
+            <div style={{ marginLeft: "auto", fontSize: 12, color: "var(--text-muted)", paddingTop: 4 }}>
+              {lastFetched != null ? <>last updated: {relativeTime(lastFetched)}</> : null}
+            </div>
+          </div>
+
           {children}
         </div>
       </div>

--- a/apps/web/src/components/guard/__tests__/GuardShell.test.tsx
+++ b/apps/web/src/components/guard/__tests__/GuardShell.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest"
 import { render } from "@testing-library/react"
 import { screen } from "@testing-library/dom"
+import type { GuardRole } from "@/hooks/useGuardRole"
 import { GuardShell } from "../GuardShell"
 import { GUARD_SECTIONS } from "@/lib/navigation/guardSections"
 
@@ -8,22 +9,73 @@ vi.mock("next/navigation", () => ({
   usePathname: () => "/theguard",
 }))
 
+const mockUseGuardRole = vi.fn<() => { role: GuardRole | null; permissions: unknown; loading: boolean }>()
+vi.mock("@/hooks/useGuardRole", async () => {
+  const actual = await vi.importActual<typeof import("@/hooks/useGuardRole")>("@/hooks/useGuardRole")
+  return { ...actual, useGuardRole: () => mockUseGuardRole() }
+})
+
+function setRole(role: GuardRole | null) {
+  mockUseGuardRole.mockReturnValue({ role, permissions: {}, loading: false })
+}
+
 describe("GuardShell — six-section IA", () => {
   it("renders every GUARD_SECTIONS entry as a nav link", () => {
+    setRole(null)
     render(<GuardShell>content</GuardShell>)
     for (const s of GUARD_SECTIONS) {
       expect(screen.getByRole("link", { name: s.label })).toBeInTheDocument()
     }
   })
 
-  it("keeps Compliance and Settings OUT of the rail (palette-only)", () => {
+  it("renders children in the content column", () => {
+    setRole(null)
+    render(<GuardShell>hello body</GuardShell>)
+    expect(screen.getByText("hello body")).toBeInTheDocument()
+  })
+})
+
+describe("GuardShell — admin cluster", () => {
+  it("hides Compliance and Settings when role is null (loading)", () => {
+    setRole(null)
     render(<GuardShell>content</GuardShell>)
     expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
     expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
   })
 
-  it("renders children inside the shell", () => {
-    render(<GuardShell>hello body</GuardShell>)
-    expect(screen.getByText("hello body")).toBeInTheDocument()
+  it("shows Compliance for security", () => {
+    setRole("security")
+    render(<GuardShell>content</GuardShell>)
+    expect(screen.getByRole("link", { name: "Compliance" })).toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
+  })
+
+  it("shows Compliance and Settings for admin", () => {
+    setRole("admin")
+    render(<GuardShell>content</GuardShell>)
+    expect(screen.getByRole("link", { name: "Compliance" })).toBeInTheDocument()
+    expect(screen.getByRole("link", { name: "Settings" })).toBeInTheDocument()
+  })
+
+  it("hides both from developer", () => {
+    setRole("developer")
+    render(<GuardShell>content</GuardShell>)
+    expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
+  })
+
+  it("hides both from viewer", () => {
+    setRole("viewer")
+    render(<GuardShell>content</GuardShell>)
+    expect(screen.queryByRole("link", { name: "Compliance" })).not.toBeInTheDocument()
+    expect(screen.queryByRole("link", { name: "Settings" })).not.toBeInTheDocument()
+  })
+})
+
+describe("GuardShell — collapse toggle", () => {
+  it("renders the collapse toggle button", () => {
+    setRole("admin")
+    render(<GuardShell>content</GuardShell>)
+    expect(screen.getByRole("button", { name: /collapse guard nav/i })).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
## Summary

Phase **1d** — fixes the two-nav duplication issue and completes the Guard IA arc.

**Root cause of the two-nav screenshot from earlier:** 1b shipped both the AppShell sidebar sub-nav *and* the GuardShell rail with the same six items. This PR deletes the AppShell duplication and reworks GuardShell into the truly-left collapsible rail we scoped.

## What ships

### AppShell — delete duplicate sub-nav
Removes the six-item Guard sub-nav block. Top-level "Guard" sidebar item stays. Palette entries stay (⌘K discovery unaffected).

### GuardShell — full layout rewrite
- **Truly-left rail** — grid reflow so the rail sits flush against AppShell's content-area edge (not indented inside a maxWidth container). Header + description move into the right column, centered inside \`maxWidth: 1080\`.
- **Collapsible** — 200px expanded, 56px icon-only collapsed. Persisted via \`localStorage: guard:railCollapsed\`. Animated with \`transition: width .15s ease\` on the aside width.
- **Section icons** — six inline SVGs colocated with rendering. No shared icon registry.
- **Admin cluster** at rail bottom, role-gated via \`useGuardRole\`:
  - **Compliance** — visible to \`admin | security\`
  - **Settings** — visible to \`admin\` only
  - Hidden entirely for developer, viewer, null (loading)
- **Collapse toggle** at rail bottom — chevron + \"Collapse\" label when expanded, chevron only when collapsed. \`aria-label\` on both states.
- **A11y** — rail items get \`aria-label\` + \`title\` when collapsed so screen readers still announce the section name.

### Tests
Rewritten from 3 to 8 tests. Covers role gating (admin | security | developer | viewer | null) and the collapse toggle. All pass locally.

## Verifications
- ✅ \`tsc --noEmit\` clean
- ✅ \`next build\` succeeds (ran locally — lesson from 1c applied)
- ✅ 8/8 GuardShell tests pass
- ✅ CSS class \`.guard-tab-nav\` retained in globals.css (Secure module still uses it)
- ✅ \`GuardRoleContext\` default is safe (\`role: null\`) — admin cluster hides if provider missing

## Trade-offs I want to flag

**Content column narrows from 1240px (1b) to 1080px (1d).** Wide-screen users get less horizontal room. Matches SettingsShell's pattern and gives readable text width, but Spend/Policies tables may need a second look. Easy tweak if you want it wider.

**Mobile responsive not addressed.** GuardShell rail at 200px + AppShell sidebar on narrow viewports is impractical. Deferred to a follow-up — Guard console is desktop-first.

## Test plan
- [ ] \`/theguard/*\` and \`/logs/guard\` render the truly-left rail, no duplicate in AppShell sidebar.
- [ ] Click the six rail items — each navigates to its section, highlight follows.
- [ ] Log in as admin — Compliance and Settings appear in admin cluster at rail bottom.
- [ ] Log in as security — Compliance visible, Settings hidden.
- [ ] Log in as developer/viewer — admin cluster fully hidden.
- [ ] Click the Collapse button — rail shrinks to icon-only strip.
- [ ] Reload the page — rail stays collapsed (localStorage).
- [ ] Hover a collapsed rail item — tooltip shows the section label.
- [ ] On \`/theguard/settings?tab=enforcement\` (1c URL) — Settings admin cluster item highlights.