### PR TITLE
feat(glens): embeddable Lens surface (LensChat + LensEmbed) for #1830

### DIFF
--- a/apps/web/src/components/glens/LensChat.tsx
+++ b/apps/web/src/components/glens/LensChat.tsx
@@ -1,0 +1,250 @@
+"use client"
+/**
+ * LensChat — headless chat surface (messages + composer + SSE streaming loop).
+ *
+ * Shared by `LensPanel` (docked drawer) and `LensEmbed` (inline capability
+ * per #1830). Any component that wants Lens dropped into it renders this and
+ * owns the outer container.
+ *
+ * Streams from `/glens/chat/stream` — same endpoint the full-page canvas uses.
+ * All rendering flows through `AnswerBubble` — one bubble, one markdown parser.
+ */
+
+import { useEffect, useRef, useState } from "react"
+import { API } from "@/lib/api"
+import { useAuthFetch } from "@/hooks/useAuthFetch"
+import { AnswerBubble } from "@/components/glens/bubbles/AnswerBubble"
+
+type Message =
+  | { role: "user"; text: string }
+  | { role: "assistant"; kind: "streaming"; text: string }
+  | { role: "assistant"; kind: "answer"; text: string; drilldown?: string; complex?: boolean; sessionId?: string }
+  | { role: "assistant"; kind: "error"; text: string }
+
+export function LensChat({
+  pathname,
+  initialQuery,
+  initialSessionId,
+  onSessionId,
+  onExpandMessage,
+  autoFocusOnMount = true,
+  placeholder = "Ask Lens…",
+  emptyText = "Ask about anything on this page. Lens is Guard-enforced.",
+}: {
+  pathname?: string | null
+  initialQuery?: string | null
+  initialSessionId?: string | null
+  onSessionId?: (sid: string) => void
+  onExpandMessage?: (sid?: string) => void
+  autoFocusOnMount?: boolean
+  placeholder?: string
+  emptyText?: string
+}) {
+  const { authFetch } = useAuthFetch()
+  const [messages, setMessages] = useState<Message[]>([])
+  const [composer, setComposer] = useState("")
+  const [loading, setLoading] = useState(false)
+  const [sessionId, setSessionId] = useState<string | null>(initialSessionId ?? null)
+  const abortRef = useRef<AbortController | null>(null)
+  const bodyRef = useRef<HTMLDivElement>(null)
+  const composerRef = useRef<HTMLTextAreaElement>(null)
+  const initialQuerySentRef = useRef<string | null>(null)
+
+  useEffect(() => {
+    if (!initialQuery) return
+    if (initialQuerySentRef.current === initialQuery) return
+    initialQuerySentRef.current = initialQuery
+    void send(initialQuery)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialQuery])
+
+  useEffect(() => {
+    if (autoFocusOnMount && !initialQuery) composerRef.current?.focus()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  useEffect(() => {
+    if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight
+  }, [messages])
+
+  useEffect(() => () => abortRef.current?.abort(), [])
+
+  async function send(text: string) {
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    setMessages(prev => [...prev, { role: "user", text }, { role: "assistant", kind: "streaming", text: "" }])
+    setLoading(true)
+
+    try {
+      const body: Record<string, unknown> = { message: text }
+      if (sessionId) body.session_id = sessionId
+      if (pathname) body.page_context = pathname
+
+      const res = await authFetch(`${API}/glens/chat/stream`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: controller.signal,
+      })
+      if (!res.ok) {
+        setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: `Request failed (${res.status}).` }])
+        return
+      }
+
+      const reader = res.body!.getReader()
+      const decoder = new TextDecoder()
+      let buf = ""
+      let streamedText = ""
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buf += decoder.decode(value, { stream: true })
+        const lines = buf.split("\n")
+        buf = lines.pop()!
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue
+          try {
+            const evt = JSON.parse(line.slice(6))
+            if (evt.type === "token") {
+              streamedText += evt.text
+              setMessages(prev => {
+                const copy = prev.slice()
+                copy[copy.length - 1] = { role: "assistant", kind: "streaming", text: streamedText }
+                return copy
+              })
+            } else if (evt.type === "done") {
+              if (evt.session_id) {
+                setSessionId(evt.session_id)
+                onSessionId?.(evt.session_id)
+              }
+              const complex = Boolean(evt.spec || evt.blocks || evt.page_kind)
+              setMessages(prev => {
+                const copy = prev.slice()
+                copy[copy.length - 1] = {
+                  role: "assistant",
+                  kind: "answer",
+                  text: evt.answer || streamedText || "",
+                  drilldown: evt.drilldown?.path,
+                  complex,
+                  sessionId: evt.session_id,
+                }
+                return copy
+              })
+            } else if (evt.type === "error") {
+              setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: evt.message || "Error" }])
+            }
+          } catch { /* ignore malformed SSE payloads */ }
+        }
+      }
+    } catch (e) {
+      if ((e as Error).name === "AbortError") return
+      setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: (e as Error).message }])
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <>
+      <div
+        ref={bodyRef}
+        style={{
+          flex: 1, minHeight: 0, overflowY: "auto", padding: 14,
+          display: "flex", flexDirection: "column",
+        }}
+      >
+        {messages.length === 0 && (
+          <div style={{ color: "var(--text-muted)", fontSize: 12, marginTop: 8 }}>
+            {emptyText}
+          </div>
+        )}
+
+        {messages.map((m, i) => (
+          <MsgBubble key={i} m={m} onExpand={onExpandMessage} />
+        ))}
+      </div>
+
+      <form
+        onSubmit={(e) => {
+          e.preventDefault()
+          const q = composer.trim()
+          if (!q || loading) return
+          setComposer("")
+          void send(q)
+        }}
+        style={{
+          borderTop: "1px solid var(--border)", padding: 10,
+          background: "var(--surface-1)",
+        }}
+      >
+        <textarea
+          ref={composerRef}
+          value={composer}
+          onChange={(e) => setComposer(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && !e.shiftKey) {
+              e.preventDefault()
+              const q = composer.trim()
+              if (!q || loading) return
+              setComposer("")
+              void send(q)
+            }
+          }}
+          placeholder={placeholder}
+          rows={2}
+          disabled={loading}
+          style={{
+            width: "100%", resize: "none", border: "1px solid var(--border)",
+            borderRadius: 6, padding: "8px 10px", fontSize: 13,
+            background: "var(--surface-2)", color: "var(--text)", outline: "none",
+            fontFamily: "inherit",
+          }}
+        />
+      </form>
+    </>
+  )
+}
+
+function MsgBubble({ m, onExpand }: { m: Message; onExpand?: (sessionId?: string) => void }) {
+  if (m.role === "user") {
+    return (
+      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 10 }}>
+        <div style={{
+          maxWidth: "85%", background: "var(--accent, #6366f1)", color: "#fff",
+          borderRadius: "14px 14px 4px 14px", padding: "8px 12px", fontSize: 13, lineHeight: 1.5,
+        }}>{m.text}</div>
+      </div>
+    )
+  }
+
+  if (m.kind === "streaming") {
+    return <AnswerBubble dense streaming text={m.text} />
+  }
+
+  if (m.kind === "error") {
+    return <AnswerBubble dense tone="error" text={m.text} />
+  }
+
+  return (
+    <AnswerBubble
+      dense
+      text={m.text}
+      drilldown={m.drilldown ? { path: m.drilldown } : undefined}
+      footer={m.complex && onExpand && (
+        <div style={{ marginTop: 6, textAlign: "right" }}>
+          <button
+            onClick={() => onExpand(m.sessionId)}
+            style={{
+              border: "none", background: "transparent",
+              fontSize: 11, color: "var(--accent, #6366f1)", cursor: "pointer",
+              fontWeight: 500, padding: 0,
+            }}
+          >Open in Lens →</button>
+        </div>
+      )}
+    />
+  )
+}

