### PR TITLE
fix(web): honest Tier vs Lifecycle copy on Identities page

### DIFF
--- a/apps/web/src/app/(app)/agent-identity/page.tsx
+++ b/apps/web/src/app/(app)/agent-identity/page.tsx
@@ -966,7 +966,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
         <div role="tabpanel" id="tabpanel-identities" aria-labelledby="tab-identities" hidden={activeTab !== "identities"} style={{ display: activeTab === "identities" ? "block" : "none" }}>
           <div style={{ fontSize: 15, fontWeight: 700, color: "var(--text)", marginBottom: 4 }}>Agent identities</div>
           <p style={{ fontSize: 12, color: "var(--text-muted)", margin: "0 0 12px" }}>
-            Every agent has an accountable owner, a risk tier, a lifecycle state, and a certification cadence. Tier drives what the agent is allowed to do; lifecycle drives whether it can act at all. Deactivating an identity revokes its tokens on the next check.
+            Every agent has an accountable owner, a risk tier, a lifecycle state, and a certification cadence. Lifecycle is enforced immediately — deactivated or expired identities cannot authenticate. Tier is a policy label Guard rules can gate on; no built-in rule uses it yet.
           </p>
           {sourceFilter && (
             <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 8, fontSize: 12, color: "var(--text-2)" }}>
@@ -1124,7 +1124,7 @@ function Inner({ getToken }: { getToken: (() => Promise<string | null>) | null }
             })()}
           </div>
           <p style={{ fontSize: 11, color: "var(--text-muted)", margin: "8px 0 0" }}>
-            Tier 3 agents are the strictest (regulated decisions, requires human oversight); Tier 1 is drafting-adjacent (reversible, low blast radius). Only workspace admins can change tier, lifecycle, or certify.
+            Tier is a policy label — write a Cedar rule matching <code>context.risk_tier == &quot;tier_3&quot;</code> to require stricter handling for regulated decisions. Setting Lifecycle to Deactivated or Expired blocks authentication on the next call. Only workspace admins can change tier, lifecycle, or certify.
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary

The two paragraphs framing the Identities table oversold what Tier actually does today. Small copy fix.

## The lies
- **Intro:** *\"Tier drives what the agent is allowed to do.\"* → not true today. No built-in rule references \`risk_tier\`.
- **Footer:** *\"Tier 3 agents are the strictest (regulated decisions, requires human oversight).\"* → also not true. Nothing enforces stricter behavior for Tier 3 out of the box.

## The truth
- **Lifecycle IS enforced immediately.** \`apps/api/app/core/auth.py:236-240\` and two other sites block \`lifecycle_state ∈ ('deactivated', 'expired')\` with 401 on the next auth call.
- **Tier is a label** available to Cedar policies via \`match_agent_risk_tier\` (\`cedar_adapter/mapper.py:255\`). If you want Tier 3 to be stricter, write a Cedar rule.

## The fix
Both paragraphs rewritten to match reality, with a concrete Cedar example so admins know how to wire enforcement when they need it.

## Diff
1 file, +2 / -2.

## Verifications
- typecheck clean
- next build succeeds