### PR TITLE
fix(guard): coverage endpoint 500 — skip stale rules instead of raising

### DIFF
--- a/apps/api/app/modules/guard/coverage.py
+++ b/apps/api/app/modules/guard/coverage.py
@@ -12,6 +12,7 @@ log = structlog.get_logger(__name__)
 
 from app.modules.guard.enforcement import (
     GATES,
+    EnforcementMetadataError,
     conservative_custom_enforcement,
     derive_gates,
     derive_surface_status,
@@ -79,12 +80,25 @@ def workspace_coverage_matrix(db: Session, workspace_id: uuid.UUID) -> list[dict
     matrix: list[dict[str, Any]] = []
     for rule_id, rule in resolved.items():
         metadata = rule.get("enforcement")
-        if metadata is None:
-            if rule.get("_builtin"):
+        # Validate what we have; fall back to the conservative contract when
+        # metadata is missing. A single stale rule must not crash the whole
+        # coverage endpoint — log + skip it instead so the matrix still
+        # renders for every other rule in the workspace.
+        try:
+            if metadata is None:
+                metadata = conservative_custom_enforcement(rule)
+            else:
                 validate_enforcement_metadata(rule)
-            metadata = conservative_custom_enforcement(rule)
-        else:
-            validate_enforcement_metadata(rule)
+        except EnforcementMetadataError as exc:
+            log.warning(
+                "guard.coverage.rule_metadata_invalid",
+                rule_id=rule_id,
+                pack=rule.get("_pack_slug"),
+                pack_version=rule.get("_pack_version"),
+                builtin=bool(rule.get("_builtin")),
+                error=str(exc),
+            )
+            continue
 
         base_action = rule.get("action", "audit")
         effective_action = base_action

--- a/apps/api/tests/guard/test_coverage_divergence_log.py
+++ b/apps/api/tests/guard/test_coverage_divergence_log.py
@@ -190,3 +190,51 @@ def test_derived_fields_land_on_coverage_row():
     assert row["derived_hook"] == "hard"
     assert row["derived_runtime"] == "hard"
     assert row["derived_proxy"] == "not_supported"
+
+
+def test_stale_rule_is_skipped_not_500():
+    """One rule with invalid enforcement metadata must not crash the whole
+    coverage endpoint. Skip the bad rule, log a warning, keep the rest.
+
+    Repro for the /theguard/policies "Enforcement coverage" 500 seen in
+    prod 2026-09-12 (error_id a9e4c83e). Ariba workspace had a pack whose
+    rule was missing enforcement metadata — one raise from
+    validate_enforcement_metadata took the whole matrix down.
+    """
+    good = {
+        "id": "good-rule",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": _authored({
+            "proxy": "not_supported", "mcp": "hard",
+            "hook": "hard", "runtime": "hard",
+        }),
+    }
+    # Stale rule: enforcement key exists but version is wrong → validator raises.
+    bad = {
+        "id": "stale-rule",
+        "action": "block",
+        "persona": "agent",
+        "gates": ["action"],
+        "enforcement": {
+            "version": 999,  # not the accepted CONTRACT_VERSION
+            "proxy": "not_supported", "mcp": "hard",
+            "hook": "hard", "runtime": "hard",
+            "guarantee": "test", "requires": [], "known_limitations": [],
+        },
+    }
+    db = _make_db([good, bad])
+    calls: list[tuple[str, dict]] = []
+    with patch(
+        "app.modules.guard.coverage._get_pack",
+        return_value=_pack_object([good, bad]),
+    ), patch("app.modules.guard.coverage.log.warning",
+             side_effect=lambda event, **kw: calls.append((event, kw))):
+        matrix = workspace_coverage_matrix(db, uuid.uuid4())
+
+    ids = [row["rule_id"] for row in matrix]
+    assert "good-rule" in ids
+    assert "stale-rule" not in ids
+    invalid = [kw for ev, kw in calls if ev == "guard.coverage.rule_metadata_invalid"]
+    assert any(kw["rule_id"] == "stale-rule" for kw in invalid)


### PR DESCRIPTION
## Repro

`/theguard/policies` → **Enforcement coverage** tab returns
`{"detail":"An internal error occurred.","error_id":"a9e4c83e"}`
in production (Ariba workspace, 2026-09-12).

Root cause: `workspace_coverage_matrix` iterates every rule from every
installed pack + every custom rule, and calls `validate_enforcement_metadata`
per rule. If **any** rule has stale or missing metadata, the validator raises
`EnforcementMetadataError` (a `ValueError`), which propagates as a 500 —
one bad rule crashes the entire coverage endpoint for the workspace.

## Two fixes

### 1. Latent None-crash for builtin rules

At `coverage.py:82-85`, when `enforcement` was missing on a builtin rule:

```python
if metadata is None:
    if rule.get("_builtin"):
        validate_enforcement_metadata(rule)          # ← raises: isinstance(None, dict) is False
    metadata = conservative_custom_enforcement(rule) # ← never reached for builtin
```

The validator's very first check is `isinstance(metadata, dict)`, so this
always raised for `None`. Removed the pre-fallback validation call — the
fallback returns a valid metadata dict on its own.

### 2. Whole-endpoint-crashes-on-one-bad-rule

Wrap the per-rule validation + fallback in `try/except EnforcementMetadataError`.
Log a structured warning with `rule_id` / `pack` / `pack_version` / `error`
and skip that row. Every other rule in the workspace still surfaces in
the matrix.

**Trade-off:** users may see one fewer row than expected, but the page
renders instead of 500ing. The structured log
`guard.coverage.rule_metadata_invalid` gives ops a signal to find and
republish the stale pack. Better than "everyone sees an error until we
ship a fix."

## Regression test

`test_stale_rule_is_skipped_not_500` in `test_coverage_divergence_log.py`:
one rule with an invalid enforcement contract (`version: 999`) in a
two-rule pack. Asserts the matrix still returns the good rule and warns
once for the bad rule.

## Type

- [x] Bug fix

## Checklist

- [x] Regression test added at `apps/api/tests/guard/test_coverage_divergence_log.py::test_stale_rule_is_skipped_not_500`
- [x] `pytest apps/api/tests/guard/test_coverage_divergence_log.py` — all 6 green locally
- [x] DCO trailer on commit

## Post-merge

Watch for `guard.coverage.rule_metadata_invalid` log lines in Render — they name the stale rule + pack + version. Republish the affected pack to make the rule surface in the matrix again.
