### PR TITLE
feat(web): standardize Secure IA to match Guard rail pattern

### DIFF
--- a/apps/web/src/app/(app)/secure/_components.tsx
+++ b/apps/web/src/app/(app)/secure/_components.tsx
@@ -2,7 +2,13 @@
 
 import Link from "next/link"
 import { usePathname } from "next/navigation"
+import { useEffect, useState } from "react"
 import { timeAgo } from "@/lib/runUtils"
+import { SECURE_SECTIONS, activeSecureSection, type SecureSectionId } from "@/lib/navigation/secureSections"
+
+const COLLAPSE_KEY = "secure:railCollapsed"
+const RAIL_EXPANDED = 200
+const RAIL_COLLAPSED = 56
 
 export function SecureLoopIcon({ size = 20 }: { size?: number }) {
   return (
@@ -52,47 +58,153 @@ export const STATUS_STYLES: Record<FindingStatus, { bg: string; color: string; l
   dismissed: { bg: "var(--surface-3)", color: "var(--text-muted)", label: "Dismissed" },
 }
 
-const SECURE_TABS = [
-  { href: "/secure",          label: "Overview" },
-  { href: "/secure/activity", label: "Activity" },
-]
+function SectionIcon({ id }: { id: SecureSectionId }) {
+  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
+  switch (id) {
+    case "overview": return <svg {...common}><path d="M3 3h7v7H3zm11 0h7v7h-7zM3 14h7v7H3zm11 0h7v7h-7z" /></svg>
+    case "findings": return <svg {...common}><circle cx="11" cy="11" r="8" /><path d="m21 21-4.35-4.35" /></svg>
+  }
+}
+
+function ChevronLeft() {
+  return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
+}
+
+function ChevronRight() {
+  return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="9 18 15 12 9 6" /></svg>
+}
+
+function RailItem({
+  href, label, icon, active, collapsed,
+}: {
+  href: string
+  label: string
+  icon: React.ReactNode
+  active: boolean
+  collapsed: boolean
+}) {
+  return (
+    <Link
+      href={href}
+      aria-current={active ? "page" : undefined}
+      aria-label={collapsed ? label : undefined}
+      title={collapsed ? label : undefined}
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 10,
+        padding: collapsed ? "8px" : "8px 12px",
+        justifyContent: collapsed ? "center" : "flex-start",
+        fontSize: 13.5,
+        fontWeight: active ? 650 : 500,
+        color: active ? "var(--text)" : "var(--text-3)",
+        background: active ? "var(--surface-2)" : "transparent",
+        borderRadius: 6,
+        textDecoration: "none",
+        transition: "background .12s, color .12s",
+      }}
+    >
+      <span style={{ display: "flex", flexShrink: 0 }}>{icon}</span>
+      {!collapsed && <span>{label}</span>}
+    </Link>
+  )
+}
 
 export function SecureShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname()
