### PR TITLE
feat(api): normalize agent_identity source per creator + expose expires_at

### DIFF
--- a/apps/api/alembic/versions/0122_backfill_agent_identity_source.py
+++ b/apps/api/alembic/versions/0122_backfill_agent_identity_source.py
@@ -1,0 +1,56 @@
+"""backfill agent_identities.source per creator (Identities Option C prep)
+
+Data-only migration — no schema change. The `source` column already exists
+(added in migration 0090) but every non-Okta creator was using the default
+"conduct" value. That made `source` useless as a discriminator between
+trial / CLI-minted / auto-provisioned / manually-created identities.
+
+Going forward, each creator sets its own explicit `source`:
+  - trial_seed.py       -> "conduct_trial"
+  - cli_token.py        -> "conduct_cli"
+  - mint_agent_identity -> "conduct_auto" (default; used by guard join flow)
+  - create endpoint     -> "conduct_api"
+  - okta_sync.py        -> "okta_jwt" (unchanged)
+
+Backfill existing rows by inferring source from the name pattern the
+respective creator historically used. Anything that doesn't match a
+pattern stays as "conduct" — safe legacy catchall for pre-normalization
+manually-created rows.
+
+Revision ID: 0122
+Revises: 0121
+Create Date: 2026-09-12
+"""
+from alembic import op
+
+
+revision = "0122"
+down_revision = "0121"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Trials — exact name match set by trial_seed.py.
+    op.execute(
+        "UPDATE agent_identities SET source = 'conduct_trial' "
+        "WHERE source = 'conduct' AND name = 'Trial (7 days)'"
+    )
+    # CLI-minted — name suffix set by cli_token.py.
+    op.execute(
+        "UPDATE agent_identities SET source = 'conduct_cli' "
+        "WHERE source = 'conduct' AND name LIKE '%% (CLI)'"
+    )
+    # Auto-provisioned via guard join flow — name suffix set by config.py.
+    op.execute(
+        "UPDATE agent_identities SET source = 'conduct_auto' "
+        "WHERE source = 'conduct' AND name LIKE '%% (auto)'"
+    )
+
+
+def downgrade() -> None:
+    # Reverse — collapse the three explicit values back to the legacy default.
+    op.execute(
+        "UPDATE agent_identities SET source = 'conduct' "
+        "WHERE source IN ('conduct_trial', 'conduct_cli', 'conduct_auto')"
+    )

--- a/apps/api/app/modules/agent_identity/router.py
+++ b/apps/api/app/modules/agent_identity/router.py
@@ -36,11 +36,11 @@ def _generate_token() -> tuple[str, str]:
     return raw, raw[:_DISPLAY_PREFIX_LEN]
 
 
-def mint_agent_identity(db: Session, workspace_id: str, name: str) -> tuple[AgentIdentity, str]:
+def mint_agent_identity(db: Session, workspace_id: str, name: str, source: str = "conduct_auto") -> tuple[AgentIdentity, str]:
     """Internal helper — mint an Agent Identity for a user without auth checks.
 
     Returns (AgentIdentity row, plaintext token). Caller must commit if needed.
-    Used by guard join flow to auto-mint on invite accept.
+    Used by guard join flow to auto-mint on invite accept (default source).
     """
     plaintext, prefix = _generate_token()
     now = datetime.now(timezone.utc)