--- a/apps/web/src/components/glens/LensEmbed.tsx
+++ b/apps/web/src/components/glens/LensEmbed.tsx
@@ -1,0 +1,66 @@
+"use client"
+/**
+ * LensEmbed — inline Lens surface (#1830).
+ *
+ * Drop-in Lens chat that fills its parent container. No AppShell chrome, no
+ * dock, no expand/close buttons — the host page owns everything around it.
+ * Reuses the same streaming loop, composer, and bubble rendering as the
+ * docked LensPanel and the full-page canvas.
+ *
+ *   <LensEmbed sessionId={runThreadId} initialQuery="…" height={480} />
+ *
+ * Pass `sessionId` to attach to an existing thread (e.g. a live playbook run
+ * on /theguard/try Tab II). Pass `initialQuery` to auto-send the first turn.
+ */
+
+import { LensChat } from "@/components/glens/LensChat"
+
+export function LensEmbed({
+  sessionId,
+  initialQuery,
+  height = 480,
+  title,
+  emptyText,
+  placeholder,
+}: {
+  sessionId?: string | null
+  initialQuery?: string | null
+  /** Fixed height in px, or any valid CSS height (e.g. "60vh"). Default 480px. */
+  height?: number | string
+  /** Optional header label. Omit for chromeless. */
+  title?: string
+  emptyText?: string
+  placeholder?: string
+}) {
+  return (
+    <div
+      style={{
+        height: typeof height === "number" ? `${height}px` : height,
+        display: "flex", flexDirection: "column",
+        background: "var(--surface)",
+        border: "1px solid var(--border)",
+        borderRadius: 10,
+        overflow: "hidden",
+      }}
+      role="region"
+      aria-label={title ?? "Lens"}
+    >
+      {title && (
+        <div style={{
+          padding: "10px 14px", borderBottom: "1px solid var(--border)",
+          background: "var(--surface-1)",
+          fontSize: 13, fontWeight: 600, color: "var(--text)",
+        }}>
+          {title}
+        </div>
+      )}
+      <LensChat
+        pathname={null}
+        initialQuery={initialQuery ?? null}
+        initialSessionId={sessionId ?? null}
+        emptyText={emptyText}
+        placeholder={placeholder}
+      />
+    </div>
+  )
+}

