### PR TITLE
feat(glens): real streaming + unified bubble + embeddable Lens surface

### DIFF
--- a/apps/api/app/modules/glens/routers/chat.py
+++ b/apps/api/app/modules/glens/routers/chat.py
@@ -803,9 +803,11 @@ async def glens_chat_stream(
                 check_grounded(answer, tool_results, skill="governance")
                 if drilldown:
                     answer += f"\n\n[View all →]({drilldown})"
-                for char in answer:
-                    await event_q.put({"type": "token", "text": char})
-                    await asyncio.sleep(0)
+                # ponytail: fake-stream at ~4-char/8ms — matches GPT/Claude cadence.
+                # Real Phase-1 streaming would need tool_use detection mid-stream; not worth it yet.
+                for i in range(0, len(answer), 4):
+                    await event_q.put({"type": "token", "text": answer[i:i + 4]})
+                    await asyncio.sleep(0.008)
                 await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope, "run_started_envelope": run_started_envelope})
                 return
 
@@ -818,9 +820,9 @@ async def glens_chat_stream(
             check_grounded(answer, tool_results, skill="governance")
             if drilldown and not _answer_is_apology(answer):
                 link = f"\n\n[View all →]({drilldown})"
-                for char in link:
-                    await event_q.put({"type": "token", "text": char})
-                    await asyncio.sleep(0)
+                for i in range(0, len(link), 4):
+                    await event_q.put({"type": "token", "text": link[i:i + 4]})
+                    await asyncio.sleep(0.008)
                 answer += link
             await event_q.put({"type": "done", "answer": answer, "confirm_envelope": confirm_envelope, "run_started_envelope": run_started_envelope})
         except Exception as e:
@@ -882,4 +884,15 @@ async def glens_chat_stream(
         finally:
             task.cancel()
 
-    return StreamingResponse(generate(), media_type="text/event-stream")
+    return StreamingResponse(
+        generate(),
+        media_type="text/event-stream",
+        headers={
+            # Force upstream proxies (nginx, Render, Cloudflare) to flush each
+            # SSE frame instead of buffering. Without these, tokens arrive in
+            # one dump at end-of-stream instead of streaming like GPT/Claude.
+            "Cache-Control": "no-cache, no-transform",
+            "X-Accel-Buffering": "no",
+            "Connection": "keep-alive",
+        },
+    )


### PR DESCRIPTION
## Summary

Three Lens improvements, all sharing one streaming loop and one renderer:

### 1. Streaming actually streams

- SSE was being buffered by nginx / Render because \`StreamingResponse\` had no anti-buffering headers. Added \`Cache-Control: no-cache, no-transform\`, \`X-Accel-Buffering: no\`, \`Connection: keep-alive\`. Phase-2 synthesis was already streaming real tokens from the LLM — the frames now reach the browser as produced.
- Phase-1 early-text path fake-streamed char-by-char with \`asyncio.sleep(0)\` (no cadence). Switched to 4-char chunks with \`sleep(0.008)\` — matches GPT/Claude typing feel.

### 2. One bubble, both surfaces

- Docked \`LensPanel\` rendered raw \`whiteSpace: pre-wrap\`; full-page \`GLensChatPage\` rendered markdown via \`AnswerBubble\`. Same streamed text, two renderers.
- Widened \`AnswerBubble\` into the single shared assistant bubble both surfaces render through (\`dense\`, \`streaming\`, \`tone\`, \`footer\` props). Any future markdown feature lands once and hits both.

### 3. Embeddable Lens surface (closes half of #1830)

- Extracted the chat guts into headless \`<LensChat>\` (messages viewport + composer + SSE loop). \`LensPanel\` shrunk 244 → 16 lines around it.
- Added \`<LensEmbed>\` — inline Lens for #1830 Tab II (\"Run a workflow in Lens\" embedded demo):

  \`\`\`tsx
  <LensEmbed sessionId={runThreadId} initialQuery=\"…\" height={480} />
  \`\`\`

- No AppShell chrome, no dock, fills parent container. Attach to a live run's thread via \`sessionId\`. Same streaming + markdown as the other two surfaces.

## Skipped

- Real Phase-1 token streaming from the LLM — needs tool_use detection mid-stream; ~500ms saved; not worth the complexity yet.
- The rest of #1830 (backend \`POST /guard/trial/demo/workflow/{slug}\`, seeded demo playbook, tabbed \`/theguard/try\` UI) — that's a separate epic and depends on #1828 / #1829. \`<LensEmbed>\` is drop-in ready when it lands.

## Test plan

- [ ] Ask Lens a no-tool question on both docked and full-page — response types out with cursor at ~4 chars per 8ms.
- [ ] Ask Lens a tool-hitting question — synthesis streams token-by-token.
- [ ] Docked panel renders **bold**, \`[links](url)\`, bullet lists, and \`| tables |\` the same as the full-page canvas.
- [ ] Full-page streaming shows the blinking cursor.
- [ ] Error state on the docked panel renders red.
- [ ] \"Open in Lens →\" still appears on complex docked answers.
- [ ] \`<LensEmbed>\` renders inside a plain \`<div>\` with no AppShell — chat, streaming, markdown all work.
- [ ] \`<LensEmbed sessionId=\"…\" />\` continues an existing thread instead of starting a new one.
- [ ] Prod behind Render: no reverse-proxy buffering.