### PR TITLE
chore(web): extract Sync panel to /theguard/connections/sync

### DIFF
--- a/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
@@ -1,0 +1,38 @@
+"use client"
+
+import { useEffect } from "react"
+import { useRouter } from "next/navigation"
+import { useWorkspace } from "@/lib/WorkspaceContext"
+import { useGuardTeam } from "@/hooks/useGuardTeam"
+import { useGuardRole } from "@/hooks/useGuardRole"
+import AppShell from "@/components/AppShell"
+import { GuardShell } from "@/components/guard/GuardShell"
+import SyncPanel from "@/features/guard/connections/sync/Panel"
+
+export default function GuardSyncPage() {
+  return (
+    <AppShell>
+      <SyncContent />
+    </AppShell>
+  )
+}
+
+function SyncContent() {
+  const { activeWorkspace } = useWorkspace()
+  const { teamId } = useGuardTeam()
+  const { permissions, role: resolvedRole } = useGuardRole(teamId, activeWorkspace?.id ?? null)
+  const router = useRouter()
+
+  useEffect(() => {
+    if (resolvedRole !== null && !permissions.canEditSettings) router.replace("/theguard")
+  }, [resolvedRole, permissions.canEditSettings, router])
+
+  return (
+    <GuardShell>
+      <SyncPanel
+        workspaceId={activeWorkspace?.id ?? null}
+        isAdmin={permissions.canEditSettings}
+      />
+    </GuardShell>
+  )
+}

