### PR TITLE
docs(guard): tier enforcement verification script + example

### DIFF
--- a/docs/guard/examples/README.md
+++ b/docs/guard/examples/README.md
@@ -1,0 +1,49 @@
+# Guard examples
+
+## Tier enforcement verification
+
+Cedar rules can gate on the caller's `risk_tier` via `context.risk_tier == "tier_3"`. Enforcement lives in the MCP + LLM proxy PEPs (PR #1847).
+
+### Files
+
+- **`tier3-no-shell.json`** — sample Cedar policy that forbids Tier 3 identities. Importable via `POST /guard/registry/import-cedar`.
+- **`verify_tier.sh`** — runnable end-to-end verification. Imports the rule, fires `guard_check` as the current identity, reports whether tier enforcement fired.
+
+### Run it
+
+The script reads `~/.conduct/config.json` (written by `conduct login`) for `api_url`, `agent_token`, and `workspace_id` — no env vars needed:
+
+```bash
+bash docs/guard/examples/verify_tier.sh
+```
+
+Override the config path if needed:
+
+```bash
+CONDUCT_CONFIG=/path/to/other-config.json bash docs/guard/examples/verify_tier.sh
+```
+
+### Expected output
+
+**When the caller identity is currently Tier 3:**
+```
+✅ Tier enforcement fired — the caller identity is currently Tier 3.
+   Next: flip the identity's Tier dropdown to Tier 1 in /agent-identity,
+   then rerun this script — expect 'ok' instead of BLOCKED.
+```
+
+**When the caller identity is Tier 1 or Tier 2:**
+```
+ℹ️  No block — the caller identity is NOT currently Tier 3.
+   To verify enforcement:
+     1. Open /agent-identity, find the identity for you@example.com,
+        set the Tier dropdown to Tier 3.
+     2. Rerun this script — expect BLOCKED.
+```
+
+Full round-trip: run once → flip tier via UI → run again. Both outcomes prove the enforcement path end-to-end.
+
+### Cleanup
+
+- Uninstall the `tier-controls` pack from Guard → Registry when you're done.
+- Reset the Tier 3 identity back to Tier 1 via `/agent-identity` if you flipped it.

