### PR TITLE
fix(web): move Guard rail collapse toggle to top

### DIFF
--- a/apps/web/src/components/guard/GuardShell.tsx
+++ b/apps/web/src/components/guard/GuardShell.tsx
@@ -150,12 +150,39 @@ export function GuardShell({
       <aside style={{
         width: railWidth,
         borderRight: "1px solid var(--border)",
-        padding: "24px 8px 16px",
+        padding: "12px 8px 16px",
         display: "flex",
         flexDirection: "column",
         gap: 2,
         transition: "width .15s ease",
       }}>
+        {/* Collapse toggle — top of rail, right-aligned when expanded, centered when collapsed. */}
+        <div style={{ display: "flex", justifyContent: collapsed ? "center" : "flex-end", marginBottom: 8 }}>
+          <button
+            onClick={() => setCollapsed(c => !c)}
+            aria-label={collapsed ? "Expand Guard nav" : "Collapse Guard nav"}
+            title={collapsed ? "Expand" : "Collapse"}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 28,
+              height: 28,
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              color: "var(--text-3)",
+              cursor: "pointer",
+              borderRadius: 6,
+              transition: "background .12s",
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--surface-2)" }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent" }}
+          >
+            {collapsed ? <ChevronRight /> : <ChevronLeft />}
+          </button>
+        </div>
+
         <nav aria-label="Guard sections" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
           {GUARD_SECTIONS.map(s => (
             <RailItem
@@ -196,30 +223,6 @@ export function GuardShell({
           </>
         )}
 
-        {/* Collapse toggle */}
-        <button
-          onClick={() => setCollapsed(c => !c)}
-          aria-label={collapsed ? "Expand Guard nav" : "Collapse Guard nav"}
-          title={collapsed ? "Expand" : "Collapse"}
-          style={{
-            marginTop: "auto",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 6,
-            padding: "8px",
-            border: "none",
-            background: "transparent",
-            color: "var(--text-3)",
-            cursor: "pointer",
-            fontSize: 12,
-            borderRadius: 6,
-          }}
-          onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--surface-2)" }}
-          onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent" }}
-        >
-          {collapsed ? <ChevronRight /> : <><ChevronLeft /><span>Collapse</span></>}
-        </button>
       </aside>
 
       {/* Right column: header + content, centered inside. */}


### PR DESCRIPTION
## Summary

The top-toggle fixup from PR #1837 didn't make it into the squash-merge — the bottom-placed toggle version landed on main. This PR reapplies just that fixup on a fresh branch.

## What changed
- Collapse toggle moves from rail bottom to rail top.
- Icon-only 28×28 chevron button.
- Right-aligned when expanded (\`◀\` — click to collapse).
- Center-aligned when collapsed (\`▶\` — click to expand).
- No trailing \"Collapse\" text — direction change conveys state, matches VSCode/Linear/Notion patterns.

## Verifications
- typecheck clean
- 8/8 GuardShell tests pass
- next build succeeds

## Test plan
- [ ] Load any \`/theguard/*\` page — chevron appears top-right of the rail.
- [ ] Click chevron — rail collapses, chevron flips direction, moves to center.
- [ ] Refresh — collapsed state persists (localStorage).
- [ ] Click again — rail expands, chevron returns to top-right.