--- a/apps/web/src/app/(app)/theguard/settings/page.tsx
+++ b/apps/web/src/app/(app)/theguard/settings/page.tsx
@@ -33,12 +33,10 @@ interface TeamPrefs {
 type GuardSettingsTab =
   | "enforcement"
   | "guardrails"
-  | "sync"
 
 const GUARD_SETTINGS_TABS: readonly SettingsTab<GuardSettingsTab>[] = [
   { key: "enforcement",   label: "Enforcement" },
   { key: "guardrails",    label: "Cost & performance" },
-  { key: "sync",          label: "Sync status" },
 ]
 
 
@@ -96,11 +94,11 @@ function SettingsContent() {
   const router = useRouter()
   const searchParams = useSearchParams()
 
-  // Legacy ?tab=notifications bookmarks: Notifications panel now lives at its own URL.
+  // Legacy ?tab=notifications and ?tab=sync bookmarks — panels now live at their own URLs.
   useEffect(() => {
-    if (searchParams?.get("tab") === "notifications") {
-      router.replace("/theguard/connections/notifications")
-    }
+    const tab = searchParams?.get("tab")
+    if (tab === "notifications") router.replace("/theguard/connections/notifications")
+    else if (tab === "sync") router.replace("/theguard/connections/sync")
   }, [searchParams, router])
 
   useEffect(() => {
@@ -129,17 +127,10 @@ function SettingsContent() {
   const [notifyOnFailOpen, setNotifyOnFailOpen] = useState(true)
   const [enforcementError, setEnforcementError] = useState<string | null>(null)
 
-  // Re-sync state
-  const [resyncing, setResyncing] = useState(false)
-  const [resyncDone, setResyncDone] = useState(false)
-
   // Token guardrails
   const { guardrails: tokenGuardrails, refresh: refreshGuardrails } = useTokenGuardrails(activeWorkspace?.id ?? null)
   const [guardrailState, setGuardrailState] = useState({ prompt_caching: true, model_routing: true, prompt_splitting: true })
   const [guardrailSaved, setGuardrailSaved] = useState(false)
-
-  // Sync status
-  const [toolCoverage, setToolCoverage] = useState<Array<{ detected_tools: string[]; mcp_registered: string[]; hook_registered: string[] }> | null>(null)
 
   // MCP connect
 
@@ -168,10 +159,6 @@ function SettingsContent() {
       if (data.deny_on_error !== undefined) setDenyOnError(data.deny_on_error)
       if (data.notify_on_fail_open !== undefined) setNotifyOnFailOpen(data.notify_on_fail_open)
       setLastFetched(new Date())
-      // Load sync coverage in parallel — non-fatal
-      guard.developerTools.list(authFetch, wsId)
-        .then(d => { if (d) setToolCoverage(d) })
-        .catch(() => {})
     } catch (e: any) {
       if (e?.message?.includes("404") || String(e).includes("404")) { setLoading(false); return }
       setError(e instanceof Error ? e.message : "Failed to load settings")
@@ -196,23 +183,6 @@ function SettingsContent() {
     if (!res.ok) throw new Error(`Save failed (${res.status})`)
     return res.json()
   }
-
-  async function handleResync() {
-    if (!wsId || resyncing) return
-    setResyncing(true)
-    setResyncDone(false)
-    try {
-      const res = await guard.config.resync(authFetch, wsId)
-      if (!res.ok) throw new Error(`Resync failed (${res.status})`)
-      setResyncDone(true)
-      setTimeout(() => setResyncDone(false), 2000)
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Resync failed")
-    } finally {
-      setResyncing(false)
-    }
-  }
-
 
   async function handleToggle(field: "notify_on_block" | "notify_on_budget", value: boolean) {
     setPrefs(p => ({ ...p, [field]: value }))
@@ -283,59 +253,6 @@ function SettingsContent() {
           isAdmin={isAdmin}
           initialTab="enforcement"
           panels={{
-            sync: (
-              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20 }}>
-              <div className="card" style={{ padding: "18px 20px", minWidth: 0 }}>
-                <div className="eyebrow" style={{ marginBottom: 12 }}>Sync status</div>
-                {toolCoverage === null ? (
-                  <div style={{ height: 40 }} />
-                ) : (() => {
-                  const total = toolCoverage.length
-                  const synced = toolCoverage.filter(dev =>
-                    dev.detected_tools.every(t =>
-                      dev.mcp_registered.includes(t) || dev.hook_registered.includes(t)
-                    )
-                  ).length
-                  const allGood = total === 0 || synced === total
-                  return (
-                    <>
-                      <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
-                        <span style={{ fontSize: 26, fontWeight: 700, color: allGood ? "var(--ok)" : "var(--warn)" }}>
-                          {total === 0 ? "—" : `${synced}/${total}`}
-                        </span>
-                        <span style={{ fontSize: 13, color: "var(--text-3)" }}>machines in sync</span>
-                      </div>
-                      <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 4 }}>
-                        Policies propagate within <strong style={{ color: "var(--text-2)" }}>60s</strong> of a change.
-                      </div>
-                      <div style={{ display: "flex", alignItems: "center", gap: 7, marginTop: 14, fontSize: 12.5, color: allGood ? "var(--ok)" : "var(--warn)" }}>
-                        <span className="conduct-pulse-dot" style={{ background: allGood ? "var(--ok)" : "var(--warn)" }} />
-                        {total === 0 ? "No developers connected yet" : allGood ? "All developers up to date" : `${total - synced} developer${total - synced !== 1 ? "s" : ""} need sync — run: conduct guard sync`}
-                      </div>
-                    </>
-                  )
-                })()}
-              </div>
-              <div className="card" style={{ padding: "16px 20px", display: "flex", alignItems: "center", gap: 12 }}>
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                  <path d="M23 4v6h-6M1 20v-6h6" />
-                  <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
-                </svg>
-                <div style={{ flex: 1 }}>
-                  <div style={{ fontWeight: 600, fontSize: 13 }}>Re-sync all machines</div>
-                  <div style={{ fontSize: 11.5, color: "var(--text-muted)" }}>Force a policy push now</div>
-                </div>
-                <button
-                  className="btn btn-ghost btn-sm"
-                  disabled={!isAdmin || resyncing}
-                  style={{ opacity: isAdmin ? 1 : 0.5 }}
-                  onClick={handleResync}
-                >
-                  {resyncing ? "Syncing…" : resyncDone ? "Synced" : "Re-sync"}
-                </button>
-              </div>
-              </div>
-            ),
             enforcement: (
               <div style={{ display: "grid", gridTemplateColumns: "repeat(3, minmax(0, 1fr))", gap: 20, alignItems: "stretch" }}>
               <div className="card" style={{ padding: "18px 20px", minWidth: 0 }}>

--- a/apps/web/src/features/guard/connections/sync/Panel.tsx
+++ b/apps/web/src/features/guard/connections/sync/Panel.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { guard } from "@/lib/api"
+
+type ToolCoverage = Array<{
+  detected_tools: string[]
+  mcp_registered: string[]
+  hook_registered: string[]
+}>
+
+export default function SyncPanel({
+  workspaceId,
+  isAdmin,
+}: {
+  workspaceId: string | null
+  isAdmin: boolean
+}) {
+  const { authFetch } = useAuthFetch()
+  const [toolCoverage, setToolCoverage] = useState<ToolCoverage | null>(null)
+  const [resyncing, setResyncing] = useState(false)
+  const [resyncDone, setResyncDone] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!workspaceId) return
+    guard.developerTools.list(authFetch, workspaceId)
+      .then(d => { if (d) setToolCoverage(d) })
+      .catch(() => {})
+  }, [authFetch, workspaceId])
+
+  async function handleResync() {
+    if (!workspaceId || resyncing) return
+    setResyncing(true)
+    setResyncDone(false)
+    try {
+      const res = await guard.config.resync(authFetch, workspaceId)
+      if (!res.ok) throw new Error(`Resync failed (${res.status})`)
+      setResyncDone(true)
+      setTimeout(() => setResyncDone(false), 2000)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Resync failed")
+    } finally {
+      setResyncing(false)
+    }
+  }
+
+  return (
+    <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 20 }}>
+      <div className="card" style={{ padding: "18px 20px", minWidth: 0 }}>
+        <div className="eyebrow" style={{ marginBottom: 12 }}>Sync status</div>
+        {toolCoverage === null ? (
+          <div style={{ height: 40 }} />
+        ) : (() => {
+          const total = toolCoverage.length
+          const synced = toolCoverage.filter(dev =>
+            dev.detected_tools.every(t =>
+              dev.mcp_registered.includes(t) || dev.hook_registered.includes(t)
+            )
+          ).length
+          const allGood = total === 0 || synced === total
+          return (
+            <>
+              <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                <span style={{ fontSize: 26, fontWeight: 700, color: allGood ? "var(--ok)" : "var(--warn)" }}>
+                  {total === 0 ? "—" : `${synced}/${total}`}
+                </span>
+                <span style={{ fontSize: 13, color: "var(--text-3)" }}>machines in sync</span>
+              </div>
+              <div style={{ fontSize: 12.5, color: "var(--text-muted)", marginTop: 4 }}>
+                Policies propagate within <strong style={{ color: "var(--text-2)" }}>60s</strong> of a change.
+              </div>
+              <div style={{ display: "flex", alignItems: "center", gap: 7, marginTop: 14, fontSize: 12.5, color: allGood ? "var(--ok)" : "var(--warn)" }}>
+                <span className="conduct-pulse-dot" style={{ background: allGood ? "var(--ok)" : "var(--warn)" }} />
+                {total === 0 ? "No developers connected yet" : allGood ? "All developers up to date" : `${total - synced} developer${total - synced !== 1 ? "s" : ""} need sync — run: conduct guard sync`}
+              </div>
+            </>
+          )
+        })()}
+      </div>
+      <div className="card" style={{ padding: "16px 20px", display: "flex", alignItems: "center", gap: 12 }}>
+        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="var(--text-3)" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M23 4v6h-6M1 20v-6h6" />
+          <path d="M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15" />
+        </svg>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontWeight: 600, fontSize: 13 }}>Re-sync all machines</div>
+          <div style={{ fontSize: 11.5, color: "var(--text-muted)" }}>Force a policy push now</div>
+        </div>
+        <button
+          className="btn btn-ghost btn-sm"
+          disabled={!isAdmin || resyncing}
+          style={{ opacity: isAdmin ? 1 : 0.5 }}
+          onClick={handleResync}
+        >
+          {resyncing ? "Syncing…" : resyncDone ? "Synced" : "Re-sync"}
+        </button>
+        {error && (
+          <span style={{ fontSize: 11, color: "var(--err)" }}>{error}</span>
+        )}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

Phase 2 Chunk A, panel **2 of 4** (Sync). Moves the "Sync status" tab out of `/theguard/settings` into a dedicated route.

- **New**: `apps/web/src/features/guard/connections/sync/Panel.tsx` — owns its own `toolCoverage` fetch, `handleResync`, and local error state
- **New**: `apps/web/src/app/(app)/theguard/connections/sync/page.tsx` — thin AppShell + GuardShell wrapper, same permission gate as settings
- **Settings**: `sync` dropped from `GuardSettingsTab` + tabs array + panels block; `toolCoverage`, `resyncing`, `resyncDone` state and `handleResync` removed; the "load sync coverage in parallel" side-effect in the settings load also removed (settings no longer needs it)
- **Legacy bookmarks**: `SettingsContent` redirect useEffect extended to handle both `?tab=notifications` and `?tab=sync`
- **Section rail**: no change needed — `guardSections.ts` already active-prefixes `/theguard/connections`

**Explicitly out of scope**: URL renames, schema/API changes, styling changes, Connections sub-nav (still deferred until panels 3–4 land).

Continues the plan started in #1854.

## Test plan
- [ ] Visit `/theguard/connections/sync` — shows "N/M machines in sync" card + "Re-sync all machines" card
- [ ] Click Re-sync → button flips to "Syncing…" then "Synced" for ~2s then back to "Re-sync"
- [ ] Non-admin: Re-sync button is disabled (opacity 0.5); redirected to `/theguard` if role resolves without settings edit perms
- [ ] Legacy bookmark `/theguard/settings?tab=sync` redirects to the new URL
- [ ] Legacy bookmark `/theguard/settings?tab=notifications` still redirects to `/theguard/connections/notifications`
- [ ] `/theguard/settings` (no tab) renders only Enforcement + Cost & performance tabs — no Sync, no Notifications
- [ ] Guard vertical rail highlights **Connections** on the new URL