+  const activeId = activeSecureSection(pathname ?? "")
+  const [collapsed, setCollapsed] = useState(false)
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try { if (window.localStorage.getItem(COLLAPSE_KEY) === "1") setCollapsed(true) } catch { /* ignore */ }
+  }, [])
+
+  useEffect(() => {
+    if (typeof window === "undefined") return
+    try { window.localStorage.setItem(COLLAPSE_KEY, collapsed ? "1" : "0") } catch { /* ignore */ }
+  }, [collapsed])
+
+  const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED
+
   return (
-    <div style={{ maxWidth: 1240, margin: "0 auto", padding: "28px 24px 48px" }}>
-      <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
-        <div>
-          <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
-            <span style={{ width: 32, height: 32, borderRadius: 9, background: "#dc2626", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
-              <SecureLoopIcon size={16} />
-            </span>
-            <h1 style={{ fontSize: 22, fontWeight: 700, color: "var(--text)", letterSpacing: "-.02em", margin: 0 }}>
-              Secure
-            </h1>
-            <span className="sbadge ok" style={{ marginTop: 2 }}>
-              <span className="conduct-pulse-dot" />
-              active
-            </span>
+    <div style={{ display: "grid", gridTemplateColumns: "auto 1fr", minHeight: "100%" }}>
+      {/* Truly-left rail — mirrors GuardShell. */}
+      <aside style={{
+        width: railWidth,
+        borderRight: "1px solid var(--border)",
+        padding: "12px 8px 16px",
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        transition: "width .15s ease",
+      }}>
+        {/* Collapse toggle at top, right-aligned when expanded, centered when collapsed. */}
+        <div style={{ display: "flex", justifyContent: collapsed ? "center" : "flex-end", marginBottom: 8 }}>
+          <button
+            onClick={() => setCollapsed(c => !c)}
+            aria-label={collapsed ? "Expand Secure nav" : "Collapse Secure nav"}
+            title={collapsed ? "Expand" : "Collapse"}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              width: 28,
+              height: 28,
+              padding: 0,
+              border: "none",
+              background: "transparent",
+              color: "var(--text-3)",
+              cursor: "pointer",
+              borderRadius: 6,
+              transition: "background .12s",
+            }}
+            onMouseEnter={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "var(--surface-2)" }}
+            onMouseLeave={(e) => { (e.currentTarget as HTMLButtonElement).style.background = "transparent" }}
+          >
+            {collapsed ? <ChevronRight /> : <ChevronLeft />}
+          </button>
+        </div>
+
+        <nav aria-label="Secure sections" style={{ display: "flex", flexDirection: "column", gap: 2 }}>
+          {SECURE_SECTIONS.map(s => (
+            <RailItem
+              key={s.id}
+              href={s.href}
+              label={s.label}
+              icon={<SectionIcon id={s.id} />}
+              active={s.id === activeId}
+              collapsed={collapsed}
+            />
+          ))}
+        </nav>
+      </aside>
+
+      {/* Right column: header + content, centered inside. */}
+      <div style={{ padding: "28px 24px 48px", minWidth: 0 }}>
+        <div style={{ maxWidth: 1080, margin: "0 auto" }}>
+          <div style={{ display: "flex", alignItems: "flex-start", marginBottom: 20 }}>
+            <div>
+              <div style={{ display: "flex", alignItems: "center", gap: 11 }}>
+                <span style={{ width: 32, height: 32, borderRadius: 9, background: "#dc2626", color: "#fff", display: "grid", placeItems: "center", flexShrink: 0 }}>
+                  <SecureLoopIcon size={16} />
+                </span>
+                <h1 style={{ fontSize: 22, fontWeight: 700, color: "var(--text)", letterSpacing: "-.02em", margin: 0 }}>
+                  Secure
+                </h1>
+                <span className="sbadge ok" style={{ marginTop: 2 }}>
+                  <span className="conduct-pulse-dot" />
+                  active
+                </span>
+              </div>
+              <p style={{ fontSize: 13, color: "var(--text-3)", marginTop: 5 }}>
+                Security findings from every scan — PR reviews, BugHunter, Guard violations. Triages automatically, triggers fixes.
+              </p>
+            </div>
           </div>
-          <p style={{ fontSize: 13, color: "var(--text-3)", marginTop: 5 }}>
-            Security findings from every scan — PR reviews, BugHunter, Guard violations. Triages automatically, triggers fixes.
-          </p>
+          {children}
         </div>
       </div>
