### PR TITLE
feat(guard): merge Enforcement settings into Policies → Enforcement coverage tab (#1862)

### DIFF
--- a/apps/web/src/app/(app)/theguard/policies/enforcement/page.tsx
+++ b/apps/web/src/app/(app)/theguard/policies/enforcement/page.tsx
@@ -1,38 +1,10 @@
-"use client"
+// Enforcement settings merged into the Policies page's "Enforcement
+// coverage" tab so users configure enforcement mode + see coverage in
+// one place. This route stays as a redirect so old bookmarks and the
+// palette entry "Guard · Enforcement" (AppShell) still land users on
+// the right tab.
+import { redirect } from "next/navigation"
 
-import { useEffect } from "react"
-import { useRouter } from "next/navigation"
-import { useWorkspace } from "@/lib/WorkspaceContext"
-import { useGuardTeam } from "@/hooks/useGuardTeam"
-import { useGuardRole } from "@/hooks/useGuardRole"
-import AppShell from "@/components/AppShell"
-import { GuardShell } from "@/components/guard/GuardShell"
-import EnforcementPanel from "@/features/guard/policies/enforcement/Panel"
-
-export default function GuardEnforcementPage() {
-  return (
-    <AppShell>
-      <EnforcementContent />
-    </AppShell>
-  )
-}
-
-function EnforcementContent() {
-  const { activeWorkspace } = useWorkspace()
-  const { teamId } = useGuardTeam()
-  const { permissions, role: resolvedRole } = useGuardRole(teamId, activeWorkspace?.id ?? null)
-  const router = useRouter()
-
-  useEffect(() => {
-    if (resolvedRole !== null && !permissions.canEditSettings) router.replace("/theguard")
-  }, [resolvedRole, permissions.canEditSettings, router])
-
-  return (
-    <GuardShell>
-      <EnforcementPanel
-        workspaceId={activeWorkspace?.id ?? null}
-        isAdmin={permissions.canEditSettings}
-      />
-    </GuardShell>
-  )
+export default function Page() {
+  redirect("/theguard/policies?view=coverage")
 }

--- a/apps/web/src/app/(app)/theguard/policies/page.tsx
+++ b/apps/web/src/app/(app)/theguard/policies/page.tsx
@@ -11,6 +11,7 @@ import { useWorkspace } from "@/lib/WorkspaceContext"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
 import { EnforcementCoverageMatrix } from "@/components/guard/EnforcementCoverageMatrix"
+import EnforcementPanel from "@/features/guard/policies/enforcement/Panel"
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -1038,6 +1039,10 @@ function PoliciesContent() {
   useEffect(() => {
     const p = searchParams.get("persona")
     if (p) setTimeout(() => document.getElementById(`section-${p}`)?.scrollIntoView({ behavior: "smooth", block: "start" }), 300)
+    // Land on the Enforcement coverage tab when redirected from the old
+    // /theguard/policies/enforcement URL (or any ?view=coverage deep link).
+    const v = searchParams.get("view")
+    if (v === "policies" || v === "coverage") setPageView(v)
   }, [searchParams])
   const { teamId, loading: teamLoading, error: teamError } = useGuardTeam()
   const { activeWorkspace } = useWorkspace()
@@ -1354,7 +1359,19 @@ function PoliciesContent() {
         </div>
 
         {pageView === "coverage" ? (
-          <EnforcementCoverageMatrix workspaceId={teamId} />
+          <>
+            {/* Enforcement settings — merged here from the standalone
+                /theguard/policies/enforcement page. One home for
+                everything enforcement: settings on top, coverage matrix
+                below. Old URL now redirects to ?view=coverage. */}
+            <div style={{ marginBottom: 20 }}>
+              <EnforcementPanel
+                workspaceId={activeWorkspace?.id ?? null}
+                isAdmin={permissions.canEditSettings}
+              />
+            </div>
+            <EnforcementCoverageMatrix workspaceId={teamId} />
+          </>
         ) : (
           <>
         {/* Sub-header row */}


### PR DESCRIPTION
Part of Phase 2 IA cleanup (#1862).

## Problem

Two enforcement-adjacent surfaces existed with zero cross-reference:

| URL | Content |
|-----|---------|
| `/theguard/policies` → **Enforcement coverage** tab | The matrix (rules × surfaces) |
| `/theguard/policies/enforcement` | The settings (mode / fail_mode / notify / deny toggles) |

Same job (govern how Guard enforces), split across two URLs, neither linking to the other. Users on the coverage tab had no way to jump to the mode toggle; users at the settings page had no way to see coverage without navigating away.

## Fix

Embed `EnforcementPanel` at the top of the Enforcement coverage tab. One home for everything enforcement — mode + fail_mode + notify + deny toggles on top, coverage matrix below.

- Import `EnforcementPanel` + render it above `EnforcementCoverageMatrix` when `pageView === "coverage"`.
- Hydrate `pageView` from `?view=` on load so the redirect below lands on the right tab.
- `/theguard/policies/enforcement` collapsed from a 38-line component page to a 10-line redirect stub → `/theguard/policies?view=coverage`.

Old URL + palette entry "Guard · Enforcement" (AppShell) still land users on the correct tab. **No API changes.** Matches the pattern shipped in #1864 (Session Reports canonicalization).

## Type

- [x] Refactor / IA change (no user-visible behavior loss)

## Checklist

- [x] `pnpm typecheck` — clean (all-green, including pre-existing CSS-import warnings now silenced by #1863's `types/css.d.ts`).
- [x] DCO trailer on commit.
- [x] No secrets, no PII in the diff.
