### PR TITLE
chore(web): Guard sub-nav + retire Settings rail entry

### DIFF
--- a/apps/web/src/app/(app)/theguard/connections/notifications/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/notifications/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import NotificationsPanel from "@/features/guard/connections/notifications/Panel"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardNotificationsPage() {
   return (
@@ -29,6 +30,7 @@ function NotificationsContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={CONNECTIONS_TABS} />
       <NotificationsPanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
@@ -4,6 +4,7 @@ import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import ProxySettings from "@/components/settings/ProxySettings"
 import { useWorkspace } from "@/lib/WorkspaceContext"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardProxyConnectionsPage() {
   const { activeWorkspace } = useWorkspace()
@@ -12,6 +13,7 @@ export default function GuardProxyConnectionsPage() {
   return (
     <AppShell>
       <GuardShell>
+        <GuardSectionTabs tabs={CONNECTIONS_TABS} />
         <div style={{ maxWidth: 960 }}>
           <h2 style={{ fontSize: 18, fontWeight: 650, margin: "8px 0 4px" }}>
             Proxy &amp; gateways

--- a/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import SyncPanel from "@/features/guard/connections/sync/Panel"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardSyncPage() {
   return (
@@ -29,6 +30,7 @@ function SyncContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={CONNECTIONS_TABS} />
       <SyncPanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/spend/optimization/page.tsx
+++ b/apps/web/src/app/(app)/theguard/spend/optimization/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import CostPerformancePanel from "@/features/guard/spend/optimization/Panel"
+import { GuardSectionTabs, SPEND_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardCostPerformancePage() {
   return (
@@ -29,6 +30,7 @@ function CostPerformanceContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={SPEND_TABS} />
       <CostPerformancePanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/spend/page.tsx
+++ b/apps/web/src/app/(app)/theguard/spend/page.tsx
@@ -11,6 +11,7 @@ import { useGuardSavings } from "@/hooks/useGuardSavings"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import { ByAiToolTable } from "@/components/guard/ByAiToolTable"
+import { GuardSectionTabs, SPEND_TABS } from "@/features/guard/GuardSectionTabs"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -668,6 +669,7 @@ function SpendContent() {
   if (!roleLoading && !canViewSpend) {
     return (
       <GuardShell lastFetched={lastUpdated}>
+        <GuardSectionTabs tabs={SPEND_TABS} />
         <div className="card" style={{ padding: "64px 24px", textAlign: "center", fontSize: 13, color: "var(--text-muted)" }}>
           You don&apos;t have access to spend data. Contact your admin.
         </div>
@@ -677,6 +679,7 @@ function SpendContent() {
 
   return (
     <GuardShell lastFetched={lastUpdated}>
+      <GuardSectionTabs tabs={SPEND_TABS} />
       {/* Page controls row */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, marginBottom: 20 }}>
         <select

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -153,7 +153,7 @@ const PALETTE_COMMANDS = [
   { group: "ASK", label: "Lens", href: "/lens", icon: "Spark" as const },
   ...GUARD_SECTIONS.map(s => ({ group: "GOVERN" as const, label: `Guard · ${s.label}`, href: s.href, icon: "Shield" as const })),
   { group: "GOVERN", label: "Guard · Compliance", href: "/theguard/compliance", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Settings", href: "/theguard/settings", icon: "Shield" as const },
+  { group: "GOVERN", label: "Guard · Enforcement", href: "/theguard/policies/enforcement", icon: "Shield" as const },
   { group: "WORKSPACE", label: "Integrations", href: "/integrations", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Agent ID", href: "/agent-identity", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Settings · Vault", href: "/settings", icon: "Gear" as const },

--- a/apps/web/src/components/guard/GuardShell.tsx
+++ b/apps/web/src/components/guard/GuardShell.tsx
@@ -40,11 +40,6 @@ function ComplianceIcon() {
   return <svg {...common}><path d="M9 12l2 2 4-4" /><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
 }
 
-function SettingsIcon() {
-  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
-  return <svg {...common}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" /></svg>
-}
-
 function ChevronLeft() {
   return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
 }
@@ -137,11 +132,9 @@ export function GuardShell({
   }, [])
 
   const showCompliance = role === "admin" || role === "security"
-  const showSettings   = role === "admin"
-  const hasAdminItems  = showCompliance || showSettings
+  const hasAdminItems  = showCompliance
 
   const isComplianceActive = pathname?.startsWith("/theguard/compliance") ?? false
-  const isSettingsActive   = pathname?.startsWith("/theguard/settings") ?? false
 
   const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED
 
@@ -208,15 +201,6 @@ export function GuardShell({
                   label="Compliance"
                   icon={<ComplianceIcon />}
                   active={isComplianceActive}
-                  collapsed={collapsed}
-                />
-              )}
-              {showSettings && (
-                <RailItem
-                  href="/theguard/settings"
-                  label="Settings"
-                  icon={<SettingsIcon />}
-                  active={isSettingsActive}
                   collapsed={collapsed}
                 />
               )}

--- a/apps/web/src/features/guard/GuardSectionTabs.tsx
+++ b/apps/web/src/features/guard/GuardSectionTabs.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+export interface GuardSectionTab {
+  href: string
+  label: string
+}
+
+export const CONNECTIONS_TABS: readonly GuardSectionTab[] = [
+  { href: "/theguard/connections/proxy",         label: "Proxy & gateways" },
+  { href: "/theguard/connections/notifications", label: "Notifications" },
+  { href: "/theguard/connections/sync",          label: "Sync" },
+]
+
+export const SPEND_TABS: readonly GuardSectionTab[] = [
+  { href: "/theguard/spend",              label: "Overview" },
+  { href: "/theguard/spend/optimization", label: "Optimization" },
+]
+
+export function GuardSectionTabs({ tabs }: { tabs: readonly GuardSectionTab[] }) {
+  const pathname = usePathname()
+  return (
+    <nav
+      aria-label="Section tabs"
+      style={{
+        display: "flex",
+        gap: 4,
+        borderBottom: "1px solid var(--border)",
+        marginBottom: 20,
+      }}
+    >
+      {tabs.map(t => {
+        const active = pathname === t.href
+        return (
+          <Link
+            key={t.href}
+            href={t.href}
+            style={{
+              padding: "8px 14px",
+              fontSize: 13,
+              fontWeight: active ? 600 : 500,
+              color: active ? "var(--text)" : "var(--text-3)",
+              borderBottom: `2px solid ${active ? "var(--accent)" : "transparent"}`,
+              marginBottom: -1,
+              textDecoration: "none",
+              transition: "color .12s",
+            }}
+          >
+            {t.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}


### PR DESCRIPTION
## Summary

Two follow-ups after the panel extraction arc (#1854, #1856, #1857, #1858):

### 1. Sub-nav within sections
New shared component \`features/guard/GuardSectionTabs.tsx\` renders a tab bar at the top of Connections and Spend pages so users can discover the panels that used to live behind \`/theguard/settings\` tabs.

- **Connections** → Proxy & gateways · Notifications · Sync
- **Spend** → Overview · Optimization

### 2. Retire the "Settings" rail entry
With all four panels moved into their sections, the standalone \"Settings\" item in \`GuardShell\`'s admin cluster has no unique job — every destination it reached is now reachable via section rail + sub-tab.

- **\`GuardShell.tsx\`**: dropped the admin-cluster Settings \`RailItem\`, its \`SettingsIcon\`, and the now-unused \`isSettingsActive\`/\`showSettings\` refs. Compliance still shown (admin/security).
- **\`AppShell.tsx\`**: ⌘K palette entry renamed \"Guard · Settings\" → \"Guard · Enforcement\", href \`/theguard/settings\` → \`/theguard/policies/enforcement\`.

Old \`/theguard/settings\` route stays as a redirect shim (from #1858) — any lingering bookmarks or deep links keep working.

## Test plan
- [ ] Visit \`/theguard/connections/proxy\` — tab bar shows Proxy · Notifications · Sync; Proxy is bold + underlined
- [ ] Click Notifications tab → lands on \`/theguard/connections/notifications\` with same tab bar, Notifications highlighted
- [ ] Click Sync tab → lands on \`/theguard/connections/sync\`, Sync highlighted
- [ ] Visit \`/theguard/spend\` — Overview · Optimization tabs, Overview highlighted
- [ ] Click Optimization → lands on \`/theguard/spend/optimization\`, Optimization highlighted
- [ ] Non-admin visiting \`/theguard/spend\` sees the tabs (the redirect on the panel itself still fires when they click Optimization)
- [ ] Guard vertical rail no longer shows the \"Settings\" item under the admin divider; Compliance still shown for admin/security
- [ ] ⌘K palette entry \"Guard · Enforcement\" navigates to \`/theguard/policies/enforcement\`
- [ ] Legacy \`/theguard/settings\` link (from anywhere) still redirects correctly (from #1858)