### PR TITLE
feat(guard): migrate Compliance + Spend to shared primitives (Phase 2b, #1862)

### DIFF
--- a/apps/web/src/app/(app)/theguard/compliance/page.tsx
+++ b/apps/web/src/app/(app)/theguard/compliance/page.tsx
@@ -6,6 +6,7 @@ import { useGuardRole } from "@/hooks/useGuardRole"
 import { useWorkspace } from "@/lib/WorkspaceContext"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import { GuardPageHeader } from "@/components/guard/common"
 import { useAuthFetch } from "@/hooks/useAuthFetch"
 import { guard } from "@/lib/api"
 
@@ -312,6 +313,11 @@ function ComplianceContent() {
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      <GuardPageHeader
+        title="Compliance"
+        description="Audit-ready evidence, hook policy simulation, and workspace grade. Snapshot generated on demand from Guard's live data."
+        lastUpdated={new Date(generated_at)}
+      />
       {/* Grade + summary */}
       <div className="card" style={{ padding: "20px 24px" }}>
         <div style={{ display: "flex", alignItems: "center", gap: 20 }}>

--- a/apps/web/src/app/(app)/theguard/spend/page.tsx
+++ b/apps/web/src/app/(app)/theguard/spend/page.tsx
@@ -10,6 +10,7 @@ import { useWorkspace } from "@/lib/WorkspaceContext"
 import { useGuardSavings } from "@/hooks/useGuardSavings"
 import AppShell from "@/components/AppShell"
 import { GuardShell } from "@/components/guard/GuardShell"
+import { GuardSectionHeader } from "@/components/guard/common"
 import { ByAiToolTable } from "@/components/guard/ByAiToolTable"
 import { GuardSectionTabs, SPEND_TABS } from "@/features/guard/GuardSectionTabs"
 
@@ -748,7 +749,7 @@ function SpendContent() {
         </div>
       ) : data ? (
         <>
-          <div className="eyebrow" style={{ marginBottom: 11 }}>Spend for {monthLabel}</div>
+          <GuardSectionHeader title={`Spend for ${monthLabel}`} />
           <div style={{ display: "grid", gridTemplateColumns: "repeat(4, 1fr)", gap: 12, marginBottom: 22 }}>
             {[
               [`${CURRENCY_SYMBOLS[currency]}${fromUsd(data.total_cost_usd, currency).toFixed(2)}`, "Est. cost this month", "plain"],


### PR DESCRIPTION
Closes the visual half of Phase 2 tracked in #1862. Third round of primitives adoption after #1861 (Inbox + Activity) and #1870 (Approvals + Discovery).

## Migrations

### Compliance — `/theguard/compliance`

- Added **`GuardPageHeader`** — page previously had NO header at all; users landed directly on the grade summary card. New header explains what Compliance is + shows evidence generation timestamp via `lastUpdated`.

### Spend — `/theguard/spend`

- Swapped the primary "Spend for {monthLabel}" `eyebrow` section title for **`GuardSectionHeader`**.

## What's intentionally NOT in this PR

- **Column headers + metric-card sub-labels on Spend** — not section boundaries, they're table cells and small captions under large numbers. Different pattern than what `GuardSectionHeader` models.
- **`/theguard/blocks/[id]` receipt page** — doesn't use `GuardShell` at all (deep-link permalink from block responses). Adding the rail + a header is a larger UX change worth its own PR + design pass.
- **Remaining `/logs/guard` sub-tabs** (Sessions & Machines, Session Reports, Tool Errors) — render inside the same `page.tsx` whose main header + filter bar were already migrated in #1861. Sub-tab content is per-view inline; migration would be many small swaps with low visual impact. Punted to a follow-up if the noise becomes worth the effort.

## Result

With this PR the primary Guard pages — **Overview · Inbox · Activity · Discovery · Approvals · Policies · Spend · Compliance** — all consume the same `GuardPageHeader` / `GuardFilterBar` / `GuardBadge` / `GuardTimeCount` / `GuardSectionHeader` primitives. That closes the Phase 2 IA + visual work tracked in #1862.

## Post-Phase-2 wrap (still open)

- `packages/conduct-cli/src/conduct_cli/main.py:1376,1399` `security_scanner` slug cleanup
- Tag `cli/v0.13.0` + PyPI publish via OIDC
- Close #1840 epic

## Type

- [x] Refactor / internal change (no user-visible behavior change other than the new Compliance header)

## Checklist

- [x] `pnpm typecheck` — clean.
- [x] DCO trailer on commit.