--- a/docs/guard/examples/tier3-no-shell.json
+++ b/docs/guard/examples/tier3-no-shell.json
@@ -1,0 +1,31 @@
+{
+  "format": "cedar_json",
+  "pack_slug": "tier-controls",
+  "pack_name": "Tier Controls (verification)",
+  "pack_version": "1.0.0",
+  "pack_description": "Sample tier-based enforcement rules for /docs/guard/examples/verify_tier.sh",
+  "preview_only": false,
+  "policies": [
+    {
+      "effect": "forbid",
+      "annotations": {
+        "id": "tier3-no-shell",
+        "advice": "block",
+        "message": "Tier 3 agents cannot execute shell commands. Use a Tier 1/2 identity or request a policy exception."
+      },
+      "principal": {},
+      "action": {},
+      "conditions": [
+        {
+          "kind": "when",
+          "body": {
+            "==": [
+              {".": {"left": {"Var": "context"}, "attr": "risk_tier"}},
+              {"Value": "tier_3"}
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/docs/guard/examples/verify_tier.sh
+++ b/docs/guard/examples/verify_tier.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+# Verify Guard tier enforcement end-to-end.
+#
+# Reads `~/.conduct/config.json` (populated by `conduct login`) to pick up
+# the api_url, agent_token, and workspace_id automatically. Set the env var
+# CONDUCT_CONFIG to point at a different file.
+#
+# Usage:
+#   bash docs/guard/examples/verify_tier.sh
+#
+# What it does:
+#   1. Imports a Cedar rule that blocks any identity with risk_tier=tier_3.
+#   2. Calls guard_check as the current identity.
+#   3. Reports whether tier enforcement fired (BLOCKED) or the caller is
+#      currently exempt (ok). Prompts you to flip the tier in the UI and
+#      re-run to prove the other case.
+#
+# Requires: curl, jq.
+
+set -euo pipefail
+
+CONFIG="${CONDUCT_CONFIG:-$HOME/.conduct/config.json}"
+if [ ! -f "$CONFIG" ]; then
+  echo "❌ No config at $CONFIG"
+  echo "   Run 'conduct login' first, or set CONDUCT_CONFIG=/path/to/config.json"
+  exit 2
+fi
+
+command -v jq >/dev/null || { echo "❌ jq is required (brew install jq)"; exit 2; }
+
+API=$(jq -r '.api_url // empty' "$CONFIG")
+TOKEN=$(jq -r '.agent_token // empty' "$CONFIG")
+WORKSPACE=$(jq -r '.workspace_id // empty' "$CONFIG")
+EMAIL=$(jq -r '.user_email // "unknown"' "$CONFIG")
+
+if [ -z "$API" ] || [ -z "$TOKEN" ] || [ -z "$WORKSPACE" ]; then
+  echo "❌ $CONFIG missing api_url / agent_token / workspace_id"
+  exit 2
+fi
+
+echo "API:       $API"
+echo "Workspace: $WORKSPACE"
+echo "Identity:  $EMAIL"
+echo ""
+
+RULE_FILE="$(dirname "$0")/tier3-no-shell.json"
+
+# ─── 1. Import the tier-gate rule ────────────────────────────────────────────
+echo "▶ Importing Cedar rule (blocks any Tier 3 identity)…"
+IMPORT_RESP=$(curl -sS -X POST "$API/guard/registry/import-cedar" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Workspace-ID: $WORKSPACE" \
+  -H "Content-Type: application/json" \
+  --data-binary @"$RULE_FILE")
+
+IMPORTED=$(echo "$IMPORT_RESP" | jq -r '.rules_imported // (.pack.rules | length) // 0' 2>/dev/null || echo "?")
+if [ "$IMPORTED" = "0" ] || [ "$IMPORTED" = "?" ]; then
+  echo "❌ Import failed:"
+  echo "$IMPORT_RESP" | jq .
+  exit 1
+fi
+echo "   → imported $IMPORTED rule(s)"
+echo ""
+
+# ─── 2. Fire guard_check as the current identity ─────────────────────────────
+echo "▶ Firing guard_check(shell) as the current identity…"
+RESP=$(curl -sS -X POST "$API/guard/mcp?workspace_id=$WORKSPACE" \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":"verify-tier","method":"tools/call","params":{"name":"guard_check","arguments":{"tool_name":"shell","tool_input":{"command":"ls"}}}}')
+
+BODY=$(echo "$RESP" | jq -r '.result.content[0].text // (.error.message // .)')
+echo "── response ──"
+echo "$BODY"
+echo "──────────────"
+echo ""
+
+# ─── 3. Interpret ────────────────────────────────────────────────────────────
+if echo "$BODY" | grep -q "BLOCKED"; then
+  echo "✅ Tier enforcement fired — the caller identity is currently Tier 3."
+  echo "   Next: flip the identity's Tier dropdown to Tier 1 in /agent-identity,"
+  echo "   then rerun this script — expect 'ok' instead of BLOCKED."
+elif echo "$BODY" | grep -qE "^ok|^\s*$"; then
+  echo "ℹ️  No block — the caller identity is NOT currently Tier 3."
+  echo "   To verify enforcement:"
+  echo "     1. Open /agent-identity, find the identity for $EMAIL,"
+  echo "        set the Tier dropdown to Tier 3."
+  echo "     2. Rerun this script — expect BLOCKED."
+else
+  echo "⚠️  Unexpected response. Check the raw output above."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

Adds \`docs/guard/examples/\` with a runnable end-to-end verification of the Cedar-based tier enforcement shipped in PR #1847.

## Contents

- **\`tier3-no-shell.json\`** — sample Cedar policy that blocks any identity with \`risk_tier = tier_3\`.
- **\`verify_tier.sh\`** — one-command verification. Reads \`~/.conduct/config.json\` for auth (no env vars needed), imports the rule, fires \`guard_check\` as the current identity, and reports whether enforcement fired.
- **\`README.md\`** — usage + expected outputs + cleanup.

## Usage

\`\`\`bash
bash docs/guard/examples/verify_tier.sh
\`\`\`

That's it. Requires \`curl\` + \`jq\`. Uses whatever workspace + identity is in \`~/.conduct/config.json\` (populated by \`conduct login\`).

Flip the identity's Tier in \`/agent-identity\` between runs to prove both the block and pass cases from one script.

## Depends on

PR #1847 (tier enforcement wiring). Script will import the rule successfully on older builds but the block half won't fire until that lands.