### PR TITLE
feat(guard): migrate Approvals + Discovery to shared primitives (Phase 2a, #1862)

### DIFF
--- a/apps/web/src/app/(app)/theguard/approvals/page.tsx
+++ b/apps/web/src/app/(app)/theguard/approvals/page.tsx
@@ -4,6 +4,13 @@ import { useCallback, useEffect, useMemo, useState } from "react"
 import { useSearchParams } from "next/navigation"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import {
+  GuardBadge,
+  GuardFilterBar,
+  GuardPageHeader,
+  timeAgo,
+  type FilterPill,
+} from "@/components/guard/common"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { API } from "@/lib/api/client"
 
@@ -43,15 +50,6 @@ interface ListOut {
 
 // ─── Helpers ───────────────────────────────────────────────────────────────
 
-function timeAgo(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime()
-  const sec = Math.floor(diff / 1000)
-  if (sec < 60) return `${Math.max(sec, 0)}s ago`
-  const min = Math.floor(sec / 60)
-  if (min < 60) return `${min}m ago`
-  return `${Math.floor(min / 60)}h ago`
-}
-
 function timeUntil(iso: string): string {
   const diff = new Date(iso).getTime() - Date.now()
   if (diff <= 0) return "expired"
@@ -67,13 +65,6 @@ const STATUS_LABEL: Record<ApprovalStatus, string> = {
   approved:  "Approved",
   rejected:  "Rejected",
   timed_out: "Timed out",
-}
-
-const STATUS_COLOR: Record<ApprovalStatus, { bg: string; fg: string }> = {
-  pending:   { bg: "var(--warn-bg)", fg: "var(--warn)" },
-  approved:  { bg: "var(--ok-bg)",   fg: "var(--ok)"   },
-  rejected:  { bg: "var(--err-bg)",  fg: "var(--err)"  },
-  timed_out: { bg: "var(--info-bg)", fg: "var(--info)" },
 }
 
 // ─── Page ──────────────────────────────────────────────────────────────────
@@ -162,37 +153,22 @@ export default function ApprovalsPage() {
   return (
     <AppShell>
       <GuardShell lastFetched={lastFetched}>
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 20 }}>
-          <div>
-            <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--text)" }}>Approvals</h2>
-            <div style={{ fontSize: 12, color: "var(--text-muted)", marginTop: 4 }}>
-              Human-in-the-loop pauses triggered by Guard rules with action=approval.
-            </div>
-          </div>
-          <div style={{ display: "flex", gap: 8 }}>
-            {(["pending", "approved", "rejected", "timed_out", "all"] as const).map(k => (
-              <button
-                key={k}
-                onClick={() => setFilter(k)}
-                style={{
-                  padding: "6px 12px",
-                  borderRadius: 6,
-                  border: "1px solid var(--border)",
-                  background: filter === k ? "var(--surface-2)" : "transparent",
-                  color: "var(--text)",
-                  fontSize: 12,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                }}
-              >
-                {k === "all" ? "All" : STATUS_LABEL[k as ApprovalStatus]}
-                {k !== "all" && filter !== k && counts[k as ApprovalStatus] > 0 && (
-                  <span style={{ marginLeft: 6, color: "var(--text-muted)" }}>{counts[k as ApprovalStatus]}</span>
-                )}
-              </button>
-            ))}
-          </div>
-        </div>
+        <GuardPageHeader
+          title="Approvals"
+          description="Human-in-the-loop pauses triggered by Guard rules with action=approval."
+          lastUpdated={lastFetched}
+        />
+        <GuardFilterBar<ApprovalStatus | "all">
+          pills={([
+            { value: "pending",   label: "Pending",   count: counts.pending },
+            { value: "approved",  label: "Approved",  count: counts.approved },
+            { value: "rejected",  label: "Rejected",  count: counts.rejected },
+            { value: "timed_out", label: "Timed out", count: counts.timed_out },
+            { value: "all",       label: "All" },
+          ] as const) as readonly FilterPill<ApprovalStatus | "all">[]}
+          active={filter as ApprovalStatus | "all"}
+          onChange={setFilter as (v: ApprovalStatus | "all") => void}
+        />
 
         {err && (
           <div style={{ padding: 12, borderRadius: 6, background: "var(--err-bg)", color: "var(--err)", fontSize: 13, marginBottom: 16 }}>
@@ -213,7 +189,6 @@ export default function ApprovalsPage() {
         <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
           {items.map(row => {
             const isExpanded = expandedId === row.id
-            const color = STATUS_COLOR[row.status]
             const isPending = row.status === "pending"
             return (
               <div
@@ -230,20 +205,7 @@ export default function ApprovalsPage() {
                 <div style={{ display: "flex", alignItems: "flex-start", justifyContent: "space-between", gap: 12 }}>
                   <div style={{ minWidth: 0, flex: 1 }}>
                     <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
-                      <span
-                        style={{
-                          padding: "2px 8px",
-                          borderRadius: 4,
-                          background: color.bg,
-                          color: color.fg,
-                          fontSize: 11,
-                          fontWeight: 700,
-                          textTransform: "uppercase",
-                          letterSpacing: 0.4,
-                        }}
-                      >
-                        {STATUS_LABEL[row.status]}
-                      </span>
+                      <GuardBadge kind="status" value={row.status} label={STATUS_LABEL[row.status]} />
                       <span style={{ fontFamily: "var(--font-mono, monospace)", fontSize: 12, color: "var(--text)" }}>
                         {row.rule_id}
                       </span>

--- a/apps/web/src/app/(app)/theguard/discovery/page.tsx
+++ b/apps/web/src/app/(app)/theguard/discovery/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import { GuardPageHeader, GuardSectionHeader } from "@/components/guard/common"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 import { useGuardRole } from "@/hooks/useGuardRole"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
@@ -204,13 +205,10 @@ export default function DiscoveryPage() {
       {modalAgent && <RemediationModal agent={modalAgent} onClose={() => setModalAgent(null)} />}
       <div className="max-w-5xl mx-auto px-6 py-8 space-y-8">
 
-        {/* Header */}
-        <div>
-          <h1 className="text-2xl font-semibold text-stone-900">Agent Discovery</h1>
-          <p className="text-sm text-stone-500 mt-1">
-            Every hook, MCP call, and proxy request registers the agent automatically. Shadow AI surfaces here — and how many Guard governs.
-          </p>
-        </div>
+        <GuardPageHeader
+          title="Agent Discovery"
+          description="Every hook, MCP call, and proxy request registers the agent automatically. Shadow AI surfaces here — and how many Guard governs."
+        />
 
         {loading ? (
           <p className="text-sm text-stone-400">Loading...</p>
@@ -312,7 +310,7 @@ export default function DiscoveryPage() {
             {scans.length > 0 && (
               <div className="card" style={{ overflow: "hidden" }}>
                 <div style={{ padding: "10px 18px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
-                  <p className="eyebrow">Scan History</p>
+                  <GuardSectionHeader title="Scan History" />
                 </div>
                 <div style={{ display: "grid", gridTemplateColumns: "1.4fr 1.2fr 0.8fr 0.8fr 0.8fr", gap: 12, padding: "10px 18px", borderBottom: "1px solid var(--border)", background: "var(--surface-2)" }}>
                   {["When", "Triggered by", "Agents found", "Under Guard", "Status"].map((h, i) => (


### PR DESCRIPTION
Part of Phase 2 tracked in #1862. Second round of primitives adoption after #1861 (Inbox + Activity).

## Migrations

### Approvals — `/theguard/approvals`

- **`GuardPageHeader`** replaces the inline `<h2>` + description + right-slot layout. Also picks up the standard last-updated stamp.
- **`GuardFilterBar`** replaces the inline pending/approved/rejected/timed_out chip row. Counts show in the standard pill count style.
- **`GuardBadge kind="status"`** replaces the per-row inline `STATUS_COLOR` map + `<span>`. Custom `label` prop supported so we still render "Pending" / "Timed out" — colors flow from the shared palette.
- Local `timeAgo` removed; imported from `@/components/guard/common`.

### Discovery — `/theguard/discovery`

- **`GuardPageHeader`** replaces the Tailwind `<h1>` + description.
- **`GuardSectionHeader`** replaces the "Scan History" eyebrow.

## What's intentionally left per-page

- Discovery's local **`GuardBadge`** (under / missing / partial coverage) — compound state that doesn't map cleanly onto the shared `kind="status"` enum. Revisit in Phase 2b if we add a `"coverage"` variant.
- Discovery's local **`RiskBadge`** — numeric range → tone mapping (0-3 low / 4-6 medium / 7+ high). Same story — needs a `"risk"` variant on the shared badge if we want to unify.

Design principle from #1861 still holds: row visual model stays per-page (cards for queues, tables for firehoses). The primitives unify header / filter / badge / time / section, not the row layout.

## Type

- [x] Refactor / internal change (no user-visible behavior change)

## Checklist

- [x] `pnpm typecheck` — clean.
- [x] DCO trailer on commit.
- [x] Net ~40-line reduction across the two pages.

Follow-ups still open on #1862:
- **PR 2b** — migrate `/theguard/spend`, `/theguard/blocks/[id]`, `/theguard/compliance`, and the remaining `/logs/guard` tabs.
