### PR TITLE
chore(web): Guard sub-nav cleanup + dock Lens as resizable side panel

### DIFF
--- a/apps/web/src/app/(app)/theguard/connections/notifications/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/notifications/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import NotificationsPanel from "@/features/guard/connections/notifications/Panel"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardNotificationsPage() {
   return (
@@ -29,6 +30,7 @@ function NotificationsContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={CONNECTIONS_TABS} />
       <NotificationsPanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/proxy/page.tsx
@@ -4,6 +4,7 @@ import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import ProxySettings from "@/components/settings/ProxySettings"
 import { useWorkspace } from "@/lib/WorkspaceContext"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardProxyConnectionsPage() {
   const { activeWorkspace } = useWorkspace()
@@ -12,6 +13,7 @@ export default function GuardProxyConnectionsPage() {
   return (
     <AppShell>
       <GuardShell>
+        <GuardSectionTabs tabs={CONNECTIONS_TABS} />
         <div style={{ maxWidth: 960 }}>
           <h2 style={{ fontSize: 18, fontWeight: 650, margin: "8px 0 4px" }}>
             Proxy &amp; gateways

--- a/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
+++ b/apps/web/src/app/(app)/theguard/connections/sync/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import SyncPanel from "@/features/guard/connections/sync/Panel"
+import { GuardSectionTabs, CONNECTIONS_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardSyncPage() {
   return (
@@ -29,6 +30,7 @@ function SyncContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={CONNECTIONS_TABS} />
       <SyncPanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/spend/optimization/page.tsx
+++ b/apps/web/src/app/(app)/theguard/spend/optimization/page.tsx
@@ -8,6 +8,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import CostPerformancePanel from "@/features/guard/spend/optimization/Panel"
+import { GuardSectionTabs, SPEND_TABS } from "@/features/guard/GuardSectionTabs"
 
 export default function GuardCostPerformancePage() {
   return (
@@ -29,6 +30,7 @@ function CostPerformanceContent() {
 
   return (
     <GuardShell>
+      <GuardSectionTabs tabs={SPEND_TABS} />
       <CostPerformancePanel
         workspaceId={activeWorkspace?.id ?? null}
         isAdmin={permissions.canEditSettings}

--- a/apps/web/src/app/(app)/theguard/spend/page.tsx
+++ b/apps/web/src/app/(app)/theguard/spend/page.tsx
@@ -11,6 +11,7 @@ import { useGuardSavings } from "@/hooks/useGuardSavings"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import { ByAiToolTable } from "@/components/guard/ByAiToolTable"
+import { GuardSectionTabs, SPEND_TABS } from "@/features/guard/GuardSectionTabs"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -668,6 +669,7 @@ function SpendContent() {
   if (!roleLoading && !canViewSpend) {
     return (
       <GuardShell lastFetched={lastUpdated}>
+        <GuardSectionTabs tabs={SPEND_TABS} />
         <div className="card" style={{ padding: "64px 24px", textAlign: "center", fontSize: 13, color: "var(--text-muted)" }}>
           You don&apos;t have access to spend data. Contact your admin.
         </div>
@@ -677,6 +679,7 @@ function SpendContent() {
 
   return (
     <GuardShell lastFetched={lastUpdated}>
+      <GuardSectionTabs tabs={SPEND_TABS} />
       {/* Page controls row */}
       <div style={{ display: "flex", alignItems: "center", justifyContent: "flex-end", gap: 8, marginBottom: 20 }}>
         <select

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -153,7 +153,7 @@ const PALETTE_COMMANDS = [
   { group: "ASK", label: "Lens", href: "/lens", icon: "Spark" as const },
   ...GUARD_SECTIONS.map(s => ({ group: "GOVERN" as const, label: `Guard · ${s.label}`, href: s.href, icon: "Shield" as const })),
   { group: "GOVERN", label: "Guard · Compliance", href: "/theguard/compliance", icon: "Shield" as const },
-  { group: "GOVERN", label: "Guard · Settings", href: "/theguard/settings", icon: "Shield" as const },
+  { group: "GOVERN", label: "Guard · Enforcement", href: "/theguard/policies/enforcement", icon: "Shield" as const },
   { group: "WORKSPACE", label: "Integrations", href: "/integrations", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Agent ID", href: "/agent-identity", icon: "Gear" as const },
   { group: "WORKSPACE", label: "Settings · Vault", href: "/settings", icon: "Gear" as const },

--- a/apps/web/src/components/AppShell.tsx
+++ b/apps/web/src/components/AppShell.tsx
@@ -232,6 +232,9 @@ function AppShellInnerContent({
   const [lensPanelOpen, setLensPanelOpen] = useState(false)
   const [lensPanelInitialQuery, setLensPanelInitialQuery] = useState<string | null>(null)
 
+  // Suppress side panel on full-page Lens routes (would render Lens twice).
+  const lensPanelSuppressed = pathname?.startsWith("/lens") ?? false
+
   // Persist open/closed state (#B5). localStorage read is client-only.
   useEffect(() => {
     if (typeof window === "undefined") return
@@ -241,6 +244,19 @@ function AppShellInnerContent({
     if (typeof window === "undefined") return
     try { window.localStorage.setItem("lens:panelOpen", lensPanelOpen ? "1" : "0") } catch { /* ignore */ }
   }, [lensPanelOpen])
+
+  // ⌘. / Ctrl+. toggles Lens panel from anywhere.
+  useEffect(() => {
+    if (lensPanelSuppressed) return
+    const onKey = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === ".") {
+        e.preventDefault()
+        setLensPanelOpen(v => !v)
+      }
+    }
+    window.addEventListener("keydown", onKey)
+    return () => window.removeEventListener("keydown", onKey)
+  }, [lensPanelSuppressed])
 
   // Team rename/create/delete state
   const [creatingTeam, setCreatingTeam] = useState(false)
@@ -1288,15 +1304,17 @@ function AppShellInnerContent({
           <ErrorBoundary>{children}</ErrorBoundary>
         </main>
       </div>
-    </div>
 
-    {/* Command Palette */}
-    <LensPanel
-      open={lensPanelOpen}
-      initialQuery={lensPanelInitialQuery}
-      pathname={pathname}
-      onClose={() => { setLensPanelOpen(false); setLensPanelInitialQuery(null) }}
-    />
+      {/* Lens — docked side panel (pushes content, not an overlay) */}
+      {!lensPanelSuppressed && (
+        <LensPanel
+          open={lensPanelOpen}
+          initialQuery={lensPanelInitialQuery}
+          pathname={pathname}
+          onClose={() => { setLensPanelOpen(false); setLensPanelInitialQuery(null) }}
+        />
+      )}
+    </div>
 
     {paletteOpen && (
       <div

--- a/apps/web/src/components/glens/LensPanel.tsx
+++ b/apps/web/src/components/glens/LensPanel.tsx
@@ -45,6 +45,37 @@ export function LensPanel({
   const composerRef = useRef<HTMLTextAreaElement>(null)
   const initialQuerySentRef = useRef<string | null>(null)
 
+  // Persisted, drag-to-resize width (min 320, max 720).
+  const [width, setWidth] = useState(420)
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem("lens:panelWidth")
+      const n = raw ? parseInt(raw, 10) : NaN
+      if (Number.isFinite(n) && n >= 320 && n <= 720) setWidth(n)
+    } catch { /* ignore */ }
+  }, [])
+  const startDrag = (e: React.MouseEvent) => {
+    e.preventDefault()
+    const startX = e.clientX
+    const startW = width
+    const onMove = (ev: MouseEvent) => {
+      const next = Math.min(720, Math.max(320, startW + (startX - ev.clientX)))
+      setWidth(next)
+    }
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove)
+      window.removeEventListener("mouseup", onUp)
+      document.body.style.cursor = ""
+      try { window.localStorage.setItem("lens:panelWidth", String(widthRef.current)) } catch { /* ignore */ }
+    }
+    document.body.style.cursor = "col-resize"
+    window.addEventListener("mousemove", onMove)
+    window.addEventListener("mouseup", onUp)
+  }
+  // ponytail: mirror width into a ref so the mouseup handler reads the latest value
+  const widthRef = useRef(width)
+  useEffect(() => { widthRef.current = width }, [width])
+
   // Auto-send the initial query once per open/query pair.
   useEffect(() => {
     if (!open || !initialQuery) return
@@ -150,16 +181,26 @@ export function LensPanel({
   if (!open) return null
 
   return (
-    <div
+    <aside
       style={{
-        position: "fixed", top: 0, right: 0, bottom: 0, width: 420, zIndex: 300,
+        width, flexShrink: 0, height: "100vh",
         background: "var(--surface)", borderLeft: "1px solid var(--border)",
         display: "flex", flexDirection: "column",
-        boxShadow: "-4px 0 20px rgba(0,0,0,.12)",
+        boxShadow: "-4px 0 20px rgba(0,0,0,.06)",
+        position: "relative",
       }}
-      role="dialog"
+      role="complementary"
       aria-label="Ask Lens panel"
     >
+      {/* Drag handle — thin invisible strip on the left border */}
+      <div
+        onMouseDown={startDrag}
+        aria-hidden
+        style={{
+          position: "absolute", top: 0, bottom: 0, left: -3, width: 6,
+          cursor: "col-resize", zIndex: 1,
+        }}
+      />
       {/* Header */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
@@ -255,7 +296,7 @@ export function LensPanel({
           }}
         />
       </form>
-    </div>
+    </aside>
   )
 }
 

--- a/apps/web/src/components/guard/GuardShell.tsx
+++ b/apps/web/src/components/guard/GuardShell.tsx
@@ -40,11 +40,6 @@ function ComplianceIcon() {
   return <svg {...common}><path d="M9 12l2 2 4-4" /><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" /></svg>
 }
 
-function SettingsIcon() {
-  const common = { width: 16, height: 16, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const }
-  return <svg {...common}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z" /></svg>
-}
-
 function ChevronLeft() {
   return <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><polyline points="15 18 9 12 15 6" /></svg>
 }
@@ -137,11 +132,9 @@ export function GuardShell({
   }, [])
 
   const showCompliance = role === "admin" || role === "security"
-  const showSettings   = role === "admin"
-  const hasAdminItems  = showCompliance || showSettings
+  const hasAdminItems  = showCompliance
 
   const isComplianceActive = pathname?.startsWith("/theguard/compliance") ?? false
-  const isSettingsActive   = pathname?.startsWith("/theguard/settings") ?? false
 
   const railWidth = collapsed ? RAIL_COLLAPSED : RAIL_EXPANDED
 
@@ -208,15 +201,6 @@ export function GuardShell({
                   label="Compliance"
                   icon={<ComplianceIcon />}
                   active={isComplianceActive}
-                  collapsed={collapsed}
-                />
-              )}
-              {showSettings && (
-                <RailItem
-                  href="/theguard/settings"
-                  label="Settings"
-                  icon={<SettingsIcon />}
-                  active={isSettingsActive}
                   collapsed={collapsed}
                 />
               )}

--- a/apps/web/src/features/guard/GuardSectionTabs.tsx
+++ b/apps/web/src/features/guard/GuardSectionTabs.tsx
@@ -1,0 +1,57 @@
+"use client"
+
+import Link from "next/link"
+import { usePathname } from "next/navigation"
+
+export interface GuardSectionTab {
+  href: string
+  label: string
+}
+
+export const CONNECTIONS_TABS: readonly GuardSectionTab[] = [
+  { href: "/theguard/connections/proxy",         label: "Proxy & gateways" },
+  { href: "/theguard/connections/notifications", label: "Notifications" },
+  { href: "/theguard/connections/sync",          label: "Sync" },
+]
+
+export const SPEND_TABS: readonly GuardSectionTab[] = [
+  { href: "/theguard/spend",              label: "Overview" },
+  { href: "/theguard/spend/optimization", label: "Optimization" },
+]
+
+export function GuardSectionTabs({ tabs }: { tabs: readonly GuardSectionTab[] }) {
+  const pathname = usePathname()
+  return (
+    <nav
+      aria-label="Section tabs"
+      style={{
+        display: "flex",
+        gap: 4,
+        borderBottom: "1px solid var(--border)",
+        marginBottom: 20,
+      }}
+    >
+      {tabs.map(t => {
+        const active = pathname === t.href
+        return (
+          <Link
+            key={t.href}
+            href={t.href}
+            style={{
+              padding: "8px 14px",
+              fontSize: 13,
+              fontWeight: active ? 600 : 500,
+              color: active ? "var(--text)" : "var(--text-3)",
+              borderBottom: `2px solid ${active ? "var(--accent)" : "transparent"}`,
+              marginBottom: -1,
+              textDecoration: "none",
+              transition: "color .12s",
+            }}
+          >
+            {t.label}
+          </Link>
+        )
+      })}
+    </nav>
+  )
+}

--- a/apps/web/src/types/css.d.ts
+++ b/apps/web/src/types/css.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css"


### PR DESCRIPTION
## Summary

Two web-only cleanups bundled here:

**1. Guard sub-nav.** Sub-nav hardened + old Settings rail entry removed (the entry point moved into the Guard sub-nav).

**2. Docked Lens.** `LensPanel` was a fixed overlay covering the page; it's now a docked flex child of `AppShell` that pushes content, VSCode-Copilot style.
- Suppressed on `/lens` routes (would otherwise render Lens twice).
- Drag the left border to resize (320–720px), persisted to `lens:panelWidth`.
- `Cmd+.` / `Ctrl+.` toggles the panel from any app page.
- `src/types/css.d.ts` added to silence two pre-existing tsc CSS-import warnings.

Follow-up on the streaming feel (buffered SSE + fake char-stream) is out of scope here — see #1865.

## Type

- [x] Refactor / internal change (no user-visible behaviour change apart from the panel dock)

## How to test

- Open any `/theguard/*` page → click "Ask Lens" → panel docks on the right; page content reflows instead of being covered.
- Drag the panel's left border → width changes, persists across reloads.
- Press `Cmd+.` → toggles open/close.
- Navigate to `/lens` (full page) → side panel doesn't render (no double Lens).
- Settings rail entry is gone from the left rail.