@@ -49,6 +49,7 @@ def mint_agent_identity(db: Session, workspace_id: str, name: str) -> tuple[Agen
         workspace_id=workspace_id,
         name=name,
         provider="conduct",
+        source=source,
         token_prefix=prefix,
         token_encrypted=encrypt({"token": plaintext}),
         environment_id=None,
@@ -111,6 +112,7 @@ def create_agent_identity(
         workspace_id=workspace_id,
         name=body.name.strip(),
         provider="conduct",
+        source="conduct_api",
         token_prefix=prefix,
         token_encrypted=encrypted,
         environment_id=body.environment_id,
@@ -134,6 +136,7 @@ def create_agent_identity(
         lifecycle_state=row.lifecycle_state, last_certified_at=row.last_certified_at,
         certification_cadence_days=row.certification_cadence_days,
         risk_tier=row.risk_tier, deactivated_at=row.deactivated_at,
+        expires_at=row.expires_at,
         token=plaintext,
     )
 
@@ -160,6 +163,7 @@ def list_agent_identities(
         lifecycle_state=r.lifecycle_state, last_certified_at=r.last_certified_at,
         certification_cadence_days=r.certification_cadence_days,
         risk_tier=r.risk_tier, deactivated_at=r.deactivated_at,
+        expires_at=r.expires_at,
     ) for r in rows]
 
 
@@ -264,6 +268,7 @@ def patch_agent_identity(
         lifecycle_state=row.lifecycle_state, last_certified_at=row.last_certified_at,
         certification_cadence_days=row.certification_cadence_days,
         risk_tier=row.risk_tier, deactivated_at=row.deactivated_at,
+        expires_at=row.expires_at,
     )
 
 
@@ -300,6 +305,7 @@ def certify_agent_identity(
         lifecycle_state=row.lifecycle_state, last_certified_at=row.last_certified_at,
         certification_cadence_days=row.certification_cadence_days,
         risk_tier=row.risk_tier, deactivated_at=row.deactivated_at,
+        expires_at=row.expires_at,
     )
 
 

--- a/apps/api/app/modules/agent_identity/schemas.py
+++ b/apps/api/app/modules/agent_identity/schemas.py
@@ -28,6 +28,8 @@ class AgentIdentityOut(BaseModel):
     certification_cadence_days: Optional[int] = None
     risk_tier:           Optional[str] = None
     deactivated_at:      Optional[datetime] = None
+    # Expiry — set for trials and CLI-minted tokens; null for perpetual credentials.
+    expires_at:          Optional[datetime] = None
 
 
 class AgentIdentityCreated(AgentIdentityOut):

--- a/apps/api/app/modules/auth/cli_token.py
+++ b/apps/api/app/modules/auth/cli_token.py
@@ -73,6 +73,7 @@ def _upsert_identity(
             workspace_id=uuid.UUID(workspace_id),
             name=f"{clerk_user_id} (CLI)",
             provider="conduct",
+            source="conduct_cli",
             token_prefix=agent_prefix,
             token_encrypted=encrypt({"token": agent_raw}),
             environment_id=None,

--- a/apps/api/app/modules/guard/trial_seed.py
+++ b/apps/api/app/modules/guard/trial_seed.py
@@ -90,6 +90,7 @@ def seed_trial(db: Session, workspace_id: str) -> str | None:
         workspace_id=workspace_id,
         name=TRIAL_IDENTITY_NAME,
         provider="conduct",
+        source="conduct_trial",
         token_prefix=prefix,
         token_encrypted=encrypt({"token": plaintext}),
         environment_id=None,


### PR DESCRIPTION
## Summary

Backend prep for Identities Option C (lifecycle grouping in the UI). Makes \`source\` a real discriminator per creator so the frontend can group Identities into Human / Auto / Time-limited without name-pattern heuristics.

## What changed

### Explicit source values at every creation site

Before: all four non-Okta creators fell through to the default \`source=\"conduct\"\`, making the column useless as a discriminator.

| Creator | Old | **New** |
|---|---|---|
| \`trial_seed.py\` | conduct (default) | **conduct_trial** |
| \`cli_token.py\` | conduct (default) | **conduct_cli** |
| \`mint_agent_identity()\` (guard join) | conduct (default) | **conduct_auto** |
| \`create_agent_identity()\` (API) | conduct (default) | **conduct_api** |
| \`okta_sync.py\` | okta / okta_jwt | okta / okta_jwt (unchanged) |

### AgentIdentityOut exposes expires_at

The column has always been on the model but was never returned. Set for trials + CLI tokens (short-lived); null for perpetual credentials. UI needs it to render trial countdowns.

### Alembic 0122 — backfill

Data-only migration. Infers \`source\` from historical name patterns:
- \`\"Trial (7 days)\"\` -> \`conduct_trial\`
- \`\"... (CLI)\"\` -> \`conduct_cli\`
- \`\"... (auto)\"\` -> \`conduct_auto\`
- Anything else stays \`conduct\` (safe legacy catchall for manually-created rows).

No schema change, no drift.

## Verifications
- Python syntax check clean on all 4 modified files + migration.
- Grep confirms no tests assert \`source == \"conduct\"\`.
- \`test_agent_identity_schema.py\` already listed \`expires_at\` in expected columns — the schema addition matches existing test expectations.

## Files
5 files, +68 / -2.

## Follow-up
PR 2 (frontend) will:
- Read \`source\` and \`expires_at\` from the API response.
- Group Identities into three sections (Human / Auto / Time-limited).
- Show source badge on each row.
- Countdown for trials.

## Test plan
- [ ] Alembic upgrade runs clean on a real DB.
- [ ] New trial via signup gets \`source=conduct_trial\`.
- [ ] New CLI token via \`conduct auth login\` gets \`source=conduct_cli\`.
- [ ] Guard join flow mints identity with \`source=conduct_auto\`.
- [ ] Manual POST /agent-identities gets \`source=conduct_api\`.
- [ ] Existing rows correctly reclassified by name pattern.
- [ ] GET /agent-identities response now includes \`expires_at\` field.