### PR TITLE
polish(guard): rail order + Agents Discovered + hero label accuracy (#1840)

### DIFF
--- a/apps/web/src/app/(app)/theguard/page.tsx
+++ b/apps/web/src/app/(app)/theguard/page.tsx
@@ -871,7 +871,6 @@ function GuardDashboard() {
         warnedToday={events.filter(e => e.decision === "warned").length}
         agentPolicies={agentCount}
         proxyPolicies={proxyCount}
-        toolCoverage={toolCoverage}
       />
 
       {/* Everything below is legacy secondary — spend, sessions, tokens saved,

--- a/apps/web/src/app/(app)/theguard/page.tsx
+++ b/apps/web/src/app/(app)/theguard/page.tsx
@@ -669,6 +669,7 @@ function GuardDashboard() {
       active_developers: distinctDevs > 0 ? distinctDevs : events.length > 0 ? 1 : 0,
       events_today:      todayEvents.length,
       blocked_today:     todayEvents.filter(e => e.decision === "blocked").length,
+      warned_today:      todayEvents.filter(e => e.decision === "warned").length,
       tokens_saved_today: todayEvents.reduce(
         (s, e) => s + Math.max(0, (e.tokens_before ?? 0) - (e.tokens_after ?? 0)), 0
       ),
@@ -868,7 +869,7 @@ function GuardDashboard() {
         loading={loading}
         eventsToday={stats?.events_today ?? derivedStats.events_today}
         blockedToday={blockedToday}
-        warnedToday={events.filter(e => e.decision === "warned").length}
+        warnedToday={derivedStats.warned_today}
         agentPolicies={agentCount}
         proxyPolicies={proxyCount}
       />

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -108,7 +108,7 @@ function getBreadcrumbs(pathname: string, projects: Project[]): string[] {
   if (pathname.startsWith('/theguard/spend')) return ['Guard', 'Spend']
   if (pathname.startsWith('/theguard/policies')) return ['Guard', 'Controls', 'Policies']
   if (pathname.startsWith('/theguard/approvals')) return ['Guard', 'Controls', 'Approvals']
-  if (pathname.startsWith('/theguard/discovery')) return ['Guard', 'Agents', 'Discovery']
+  if (pathname.startsWith('/theguard/discovery')) return ['Guard', 'Agents Discovered']
   if (pathname.startsWith('/theguard/activity')) return ['Guard', 'Activity']
   if (pathname.startsWith('/theguard/connections/proxy')) return ['Guard', 'Connections', 'Proxy & gateways']
   if (pathname.startsWith('/theguard/connections')) return ['Guard', 'Connections']

--- a/apps/web/src/components/guard/overview/OverviewHero.tsx
+++ b/apps/web/src/components/guard/overview/OverviewHero.tsx
@@ -12,15 +12,17 @@
 import { useCallback, useEffect, useState } from "react"
 import Link from "next/link"
 import type { AuthFetch } from "@/lib/api"
-import { guardInbox } from "@/lib/api"
+import { guard, guardInbox } from "@/lib/api"
 
 // ─── Types ────────────────────────────────────────────────────────────────
 
 type Tone = "accent" | "ok" | "warn" | "err" | "plain"
 
-interface CoverageRow {
-  mcp_registered?: string[]
-  hook_registered?: string[]
+interface DiscoverySummary {
+  total: number
+  under_guard: number
+  missing: number
+  coverage_pct: number
 }
 
 export interface OverviewHeroProps {
@@ -32,7 +34,6 @@ export interface OverviewHeroProps {
   warnedToday: number
   agentPolicies: number | null
   proxyPolicies: number | null
-  toolCoverage: CoverageRow[]
 }
 
 // ─── Tile primitive ───────────────────────────────────────────────────────
@@ -102,6 +103,28 @@ function useInboxCounts(authFetch: AuthFetch, teamId: string | null) {
   return counts
 }
 
+// Agent Discovery summary — same source /theguard/discovery uses so the
+// hero count matches the drill-in page. Fetching here (rather than
+// receiving from the parent) keeps the tile independent of Overview
+// state and matches the pattern useInboxCounts uses.
+function useDiscoverySummary(authFetch: AuthFetch, teamId: string | null) {
+  const [summary, setSummary] = useState<DiscoverySummary | null>(null)
+
+  const load = useCallback(async () => {
+    if (!teamId) return
+    try {
+      const data = await guard.discover.summary(authFetch)
+      setSummary(data as DiscoverySummary)
+    } catch {
+      // Non-fatal — hero tile shows "—" instead
+    }
+  }, [authFetch, teamId])
+
+  useEffect(() => { void load() }, [load])
+
+  return summary
+}
+
 // ─── Component ────────────────────────────────────────────────────────────
 
 export function OverviewHero({
@@ -113,13 +136,9 @@ export function OverviewHero({
   warnedToday,
   agentPolicies,
   proxyPolicies,
-  toolCoverage,
 }: OverviewHeroProps) {
   const inboxCounts = useInboxCounts(authFetch, teamId)
-
-  const coveredDevs = toolCoverage.filter(
-    d => (d.mcp_registered?.length ?? 0) + (d.hook_registered?.length ?? 0) > 0,
-  ).length
+  const discovery = useDiscoverySummary(authFetch, teamId)
 
   return (
     <div style={{
@@ -163,13 +182,19 @@ export function OverviewHero({
       <Link href="/theguard/discovery" style={{ textDecoration: "none" }}>
         <HeroTile
           title="Agents Discovered"
-          value={toolCoverage.length}
+          value={discovery == null ? "—" : discovery.total}
           sub={
-            toolCoverage.length === 0
-              ? "run discovery to populate"
-              : `${coveredDevs}/${toolCoverage.length} under Guard`
+            discovery == null
+              ? "loading…"
+              : discovery.total === 0
+                ? "run discovery to populate"
+                : `${discovery.under_guard}/${discovery.total} under Guard · ${discovery.missing} missing`
           }
-          tone={toolCoverage.length === 0 ? "plain" : "ok"}
+          tone={
+            discovery == null || discovery.total === 0
+              ? "plain"
+              : discovery.missing > 0 ? "warn" : "ok"
+          }
         />
       </Link>
     </div>

--- a/apps/web/src/components/guard/overview/OverviewHero.tsx
+++ b/apps/web/src/components/guard/overview/OverviewHero.tsx
@@ -149,9 +149,9 @@ export function OverviewHero({
     }}>
       <Link href="/logs/guard" style={{ textDecoration: "none" }}>
         <HeroTile
-          title="Live Activity"
+          title="Activity Today"
           value={loading ? "—" : eventsToday.toLocaleString()}
-          sub={loading ? "loading…" : `${blockedToday} blocked · ${warnedToday} warned today`}
+          sub={loading ? "loading…" : `${blockedToday} blocked · ${warnedToday} warned`}
           tone={blockedToday > 0 ? "err" : "ok"}
         />
       </Link>
@@ -159,13 +159,13 @@ export function OverviewHero({
         <HeroTile
           title="Inbox"
           value={inboxCounts == null ? "—" : inboxCounts.open}
-          sub={inboxCounts == null ? "loading…" : `${inboxCounts.triaging} triaging · click to resolve`}
+          sub={inboxCounts == null ? "loading…" : `${inboxCounts.open} open · ${inboxCounts.triaging} triaging`}
           tone={inboxCounts != null && inboxCounts.open > 0 ? "warn" : "ok"}
         />
       </Link>
       <Link href="/theguard/policies" style={{ textDecoration: "none" }}>
         <HeroTile
-          title="Controls"
+          title="Active Policies"
           value={
             agentPolicies == null && proxyPolicies == null
               ? "—"

--- a/apps/web/src/lib/navigation/guardSections.ts
+++ b/apps/web/src/lib/navigation/guardSections.ts
@@ -29,7 +29,7 @@ export const GUARD_SECTIONS: readonly GuardSection[] = [
   { id: "overview",    label: "Overview",    href: "/theguard",                   activePrefixes: ["/theguard"] },
   { id: "inbox",       label: "Inbox",       href: "/theguard/inbox",             activePrefixes: ["/theguard/inbox"] },
   { id: "activity",    label: "Activity",    href: "/logs/guard",                 activePrefixes: ["/logs/guard", "/theguard/activity", "/theguard/blocks"] },
-  { id: "agents",      label: "Agents",      href: "/theguard/discovery",         activePrefixes: ["/theguard/discovery", "/theguard/agents", "/agent-identity"] },
+  { id: "agents",      label: "Agents Discovered", href: "/theguard/discovery",   activePrefixes: ["/theguard/discovery", "/theguard/agents", "/agent-identity"] },
   { id: "controls",    label: "Controls",    href: "/theguard/policies",          activePrefixes: ["/theguard/policies", "/theguard/approvals"] },
   { id: "spend",       label: "Spend",       href: "/theguard/spend",             activePrefixes: ["/theguard/spend"] },
   { id: "connections", label: "Connections", href: "/theguard/connections/proxy", activePrefixes: ["/theguard/connections"] },

--- a/apps/web/src/lib/navigation/guardSections.ts
+++ b/apps/web/src/lib/navigation/guardSections.ts
@@ -22,11 +22,15 @@ export interface GuardSection {
 }
 
 export const GUARD_SECTIONS: readonly GuardSection[] = [
+  // Order reflects the daily user loop: Inbox (finite triage queue) sits
+  // above Activity (raw feed) because the queue converges on zero if you
+  // work it — the feed never does. Same rationale every mature triage UI
+  // (Slack, Linear, GitHub notifications) uses.
   { id: "overview",    label: "Overview",    href: "/theguard",                   activePrefixes: ["/theguard"] },
   { id: "inbox",       label: "Inbox",       href: "/theguard/inbox",             activePrefixes: ["/theguard/inbox"] },
+  { id: "activity",    label: "Activity",    href: "/logs/guard",                 activePrefixes: ["/logs/guard", "/theguard/activity", "/theguard/blocks"] },
   { id: "agents",      label: "Agents",      href: "/theguard/discovery",         activePrefixes: ["/theguard/discovery", "/theguard/agents", "/agent-identity"] },
   { id: "controls",    label: "Controls",    href: "/theguard/policies",          activePrefixes: ["/theguard/policies", "/theguard/approvals"] },
-  { id: "activity",    label: "Activity",    href: "/logs/guard",                 activePrefixes: ["/logs/guard", "/theguard/activity", "/theguard/blocks"] },
   { id: "spend",       label: "Spend",       href: "/theguard/spend",             activePrefixes: ["/theguard/spend"] },
   { id: "connections", label: "Connections", href: "/theguard/connections/proxy", activePrefixes: ["/theguard/connections"] },
 ]


### PR DESCRIPTION
## What this PR does

Four small follow-ups on the Guard Inbox surface merged in #1855.
Each commit is independently reviewable.

## Type

- [x] Refactor / internal change (label + IA polish, no new behavior)
- [x] Bug fix (Discovery hero source)

## Scope

### 1. Rail order — `Overview → Inbox → Activity → Agents → Controls → Spend → Connections`

Daily user loop: Inbox (finite triage queue with resolve actions) sits
above Activity (infinite feed) because the queue converges on zero if
you work it — the feed never does. Same rationale Slack / Linear /
GitHub notifications use for queue-above-feed.

### 2. Fix — Agents Discovered tile

The Overview hero was reading `toolCoverage` (developer-tool coverage
rows — just one dev machine) instead of the real Discovery summary.
Result: hero showed "1 · 1/1 under Guard" while `/theguard/discovery`
shows "18 total · 14 under Guard · 4 missing".

Now uses `guard.discover.summary()` — the same endpoint the drill-in
page uses. Sub reads "X/Y under Guard · Z missing". Tone: warn if any
missing.

### 3. Hero labels match what the tiles show

- "Live Activity" → **"Activity Today"** (label matches the today total
  the tile actually renders).
- `warnedToday` sourced from `derivedStats.warned_today` (workspace-wide
  today count) instead of `events.filter(...)` (which returned the
  *filtered* visible page).
- "Inbox" sub: `X open · Y triaging` instead of "click to resolve" (UI
  hint, not data).
- "Controls" → **"Active Policies"** (label matches the enabled-policy
  count).

### 4. Rail label — `Agents` → **`Agents Discovered`**

Disambiguates from "Agent Identities" (cond_agt_* lifecycle — stays
under Workspace for now; would squish under Guard's rail). Also updates
the breadcrumb.

## Checklist

- [x] `pnpm typecheck` — clean (2 pre-existing CSS-import errors on main
  are unchanged).
- [x] DCO trailer on every commit.

Follow-ups still on the epic (not in this PR):
- Move Agent Identities under Guard as a proper section (needs UI
  design pass — current page has 5 tabs, would feel cramped under the
  Guard rail).
- Phase D — tag `cli/v0.13.0` + PyPI publish + close #1840.