-      <div className="guard-tab-nav">
-        {SECURE_TABS.map(tab => {
-          const isActive = tab.href === "/secure"
-            ? pathname === "/secure"
-            : pathname?.startsWith(tab.href)
-          return (
-            <Link key={tab.href} href={tab.href} className={`guard-tab${isActive ? " active" : ""}`}>
-              {tab.label}
-            </Link>
-          )
-        })}
-      </div>
-      {children}
     </div>
   )
 }

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -430,33 +430,6 @@ body {
 .btn-sm { height: 30px; font-size: 12.5px; padding: 0 11px; border-radius: 8px; }
 .btn-icon { width: 36px; padding: 0; justify-content: center; }
 
-/* Guard underline tab nav */
-.guard-tab-nav {
-  display: flex;
-  gap: 4px;
-  border-bottom: 1px solid var(--border);
-  margin-bottom: 24px;
-}
-.guard-tab {
-  background: none;
-  border: none;
-  padding: 9px 14px;
-  font-size: 13.5px;
-  font-weight: 600;
-  color: var(--text-3);
-  border-bottom: 2px solid transparent;
-  margin-bottom: -1px;
-  cursor: pointer;
-  text-decoration: none;
-  display: inline-block;
-  transition: color .12s;
-}
-.guard-tab:hover { color: var(--text-2); }
-.guard-tab.active {
-  color: var(--text);
-  border-bottom-color: var(--accent);
-}
-
 /* Page layout helpers */
 .page { max-width: 1180px; margin: 0 auto; padding: 30px 34px 80px; }
 .page-head { margin-bottom: 24px; }

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -857,37 +857,7 @@ function AppShellInnerContent({
                 active={pathname.startsWith("/secure")}
                 collapsed={collapsed}
               />
-              {/* Secure sub-nav */}
-              {pathname.startsWith("/secure") && !collapsed && (
-                <div style={{ marginLeft: 28, marginTop: 2, marginBottom: 2, display: "flex", flexDirection: "column", gap: 1 }}>
-                  {[
-                    { label: "Overview",  href: "/secure" },
-                    { label: "Findings",  href: "/secure/activity" },
-                  ].map(sub => {
-                    const subActive = sub.href === "/secure" ? pathname === "/secure" : pathname.startsWith(sub.href)
-                    return (
-                      <Link
-                        key={sub.href}
-                        href={sub.href}
-                        style={{
-                          display: "block",
-                          padding: "5px 10px",
-                          borderRadius: 7,
-                          fontSize: 13,
-                          fontWeight: subActive ? 600 : 400,
-                          color: subActive ? "var(--accent-text)" : "var(--text-3)",
-                          background: subActive ? "var(--accent-weak)" : "transparent",
-                          textDecoration: "none",
-                        }}
-                        onMouseEnter={(e: ReactMouseEvent<HTMLElement>) => { if (!subActive) (e.currentTarget as HTMLAnchorElement).style.background = "var(--surface-2)" }}
-                        onMouseLeave={(e: ReactMouseEvent<HTMLElement>) => { if (!subActive) (e.currentTarget as HTMLAnchorElement).style.background = "transparent" }}
-                      >
-                        {sub.label}
-                      </Link>
-                    )
-                  })}
-                </div>
-              )}
+              {/* Secure sub-nav removed — SecureShell now owns the section rail. */}
             </div>
           )}
           {/* BUILD group */}

--- a/apps/web/src/lib/navigation/secureSections.ts
+++ b/apps/web/src/lib/navigation/secureSections.ts
@@ -1,0 +1,27 @@
+// Secure module IA — mirrors the Guard six-section pattern.
+// Only two sections today; grows without changing shell code.
+
+export type SecureSectionId = "overview" | "findings"
+
+export interface SecureSection {
+  id: SecureSectionId
+  label: string
+  href: string
+  activePrefixes: readonly string[]
+}
+
+export const SECURE_SECTIONS: readonly SecureSection[] = [
+  { id: "overview", label: "Overview", href: "/secure",          activePrefixes: ["/secure"] },
+  { id: "findings", label: "Findings", href: "/secure/activity", activePrefixes: ["/secure/activity"] },
+]
+
+export function activeSecureSection(pathname: string): SecureSectionId | null {
+  if (pathname === "/secure") return "overview"
+  for (const s of SECURE_SECTIONS) {
+    if (s.id === "overview") continue
+    if (s.activePrefixes.some(p => pathname === p || pathname.startsWith(p + "/"))) {
+      return s.id
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

Applies the Guard 1a–1d IA pattern to the Secure module. Secure now uses the same truly-left vertical rail with top-aligned collapse toggle. The duplicate AppShell sidebar sub-nav is removed.

## What changed

- **New \`lib/navigation/secureSections.ts\`** — const array of Secure sections + \`activeSecureSection(pathname)\` matcher. Same shape as \`guardSections.ts\`. Two sections today (Overview, Findings).
- **\`AppShell.tsx\`** — deleted the Secure sub-nav block (was rendering the same two items the new rail now shows).
- **\`secure/_components.tsx\`** — \`SecureShell\` rewritten to mirror \`GuardShell\`:
  - Truly-left grid (200px expanded / 56px collapsed)
  - Section icons (inline SVGs)
  - Top-right chevron collapse toggle (VSCode/Linear pattern, matches Guard 1d)
  - Persisted via \`localStorage: secure:railCollapsed\`
  - Header with red Secure icon + title + description in the right column
- **\`globals.css\`** — deleted \`.guard-tab-nav\` / \`.guard-tab\` classes. No consumer left after this PR (Guard uses the rail, Secure uses the rail).
- **Naming fix** — AppShell called \`/secure/activity\` \"Findings\"; SecureShell called it \"Activity\". Standardized on **\"Findings\"** (matches the \`SecurityFinding\` domain type).

## Deliberate simplifications

- **No admin cluster on Secure** — no admin-only pages exist today. Add when there's a real need.
- **No shared \`ModuleShell\` component yet** — Guard has 6 unique props (live/offline, agent count, advisory, lastFetched, etc). Extracting is premature (rung 5 — duplicate first, abstract on the 3rd instance).
- **Only 2 sections today** — a vertical rail for 2 items is overkill visually, but consistency with Guard wins.

## Verifications

- ✅ \`tsc --noEmit\` clean
- ✅ \`next build\` succeeds (ran locally)
- ✅ CSS cleanup landed — grep confirms no remaining \`guard-tab-nav\` consumer

## Test plan

- [ ] \`/secure\` renders the truly-left rail with **Overview** highlighted, no duplicate in AppShell sidebar.
- [ ] \`/secure/activity\` shows **Findings** highlighted.
- [ ] Click the top chevron — rail collapses to icons only.
- [ ] Reload — collapsed state persists.
- [ ] Hover a collapsed rail item — tooltip shows the section label.