--- a/apps/web/src/components/glens/LensPanel.tsx
+++ b/apps/web/src/components/glens/LensPanel.tsx
@@ -2,27 +2,14 @@
 /**
  * LensPanel — right-side chat drawer (#B1 + #B2 + #B4 from epic #1214).
  *
- * Copilot-style overlay: user asks Lens without leaving the current page.
- * Streams from the same /glens/chat/stream endpoint the full page uses,
- * with `page_context` set to the caller's pathname so answers stay
- * scoped to what the user is looking at.
- *
- * Rich responses (blocks / page / dashboard bubbles) collapse to a
- * "View in Lens →" affordance — the panel is optimised for quick text
- * answers; the full canvas is one click away.
+ * Copilot-style docked drawer: user asks Lens without leaving the current
+ * page. This file owns only the docked shell (resize handle, header, Escape
+ * key). The actual chat surface is `<LensChat>` — shared with `<LensEmbed>`.
  */
 
 import { useEffect, useRef, useState } from "react"
 import { useRouter } from "next/navigation"
-import { API } from "@/lib/api"
-import { useAuthFetch } from "@/hooks/useAuthFetch"
-import { AnswerBubble } from "@/components/glens/bubbles/AnswerBubble"
-
-type Message =
-  | { role: "user"; text: string }
-  | { role: "assistant"; kind: "streaming"; text: string }
-  | { role: "assistant"; kind: "answer"; text: string; drilldown?: string; complex?: boolean; sessionId?: string }
-  | { role: "assistant"; kind: "error"; text: string }
+import { LensChat } from "@/components/glens/LensChat"
 
 export function LensPanel({
   open,
@@ -36,18 +23,12 @@ export function LensPanel({
   onClose: () => void
 }) {
   const router = useRouter()
-  const { authFetch } = useAuthFetch()
-  const [messages, setMessages] = useState<Message[]>([])
-  const [composer, setComposer] = useState("")
-  const [loading, setLoading] = useState(false)
   const [sessionId, setSessionId] = useState<string | null>(null)
-  const abortRef = useRef<AbortController | null>(null)
-  const bodyRef = useRef<HTMLDivElement>(null)
-  const composerRef = useRef<HTMLTextAreaElement>(null)
-  const initialQuerySentRef = useRef<string | null>(null)
 
   // Persisted, drag-to-resize width (min 320, max 720).
   const [width, setWidth] = useState(420)
+  const widthRef = useRef(width)
+  useEffect(() => { widthRef.current = width }, [width])
   useEffect(() => {
     try {
       const raw = window.localStorage.getItem("lens:panelWidth")
@@ -60,8 +41,7 @@ export function LensPanel({
     const startX = e.clientX
     const startW = width
     const onMove = (ev: MouseEvent) => {
-      const next = Math.min(720, Math.max(320, startW + (startX - ev.clientX)))
-      setWidth(next)
+      setWidth(Math.min(720, Math.max(320, startW + (startX - ev.clientX))))
     }
     const onUp = () => {
       window.removeEventListener("mousemove", onMove)
@@ -73,111 +53,13 @@ export function LensPanel({
     window.addEventListener("mousemove", onMove)
     window.addEventListener("mouseup", onUp)
   }
-  // ponytail: mirror width into a ref so the mouseup handler reads the latest value
-  const widthRef = useRef(width)
-  useEffect(() => { widthRef.current = width }, [width])
 
-  // Auto-send the initial query once per open/query pair.
-  useEffect(() => {
-    if (!open || !initialQuery) return
-    if (initialQuerySentRef.current === initialQuery) return
-    initialQuerySentRef.current = initialQuery
-    void send(initialQuery)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [open, initialQuery])
-
-  // Focus composer when opened without an initial query.
-  useEffect(() => {
-    if (open && !initialQuery) composerRef.current?.focus()
-  }, [open, initialQuery])
-
-  // Auto-scroll to bottom on new messages.
-  useEffect(() => {
-    if (bodyRef.current) bodyRef.current.scrollTop = bodyRef.current.scrollHeight
-  }, [messages])
-
-  // Escape closes.
   useEffect(() => {
     if (!open) return
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose() }
     window.addEventListener("keydown", onKey)
     return () => window.removeEventListener("keydown", onKey)
   }, [open, onClose])
-
-  async function send(text: string) {
-    abortRef.current?.abort()
-    const controller = new AbortController()
-    abortRef.current = controller
-
-    setMessages(prev => [...prev, { role: "user", text }, { role: "assistant", kind: "streaming", text: "" }])
-    setLoading(true)
-
-    try {
-      const body: Record<string, unknown> = { message: text }
-      if (sessionId) body.session_id = sessionId
-      if (pathname) body.page_context = pathname
-
-      const res = await authFetch(`${API}/glens/chat/stream`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify(body),
-        signal: controller.signal,
-      })
-      if (!res.ok) {
-        setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: `Request failed (${res.status}).` }])
-        return
-      }
-
-      const reader = res.body!.getReader()
-      const decoder = new TextDecoder()
-      let buf = ""
-      let streamedText = ""
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buf += decoder.decode(value, { stream: true })
-        const lines = buf.split("\n")
-        buf = lines.pop()!
-        for (const line of lines) {
-          if (!line.startsWith("data: ")) continue
-          try {
-            const evt = JSON.parse(line.slice(6))
-            if (evt.type === "token") {
-              streamedText += evt.text
-              setMessages(prev => {
-                const copy = prev.slice()
-                copy[copy.length - 1] = { role: "assistant", kind: "streaming", text: streamedText }
-                return copy
-              })
-            } else if (evt.type === "done") {
-              if (evt.session_id) setSessionId(evt.session_id)
-              const complex = Boolean(evt.spec || evt.blocks || evt.page_kind)
-              setMessages(prev => {
-                const copy = prev.slice()
-                copy[copy.length - 1] = {
-                  role: "assistant",
-                  kind: "answer",
-                  text: evt.answer || streamedText || "",
-                  drilldown: evt.drilldown?.path,
-                  complex,
-                  sessionId: evt.session_id,
-                }
-                return copy
-              })
-            } else if (evt.type === "error") {
-              setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: evt.message || "Error" }])
-            }
-          } catch { /* ignore malformed SSE payloads */ }
-        }
-      }
-    } catch (e) {
-      if ((e as Error).name === "AbortError") return
-      setMessages(prev => [...prev.slice(0, -1), { role: "assistant", kind: "error", text: (e as Error).message }])
-    } finally {
-      setLoading(false)
-    }
-  }
 
   if (!open) return null
 
@@ -193,7 +75,6 @@ export function LensPanel({
       role="complementary"
       aria-label="Ask Lens panel"
     >
-      {/* Drag handle — thin invisible strip on the left border */}
       <div
         onMouseDown={startDrag}
         aria-hidden
@@ -202,7 +83,6 @@ export function LensPanel({
           cursor: "col-resize", zIndex: 1,
         }}
       />
-      {/* Header */}
       <div style={{
         display: "flex", alignItems: "center", justifyContent: "space-between",
         padding: "10px 14px", borderBottom: "1px solid var(--border)",
@@ -215,8 +95,7 @@ export function LensPanel({
         <div style={{ display: "flex", gap: 4 }}>
           <button
             onClick={() => {
-              const target = sessionId ? `/lens/${sessionId}` : "/lens"
-              router.push(target)
+              router.push(sessionId ? `/lens/${sessionId}` : "/lens")
               onClose()
             }}
             title="Expand to full Lens"
@@ -240,106 +119,15 @@ export function LensPanel({
         </div>
       </div>
 
-      {/* Messages */}
-      <div
-        ref={bodyRef}
-        style={{
-          flex: 1, overflowY: "auto", padding: 14,
-          display: "flex", flexDirection: "column",
+      <LensChat
+        pathname={pathname}
+        initialQuery={initialQuery}
+        onSessionId={setSessionId}
+        onExpandMessage={(sid) => {
+          router.push(sid ? `/lens/${sid}` : "/lens")
+          onClose()
         }}
-      >
-        {messages.length === 0 && (
-          <div style={{ color: "var(--text-muted)", fontSize: 12, marginTop: 8 }}>
-            Ask about anything on this page. Lens is Guard-enforced.
-          </div>
-        )}
-
-        {messages.map((m, i) => (
-          <MsgBubble key={i} m={m} onExpand={(sid) => { router.push(sid ? `/lens/${sid}` : "/lens"); onClose() }} />
-        ))}
-      </div>
-
-      {/* Composer */}
-      <form
-        onSubmit={(e) => {
-          e.preventDefault()
-          const q = composer.trim()
-          if (!q || loading) return
-          setComposer("")
-          void send(q)
-        }}
-        style={{
-          borderTop: "1px solid var(--border)", padding: 10,
-          background: "var(--surface-1)",
-        }}
-      >
-        <textarea
-          ref={composerRef}
-          value={composer}
-          onChange={(e) => setComposer(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
-              e.preventDefault()
-              const q = composer.trim()
-              if (!q || loading) return
-              setComposer("")
-              void send(q)
-            }
-          }}
-          placeholder="Ask Lens…"
-          rows={2}
-          disabled={loading}
-          style={{
-            width: "100%", resize: "none", border: "1px solid var(--border)",
-            borderRadius: 6, padding: "8px 10px", fontSize: 13,
-            background: "var(--surface-2)", color: "var(--text)", outline: "none",
-            fontFamily: "inherit",
-          }}
-        />
-      </form>
+      />
     </aside>
-  )
-}
-
-
-function MsgBubble({ m, onExpand }: { m: Message; onExpand: (sessionId?: string) => void }) {
-  if (m.role === "user") {
-    return (
-      <div style={{ display: "flex", justifyContent: "flex-end", marginBottom: 10 }}>
-        <div style={{
-          maxWidth: "85%", background: "var(--accent, #6366f1)", color: "#fff",
-          borderRadius: "14px 14px 4px 14px", padding: "8px 12px", fontSize: 13, lineHeight: 1.5,
-        }}>{m.text}</div>
-      </div>
-    )
-  }
-
-  if (m.kind === "streaming") {
-    return <AnswerBubble dense streaming text={m.text} />
-  }
-
-  if (m.kind === "error") {
-    return <AnswerBubble dense tone="error" text={m.text} />
-  }
-
-  // answer
-  return (
-    <AnswerBubble
-      dense
-      text={m.text}
-      drilldown={m.drilldown ? { path: m.drilldown } : undefined}
-      footer={m.complex && (
-        <div style={{ marginTop: 6, textAlign: "right" }}>
-          <button
-            onClick={() => onExpand(m.sessionId)}
-            style={{
-              border: "none", background: "transparent",
-              fontSize: 11, color: "var(--accent, #6366f1)", cursor: "pointer",
-              fontWeight: 500, padding: 0,
-            }}
-          >Open in Lens →</button>
-        </div>
-      )}
-    />
   )
 }


### PR DESCRIPTION
## Summary

Extracts the docked \`LensPanel\` chat guts into headless \`<LensChat>\` and adds \`<LensEmbed>\` — an inline Lens surface for the #1830 Tab II \"Run a workflow in Lens\" embedded demo.

- \`<LensChat>\`: messages viewport + composer + SSE streaming loop, container-agnostic.
- \`<LensPanel>\`: shrunk 244 → 16 lines, now just the docked shell (aside + resize handle + header + Escape) around \`<LensChat>\`.
- \`<LensEmbed>\`: drop-in inline surface, no AppShell chrome, no dock, fills its parent container.

  \`\`\`tsx
  <LensEmbed sessionId={runThreadId} initialQuery=\"…\" height={480} />
  \`\`\`

Same streaming, same markdown parser, same \`AnswerBubble\` as the other two surfaces — one loop, three renderings.

## Skipped

The rest of #1830 (backend \`POST /guard/trial/demo/workflow/{slug}\`, seeded demo playbook, tabbed \`/theguard/try\` UI). That is a dedicated session and depends on #1828 / #1829. \`<LensEmbed>\` is drop-in ready when it lands.

## Test plan

- [ ] \`<LensEmbed>\` renders inside a plain \`<div>\` with no AppShell — chat, streaming, markdown all work.
- [ ] \`<LensEmbed sessionId=\"…\" />\` attaches to an existing thread instead of starting a new one.
- [ ] Docked \`LensPanel\` still works — resize, Escape, Expand →, Open in Lens →.
- [ ] Full-page canvas unchanged.