### PR TITLE
feat(web): Identities Option A — friendlier row labels

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -984,8 +984,12 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                           transition: "background 400ms ease-out",
                         }}
                       >
-                        <td style={{ padding: "8px 12px" }}>
-                          <div style={{ fontWeight: 500, color: "var(--text)" }}>{id.name}</div>
+                        <td style={{ padding: "8px 12px" }} title={id.name}>
+                          {/* Display name: raw Clerk user IDs with backend-added "(auto)" suffix
+                              render as a friendlier label. Hover the cell to see the original. */}
+                          <div style={{ fontWeight: 500, color: "var(--text)" }}>
+                            {(id.name.startsWith("user_") && id.name.includes("(auto)")) ? "Auto-provisioned agent" : id.name}
+                          </div>
                           <div style={{ fontFamily: "monospace", fontSize: 10, color: "var(--text-muted)" }}>{id.token_prefix?.startsWith("okta_import") ? "external identity" : id.token_prefix}</div>
                         </td>
                         <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-2)" }}>
@@ -1023,12 +1027,12 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
                         <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-muted)" }}>
                           {id.last_certified_at
                             ? id.last_certified_at.slice(0, 10)
-                            : <span>never</span>}
+                            : <span style={{ fontStyle: "italic", opacity: 0.7 }}>not yet</span>}
                         </td>
                         <td style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-muted)" }} title={id.last_used_at ?? undefined}>
                           {id.last_used_at
                             ? id.last_used_at.slice(0, 16).replace("T", " ") + " UTC"
-                            : <span>never</span>}
+                            : <span style={{ fontStyle: "italic", opacity: 0.7 }}>not yet used</span>}
                         </td>
                         <td style={{ padding: "8px 12px", textAlign: "right" }}>
                           {isAdmin && (


### PR DESCRIPTION
## Summary

10-minute cosmetic cleanup on \`Agent Identity → Identities\`. Pre-Option-C tidying — no data or API changes.

## What changed
- **Auto-provisioned display name:** identities named \`user_3JCAdHQ1Y70E4CQf5AbylP5ZDhU (auto)\` now render as **\"Auto-provisioned agent\"**. Hover the cell to see the original identity string (\`title\` attribute preserves the raw name for debugging).
- **Empty date cells:** the bare \`never\` in Last certified and Last used columns becomes italic muted **\"not yet\"** and **\"not yet used\"** — reads as intentional absence, not a broken field.
- **Detection heuristic** uses BOTH prefix (\`user_\`) AND suffix (\`(auto)\`) so we don't accidentally rewrite legitimate names that happen to start with \`user_\`.

## What did NOT change
- Owner column — still shows raw \`owner_user_id\` when set. That's Option C's problem (needs lifecycle grouping + Clerk lookup).
- Table structure, columns, actions — untouched.
- API contract — no backend change.

## Verifications
- typecheck clean
- next build succeeds

## Diff
1 file, +8/−4.

## Test plan
- [ ] Identity with name matching \`user_XXX (auto)\` shows \"Auto-provisioned agent\" as the primary label.
- [ ] Same identity's hover tooltip shows the original raw name.
- [ ] Trial (7 days) row unchanged (name doesn't match the pattern).
- [ ] Newly-created identity shows \"not yet\" for Last certified and \"not yet used\" for Last used.
- [ ] Identity with real dates renders those dates unchanged.