### PR TITLE
feat(web): Agent Identity — vertical tab rail (matches Settings/Guard pattern)

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -454,7 +454,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
 
   return (
     <AppShell>
-      <div style={{ maxWidth: 960, margin: "0 auto", padding: "32px 24px", display: "flex", flexDirection: "column", gap: 20 }}>
+      <div style={{ maxWidth: 1200, margin: "0 auto", padding: "32px 24px", display: "flex", flexDirection: "column", gap: 20 }}>
         <div>
           <h1 style={{ fontSize: 20, fontWeight: 700, color: "var(--text)", margin: 0 }}>Agent Identity</h1>
           <p style={{ fontSize: 13, color: "var(--text-muted)", margin: "4px 0 0" }}>
@@ -462,9 +462,10 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
           </p>
         </div>
 
-        <div style={{ marginBottom: -8 }}>
-          <TabBar tabs={TABS} labels={TAB_LABELS} activeTab={activeTab} onSelect={selectTab} />
-        </div>
+        {/* Vertical tab rail (left) + content column (right) — mirrors SettingsShell / GuardShell pattern. */}
+        <div style={{ display: "grid", gridTemplateColumns: "180px 1fr", gap: 24, alignItems: "start" }}>
+          <TabBar tabs={TABS} labels={TAB_LABELS} activeTab={activeTab} onSelect={selectTab} orientation="vertical" />
+          <div style={{ minWidth: 0, display: "flex", flexDirection: "column", gap: 20 }}>
 
         {/* CLI Developer Token */}
         <div role="tabpanel" id="tabpanel-tokens" aria-labelledby="tab-tokens" hidden={activeTab !== "tokens"} style={{ display: activeTab === "tokens" ? "flex" : "none", flexDirection: "column", gap: 20 }}>
@@ -1127,6 +1128,9 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
             Tier 3 agents are the strictest (regulated decisions, requires human oversight); Tier 1 is drafting-adjacent (reversible, low blast radius). Only workspace admins can change tier, lifecycle, or certify.
           </p>
         </div>
+
+          </div>{/* /content column */}
+        </div>{/* /grid */}
       </div>
     </AppShell>
   )

--- a/apps/web/src/components/TabBar.tsx
+++ b/apps/web/src/components/TabBar.tsx
@@ -22,15 +22,32 @@ export function TabBar<T extends string>({
   activeTab,
   onSelect,
   idPrefix = "tab",
+  orientation = "horizontal",
 }: {
   tabs: readonly T[]
   labels: Record<T, string>
   activeTab: T
   onSelect: (tab: T) => void
   idPrefix?: string
+  orientation?: "horizontal" | "vertical"
 }) {
+  const isVertical = orientation === "vertical"
   return (
-    <div role="tablist" style={{ display: "flex", gap: 4, borderBottom: "1px solid var(--border)" }}>
+    <div
+      role="tablist"
+      aria-orientation={orientation}
+      style={isVertical ? {
+        display: "flex",
+        flexDirection: "column",
+        gap: 2,
+        borderRight: "1px solid var(--border)",
+        paddingRight: 14,
+      } : {
+        display: "flex",
+        gap: 4,
+        borderBottom: "1px solid var(--border)",
+      }}
+    >
       {tabs.map(tab => (
         <button
           key={tab}
@@ -39,7 +56,18 @@ export function TabBar<T extends string>({
           aria-controls={`tabpanel-${tab}`}
           id={`${idPrefix}-${tab}`}
           onClick={() => onSelect(tab)}
-          style={{
+          style={isVertical ? {
+            background: activeTab === tab ? "var(--surface-2)" : "transparent",
+            border: "none",
+            padding: "8px 12px",
+            fontSize: 13.5,
+            fontWeight: activeTab === tab ? 650 : 500,
+            cursor: "pointer",
+            textAlign: "left",
+            color: activeTab === tab ? "var(--text)" : "var(--text-3)",
+            borderRadius: 6,
+            transition: "background .12s, color .12s",
+          } : {
             background: "none",
             border: "none",
             padding: "9px 14px",


### PR DESCRIPTION
## Summary

Standardizes the tab layout on \`/agent-identity\` to match \`SettingsShell\`, \`GuardShell\`, and \`SecureShell\` — vertical left rail instead of horizontal underlined tabs.

## What changed

### \`TabBar.tsx\`
- New optional prop: \`orientation?: \"horizontal\" | \"vertical\"\` (default \`\"horizontal\"\` — backward compatible).
- Vertical mode uses SettingsShell-style item styling: rounded corners, \`surface-2\` background when active, \`borderRight\` on the tablist container.
- Sets \`aria-orientation\` on the tablist accordingly.

### \`agent-identity/page.tsx\`
- Wraps TabBar + all five tabpanels (Tokens / Run tokens / Identities / Lens sessions / Integrations) in a \`180px + 1fr\` grid.
- Container \`maxWidth: 960 → 1200\` so the content column keeps meaningful width after the rail.
- All panel content, actions, filters, and functionality preserved.

## Diff
2 files, +38 / -6.

## Verifications
- ✅ typecheck clean
- ✅ next build succeeds
- ✅ Agent Identity was the only TabBar consumer (grep confirmed); horizontal default preserved for any future caller.

## Test plan
- [ ] Load \`/agent-identity\` — tabs render vertically on the left.
- [ ] Active tab highlights with surface-2 background.
- [ ] Click each tab — content panels swap correctly.
- [ ] URL syncs via existing \`?tab=\` param (unchanged).
- [ ] Identities tab shows the three lifecycle sections (from PR #1843) intact.
- [ ] Content column width feels correct — Identities table doesn't horizontal-scroll on desktop.