### PR TITLE
feat(guard): shared UI primitives + refactor Inbox + Activity (#1840)

### DIFF
--- a/apps/web/src/app/(app)/logs/guard/page.tsx
+++ b/apps/web/src/app/(app)/logs/guard/page.tsx
@@ -22,6 +22,11 @@ import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api"
 import { GuardShell } from "@/components/guard/GuardShell"
 import { ActivityRow, ActivityHeader, ToolBadge, DecisionBadge, BlastRadiusBadge, formatTs, type AuditEvent } from "@/components/guard/ActivityRow"
+import {
+  GuardFilterBar,
+  GuardPageHeader,
+  type FilterPill,
+} from "@/components/guard/common"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -392,6 +397,12 @@ function ActivityContent() {
         </div>
       )}
 
+      <GuardPageHeader
+        title="Activity"
+        description="Real-time firehose of every AI tool call routed through Guard. Every row is chained and audit-verifiable."
+        lastUpdated={lastUpdated}
+      />
+
       {/* Audit chain badge */}
       {chainStatus && (
         <div style={{ display: "flex", alignItems: "center", gap: 6, marginBottom: 12 }}>
@@ -430,31 +441,17 @@ function ActivityContent() {
         ))}
       </div>
 
-      {/* Filter chips + realtime indicator */}
-      {activeView === "events" && (<div style={{ display: "flex", alignItems: "center", gap: 9, marginBottom: 16, flexWrap: "wrap" }}>
-        {/* Decision filter chips */}
-        {["", "blocked", "warned", "allowed"].map(d => {
-          const label = d === "" ? "All" : d.charAt(0).toUpperCase() + d.slice(1)
-          const active = filterDecision === d
-          return (
-            <button
-              key={d}
-              onClick={() => setFilterDecision(d)}
-              className="chip"
-              style={{
-                height: 30,
-                fontWeight: 600,
-                background: active ? "var(--accent-weak)" : "var(--surface)",
-                borderColor: active ? "var(--accent-ring)" : "var(--border)",
-                color: active ? "var(--accent-text)" : "var(--text-2)",
-              }}
-            >
-              {label}
-            </button>
-          )
-        })}
-
-        {/* More filters */}
+      {/* Filter bar + realtime indicator */}
+      {activeView === "events" && (<GuardFilterBar<string>
+        pills={([
+          { value: "",        label: "All" },
+          { value: "blocked", label: "Blocked" },
+          { value: "warned",  label: "Warned" },
+          { value: "allowed", label: "Allowed" },
+        ]) as readonly FilterPill<string>[]}
+        active={filterDecision}
+        onChange={setFilterDecision}
+      >
         {!permissionsLoading && permissions.canViewAllActivity && (
           <select
             value={filterDeveloper}
@@ -573,7 +570,7 @@ function ActivityContent() {
             SOC 2 Report →
           </a>
         )}
-      </div>)}
+      </GuardFilterBar>)}
 
       {/* Sessions & Machines view */}
       {activeView === "sessions" && sessionsError && (

--- a/apps/web/src/app/(app)/theguard/inbox/page.tsx
+++ b/apps/web/src/app/(app)/theguard/inbox/page.tsx
@@ -3,6 +3,14 @@
 import { useCallback, useEffect, useMemo, useState } from "react"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import {
+  GuardBadge,
+  GuardFilterBar,
+  GuardPageHeader,
+  GuardSectionHeader,
+  timeAgo,
+  type FilterPill,
+} from "@/components/guard/common"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { guardInbox } from "@/lib/api"
 import type {
@@ -13,31 +21,6 @@ import type {
   InboxSource,
   ResolvedReason,
 } from "@/lib/api"
-
-// ─── Formatting helpers ───────────────────────────────────────────────────
-
-function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime()
-  const sec = Math.floor(diff / 1000)
-  if (sec < 60) return `${Math.max(sec, 0)}s ago`
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  const hr = Math.floor(min / 60)
-  if (hr < 24) return `${hr}h ago`
-  return `${Math.floor(hr / 24)}d ago`
-}
-
-const SEVERITY_COLOR: Record<string, { bg: string; fg: string }> = {
-  critical: { bg: "var(--err-bg)",  fg: "var(--err)"  },
-  medium:   { bg: "var(--warn-bg)", fg: "var(--warn)" },
-  low:      { bg: "var(--info-bg)", fg: "var(--info)" },
-}
-
-const STATUS_COLOR: Record<string, { bg: string; fg: string }> = {
-  open:     { bg: "var(--warn-bg)", fg: "var(--warn)" },
-  triaging: { bg: "var(--info-bg)", fg: "var(--info)" },
-  resolved: { bg: "var(--ok-bg)",   fg: "var(--ok)"   },
-}
 
 const REASON_LABEL: Record<ResolvedReason, string> = {
   expected:         "Expected — working as intended",
@@ -154,49 +137,48 @@ export default function GuardInboxPage() {
   return (
     <AppShell>
       <GuardShell lastFetched={lastFetched}>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
-          <div>
-            <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--text)" }}>Inbox</h2>
-            <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>
-              Deduped triage of blocked, warned, and approved events. One row per rule × source × message.
-            </div>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: 8, fontSize: 12, color: "var(--text-muted)" }}>
-            <span>Sync events from the last</span>
-            <select
-              value={backfillDays}
-              onChange={e => setBackfillDays(Number(e.target.value))}
-              disabled={backfillBusy}
-              style={{
-                background: "var(--surface)",
-                color: "var(--text)",
-                border: "1px solid var(--border)",
-                borderRadius: 4,
-                padding: "4px 8px",
-                fontSize: 12,
-              }}
-            >
-              <option value={30}>30 days</option>
-              <option value={60}>60 days</option>
-              <option value={90}>90 days</option>
-            </select>
-            <button
-              onClick={runBackfill}
-              disabled={backfillBusy}
-              style={{
-                background: "var(--surface)",
-                color: "var(--text)",
-                border: "1px solid var(--border)",
-                borderRadius: 4,
-                padding: "4px 12px",
-                fontSize: 12,
-                cursor: backfillBusy ? "wait" : "pointer",
-              }}
-            >
-              {backfillBusy ? "Syncing…" : "Sync now"}
-            </button>
-          </div>
-        </div>
+        <GuardPageHeader
+          title="Inbox"
+          description="Deduped triage of blocked, warned, and approved events. One row per rule × source × message."
+          lastUpdated={lastFetched}
+          right={
+            <>
+              <span>Sync last</span>
+              <select
+                value={backfillDays}
+                onChange={e => setBackfillDays(Number(e.target.value))}
+                disabled={backfillBusy}
+                style={{
+                  background: "var(--surface)",
+                  color: "var(--text)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 4,
+                  padding: "4px 8px",
+                  fontSize: 12,
+                }}
+              >
+                <option value={30}>30 days</option>
+                <option value={60}>60 days</option>
+                <option value={90}>90 days</option>
+              </select>
+              <button
+                onClick={runBackfill}
+                disabled={backfillBusy}
+                style={{
+                  background: "var(--surface)",
+                  color: "var(--text)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 4,
+                  padding: "4px 12px",
+                  fontSize: 12,
+                  cursor: backfillBusy ? "wait" : "pointer",
+                }}
+              >
+                {backfillBusy ? "Syncing…" : "Sync now"}
+              </button>
+            </>
+          }
+        />
 
         {backfillMsg && (
           <div style={{
@@ -208,32 +190,16 @@ export default function GuardInboxPage() {
           </div>
         )}
 
-        {/* Filter bar */}
-        <div style={{ display: "flex", gap: 8, marginBottom: 12, flexWrap: "wrap" }}>
-          {(["open", "triaging", "resolved", "all"] as const).map(k => (
-            <button
-              key={k}
-              onClick={() => setStatusFilter(k)}
-              style={{
-                padding: "6px 12px",
-                fontSize: 12,
-                borderRadius: 4,
-                border: "1px solid var(--border)",
-                background: statusFilter === k ? "var(--accent-bg)" : "var(--surface)",
-                color: statusFilter === k ? "var(--accent)" : "var(--text-muted)",
-                fontWeight: statusFilter === k ? 600 : 400,
-                cursor: "pointer",
-              }}
-            >
-              {k === "all" ? "All" : k[0].toUpperCase() + k.slice(1)}
-              {k !== "all" && counts[k as keyof typeof counts] > 0 && (
-                <span style={{ marginLeft: 6, fontSize: 11, opacity: 0.7 }}>
-                  {counts[k as keyof typeof counts]}
-                </span>
-              )}
-            </button>
-          ))}
-          <div style={{ width: 1, background: "var(--border)", margin: "0 4px" }} />
+        <GuardFilterBar<InboxStatus | "all">
+          pills={([
+            { value: "open",     label: "Open",     count: counts.open },
+            { value: "triaging", label: "Triaging", count: counts.triaging },
+            { value: "resolved", label: "Resolved", count: counts.resolved },
+            { value: "all",      label: "All" },
+          ] as const) as readonly FilterPill<InboxStatus | "all">[]}
+          active={statusFilter}
+          onChange={setStatusFilter}
+        >
           <select
             value={severityFilter}
             onChange={e => setSeverityFilter(e.target.value as InboxSeverity | "all")}
@@ -263,7 +229,7 @@ export default function GuardInboxPage() {
             <option value="hook">Hook</option>
             <option value="runtime">Runtime</option>
           </select>
-        </div>
+        </GuardFilterBar>
 
         {error && (
           <div style={{
@@ -292,8 +258,6 @@ export default function GuardInboxPage() {
         {rows.length > 0 && (
           <div style={{ border: "1px solid var(--border)", borderRadius: 6, overflow: "hidden" }}>
             {rows.map((row, idx) => {
-              const sevColor = SEVERITY_COLOR[row.severity] ?? SEVERITY_COLOR.medium
-              const statusColor = STATUS_COLOR[row.status] ?? STATUS_COLOR.open
               const isExpanded = expandedId === row.id
               const rowEvents = events[row.id] ?? []
               return (
@@ -313,13 +277,7 @@ export default function GuardInboxPage() {
                       fontSize: 13,
                     }}
                   >
-                    <span style={{
-                      display: "inline-block", padding: "2px 8px", fontSize: 11,
-                      borderRadius: 4, background: sevColor.bg, color: sevColor.fg, fontWeight: 600,
-                      textAlign: "center",
-                    }}>
-                      {row.severity}
-                    </span>
+                    <GuardBadge kind="severity" value={row.severity} />
                     <div style={{ overflow: "hidden" }}>
                       <div style={{ color: "var(--text)", fontWeight: 500, marginBottom: 2 }}>
                         {row.rule_id}
@@ -337,13 +295,7 @@ export default function GuardInboxPage() {
                     <span style={{ color: "var(--text-muted)", fontSize: 12 }}>
                       {row.occurrences}× · {timeAgo(row.last_seen_at)}
                     </span>
-                    <span style={{
-                      display: "inline-block", padding: "2px 8px", fontSize: 11,
-                      borderRadius: 4, background: statusColor.bg, color: statusColor.fg,
-                      textAlign: "center",
-                    }}>
-                      {row.status}
-                    </span>
+                    <GuardBadge kind="status" value={row.status} />
                     <span style={{ color: "var(--text-muted)", textAlign: "right" }}>
                       {isExpanded ? "▾" : "▸"}
                     </span>
@@ -353,9 +305,7 @@ export default function GuardInboxPage() {
                     <div style={{ padding: "0 16px 16px 16px", borderTop: "1px solid var(--border)" }}>
                       {/* Recent events */}
                       <div style={{ marginTop: 12, marginBottom: 16 }}>
-                        <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, color: "var(--text-muted)", marginBottom: 8 }}>
-                          Recent events ({rowEvents.length})
-                        </div>
+                        <GuardSectionHeader title="Recent events" subtitle={`${rowEvents.length}`} />
                         {rowEvents.length === 0 && (
                           <div style={{ fontSize: 12, color: "var(--text-muted)" }}>No events loaded yet.</div>
                         )}
@@ -368,7 +318,7 @@ export default function GuardInboxPage() {
                                 background: "var(--surface)", borderRadius: 3, color: "var(--text-muted)",
                               }}>
                                 <span>{timeAgo(e.ts)}</span>
-                                <span style={{ fontWeight: 500 }}>{e.decision}</span>
+                                <GuardBadge kind="decision" value={e.decision} />
                                 <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
                                   {e.ai_tool ?? "-"} {e.user_email ? `· ${e.user_email}` : ""}
                                 </span>
@@ -387,9 +337,7 @@ export default function GuardInboxPage() {
                           padding: 12, background: "var(--surface)", borderRadius: 6,
                           border: "1px solid var(--border)",
                         }}>
-                          <div style={{ fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5, color: "var(--text-muted)", marginBottom: 8 }}>
-                            Resolve
-                          </div>
+                          <GuardSectionHeader title="Resolve" />
                           <div style={{ display: "flex", gap: 8, marginBottom: 8, flexWrap: "wrap" }}>
                             {(Object.keys(REASON_LABEL) as ResolvedReason[]).map(r => (
                               <label key={r} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text)" }}>

--- a/apps/web/src/components/guard/common/GuardBadge.tsx
+++ b/apps/web/src/components/guard/common/GuardBadge.tsx
@@ -1,0 +1,76 @@
+// Shared badge component for Guard event surfaces.
+//
+// One rendering rule for every colored pill in the Guard IA:
+// severity, decision, status, source. Keeps color language consistent
+// so users learn "critical is always red, allowed is always green,
+// open is always warn-toned" no matter which page they land on.
+//
+// Extend by adding a new variant kind + palette entry — don't inline
+// styled pills in pages.
+
+import type { CSSProperties } from "react"
+
+type Kind = "severity" | "decision" | "status" | "source"
+type Tone = "critical" | "warn" | "ok" | "info" | "plain"
+
+const TONE_STYLES: Record<Tone, CSSProperties> = {
+  critical: { background: "var(--err-bg)",  color: "var(--err)"  },
+  warn:     { background: "var(--warn-bg)", color: "var(--warn)" },
+  ok:       { background: "var(--ok-bg)",   color: "var(--ok)"   },
+  info:     { background: "var(--info-bg)", color: "var(--info)" },
+  plain:    { background: "var(--surface)", color: "var(--text-muted)" },
+}
+
+function toneFor(kind: Kind, value: string): Tone {
+  const v = value.toLowerCase()
+  if (kind === "severity") {
+    if (v === "critical" || v === "high") return "critical"
+    if (v === "medium") return "warn"
+    if (v === "low") return "info"
+    return "plain"
+  }
+  if (kind === "decision") {
+    if (v === "blocked") return "critical"
+    if (v === "warned") return "warn"
+    if (v === "allowed" || v === "approved") return "ok"
+    return "plain"
+  }
+  if (kind === "status") {
+    if (v === "open" || v === "pending") return "warn"
+    if (v === "triaging") return "info"
+    if (v === "resolved" || v === "approved") return "ok"
+    if (v === "rejected") return "critical"
+    return "plain"
+  }
+  // source — all neutral by design; the color language is reserved for
+  // the "does this need my attention" axis (severity + decision).
+  return "plain"
+}
+
+export function GuardBadge({
+  kind,
+  value,
+  label,
+}: {
+  kind: Kind
+  value: string
+  label?: string
+}) {
+  const tone = toneFor(kind, value)
+  return (
+    <span
+      style={{
+        display: "inline-block",
+        padding: "2px 8px",
+        fontSize: 11,
+        fontWeight: 600,
+        borderRadius: 4,
+        textAlign: "center",
+        letterSpacing: 0.2,
+        ...TONE_STYLES[tone],
+      }}
+    >
+      {label ?? value}
+    </span>
+  )
+}

--- a/apps/web/src/components/guard/common/GuardFilterBar.tsx
+++ b/apps/web/src/components/guard/common/GuardFilterBar.tsx
@@ -1,0 +1,68 @@
+// Filter bar for Guard event pages.
+//
+// Pill-style toggles on the left (open/triaging/resolved, blocked/warned/
+// allowed, etc.) plus a slot on the right for dropdowns, date pickers,
+// or actions. Pages currently roll their own — Inbox has one arrangement,
+// Activity another, Approvals a third. This is the shared shell.
+//
+// The pills accept optional counts so a page can render
+// "Open 79 | Triaging 3 | Resolved 14 | All" without redefining the
+// visual style each time.
+
+export interface FilterPill<T extends string> {
+  value: T
+  label: string
+  count?: number
+}
+
+export function GuardFilterBar<T extends string>({
+  pills,
+  active,
+  onChange,
+  children,
+}: {
+  pills: readonly FilterPill<T>[]
+  active: T
+  onChange: (v: T) => void
+  children?: React.ReactNode
+}) {
+  return (
+    <div style={{
+      display: "flex", gap: 8, marginBottom: 12,
+      flexWrap: "wrap", alignItems: "center",
+    }}>
+      {pills.map(p => {
+        const isActive = p.value === active
+        return (
+          <button
+            key={p.value}
+            onClick={() => onChange(p.value)}
+            style={{
+              padding: "6px 12px",
+              fontSize: 12,
+              borderRadius: 4,
+              border: "1px solid var(--border)",
+              background: isActive ? "var(--accent-bg, var(--accent-weak))" : "var(--surface)",
+              color:      isActive ? "var(--accent-text, var(--accent))"    : "var(--text-muted)",
+              fontWeight: isActive ? 600 : 400,
+              cursor: "pointer",
+            }}
+          >
+            {p.label}
+            {p.count != null && (
+              <span style={{ marginLeft: 6, fontSize: 11, opacity: 0.7 }}>
+                {p.count}
+              </span>
+            )}
+          </button>
+        )
+      })}
+      {children != null && (
+        <>
+          <div style={{ width: 1, background: "var(--border)", height: 24, margin: "0 4px" }} />
+          {children}
+        </>
+      )}
+    </div>
+  )
+}

--- a/apps/web/src/components/guard/common/GuardPageHeader.tsx
+++ b/apps/web/src/components/guard/common/GuardPageHeader.tsx
@@ -1,0 +1,73 @@
+// Standard header for every Guard sub-page.
+//
+// Title on the left, optional "live" pill next to it, description
+// below, last-updated stamp in the top-right. Pages currently roll
+// their own headers — some have live pills, some have descriptions,
+// most inconsistent spacing. This centralizes the pattern.
+//
+// Not meant to replace <GuardShell> (which owns the rail and the top
+// "Guard · live" bar). This is the *inside* of a page — the section
+// title + one-liner + right-aligned status.
+
+import { timeAgo } from "./GuardTimeCount"
+
+export function GuardPageHeader({
+  title,
+  description,
+  live = false,
+  lastUpdated,
+  right,
+}: {
+  title: string
+  description?: string
+  live?: boolean
+  lastUpdated?: Date | null
+  right?: React.ReactNode
+}) {
+  return (
+    <div style={{
+      display: "flex",
+      alignItems: "flex-start",
+      justifyContent: "space-between",
+      gap: 24,
+      marginBottom: 16,
+    }}>
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+          <h2 style={{
+            fontSize: 18, fontWeight: 700, margin: 0, color: "var(--text)",
+          }}>
+            {title}
+          </h2>
+          {live && (
+            <span style={{
+              display: "inline-flex", alignItems: "center", gap: 4,
+              fontSize: 11, fontWeight: 600, padding: "2px 8px",
+              borderRadius: 12, background: "var(--ok-bg)", color: "var(--ok)",
+            }}>
+              <span style={{
+                width: 6, height: 6, borderRadius: "50%",
+                background: "var(--ok)",
+              }} />
+              live
+            </span>
+          )}
+        </div>
+        {description && (
+          <div style={{
+            fontSize: 12, color: "var(--text-muted)", marginTop: 4, lineHeight: 1.5,
+          }}>
+            {description}
+          </div>
+        )}
+      </div>
+      <div style={{
+        display: "flex", alignItems: "center", gap: 10,
+        fontSize: 12, color: "var(--text-muted)", whiteSpace: "nowrap",
+      }}>
+        {lastUpdated && <span>last updated: {timeAgo(lastUpdated)}</span>}
+        {right}
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/components/guard/common/GuardSectionHeader.tsx
+++ b/apps/web/src/components/guard/common/GuardSectionHeader.tsx
@@ -1,0 +1,34 @@
+// Section divider used inside Guard pages — e.g. "Ad-hoc sessions ·
+// 50 events" on Activity, "More metrics" on Overview, "Recent events"
+// on Inbox row expand. Same treatment everywhere so section boundaries
+// scan the same.
+
+export function GuardSectionHeader({
+  title,
+  subtitle,
+  right,
+}: {
+  title: string
+  subtitle?: string
+  right?: React.ReactNode
+}) {
+  return (
+    <div style={{
+      display: "flex", alignItems: "center", gap: 12, marginBottom: 10,
+    }}>
+      <span style={{
+        fontSize: 11, textTransform: "uppercase", letterSpacing: 0.5,
+        color: "var(--text-muted)", fontWeight: 600,
+      }}>
+        {title}
+      </span>
+      {subtitle && (
+        <span style={{ fontSize: 12, color: "var(--text-muted)" }}>
+          {subtitle}
+        </span>
+      )}
+      <div style={{ flex: 1, height: 1, background: "var(--border)" }} />
+      {right}
+    </div>
+  )
+}

--- a/apps/web/src/components/guard/common/GuardTimeCount.tsx
+++ b/apps/web/src/components/guard/common/GuardTimeCount.tsx
@@ -1,0 +1,41 @@
+// Shared time + count formatters for Guard event surfaces.
+// Keeping them in one file guarantees Inbox "18× · 59m ago" reads the
+// same as Activity "59m ago" as Discovery "59m ago" — no per-page
+// drift. If we ever adopt a locale-aware format, this is the one place
+// that changes.
+
+export function timeAgo(iso: string | Date | null | undefined): string {
+  if (!iso) return "—"
+  const then = typeof iso === "string" ? new Date(iso).getTime() : iso.getTime()
+  const sec = Math.floor((Date.now() - then) / 1000)
+  if (sec < 5) return "just now"
+  if (sec < 60) return `${sec}s ago`
+  const min = Math.floor(sec / 60)
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  return `${Math.floor(hr / 24)}d ago`
+}
+
+export function countAndAge(count: number, iso: string | Date | null | undefined): string {
+  return `${count.toLocaleString()}× · ${timeAgo(iso)}`
+}
+
+// Small pure-display component so JSX callers don't have to import both
+// the fn and remember the format.
+export function GuardTimeCount({
+  count,
+  ts,
+  muted = true,
+}: {
+  count?: number
+  ts: string | Date | null | undefined
+  muted?: boolean
+}) {
+  const text = count == null ? timeAgo(ts) : countAndAge(count, ts)
+  return (
+    <span style={{ fontSize: 12, color: muted ? "var(--text-muted)" : "var(--text)" }}>
+      {text}
+    </span>
+  )
+}

--- a/apps/web/src/components/guard/common/index.ts
+++ b/apps/web/src/components/guard/common/index.ts
@@ -1,0 +1,5 @@
+export { GuardPageHeader } from "./GuardPageHeader"
+export { GuardFilterBar, type FilterPill } from "./GuardFilterBar"
+export { GuardBadge } from "./GuardBadge"
+export { GuardTimeCount, timeAgo, countAndAge } from "./GuardTimeCount"
+export { GuardSectionHeader } from "./GuardSectionHeader"


### PR DESCRIPTION
## What this PR does

Introduces a shared **Guard UI primitives** kit so every page in the
Guard IA speaks the same visual language, then refactors the two
highest-traffic pages (Inbox + Activity) to consume the primitives.

## Type

- [x] Feature (new component kit)
- [x] Refactor (Inbox + Activity)

## Why

Every Guard page was rolling its own header, filter bar, badge palette,
and time formatter. Same job, different visual language across
Inbox / Activity / Discovery / Approvals — users had to relearn the
patterns page-by-page.

## New primitives — `apps/web/src/components/guard/common/`

| Primitive | Purpose |
|-----------|---------|
| `GuardPageHeader` | H2 + optional "live" pill + description + last-updated + right slot |
| `GuardFilterBar` | pill filter buttons + slot for dropdowns / date pickers / actions |
| `GuardBadge` | one component for **severity** / **decision** / **status** / **source**; color language locked (critical always red, allowed always green, open always warn) |
| `GuardTimeCount` | `"X× · Ym ago"` formatter (fn + component) |
| `GuardSectionHeader` | uppercase eyebrow + subtitle + divider |

Barrel exports from `apps/web/src/components/guard/common/index.ts`.

## Migrations in this PR

- **`/theguard/inbox`** — drops the inline `SEVERITY_COLOR` /
  `STATUS_COLOR` maps, inline filter chips, custom section-header
  spans, custom `timeAgo` helper. Net ~50-line reduction.
- **`/logs/guard`** (Activity) — adds a proper `GuardPageHeader`
  (was implicit before); swaps the decision filter chips for
  `GuardFilterBar`. Other filters stay in the children slot.

## What's intentionally NOT unified

Row visual model stays per-page — **cards for finite queues** (Inbox,
Approvals), **tables for firehoses** (Activity, Session Reports).
Different jobs warrant different row layouts. What's shared: header,
filter bar, badges, formatters, section dividers.

## Follow-ups (separate PRs)

- `/theguard/discovery` — table + row style
- `/theguard/approvals` — status pills + row card
- `/theguard/spend` — chart cards
- `/theguard/blocks` — receipt card
- Extend `GuardFilterBar` with a compound "clear filters" affordance
  once >3 non-pill filters are common

## Checklist

- [x] `pnpm typecheck` — clean (2 pre-existing CSS-import errors on main
  are unchanged).
- [x] DCO trailer on every commit.
- [x] No route changes. No API changes.
